### PR TITLE
fix(mcp): redirect stdout to stderr at import to protect JSON-RPC wire

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -17,21 +17,27 @@ Tools (write):
   mempalace_delete_drawer   — remove a drawer by ID
 """
 
-import argparse
-import os
+# Issue #225: save real stdout BEFORE any other import so chatter from
+# chromadb/posthog/etc cannot corrupt the JSON-RPC wire on stdout. Use
+# _real_stdout for protocol responses below.
 import sys
-import json
-import logging
-import hashlib
-from datetime import datetime
+_real_stdout = sys.stdout
+sys.stdout = sys.stderr
 
-from .config import MempalaceConfig
-from .version import __version__
-from .searcher import search_memories
-from .palace_graph import traverse, find_tunnels, graph_stats
-import chromadb
+import argparse  # noqa: E402
+import os  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import hashlib  # noqa: E402
+from datetime import datetime  # noqa: E402
 
-from .knowledge_graph import KnowledgeGraph
+from .config import MempalaceConfig  # noqa: E402
+from .version import __version__  # noqa: E402
+from .searcher import search_memories  # noqa: E402
+from .palace_graph import traverse, find_tunnels, graph_stats  # noqa: E402
+import chromadb  # noqa: E402
+
+from .knowledge_graph import KnowledgeGraph  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
 logger = logging.getLogger("mempalace_mcp")
@@ -800,8 +806,8 @@ def main():
             request = json.loads(line)
             response = handle_request(request)
             if response is not None:
-                sys.stdout.write(json.dumps(response) + "\n")
-                sys.stdout.flush()
+                _real_stdout.write(json.dumps(response) + "\n")
+                _real_stdout.flush()
         except KeyboardInterrupt:
             break
         except Exception as e:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -342,3 +342,48 @@ class TestDiaryTools:
 
         r = tool_diary_read(agent_name="Nobody")
         assert r["entries"] == []
+
+
+# Issue #225 — MCP stdio protocol must not be polluted by import-time chatter.
+
+
+def test_mcp_server_redirects_stdout_at_import():
+    """Issue #225: importing mempalace.mcp_server must redirect sys.stdout
+    to sys.stderr so that any subsequent print() (from chromadb, posthog, our
+    own modules, or anywhere else) lands on stderr instead of corrupting the
+    MCP JSON-RPC wire on stdout."""
+    import subprocess
+    import sys as _sys
+
+    # Print a marker AFTER importing mcp_server. With the fix, sys.stdout is
+    # sys.stderr, so the marker lands on stderr; without the fix it would
+    # land on stdout (and be visible to MCP clients).
+    code = (
+        "import mempalace.mcp_server as _; "
+        "print('POLLUTION_MARKER_42')"
+    )
+    proc = subprocess.run(
+        [_sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert "POLLUTION_MARKER_42" not in proc.stdout
+    assert "POLLUTION_MARKER_42" in proc.stderr
+
+
+def test_mcp_server_stdout_emits_only_json():
+    """Issue #225: e2e check — every non-empty stdout line is valid JSON."""
+    import subprocess
+    import sys as _sys
+
+    proc = subprocess.run(
+        [_sys.executable, "-m", "mempalace.mcp_server"],
+        input='{"method":"initialize","id":1,"params":{}}\n',
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    for line in proc.stdout.splitlines():
+        if line.strip():
+            json.loads(line)  # raises if any line is non-JSON


### PR DESCRIPTION
## What does this PR do?

The MCP protocol uses stdout for JSON-RPC. Any `print()` from imported modules — chromadb's posthog telemetry chatter, our own banners, OnnxRuntime EP messages — corrupts the message stream and produces `Unexpected token` errors in Claude Desktop.

Saves the real stdout into `_real_stdout` BEFORE any other import, then redirects `sys.stdout` to `sys.stderr` so all subsequent writes (including import-time chatter from chromadb / posthog / our own modules) land harmlessly on stderr. `main()` uses `_real_stdout` for the JSON-RPC response writes.

Fixes #225.

## How to test

```bash
python -m pytest tests/test_mcp_server.py::test_mcp_server_redirects_stdout_at_import \
                 tests/test_mcp_server.py::test_mcp_server_stdout_emits_only_json -v
```

The first test imports `mempalace.mcp_server`, then prints a marker to `sys.stdout`, and asserts the marker lands on stderr (not stdout). It fails without the fix.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`) — 119 passed, 0 failed
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
