### PR TITLE
feat: add Aider chat history markdown normalizer

### DIFF
--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -39,14 +39,53 @@ def normalize(filepath: str) -> str:
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
         return content
 
-    # Try JSON normalization
     ext = Path(filepath).suffix.lower()
+
+    # Try Aider markdown normalization
+    if ext == ".md" and sum(1 for line in lines if line.startswith("#### ")) >= 2:
+        normalized = _try_aider_md(content)
+        if normalized:
+            return normalized
+
+    # Try JSON normalization
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
         if normalized:
             return normalized
 
     return content
+
+
+def _try_aider_md(content: str) -> Optional[str]:
+    """Aider chat history markdown (.aider.chat.history.md)."""
+    lines = content.split("\n")
+    messages = []
+    current_user = None
+    assistant_lines = []
+
+    for line in lines:
+        if line.startswith("#### "):
+            if current_user:
+                messages.append(("user", current_user))
+                assistant_text = "\n".join(assistant_lines).strip()
+                if assistant_text:
+                    messages.append(("assistant", assistant_text))
+            current_user = line[5:].strip()
+            assistant_lines = []
+            continue
+
+        if current_user is not None:
+            assistant_lines.append(line)
+
+    if current_user:
+        messages.append(("user", current_user))
+        assistant_text = "\n".join(assistant_lines).strip()
+        if assistant_text:
+            messages.append(("assistant", assistant_text))
+
+    if len(messages) >= 2:
+        return _messages_to_transcript(messages)
+    return None
 
 
 def _try_normalize_json(content: str) -> Optional[str]:

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -41,8 +41,8 @@ def normalize(filepath: str) -> str:
 
     ext = Path(filepath).suffix.lower()
 
-    # Try Aider markdown normalization
-    if ext == ".md" and sum(1 for line in lines if line.startswith("#### ")) >= 2:
+    # Try Aider markdown normalization (filename fingerprint to avoid false positives)
+    if ext == ".md" and Path(filepath).name == ".aider.chat.history.md":
         normalized = _try_aider_md(content)
         if normalized:
             return normalized

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -221,6 +221,15 @@ def normalize_conversations(filepath: str) -> list:
         return [content]
 
     ext = Path(filepath).suffix.lower()
+
+    # An Aider history holds one conversation, so this is always a one-element
+    # list. It still has to run here: convo_miner ingests through this function,
+    # never through normalize().
+    if ext == ".md" and Path(filepath).name == ".aider.chat.history.md":
+        normalized = _try_aider_md(content)
+        if normalized:
+            return [normalized]
+
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         split = _try_normalize_json_split(content)
         if split:

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -172,10 +172,17 @@ def normalize(filepath: str) -> str:
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
         return content
 
+    ext = Path(filepath).suffix.lower()
+
+    # Try Aider markdown normalization
+    if ext == ".md" and sum(1 for line in lines if line.startswith("#### ")) >= 2:
+        normalized = _try_aider_md(content)
+        if normalized:
+            return normalized
+
     # Try JSON normalization. strip_noise is applied inside the Claude Code
     # JSONL parser (the only format that injects system tags/hook chrome);
     # other formats pass through verbatim.
-    ext = Path(filepath).suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
         if normalized:
@@ -220,6 +227,38 @@ def normalize_conversations(filepath: str) -> list:
             return split
 
     return [content]
+
+
+def _try_aider_md(content: str) -> Optional[str]:
+    """Aider chat history markdown (.aider.chat.history.md)."""
+    lines = content.split("\n")
+    messages = []
+    current_user = None
+    assistant_lines = []
+
+    for line in lines:
+        if line.startswith("#### "):
+            if current_user:
+                messages.append(("user", current_user))
+                assistant_text = "\n".join(assistant_lines).strip()
+                if assistant_text:
+                    messages.append(("assistant", assistant_text))
+            current_user = line[5:].strip()
+            assistant_lines = []
+            continue
+
+        if current_user is not None:
+            assistant_lines.append(line)
+
+    if current_user:
+        messages.append(("user", current_user))
+        assistant_text = "\n".join(assistant_lines).strip()
+        if assistant_text:
+            messages.append(("assistant", assistant_text))
+
+    if len(messages) >= 2:
+        return _messages_to_transcript(messages)
+    return None
 
 
 def _try_normalize_json(content: str) -> Optional[str]:

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -174,8 +174,8 @@ def normalize(filepath: str) -> str:
 
     ext = Path(filepath).suffix.lower()
 
-    # Try Aider markdown normalization
-    if ext == ".md" and sum(1 for line in lines if line.startswith("#### ")) >= 2:
+    # Try Aider markdown normalization (filename fingerprint to avoid false positives)
+    if ext == ".md" and Path(filepath).name == ".aider.chat.history.md":
         normalized = _try_aider_md(content)
         if normalized:
             return normalized

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -29,3 +29,23 @@ def test_empty():
     result = normalize(f.name)
     assert result.strip() == ""
     os.unlink(f.name)
