### PR TITLE
fix: add hnsw:space=cosine to drawer collection creation

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -31,7 +31,7 @@ import sys
 import argparse
 from pathlib import Path
 
-from .config import MempalaceConfig
+from .config import DRAWER_HNSW_METADATA, MempalaceConfig
 
 
 def cmd_init(args):
@@ -210,7 +210,8 @@ def cmd_repair(args):
 
     print("  Rebuilding collection...")
     client.delete_collection("mempalace_drawers")
-    new_col = client.create_collection("mempalace_drawers")
+    # Issue #218: preserve cosine metric on rebuild, don't silently revert to L2.
+    new_col = client.create_collection("mempalace_drawers", metadata=DRAWER_HNSW_METADATA)
 
     filed = 0
     for i in range(0, len(all_ids), batch_size):

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -11,6 +11,11 @@ from pathlib import Path
 DEFAULT_PALACE_PATH = os.path.expanduser("~/.mempalace/palace")
 DEFAULT_COLLECTION_NAME = "mempalace_drawers"
 
+# hnsw:space=cosine is required because searcher.py computes
+# similarity = 1 - distance, which only yields a meaningful score in [0, 1]
+# when the underlying distance is cosine. Issue #218.
+DRAWER_HNSW_METADATA = {"hnsw:space": "cosine"}
+
 DEFAULT_TOPIC_WINGS = [
     "emotions",
     "consciousness",

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 
 import chromadb
 
+from .config import DRAWER_HNSW_METADATA
 from .normalize import normalize
 
 
@@ -217,13 +218,7 @@ def get_collection(palace_path: str):
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
-        # hnsw:space=cosine is required because searcher.py computes
-        # similarity = 1 - distance, which only yields a meaningful score
-        # in the [0, 1] range when the underlying distance is cosine.
-        # See issue #218.
-        return client.create_collection(
-            "mempalace_drawers", metadata={"hnsw:space": "cosine"}
-        )
+        return client.create_collection("mempalace_drawers", metadata=DRAWER_HNSW_METADATA)
 
 
 def file_already_mined(collection, source_file: str) -> bool:

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -217,7 +217,13 @@ def get_collection(palace_path: str):
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
-        return client.create_collection("mempalace_drawers")
+        # hnsw:space=cosine is required because searcher.py computes
+        # similarity = 1 - distance, which only yields a meaningful score
+        # in the [0, 1] range when the underlying distance is cosine.
+        # See issue #218.
+        return client.create_collection(
+            "mempalace_drawers", metadata={"hnsw:space": "cosine"}
+        )
 
 
 def file_already_mined(collection, source_file: str) -> bool:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -25,7 +25,7 @@ import logging
 import hashlib
 from datetime import datetime
 
-from .config import MempalaceConfig
+from .config import DRAWER_HNSW_METADATA, MempalaceConfig
 from .version import __version__
 from .searcher import search_memories
 from .palace_graph import traverse, find_tunnels, graph_stats
@@ -71,7 +71,10 @@ def _get_collection(create=False):
         if _client_cache is None:
             _client_cache = chromadb.PersistentClient(path=_config.palace_path)
         if create:
-            _collection_cache = _client_cache.get_or_create_collection(_config.collection_name)
+            # Issue #218: cosine required so similarity = 1 - distance is meaningful.
+            _collection_cache = _client_cache.get_or_create_collection(
+                _config.collection_name, metadata=DRAWER_HNSW_METADATA
+            )
         elif _collection_cache is None:
             _collection_cache = _client_cache.get_collection(_config.collection_name)
         return _collection_cache

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -399,7 +399,13 @@ def get_collection(palace_path: str):
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
-        return client.create_collection("mempalace_drawers")
+        # hnsw:space=cosine is required because searcher.py computes
+        # similarity = 1 - distance, which only yields a meaningful score
+        # in the [0, 1] range when the underlying distance is cosine.
+        # See issue #218.
+        return client.create_collection(
+            "mempalace_drawers", metadata={"hnsw:space": "cosine"}
+        )
 
 
 def file_already_mined(collection, source_file: str) -> bool:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -17,6 +17,8 @@ from collections import defaultdict
 
 import chromadb
 
+from .config import DRAWER_HNSW_METADATA
+
 READABLE_EXTENSIONS = {
     ".txt",
     ".md",
@@ -399,13 +401,7 @@ def get_collection(palace_path: str):
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
-        # hnsw:space=cosine is required because searcher.py computes
-        # similarity = 1 - distance, which only yields a meaningful score
-        # in the [0, 1] range when the underlying distance is cosine.
-        # See issue #218.
-        return client.create_collection(
-            "mempalace_drawers", metadata={"hnsw:space": "cosine"}
-        )
+        return client.create_collection("mempalace_drawers", metadata=DRAWER_HNSW_METADATA)
 
 
 def file_already_mined(collection, source_file: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,29 @@
+"""test_cli.py — Tests for mempalace.cli command handlers."""
+
+import argparse
+
+import chromadb
+
+
+def test_cmd_repair_rebuilds_with_cosine_metadata(tmp_path, capsys):
+    """Issue #218: cmd_repair must recreate the drawer collection with
+    hnsw:space=cosine — otherwise running `mempalace repair` silently reverts
+    an already-fixed palace back to L2 distance."""
+    from mempalace.cli import cmd_repair
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    # Seed a palace with one drawer on the default (L2) metric, simulating a
+    # pre-#218 collection that needs repair.
+    client = chromadb.PersistentClient(path=str(palace))
+    old = client.create_collection("mempalace_drawers")
+    old.add(ids=["d1"], documents=["hello"], metadatas=[{"wing": "w", "room": "r"}])
+    del old
+    del client
+
+    cmd_repair(argparse.Namespace(palace=str(palace)))
+
+    client = chromadb.PersistentClient(path=str(palace))
+    rebuilt = client.get_collection("mempalace_drawers")
+    assert rebuilt.metadata.get("hnsw:space") == "cosine"

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import shutil
 import chromadb
-from mempalace.convo_miner import mine_convos
+from mempalace.convo_miner import get_collection, mine_convos
 
 
 def test_convo_mining():
@@ -24,3 +24,11 @@ def test_convo_mining():
     assert len(results["documents"][0]) > 0
 
     shutil.rmtree(tmpdir)
+
+
+def test_get_collection_uses_cosine_distance(tmp_path):
+    """Newly-created drawer collections must declare hnsw:space=cosine so that
+    searcher.py's `similarity = 1 - distance` formula yields scores in [0, 1]
+    instead of negative L2 distances. Regression test for issue #218."""
+    col = get_collection(str(tmp_path / "palace"))
+    assert col.metadata.get("hnsw:space") == "cosine"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -161,6 +161,17 @@ class TestReadTools:
         result = tool_status()
         assert "error" in result
 
+    def test_get_collection_create_uses_cosine_metadata(self, monkeypatch, config, palace_path, kg):
+        """Issue #218: MCP-first palaces (no prior `mempalace mine`) must still
+        get hnsw:space=cosine, otherwise similarity = 1 - distance returns
+        negative L2 scores."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import _get_collection
+
+        col = _get_collection(create=True)
+        assert col is not None
+        assert col.metadata.get("hnsw:space") == "cosine"
+
 
 # ── Search Tool ─────────────────────────────────────────────────────────
 

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import chromadb
 import yaml
 
-from mempalace.miner import mine, scan_project
+from mempalace.miner import get_collection, mine, scan_project
 
 
 def write_file(path: Path, content: str):
@@ -206,3 +206,11 @@ def test_scan_project_skip_dirs_still_apply_without_override():
         assert scanned_files(project_root, respect_gitignore=False) == ["main.py"]
     finally:
         shutil.rmtree(tmpdir)
+
+
+def test_get_collection_uses_cosine_distance(tmp_path):
+    """Newly-created drawer collections must declare hnsw:space=cosine so that
+    searcher.py's `similarity = 1 - distance` formula yields scores in [0, 1]
+    instead of negative L2 distances. Regression test for issue #218."""
+    col = get_collection(str(tmp_path / "palace"))
+    assert col.metadata.get("hnsw:space") == "cosine"


### PR DESCRIPTION
## What does this PR do?

Adds `metadata={'hnsw:space': 'cosine'}` to both `create_collection` call sites (`mempalace/miner.py` and `mempalace/convo_miner.py`). `searcher.py` computes `similarity = 1 - distance`, which only yields a meaningful score in `[0, 1]` when the underlying distance metric is cosine. ChromaDB defaults to L2 when no metadata is supplied, producing negative similarity scores for every search result.

Fixes #218.

## How to test

```bash
python -m pytest tests/test_miner.py::test_get_collection_uses_cosine_distance                  tests/test_convo_miner.py::test_get_collection_uses_cosine_distance -v
```

Existing collections are unaffected (the metric is set at creation time). Users with a palace already mined will need to wipe and re-mine to benefit.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`) — 119 passed, 0 failed
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)