### PR TITLE
fix: reconfigure MCP stdin/stdout to UTF-8 on Windows (fixes #363)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -7879,16 +7879,18 @@ def _dispatch_stdio_request(request: dict):
 def _run_stdio_loop() -> None:
     _restore_stdout()
 
-    # Force UTF-8 on stdio. MCP JSON-RPC is UTF-8, but Python on Windows
-    # defaults stdin/stdout to the system codepage (e.g. cp1251), which
-    # corrupts non-ASCII payloads and surfaces as generic -32000 errors on
-    # Cyrillic/CJK content. See PEP 540.
-    for stream in (sys.stdin, sys.stdout):
-        if hasattr(stream, "reconfigure"):
-            try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
-            except (AttributeError, OSError):
-                pass
+    # On Windows, Python defaults stdin/stdout to the system ANSI codepage
+    # (e.g. cp1251 or cp1252).  MCP clients send UTF-8 JSON, so non-ASCII
+    # characters arrive as mojibake with surrogate escapes and eventually
+    # break the HuggingFace tokenizer inside ChromaDB's embedding function.
+    # Reconfiguring to UTF-8 here fixes it for every downstream reader.
+    if sys.platform == "win32":
+        try:
+            sys.stdin.reconfigure(encoding="utf-8", errors="strict")
+            sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+            sys.stderr.reconfigure(encoding="utf-8", errors="strict")
+        except Exception as e:
+            logger.warning("Could not reconfigure stdio to UTF-8: %s", e)
 
     logger.info("MemPalace MCP Server starting...")
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -7883,37 +7883,25 @@ def _run_stdio_loop() -> None:
     # (e.g. cp1251 / cp1252 / cp950). MCP clients send UTF-8 JSON, so the
     # default decode produces a wrong-but-valid str whose non-ASCII chars
     # later break the HuggingFace tokenizer inside ChromaDB's embedding
-    # function. Reconfiguring to UTF-8 fixes every Python-level reader
-    # opened after main() starts; C-level dependency banners that fire at
-    # import time still go through fd-redirected stderr per #225.
+    # function. The shared helper fixes every Python-level reader opened
+    # after main() starts; C-level dependency banners that fire at import
+    # time still go through fd-redirected stderr per #225.
     #
-    # Per-stream errors policy:
+    # Per-stream policy (MCP-specific):
     #   stdin  -- surrogateescape: a malformed byte from a misbehaving
-    #             client (or a stray BOM) becomes a lone surrogate in the
-    #             decoded str instead of crashing readline. The downstream
-    #             json.loads exception path then surfaces a clean -32700
-    #             instead of the readline raising mid-loop and killing
-    #             the whole server on the first bad byte.
-    #   stdout -- strict: we control what we write here; any failure is
-    #             a real bug we want loud.
-    #   stderr -- strict: same. Logging emits ASCII-only by default;
-    #             tracebacks for non-ASCII paths are a debug concern, not
-    #             a write-side codec concern.
-    if sys.platform == "win32":
-        policies = (
-            ("stdin", "surrogateescape"),
-            ("stdout", "strict"),
-            ("stderr", "strict"),
-        )
-        for name, errors in policies:
-            stream = getattr(sys, name, None)
-            reconfigure = getattr(stream, "reconfigure", None)
-            if reconfigure is None:
-                continue
-            try:
-                reconfigure(encoding="utf-8", errors=errors)
-            except Exception as e:
-                logger.warning("Could not reconfigure %s to UTF-8: %s", name, e)
+    #             client becomes a lone surrogate in the decoded str
+    #             instead of crashing readline; downstream json.loads
+    #             surfaces a clean -32700.
+    #   stdout -- strict: we control writes here; any failure is a real
+    #             bug we want loud.
+    #   stderr -- strict: same.
+    from ._stdio import reconfigure_stdio_utf8_on_windows
+
+    reconfigure_stdio_utf8_on_windows(
+        on_failure=lambda name, exc: logger.warning(
+            "Could not reconfigure %s to UTF-8: %s", name, exc
+        ),
+    )
 
     logger.info("MemPalace MCP Server starting...")
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -7880,17 +7880,40 @@ def _run_stdio_loop() -> None:
     _restore_stdout()
 
     # On Windows, Python defaults stdin/stdout to the system ANSI codepage
-    # (e.g. cp1251 or cp1252).  MCP clients send UTF-8 JSON, so non-ASCII
-    # characters arrive as mojibake with surrogate escapes and eventually
-    # break the HuggingFace tokenizer inside ChromaDB's embedding function.
-    # Reconfiguring to UTF-8 here fixes it for every downstream reader.
+    # (e.g. cp1251 / cp1252 / cp950). MCP clients send UTF-8 JSON, so the
+    # default decode produces a wrong-but-valid str whose non-ASCII chars
+    # later break the HuggingFace tokenizer inside ChromaDB's embedding
+    # function. Reconfiguring to UTF-8 fixes every Python-level reader
+    # opened after main() starts; C-level dependency banners that fire at
+    # import time still go through fd-redirected stderr per #225.
+    #
+    # Per-stream errors policy:
+    #   stdin  -- surrogateescape: a malformed byte from a misbehaving
+    #             client (or a stray BOM) becomes a lone surrogate in the
+    #             decoded str instead of crashing readline. The downstream
+    #             json.loads exception path then surfaces a clean -32700
+    #             instead of the readline raising mid-loop and killing
+    #             the whole server on the first bad byte.
+    #   stdout -- strict: we control what we write here; any failure is
+    #             a real bug we want loud.
+    #   stderr -- strict: same. Logging emits ASCII-only by default;
+    #             tracebacks for non-ASCII paths are a debug concern, not
+    #             a write-side codec concern.
     if sys.platform == "win32":
-        try:
-            sys.stdin.reconfigure(encoding="utf-8", errors="strict")
-            sys.stdout.reconfigure(encoding="utf-8", errors="strict")
-            sys.stderr.reconfigure(encoding="utf-8", errors="strict")
-        except Exception as e:
-            logger.warning("Could not reconfigure stdio to UTF-8: %s", e)
+        policies = (
+            ("stdin", "surrogateescape"),
+            ("stdout", "strict"),
+            ("stderr", "strict"),
+        )
+        for name, errors in policies:
+            stream = getattr(sys, name, None)
+            reconfigure = getattr(stream, "reconfigure", None)
+            if reconfigure is None:
+                continue
+            try:
+                reconfigure(encoding="utf-8", errors=errors)
+            except Exception as e:
+                logger.warning("Could not reconfigure %s to UTF-8: %s", name, e)
 
     logger.info("MemPalace MCP Server starting...")
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7687,3 +7687,78 @@ class TestSearchDateFilters:
         assert "before" in schema["properties"]
         assert schema["properties"]["since"]["type"] == "string"
         assert schema["properties"]["before"]["type"] == "string"
+
+
+# ── Windows stdio UTF-8 reconfigure ──────────────────────────────────────
+
+
+class _ReconfigurableStdio:
+    """Stdio stub recording every reconfigure call without touching real OS handles."""
+
+    def __init__(self):
+        self.calls = []
+
+    def reconfigure(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def test_main_reconfigures_stdio_per_stream_policy_on_windows(monkeypatch):
+    """Each stream must reconfigure to UTF-8 with the right errors policy.
+
+    stdin uses surrogateescape so a malformed byte from a misbehaving MCP
+    client is stashed as a lone surrogate the json.loads error path can
+    surface as -32700, instead of UnicodeDecodeError killing readline.
+    stdout/stderr stay strict because we control what is written there.
+    """
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(mcp_server.sys, "platform", "win32")
+
+    stdin = _ReconfigurableStdio()
+    stdout = _ReconfigurableStdio()
+    stderr = _ReconfigurableStdio()
+    monkeypatch.setattr(mcp_server.sys, "stdin", stdin)
+    monkeypatch.setattr(mcp_server.sys, "stdout", stdout)
+    monkeypatch.setattr(mcp_server.sys, "stderr", stderr)
+
+    def _exit(*_a, **_kw):
+        raise SystemExit(0)
+
+    stdin.readline = _exit
+    monkeypatch.setattr(mcp_server, "_restore_stdout", lambda: None)
+    monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", lambda: None)
+
+    with pytest.raises(SystemExit):
+        mcp_server.main()
+
+    assert stdin.calls == [{"encoding": "utf-8", "errors": "surrogateescape"}]
+    assert stdout.calls == [{"encoding": "utf-8", "errors": "strict"}]
+    assert stderr.calls == [{"encoding": "utf-8", "errors": "strict"}]
+
+
+def test_main_skips_reconfigure_off_windows(monkeypatch):
+    """On Linux / macOS the platform branch is a no-op."""
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(mcp_server.sys, "platform", "linux")
+
+    stdin = _ReconfigurableStdio()
+    stdout = _ReconfigurableStdio()
+    stderr = _ReconfigurableStdio()
+    monkeypatch.setattr(mcp_server.sys, "stdin", stdin)
+    monkeypatch.setattr(mcp_server.sys, "stdout", stdout)
+    monkeypatch.setattr(mcp_server.sys, "stderr", stderr)
+
+    def _exit(*_a, **_kw):
+        raise SystemExit(0)
+
+    stdin.readline = _exit
+    monkeypatch.setattr(mcp_server, "_restore_stdout", lambda: None)
+    monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", lambda: None)
+
+    with pytest.raises(SystemExit):
+        mcp_server.main()
+
+    assert stdin.calls == []
+    assert stdout.calls == []
+    assert stderr.calls == []


### PR DESCRIPTION
## What does this PR do?

Fixes #363. On Windows, Python defaults `sys.stdin` to the system ANSI codepage (cp1251, cp1252, etc.), not UTF-8. When an MCP client sends JSON containing non-ASCII characters, the bytes get decoded through the wrong codepage and produce mojibake with surrogate escapes. These strings pass Python type checks but crash the HuggingFace tokenizer inside ChromaDB with `TypeError: TextInputSequence must be str in query`.

The fix adds `sys.stdin.reconfigure(encoding="utf-8")` at the top of `main()`, guarded by `sys.platform == "win32"`. `stdout` and `stderr` get the same treatment so non-ASCII JSON responses serialize cleanly. On non-Windows platforms the code is a no-op.

This effectively makes `mempalace_search` work for every non-English speaker on Windows (Russian, Chinese, Hebrew, etc.), where it currently crashes on the very first query containing non-ASCII text.

## How to test

On Windows with a non-English locale:
```bash
python -m mempalace.mcp_server
# from an MCP client, send: mempalace_search with query "привет" or "你好"
# Before: TypeError crash
# After: normal search results
```

On Linux/macOS: no behavior change (guard skips reconfigure).

```bash
ruff check mempalace/mcp_server.py
python -c "import mempalace.mcp_server; print('OK')"
```

## Checklist

- [x] Linter passes (`ruff check .`)
- [x] No hardcoded paths
- [x] Python 3.9 compatible (`reconfigure` available since 3.7)
- [x] No new dependencies