+
+
+def test_aider_md():
+    content = """#### How do I add a new route?
+
+You can add a new route by creating a file in the `routes/` directory.
+
+#### Can you also add tests for it?
+
+Sure, here's a test file.
+"""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False)
+    f.write(content)
+    f.close()
+    result = normalize(f.name)
+    assert "How do I add a new route?" in result
+    assert "You can add a new route" in result
+    assert "Can you also add tests for it?" in result
+    assert "Sure, here's a test file." in result
+    os.unlink(f.name)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -40,12 +40,32 @@ You can add a new route by creating a file in the `routes/` directory.
 
 Sure, here's a test file.
 """
-    f = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False)
-    f.write(content)
-    f.close()
-    result = normalize(f.name)
+    # Must use Aider's exact filename to trigger the parser
+    path = os.path.join(tempfile.gettempdir(), ".aider.chat.history.md")
+    with open(path, "w") as f:
+        f.write(content)
+    result = normalize(path)
     assert "How do I add a new route?" in result
     assert "You can add a new route" in result
     assert "Can you also add tests for it?" in result
     assert "Sure, here's a test file." in result
+    os.unlink(path)
+
+
+def test_aider_rejects_generic_md():
+    """Regular markdown with #### headings should NOT trigger the Aider parser."""
+    content = """#### Installation
+
+Run pip install mempalace.
+
+#### Usage
+
+Import and call normalize().
+"""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False)
+    f.write(content)
+    f.close()
+    result = normalize(f.name)
+    # Should return raw content, not normalized as chat
+    assert result == content
     os.unlink(f.name)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -78,6 +78,23 @@ def test_normalize_json_content_detected_by_brace(tmp_path):
     assert "Hey" in result
 
 
+def test_aider_md(tmp_path):
+    """Aider chat history markdown is normalized into > question / answer pairs."""
+    content = (
+        "#### How do I add a new route?\n\n"
+        "You can add a new route by creating a file in the `routes/` directory.\n\n"
+        "#### Can you also add tests for it?\n\n"
+        "Sure, here's a test file.\n"
+    )
+    f = tmp_path / "session.aider.chat.history.md"
+    f.write_text(content)
+    result = normalize(str(f))
+    assert "How do I add a new route?" in result
+    assert "You can add a new route" in result
+    assert "Can you also add tests for it?" in result
+    assert "Sure, here's a test file." in result
+
+
 def test_normalize_whitespace_only(tmp_path):
     f = tmp_path / "ws.txt"
     f.write_text("   \n  \n  ")

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -96,6 +96,28 @@ def test_aider_md(tmp_path):
     assert "Sure, here's a test file." in result
 
 
+def test_aider_md_via_conversations(tmp_path):
+    """The miner path: an Aider history normalizes to one conversation."""
+    f = tmp_path / ".aider.chat.history.md"
+    f.write_text(
+        "#### How do I add a new route?\n\n"
+        "You can add a new route by creating a file in the `routes/` directory.\n\n"
+        "#### Can you also add tests for it?\n\n"
+        "Sure, here's a test file.\n"
+    )
+    conversations = normalize_conversations(str(f))
+    assert len(conversations) == 1
+    assert conversations[0].startswith("> How do I add a new route?")
+    assert "Sure, here's a test file." in conversations[0]
+
+
+def test_aider_conversations_rejects_generic_md(tmp_path):
+    """A regular .md file with #### headings passes through unparsed."""
+    f = tmp_path / "CONTRIBUTING.md"
+    f.write_text("#### Setup\n\nRun uv sync.\n\n#### Tests\n\nRun pytest.\n")
+    assert normalize_conversations(str(f)) == [f.read_text()]
+
+
 def test_normalize_whitespace_only(tmp_path):
     f = tmp_path / "ws.txt"
     f.write_text("   \n  \n  ")

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -86,7 +86,8 @@ def test_aider_md(tmp_path):
         "#### Can you also add tests for it?\n\n"
         "Sure, here's a test file.\n"
     )
-    f = tmp_path / "session.aider.chat.history.md"
+    # Must use Aider's exact filename to trigger the parser
+    f = tmp_path / ".aider.chat.history.md"
     f.write_text(content)
     result = normalize(str(f))
     assert "How do I add a new route?" in result


### PR DESCRIPTION
## What does this PR do?

Adds a `_try_aider_md()` parser to `normalize.py` that extracts user/assistant conversations from Aider's `.aider.chat.history.md` files. Aider uses `####` headings for user messages with assistant responses as plain text between them.

Wired into the auto-detect chain ahead of JSON parsing, in both `normalize()` and `normalize_conversations()`. Detection is a filename fingerprint — the file must be named exactly `.aider.chat.history.md` — so regular markdown that happens to use `####` headings (`CONTRIBUTING.md`, `CHANGELOG.md`, API docs) is never claimed by the parser.

Partially addresses #59 (Aider was called out as "lowest-hanging fruit" in the issue).

## How to test

```bash
pytest tests/test_normalize.py -k aider -v
```

Or with a real Aider history file:
```python
from mempalace.normalize import normalize
result = normalize(".aider.chat.history.md")
print(result[:500])
```

## Checklist
- [x] Tests pass (`uv run pytest tests/ -v --ignore=tests/benchmarks`) — 4303 passed, 31 skipped
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`, `ruff format --check .`)

This contribution was developed with AI assistance (Codex).