### PR TITLE
fix: replace Unicode box-drawing character with ASCII dash to prevent Windows encoding errors (#47)

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -85,7 +85,7 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         for line in doc.strip().split("\n"):
             print(f"      {line}")
         print()
-        print(f"  {'─' * 56}")
+        print(f"  {'-' * 56}")
 
     print()
 


### PR DESCRIPTION
## Summary
This PR fixes issue #47 where Unicode box-drawing characters in search output caused UnicodeEncodeError crashes on Windows systems using cp1252 encoding.

## Changes
- Replace Unicode box-drawing character ─ with ASCII dash - in mempalace/searcher.py
- This prevents crashes on Windows console output while maintaining visual output formatting

## Why this fix
Windows consoles with cp1252 encoding cannot render the Unicode box-drawing character, causing search commands to crash. ASCII dashes are universally supported.

## Testing
- Manual verification that output separator is now ASCII
- No functional changes to search behavior