### PR TITLE
fix: expanduser() for ~ in palace_path from config/env (#40)

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -94,8 +94,8 @@ class MempalaceConfig:
         """Path to the memory palace data directory."""
         env_val = os.environ.get("MEMPALACE_PALACE_PATH") or os.environ.get("MEMPAL_PALACE_PATH")
         if env_val:
-            return env_val
-        return self._file_config.get("palace_path", DEFAULT_PALACE_PATH)
+            return os.path.expanduser(env_val)
+        return os.path.expanduser(self._file_config.get("palace_path", DEFAULT_PALACE_PATH))
 
     @property
     def collection_name(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,3 +30,20 @@ def test_init():
     cfg = MempalaceConfig(config_dir=tmpdir)
     cfg.init()
     assert os.path.exists(os.path.join(tmpdir, "config.json"))
+
+
+def test_config_path_expands_user_home():
+    tmpdir = tempfile.mkdtemp()
+    with open(os.path.join(tmpdir, "config.json"), "w") as f:
+        json.dump({"palace_path": "~/.mempalace/custom"}, f)
+    cfg = MempalaceConfig(config_dir=tmpdir)
+    expected = os.path.expanduser("~/.mempalace/custom")
+    assert cfg.palace_path == expected
+
+
+def test_env_path_expands_user_home():
+    os.environ["MEMPALACE_PALACE_PATH"] = "~/.mempalace/env_custom"
+    cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+    expected = os.path.expanduser("~/.mempalace/env_custom")
+    assert cfg.palace_path == expected
+    del os.environ["MEMPALACE_PALACE_PATH"]


### PR DESCRIPTION
## Summary
This PR fixes issue #40 where the palace_path configuration from environment variables or config files would not expand the ~ user home directory shortcut, leading to incorrect path resolution.

## Changes
- Apply os.path.expanduser() to palace_path values from both environment variables and config file
- This ensures ~/.mempalace/palace expands to /home/user/.mempalace/palace as expected

## Why this fix
Without expansion, paths like MEMPALACE_PALACE_PATH=~/custom/palace would create directories literally named ~ instead of expanding to the user's home directory.

## Testing
- Added tests to verify ~ expansion works from both config and environment variables
- Verified existing functionality remains unchanged