### PR TITLE
feat: support XDG Base Directory Specification (closes #46)

### DIFF
--- a/mempalace/cli/parser.py
+++ b/mempalace/cli/parser.py
@@ -52,7 +52,7 @@ def main():
     parser.add_argument(
         "--palace",
         default=None,
-        help="Where the palace lives (default: from ~/.mempalace/config.json or ~/.mempalace/palace)",
+        help="Where the palace lives (default: palace_path from config.json, resolved via XDG — see mempalace.config)",
     )
     parser.add_argument(
         "--backend",

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -1,7 +1,16 @@
 """
 MemPalace configuration system.
 
-Priority: env vars > config file (~/.mempalace/config.json) > defaults
+Priority: env vars > config file > defaults.
+
+The default config directory follows the XDG Base Directory Specification
+(https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+with back-compat for existing installs:
+
+  1. $MEMPALACE_CONFIG_DIR if set (explicit override, used by tests and CI)
+  2. ~/.mempalace if it already exists (existing installs keep working)
+  3. $XDG_CONFIG_HOME/mempalace if XDG_CONFIG_HOME is set
+  4. ~/.config/mempalace (XDG default fallback)
 """
 
 import errno
@@ -224,6 +233,51 @@ def sanitize_content(value: str, max_length: int = 100_000) -> str:
     return strip_lone_surrogates(value)
 
 
+# ── XDG Base Directory resolution ─────────────────────────────────────────────
+
+# Files that mark a ~/.mempalace directory as a real legacy install rather
+# than an empty/leftover directory. Any one is enough for back-compat.
+_LEGACY_MARKERS = ("config.json", "people_map.json")
+
+
+def _has_legacy_install(legacy: Path) -> bool:
+    """Return True if ``legacy`` is a real legacy install, not an empty dir.
+
+    A bare ``palace`` directory created by some other tool should not hijack
+    the XDG path, so the palace sub-directory only counts when it contains
+    an actual ChromaDB store (``chroma.sqlite3``).
+    """
+    if any((legacy / marker).is_file() for marker in _LEGACY_MARKERS):
+        return True
+    return (legacy / "palace" / "chroma.sqlite3").is_file()
+
+
+def _default_config_dir() -> Path:
+    """Return the default config directory.
+
+    See the module docstring for the resolution order.
+    """
+    env_dir = os.environ.get("MEMPALACE_CONFIG_DIR")
+    if env_dir and env_dir.strip():
+        return Path(env_dir).expanduser()
+
+    legacy = Path.home() / ".mempalace"
+    if legacy.is_dir() and _has_legacy_install(legacy):
+        return legacy
+
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg and xdg.strip():
+        xdg_path = Path(xdg).expanduser()
+        # Per XDG spec, relative paths must be ignored as invalid.
+        if xdg_path.is_absolute():
+            return xdg_path / "mempalace"
+
+    return Path.home() / ".config" / "mempalace"
+
+
+# DEPRECATED: kept only for backward compatibility with external importers.
+# This constant is frozen at the legacy location and is NOT XDG-aware — prefer
+# MempalaceConfig().palace_path in new code.
 DEFAULT_PALACE_PATH = os.path.expanduser("~/.mempalace/palace")
 DEFAULT_COLLECTION_NAME = "mempalace_drawers"
 DEFAULT_BACKEND = "chroma"
@@ -662,14 +716,13 @@ class MempalaceConfig:
 
         Args:
             config_dir: Override config directory (useful for testing).
-                        Defaults to ~/.mempalace.
+                        Defaults to the XDG-aware base directory — see
+                        _default_config_dir() for the resolution order.
             palace_path: Explicit palace data directory. This is primarily
                          used by CLI operations that received ``--palace``;
                          it takes precedence over environment and file config.
         """
-        self._config_dir = (
-            Path(config_dir) if config_dir else Path(os.path.expanduser("~/.mempalace"))
-        )
+        self._config_dir = Path(config_dir).expanduser() if config_dir else _default_config_dir()
         self._config_file = self._config_dir / "config.json"
         self._people_map_file = self._config_dir / "people_map.json"
         self._palace_path_override = (
@@ -853,8 +906,22 @@ class MempalaceConfig:
             print(f"  ! Could not write {self._config_file}: {exc}", file=sys.stderr)
 
     @property
+    def config_dir(self):
+        """Active config directory (XDG-aware).
+
+        Public accessor for the resolved config-dir path so callers outside
+        ``config.py`` can derive sibling locations (write-ahead-log dir,
+        cache dir, etc.) without reaching into ``_config_dir``.
+        """
+        return self._config_dir
+
+    @property
     def palace_path(self):
-        """Path to the memory palace data directory."""
+        """Path to the memory palace data directory.
+
+        Defaults to a "palace" sub-directory inside the active config
+        directory, so the palace follows the config wherever XDG places it.
+        """
         if self._palace_path_override is not None:
             return self._palace_path_override
         env_val = os.environ.get("MEMPALACE_PALACE_PATH") or os.environ.get("MEMPAL_PALACE_PATH")
@@ -863,7 +930,9 @@ class MempalaceConfig:
             # code path (mcp_server.py:62) and prevent surprise redirection
             # when the env var contains unresolved components.
             return os.path.abspath(os.path.expanduser(env_val))
-        return os.path.expanduser(self._file_config.get("palace_path", DEFAULT_PALACE_PATH))
+        return os.path.expanduser(
+            self._file_config.get("palace_path", str(self._config_dir / "palace"))
+        )
 
     @property
     def tunnel_file(self):

--- a/mempalace/fact_checker.py
+++ b/mempalace/fact_checker.py
@@ -321,6 +321,18 @@ def _reconfigure_stdio_utf8_on_windows():
     reconfigure_stdio_utf8_on_windows(stdout_errors="replace", stderr_errors="replace")
 
 
+def _default_palace_path() -> str:
+    """Resolve the default `--palace` location for the CLI.
+
+    Routes through `MempalaceConfig().palace_path` so XDG-aware config-dir
+    setups (and any `MEMPALACE_PALACE_PATH` override) win over the legacy
+    `~/.mempalace/palace` hardcoding this used to default to.
+    """
+    from .config import MempalaceConfig
+
+    return str(MempalaceConfig().palace_path)
+
+
 if __name__ == "__main__":
     import argparse
     import json
@@ -335,7 +347,7 @@ if __name__ == "__main__":
     parser.add_argument("text", nargs="?", help="Text to check (or use --stdin).")
     parser.add_argument(
         "--palace",
-        default=os.path.expanduser("~/.mempalace/palace"),
+        default=_default_palace_path(),
         help="Path to the palace directory.",
     )
     parser.add_argument("--stdin", action="store_true", help="Read text from stdin.")

--- a/mempalace/wal.py
+++ b/mempalace/wal.py
@@ -16,11 +16,12 @@ import json
 import logging
 import os
 from datetime import datetime
-from pathlib import Path
+
+from .config import _default_config_dir
 
 logger = logging.getLogger(__name__)
 
-_WAL_FILE = Path(os.path.expanduser("~/.mempalace/wal")) / "write_log.jsonl"
+_WAL_FILE = _default_config_dir() / "wal" / "write_log.jsonl"
 _WAL_INITIALIZED_DIR = None
 
 # Keys whose values should be redacted in WAL entries to avoid logging sensitive content

--- a/tests/mcp/test_protocol.py
+++ b/tests/mcp/test_protocol.py
@@ -2085,3 +2085,15 @@ class TestUnknownParamName:
         )
         assert "error" not in resp
         assert "result" in resp
+
+
+def test_wal_dir_nests_under_config_dir():
+    """The WAL must live under the active `MempalaceConfig.config_dir`,
+    not at a hardcoded `~/.mempalace/wal`. The previous hardcoded path
+    bypassed XDG resolution: a user with `MEMPALACE_CONFIG_DIR` pointing
+    at `~/.config/mempalace` would still see the WAL written to the
+    legacy location, fragmenting state across two directories."""
+    from mempalace import mcp_server, wal
+
+    assert wal._WAL_FILE.parent.parent == mcp_server._config.config_dir
+    assert wal._WAL_FILE.parent.name == "wal"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,12 @@
-import os
 import json
+import os
 import sqlite3
 import tempfile
 
 import pytest
 from mempalace.config import (
     MempalaceConfig,
+    _default_config_dir,
     connect_sqlite_read,
     normalize_wing_name,
     sanitize_iso_date,
@@ -16,11 +17,27 @@ from mempalace.config import (
 )
 
 
+def _set_home(monkeypatch, home):
+    """Point HOME and USERPROFILE at ``home`` so Path.home() is consistent
+    on both POSIX and Windows.
+    """
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+
 def test_default_config():
     cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
     assert "palace" in cfg.palace_path
     assert cfg.collection_name == "mempalace_drawers"
     assert cfg.backend == "chroma"
+
+
+def test_config_dir_property_exposes_resolved_path(tmp_path):
+    """`config_dir` is the public accessor callers outside config.py rely on
+    to derive sibling locations (WAL dir, cache dir, etc.) without reaching
+    into the underscore-prefixed `_config_dir`."""
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.config_dir == tmp_path
 
 
 def test_config_from_file():
@@ -1273,3 +1290,155 @@ def test_hybrid_rank_weights_malformed_config_falls_back_to_default(tmp_path, mo
     cfg = MempalaceConfig(config_dir=str(tmp_path))
     assert cfg.hybrid_rank_vector_weight == 0.6
     assert cfg.hybrid_rank_bm25_weight == 0.4
+
+
+# --- XDG Base Directory ---
+
+
+def test_default_config_dir_uses_xdg_when_set(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    _set_home(monkeypatch, fake_home)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("MEMPALACE_CONFIG_DIR", raising=False)
+
+    assert _default_config_dir() == xdg / "mempalace"
+
+    cfg = MempalaceConfig()
+    assert cfg.palace_path == str(xdg / "mempalace" / "palace")
+
+
+def test_default_config_dir_falls_back_to_dot_config(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    _set_home(monkeypatch, fake_home)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("MEMPALACE_CONFIG_DIR", raising=False)
+
+    assert _default_config_dir() == fake_home / ".config" / "mempalace"
+
+
+def test_legacy_mempalace_dir_respected_for_backcompat(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    legacy = fake_home / ".mempalace"
+    legacy.mkdir()
+    (legacy / "config.json").write_text("{}")
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+
+    _set_home(monkeypatch, fake_home)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("MEMPALACE_CONFIG_DIR", raising=False)
+
+    assert _default_config_dir() == legacy
+
+    cfg = MempalaceConfig()
+    assert cfg.palace_path == str(legacy / "palace")
+
+
+def test_empty_legacy_dir_does_not_hijack_xdg(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".mempalace").mkdir()
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+
+    _set_home(monkeypatch, fake_home)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("MEMPALACE_CONFIG_DIR", raising=False)
+
+    assert _default_config_dir() == xdg / "mempalace"
+
+
+def test_bare_palace_dir_does_not_trigger_legacy(monkeypatch, tmp_path):
+    # A bare ~/.mempalace/palace directory (without an actual ChromaDB
+    # store inside) should not be treated as a legacy install -- some
+    # other tool may have created the directory.
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    legacy = fake_home / ".mempalace"
+    legacy.mkdir()
+    (legacy / "palace").mkdir()
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+
+    _set_home(monkeypatch, fake_home)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("MEMPALACE_CONFIG_DIR", raising=False)
+
+    assert _default_config_dir() == xdg / "mempalace"
+
+
+def test_palace_with_chromadb_triggers_legacy(monkeypatch, tmp_path):
+    # A ~/.mempalace/palace directory that actually contains the ChromaDB
+    # store counts as a real legacy install even without config.json.
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    legacy = fake_home / ".mempalace"
+    legacy.mkdir()
+    palace = legacy / "palace"
+    palace.mkdir()
+    (palace / "chroma.sqlite3").write_bytes(b"")
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+
+    _set_home(monkeypatch, fake_home)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("MEMPALACE_CONFIG_DIR", raising=False)
+
+    assert _default_config_dir() == legacy
+
+
+def test_mempalace_config_dir_env_overrides_everything(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    legacy = fake_home / ".mempalace"
+    legacy.mkdir()
+    (legacy / "config.json").write_text("{}")
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    override = tmp_path / "override"
+    override.mkdir()
+
+    _set_home(monkeypatch, fake_home)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", str(override))
+
+    assert _default_config_dir() == override
+
+    cfg = MempalaceConfig()
+    assert cfg.palace_path == str(override / "palace")
+
+
+def test_empty_xdg_config_home_falls_back_to_dot_config(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    _set_home(monkeypatch, fake_home)
+    monkeypatch.delenv("MEMPALACE_CONFIG_DIR", raising=False)
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", "")
+    assert _default_config_dir() == fake_home / ".config" / "mempalace"
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", "   ")
+    assert _default_config_dir() == fake_home / ".config" / "mempalace"
+
+
+def test_relative_xdg_config_home_is_ignored(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    _set_home(monkeypatch, fake_home)
+    monkeypatch.setenv("XDG_CONFIG_HOME", "relative/path")
+    monkeypatch.delenv("MEMPALACE_CONFIG_DIR", raising=False)
+
+    assert _default_config_dir() == fake_home / ".config" / "mempalace"
+
+
+def test_init_writes_xdg_aware_palace_path(tmp_path):
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    cfg.init()
+    with open(tmp_path / "config.json") as f:
+        written = json.load(f)
+    assert written["palace_path"] == str(tmp_path / "palace")

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -365,3 +365,17 @@ class TestCLI:
             _reconfigure_stdio_utf8_on_windows()
 
         assert stdin.reconfigure_calls == []
+
+    def test_default_palace_resolves_via_mempalace_config(self, tmp_path, monkeypatch):
+        """Without `--palace`, the CLI must fall back to
+        `MempalaceConfig().palace_path`, not a hardcoded `~/.mempalace/palace`.
+        Otherwise XDG-aware config-dir users get a stale legacy default."""
+        fake_config = tmp_path / "xdg_config"
+        fake_config.mkdir()
+        monkeypatch.setenv("MEMPALACE_CONFIG_DIR", str(fake_config))
+        monkeypatch.delenv("MEMPALACE_PALACE_PATH", raising=False)
+        monkeypatch.delenv("MEMPAL_PALACE_PATH", raising=False)
+
+        from mempalace.fact_checker import _default_palace_path
+
+        assert _default_palace_path() == str(fake_config / "palace")

--- a/tests/test_hallways_palace_scoped.py
+++ b/tests/test_hallways_palace_scoped.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 
 with patch.dict("sys.modules", {"chromadb": MagicMock()}):
     from mempalace import hallways as hallways_mod
-    from mempalace.config import DEFAULT_PALACE_PATH, MempalaceConfig
+    from mempalace.config import MempalaceConfig
 
 
 # =============================================================================
@@ -28,8 +28,13 @@ with patch.dict("sys.modules", {"chromadb": MagicMock()}):
 
 class TestHallwayFileResolution:
     def test_default_hallway_file_is_sibling_of_default_palace(self):
+        # The default palace now lives at ``<config_dir>/palace`` because the
+        # config dir follows the XDG Base Directory spec (#46), so its hallway
+        # sibling resolves to ``<config_dir>/hallways.json``. DEFAULT_PALACE_PATH
+        # is the frozen legacy constant and is no longer the default base, so the
+        # expectation is derived from the resolved ``config_dir`` instead.
         cfg = MempalaceConfig()
-        expected = os.path.join(os.path.dirname(DEFAULT_PALACE_PATH), "hallways.json")
+        expected = os.path.join(cfg.config_dir, "hallways.json")
         assert cfg.hallway_file == expected
         assert hallways_mod._get_hallway_file(cfg) == expected
 

--- a/tests/test_palace_graph_tunnels.py
+++ b/tests/test_palace_graph_tunnels.py
@@ -526,15 +526,15 @@ class TestTunnelFileFollowsConfig:
     to every other process touching the configured palace.
     """
 
-    def test_default_tunnel_file_unchanged(self):
-        """Regression: with default config, tunnel_file resolves to
-        ``~/.mempalace/tunnels.json`` so existing single-user installs are
-        not silently relocated."""
-        from mempalace.config import DEFAULT_PALACE_PATH, MempalaceConfig
+    def test_default_tunnel_file_is_sibling_of_palace_path(self):
+        """Regression: tunnel_file is the sibling of palace_path (single
+        source of truth), regardless of whether the default resolves to the
+        legacy ``~/.mempalace/`` or the XDG ``~/.config/mempalace/`` layout.
+        """
+        from mempalace.config import MempalaceConfig
 
         cfg = MempalaceConfig()
-        # Default palace_path is ~/.mempalace/palace, so tunnel is sibling.
-        expected = os.path.join(os.path.dirname(DEFAULT_PALACE_PATH), "tunnels.json")
+        expected = os.path.join(os.path.dirname(cfg.palace_path), "tunnels.json")
         assert cfg.tunnel_file == expected
         assert palace_graph._get_tunnel_file(cfg) == expected
 


### PR DESCRIPTION
## What does this PR do?

Closes #46 by moving the default config directory to follow the XDG Base Directory Specification, with a careful back-compat path so existing installs keep working.

Resolution order:
1. `$MEMPALACE_CONFIG_DIR` explicit override
2. `~/.mempalace` if it contains `config.json`, `people_map.json`, or `palace/chroma.sqlite3` (back-compat)
3. `$XDG_CONFIG_HOME/mempalace` (absolute paths only, per spec)
4. `~/.config/mempalace` fallback

Edge cases handled per XDG spec: empty, whitespace, and relative `XDG_CONFIG_HOME` values are ignored. An empty `~/.mempalace` left behind by some other tool no longer hijacks the XDG fallback.

`palace_path` now defaults to `<config_dir>/palace` so the data directory stays next to the config wherever XDG places it. The legacy `DEFAULT_PALACE_PATH` module constant is kept for any external importers but marked deprecated.

## How to test

```bash
python -m pytest tests/test_config.py -v
ruff check .
ruff format --check .
```

The test suite adds coverage for all four resolution branches, precedence between env override and legacy, the empty-legacy-dir edge case, and empty / whitespace / relative XDG values.

Manual smoke:
```bash
# New XDG path
XDG_CONFIG_HOME=/tmp/xdg_test mempalace init /tmp/some_project
ls /tmp/xdg_test/mempalace/

# Legacy back-compat: existing ~/.mempalace installs get the old location.
```

## Checklist

- [x] Tests pass (`python -m pytest tests/ -v` — 5153 passed, 53 skipped on the CI selection, rebased onto current `develop`)
- [x] No hardcoded paths (legacy constant marked deprecated)
- [x] Linter passes (`ruff check .`, `ruff format --check .`)
- [x] Python 3.9 compatible

## Scope note

This PR is scoped to `MempalaceConfig` and its direct callers in line with the issue text (which asks about configuration storage). With this branch applied, a repo-wide grep for a `~/.mempalace` assembled in code still finds 17 modules building the legacy path directly: `closet_llm.py`, `daemon.py`, `dedup.py`, `diary_ingest.py`, `entity_registry.py`, `hallways.py`, `hooks_cli.py`, `knowledge_graph.py`, `layers.py`, `mcp_server/tools_diary.py` (hook_state), `miner.py`, `onboarding.py`, `palace.py`, `palace_graph.py`, `repair.py`, `server_registry.py`, and `update_awareness.py`. Those can be migrated in a follow-up PR so this one stays reviewable.


