### PR TITLE
feat: honour .mempalace-ignore during mining (closes #102)

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -150,10 +150,17 @@ SKIP_FILENAMES = {
     "mempal.yaml",
     "mempal.yml",
     ".gitignore",
+    ".mempalace-ignore",
     "package-lock.json",
     "pnpm-lock.yaml",
     "yarn.lock",
 }
+
+# Per-directory mempalace-specific ignore file. Same syntax as .gitignore but
+# honoured independently so users can exclude files from mining without
+# touching their project's git config, and it still applies when
+# --no-gitignore is passed.
+MEMPALACE_IGNORE_FILENAME = ".mempalace-ignore"
 
 # Re-export the shared defaults from ``config`` so legacy callers that
 # import ``CHUNK_SIZE`` / ``CHUNK_OVERLAP`` / ``MIN_CHUNK_SIZE`` from
@@ -238,7 +245,7 @@ def _resolve_max_chunks_per_file(override: Optional[int] = None) -> int:
 
 
 class GitignoreMatcher:
-    """Lightweight matcher for one directory's .gitignore patterns."""
+    """Lightweight matcher for one directory's gitignore-style ignore file."""
 
     def __init__(self, base_dir: Path, rules: list):
         self.base_dir = base_dir
@@ -288,8 +295,8 @@ class GitignoreMatcher:
         return rules
 
     @classmethod
-    def from_dir(cls, dir_path: Path):
-        gitignore_path = dir_path / ".gitignore"
+    def from_dir(cls, dir_path: Path, filename: str = ".gitignore"):
+        gitignore_path = dir_path / filename
         if not gitignore_path.is_file():
             return None
 
@@ -383,15 +390,16 @@ class GitignoreMatcher:
         return matches(0, 0)
 
 
-def load_gitignore_matcher(dir_path: Path, cache: dict):
-    """Load and cache one directory's .gitignore matcher."""
-    if dir_path not in cache:
-        cache[dir_path] = GitignoreMatcher.from_dir(dir_path)
-    return cache[dir_path]
+def load_gitignore_matcher(dir_path: Path, cache: dict, filename: str = ".gitignore"):
+    """Load and cache a gitignore-style matcher for ``filename`` in ``dir_path``."""
+    key = (dir_path, filename)
+    if key not in cache:
+        cache[key] = GitignoreMatcher.from_dir(dir_path, filename=filename)
+    return cache[key]
 
 
 def is_gitignored(path: Path, matchers: list, is_dir: bool = False) -> bool:
-    """Apply active .gitignore matchers in ancestor order; last match wins."""
+    """Apply active ignore matchers in ancestor order; last match wins."""
     ignored = False
     for matcher in matchers:
         decision = matcher.matches(path, is_dir=is_dir)
@@ -1642,15 +1650,26 @@ def scan_project(
     for root, dirs, filenames in os.walk(project_path):
         root_path = Path(root)
 
+        # Drop matchers whose base directory is no longer an ancestor of us.
+        active_matchers = [
+            matcher
+            for matcher in active_matchers
+            if root_path == matcher.base_dir or matcher.base_dir in root_path.parents
+        ]
+
+        # Load .gitignore for this directory (skipped when the caller opted out).
         if respect_gitignore:
-            active_matchers = [
-                matcher
-                for matcher in active_matchers
-                if root_path == matcher.base_dir or matcher.base_dir in root_path.parents
-            ]
-            current_matcher = load_gitignore_matcher(root_path, matcher_cache)
-            if current_matcher is not None:
-                active_matchers.append(current_matcher)
+            gitignore_matcher = load_gitignore_matcher(root_path, matcher_cache, ".gitignore")
+            if gitignore_matcher is not None:
+                active_matchers.append(gitignore_matcher)
+
+        # .mempalace-ignore is always honoured, even when --no-gitignore is set,
+        # so users can exclude files from mining without touching git config.
+        mempalace_ignore_matcher = load_gitignore_matcher(
+            root_path, matcher_cache, MEMPALACE_IGNORE_FILENAME
+        )
+        if mempalace_ignore_matcher is not None:
+            active_matchers.append(mempalace_ignore_matcher)
 
         dirs[:] = [
             d
@@ -1658,7 +1677,7 @@ def scan_project(
             if is_force_included(root_path / d, project_path, include_paths)
             or not should_skip_dir(d)
         ]
-        if respect_gitignore and active_matchers:
+        if active_matchers:
             dirs[:] = [
                 d
                 for d in dirs
@@ -1682,7 +1701,7 @@ def scan_project(
                 continue
             if filepath.suffix.lower() not in READABLE_EXTENSIONS and not exact_force_include:
                 continue
-            if respect_gitignore and active_matchers and not force_include:
+            if active_matchers and not force_include:
                 if is_gitignored(filepath, active_matchers, is_dir=False):
                     continue
             # Skip files matching project-level exclude_patterns (mempalace.yaml).

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -2643,3 +2643,84 @@ def test_mine_limit_summary_counts(tmp_path, capsys):
     assert "Files processed: 2" in out
     assert "Drawers filed: 6" in out
     assert "(limit: 2 new)" in out
+
+
+# ── .mempalace-ignore ──────────────────────────────────────────────────
+
+
+def test_scan_project_respects_mempalace_ignore():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".mempalace-ignore", "drafts/\nsecrets.py\n")
+        write_file(project_root / "src" / "app.py", "print('hello')\n" * 20)
+        write_file(project_root / "secrets.py", "print('secret')\n" * 20)
+        write_file(project_root / "drafts" / "note.py", "print('draft')\n" * 20)
+
+        assert scanned_files(project_root) == ["src/app.py"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_scan_project_mempalace_ignore_applies_without_gitignore():
+    # The --no-gitignore equivalent should still honour .mempalace-ignore so
+    # mining-specific exclusions can live outside the project's git config.
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".mempalace-ignore", "secrets.py\n")
+        write_file(project_root / "src" / "app.py", "print('hello')\n" * 20)
+        write_file(project_root / "secrets.py", "print('secret')\n" * 20)
+
+        assert scanned_files(project_root, respect_gitignore=False) == ["src/app.py"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_scan_project_mempalace_ignore_overrides_gitignore_negation():
+    # .mempalace-ignore is applied after .gitignore, so it has the final say
+    # when the two files disagree about the same path.
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".gitignore", "data/\n!data/keep.csv\n")
+        write_file(project_root / ".mempalace-ignore", "data/keep.csv\n")
+        write_file(project_root / "src" / "app.py", "print('main')\n" * 20)
+        write_file(project_root / "data" / "keep.csv", "a,b,c\n" * 20)
+        write_file(project_root / "data" / "drop.csv", "x,y,z\n" * 20)
+
+        assert scanned_files(project_root) == ["src/app.py"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_scan_project_mempalace_ignore_not_self_included():
+    # The ignore file itself should never end up in the scan output.
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".mempalace-ignore", "# exclude nothing\n")
+        write_file(project_root / "note.md", "hello\n" * 20)
+
+        assert scanned_files(project_root) == ["note.md"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_scan_project_nested_mempalace_ignore():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / "top.md", "top\n" * 20)
+        write_file(project_root / "sub" / ".mempalace-ignore", "ignored.md\n")
+        write_file(project_root / "sub" / "keep.md", "keep\n" * 20)
+        write_file(project_root / "sub" / "ignored.md", "drop\n" * 20)
+
+        assert scanned_files(project_root) == ["sub/keep.md", "top.md"]
+    finally:
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION
## What does this PR do?

Closes #102 by honouring a per-directory `.mempalace-ignore` file during mining. Same syntax as `.gitignore`, but it applies even when the caller passes `respect_gitignore=False`, so users can keep mining-specific exclusions (credentials, drafts, large data files) outside their project's git config.

`GitignoreMatcher.from_dir` takes a `filename` keyword argument (defaults to `.gitignore`) and `load_gitignore_matcher` keys its per-walk cache by `(directory, filename)` so both ignore files can coexist without stepping on each other. In `scan_project` the loader is called twice per directory -- `.gitignore` first (only when `respect_gitignore` is on), `.mempalace-ignore` always -- and they're appended in that order so mempalace-ignore has the final say when the two disagree.

Note on the previously-closed #144: that PR bundled this feature with an unrelated telemetry fix and was closed for scope. This PR implements only the `.mempalace-ignore` half as a focused change. The hyphenated spelling matches the issue title; a `.mempalaceignore` alias can be added in a follow-up if useful.

## How to test

```bash
python -m pytest tests/test_miner.py -v
ruff check .
ruff format --check .
```

Manual smoke:

```bash
cd /tmp && mkdir ignore_demo && cd ignore_demo
printf 'wing: demo\nrooms:\n  - {name: general}\n' > mempalace.yaml
printf 'secrets.py\ndrafts/\n' > .mempalace-ignore
printf 'print("keep me")\n' > main.py
printf 'print("secret")\n' > secrets.py
mkdir drafts && printf 'print("draft")\n' > drafts/note.py
mempalace mine .
# only main.py is filed; secrets.py and drafts/note.py are skipped
```

## Checklist

- [x] Tests pass (`python -m pytest tests/test_miner.py -v` - 23 passed)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`, `ruff format --check .`)
- [x] Python 3.9 compatible

## Coverage added

- `test_scan_project_respects_mempalace_ignore` - base case: file + directory patterns
- `test_scan_project_mempalace_ignore_applies_without_gitignore` - still honoured with `respect_gitignore=False`
- `test_scan_project_mempalace_ignore_overrides_gitignore_negation` - precedence over `.gitignore` `!foo`
- `test_scan_project_mempalace_ignore_not_self_included` - the ignore file itself is never mined
- `test_scan_project_nested_mempalace_ignore` - nested directory support
