### PR TITLE
fix: guard against empty ChromaDB query results in search paths

### DIFF
--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -286,12 +286,13 @@ class Layer3:
         except Exception as e:
             return f"Search error: {e}"
 
+        # ChromaDB 1.x may return {documents: []}; guard before [0]. Issue #195.
+        if not results.get("documents") or not results["documents"][0]:
+            return "No results found."
+
         docs = results["documents"][0]
         metas = results["metadatas"][0]
         dists = results["distances"][0]
-
-        if not docs:
-            return "No results found."
 
         lines = [f'## L3 — SEARCH RESULTS for "{query}"']
         for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists), 1):
@@ -340,6 +341,10 @@ class Layer3:
         try:
             results = col.query(**kwargs)
         except Exception:
+            return []
+
+        # ChromaDB 1.x may return {documents: []}; guard before [0]. Issue #195.
+        if not results.get("documents") or not results["documents"][0]:
             return []
 
         hits = []

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -55,13 +55,14 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         print(f"\n  Search error: {e}")
         raise SearchError(f"Search error: {e}") from e
 
+    # ChromaDB 1.x may return {documents: []}; guard before [0]. Issue #195.
+    if not results.get("documents") or not results["documents"][0]:
+        print(f'\n  No results found for: "{query}"')
+        return
+
     docs = results["documents"][0]
     metas = results["metadatas"][0]
     dists = results["distances"][0]
-
-    if not docs:
-        print(f'\n  No results found for: "{query}"')
-        return
 
     print(f"\n{'=' * 60}")
     print(f'  Results for: "{query}"')
@@ -128,6 +129,14 @@ def search_memories(
         results = col.query(**kwargs)
     except Exception as e:
         return {"error": f"Search error: {e}"}
+
+    # ChromaDB 1.x may return {documents: []}; guard before [0]. Issue #195.
+    if not results.get("documents") or not results["documents"][0]:
+        return {
+            "query": query,
+            "filters": {"wing": wing, "room": room},
+            "results": [],
+        }
 
     docs = results["documents"][0]
     metas = results["metadatas"][0]

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -4,6 +4,9 @@ test_searcher.py — Tests for the programmatic search_memories API.
 Tests the library-facing search interface (not the CLI print variant).
 """
 
+from unittest.mock import MagicMock
+
+from mempalace.layers import Layer3
 from mempalace.searcher import search_memories
 
 
@@ -43,3 +46,34 @@ class TestSearchMemories:
         assert "source_file" in hit
         assert "similarity" in hit
         assert isinstance(hit["similarity"], float)
+
+
+# Issue #195 — ChromaDB 1.x may return {documents: []} (no outer wrapper).
+# Pre-fix code did `results["documents"][0]` and crashed with IndexError.
+# These tests inject the buggy shape via mock to exercise the guard.
+
+_EMPTY_OUTER = {"ids": [], "documents": [], "metadatas": [], "distances": []}
+
+
+def _mock_empty_chromadb(monkeypatch, module):
+    fake_col = MagicMock()
+    fake_col.query.return_value = _EMPTY_OUTER
+    fake_client = MagicMock()
+    fake_client.get_collection.return_value = fake_col
+    monkeypatch.setattr(
+        f"{module}.chromadb.PersistentClient", lambda path: fake_client
+    )
+
+
+def test_search_memories_handles_empty_outer_list(monkeypatch, tmp_path):
+    """Issue #195: ChromaDB 1.x empty-outer shape must not crash."""
+    _mock_empty_chromadb(monkeypatch, "mempalace.searcher")
+    result = search_memories("anything", str(tmp_path))
+    assert result["results"] == []
+
+
+def test_layer3_search_raw_handles_empty_outer_list(monkeypatch, tmp_path):
+    """Issue #195: Layer3 also affected by the empty-outer shape."""
+    _mock_empty_chromadb(monkeypatch, "mempalace.layers")
+    result = Layer3(palace_path=str(tmp_path)).search_raw("anything")
+    assert result == []


### PR DESCRIPTION
## What does this PR do?

Guards `searcher.search`, `searcher.search_memories`, `layers.Layer3.search`, and `layers.Layer3.search_raw` against empty ChromaDB query results. ChromaDB 1.x can return `{documents: []}` (empty outer list) for queries against a fresh collection or filter that excludes everything; the pre-fix code did `results['documents'][0]` and crashed with `IndexError`.

ChromaDB 0.6.x returns `{documents: [[]]}` (empty inner) which the existing `if not docs` check already handled, so this only manifests on 1.x — but the guard hardens both shapes for free.

Fixes #195.

## How to test

```bash
python -m pytest tests/test_searcher.py::test_search_memories_handles_empty_outer_list                  tests/test_searcher.py::test_layer3_search_raw_handles_empty_outer_list -v
```

Tests inject the empty-outer shape via mock so they exercise the guard regardless of installed ChromaDB version. Without the fix they raise `IndexError: list index out of range`.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`) — 119 passed, 0 failed
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)