### PR TITLE
fix: prevent HNSW index bloat from resize+persist cycles

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -71,7 +71,13 @@ def _get_collection(create=False):
         if _client_cache is None:
             _client_cache = chromadb.PersistentClient(path=_config.palace_path)
         if create:
-            _collection_cache = _client_cache.get_or_create_collection(_config.collection_name)
+            _collection_cache = _client_cache.get_or_create_collection(
+                _config.collection_name,
+                metadata={
+                    "hnsw:batch_size": 50_000,
+                    "hnsw:sync_threshold": 50_000,
+                },
+            )
         elif _collection_cache is None:
             _collection_cache = _client_cache.get_collection(_config.collection_name)
         return _collection_cache

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -393,13 +393,21 @@ def chunk_text(content: str, source_file: str) -> list:
 # =============================================================================
 
 
+_HNSW_METADATA = {
+    "hnsw:batch_size": 50_000,
+    "hnsw:sync_threshold": 50_000,
+}
+
+
 def get_collection(palace_path: str):
     os.makedirs(palace_path, exist_ok=True)
     client = chromadb.PersistentClient(path=palace_path)
     try:
         return client.get_collection("mempalace_drawers")
     except Exception:
-        return client.create_collection("mempalace_drawers")
+        return client.create_collection(
+            "mempalace_drawers", metadata=_HNSW_METADATA
+        )
 
 
 def file_already_mined(collection, source_file: str) -> bool:
@@ -489,21 +497,34 @@ def process_file(
         print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
         return len(chunks), room
 
-    drawers_added = 0
+    ids = []
+    documents = []
+    metadatas = []
+    now = datetime.now().isoformat()
+    try:
+        mtime = os.path.getmtime(source_file)
+    except OSError:
+        mtime = None
     for chunk in chunks:
-        added = add_drawer(
-            collection=collection,
-            wing=wing,
-            room=room,
-            content=chunk["content"],
-            source_file=source_file,
-            chunk_index=chunk["chunk_index"],
-            agent=agent,
-        )
-        if added:
-            drawers_added += 1
+        drawer_id = f"drawer_{wing}_{room}_{hashlib.md5((source_file + str(chunk['chunk_index'])).encode(), usedforsecurity=False).hexdigest()[:16]}"
+        meta = {
+            "wing": wing,
+            "room": room,
+            "source_file": source_file,
+            "chunk_index": chunk["chunk_index"],
+            "added_by": agent,
+            "filed_at": now,
+        }
+        if mtime is not None:
+            meta["source_mtime"] = mtime
+        ids.append(drawer_id)
+        documents.append(chunk["content"])
+        metadatas.append(meta)
 
-    return drawers_added, room
+    if ids:
+        collection.upsert(documents=documents, ids=ids, metadatas=metadatas)
+
+    return len(ids), room
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Set `hnsw:batch_size` and `hnsw:sync_threshold` to 50,000 on ChromaDB collection creation to defer index persistence until large batches complete
- Batch per-file drawer upserts in `process_file()` instead of inserting one drawer at a time via `add_drawer()`
- Apply the same HNSW metadata in `mcp_server.py` for collections created via the MCP server

Fixes #344

## Problem

Mining ~56,000 drawers (from a GSD project database export) caused `link_lists.bin` to grow to **441GB apparent / 168GB on disk** instead of the expected ~8MB. This caused two sequential system crashes from disk/memory exhaustion before the problem was identified. The corrupted index made `mempalace status` segfault (exit 139) and rendered the palace unusable.

**Root cause**: With default HNSW params (`batch_size=100`, `sync_threshold=1000`, initial capacity 1000), inserting 56K drawers one at a time triggers ~30 index resizes and ~560 `persistDirty()` calls. The `persistDirty()` function uses relative seek positioning in `link_lists.bin`, and after many resize cycles the accumulated seek positions drift, causing the OS to extend the sparse file with zero-filled regions. Each cycle compounds the problem.

**Numbers**:
- 56,387 drawers from 2,395 GSD project files
- `link_lists.bin`: 473,786,104,508 bytes apparent (441GB), 168GB actual disk
- `data_level0.bin`: 64MB (correctly sized)
- Expected `link_lists.bin` for 56K vectors at M=16: ~8.4MB
- Ratio: 56,083x expected size

## Changes

**`miner.py`**:
- Added `_HNSW_METADATA` constant with tuned batch/sync thresholds
- `get_collection()` passes metadata on `create_collection()`
- `process_file()` now collects all drawer IDs, documents, and metadata into lists and calls `collection.upsert()` once per file instead of once per chunk

**`mcp_server.py`**:
- `_get_collection(create=True)` passes the same HNSW metadata to `get_or_create_collection()`

## Test plan

- [ ] Mine a project with <1K drawers -- verify behavior unchanged
- [ ] Mine a project with 10K+ drawers -- verify `link_lists.bin` stays under 1MB
- [ ] Mine a project with 50K+ drawers -- verify no bloat (was 441GB, should be <50MB)
- [ ] Verify `mempalace status` and `mempalace search` work after large mines
- [ ] Verify MCP server creates collections with correct metadata