### PR TITLE
feat: Synapse Phase 1 — biologically-inspired memory scoring layer (#441)

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -172,6 +172,21 @@ class MempalaceConfig:
     def synapse_log_retention_days(self):
         return self._file_config.get("synapse_log_retention_days", 90)
 
+    @property
+    def synapse_consolidation_inactive_days(self):
+        """Days without retrieval before a drawer is a consolidation candidate."""
+        return self._file_config.get("synapse_consolidation_inactive_days", 180)
+
+    @property
+    def synapse_soft_archive_suggestions_enabled(self):
+        """Surface soft-archive move suggestions for inactive drawers (#336)."""
+        return self._file_config.get("synapse_soft_archive_suggestions_enabled", True)
+
+    @property
+    def synapse_soft_archive_target_wing(self):
+        """Suggested wing name for cold-storage moves (nudge only)."""
+        return self._file_config.get("synapse_soft_archive_target_wing", "archive")
+
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""
         self._config_dir.mkdir(parents=True, exist_ok=True)

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -123,6 +123,18 @@ class MempalaceConfig:
         """Mapping of hall names to keyword lists."""
         return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
 
+    @property
+    def synapse_enabled(self):
+        return self._file_config.get("synapse_enabled", False)
+
+    @property
+    def synapse_ltp_window_days(self):
+        return self._file_config.get("synapse_ltp_window_days", 30)
+
+    @property
+    def synapse_tagging_window_hours(self):
+        return self._file_config.get("synapse_tagging_window_hours", 24)
+
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""
         self._config_dir.mkdir(parents=True, exist_ok=True)

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -141,6 +141,14 @@ class MempalaceConfig:
         return self._file_config.get("synapse_association_enabled", False)
 
     @property
+    def synapse_association_max_boost(self):
+        return self._file_config.get("synapse_association_max_boost", 1.5)
+
+    @property
+    def synapse_association_coefficient(self):
+        return self._file_config.get("synapse_association_coefficient", 0.15)
+
+    @property
     def synapse_ltp_window_days(self):
         return self._file_config.get("synapse_ltp_window_days", 30)
 

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -125,15 +125,44 @@ class MempalaceConfig:
 
     @property
     def synapse_enabled(self):
+        """Synapse master switch — false disables scoring and retrieval logging."""
         return self._file_config.get("synapse_enabled", False)
+
+    @property
+    def synapse_ltp_enabled(self):
+        return self._file_config.get("synapse_ltp_enabled", True)
+
+    @property
+    def synapse_tagging_enabled(self):
+        return self._file_config.get("synapse_tagging_enabled", True)
+
+    @property
+    def synapse_association_enabled(self):
+        return self._file_config.get("synapse_association_enabled", False)
 
     @property
     def synapse_ltp_window_days(self):
         return self._file_config.get("synapse_ltp_window_days", 30)
 
     @property
+    def synapse_ltp_max_boost(self):
+        return self._file_config.get("synapse_ltp_max_boost", 2.0)
+
+    @property
     def synapse_tagging_window_hours(self):
         return self._file_config.get("synapse_tagging_window_hours", 24)
+
+    @property
+    def synapse_tagging_max_boost(self):
+        return self._file_config.get("synapse_tagging_max_boost", 1.5)
+
+    @property
+    def synapse_log_retrievals(self):
+        return self._file_config.get("synapse_log_retrievals", True)
+
+    @property
+    def synapse_log_retention_days(self):
+        return self._file_config.get("synapse_log_retention_days", 90)
 
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -101,15 +101,18 @@ def tool_status():
             candidates = synapse_db.get_consolidation_candidates(inactive_days=180)
             log_stats = synapse_db.get_log_stats()
             status_dict["synapse"] = {
-                "ltp_window_days": cfg.synapse_ltp_window_days,
-                "tagging_window_hours": cfg.synapse_tagging_window_hours,
                 "ltp_enabled": cfg.synapse_ltp_enabled,
                 "tagging_enabled": cfg.synapse_tagging_enabled,
                 "association_enabled": cfg.synapse_association_enabled,
                 "log_retrievals": cfg.synapse_log_retrievals,
-                "consolidation_candidates": len(candidates),
-                "consolidation_details": candidates[:10],  # 上位10件のみ
+                "ltp_window_days": cfg.synapse_ltp_window_days,
+                "ltp_max_boost": cfg.synapse_ltp_max_boost,
+                "tagging_window_hours": cfg.synapse_tagging_window_hours,
+                "tagging_max_boost": cfg.synapse_tagging_max_boost,
+                "log_retention_days": cfg.synapse_log_retention_days,
                 "log_stats": log_stats,
+                "consolidation_candidates": len(candidates),
+                "consolidation_details": candidates[:10],
             }
     except Exception:
         status_dict["synapse_enabled"] = False

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -93,13 +93,23 @@ def tool_status():
             from .synapse import SynapseDB
 
             synapse_db = SynapseDB(palace_path)
-            synapse_db.refresh_stats(window_days=cfg.synapse_ltp_window_days)
+            synapse_db.cleanup_old_logs(retention_days=cfg.synapse_log_retention_days)
+            synapse_db.refresh_stats(
+                window_days=cfg.synapse_ltp_window_days,
+                ltp_max_boost=cfg.synapse_ltp_max_boost,
+            )
             candidates = synapse_db.get_consolidation_candidates(inactive_days=180)
+            log_stats = synapse_db.get_log_stats()
             status_dict["synapse"] = {
                 "ltp_window_days": cfg.synapse_ltp_window_days,
                 "tagging_window_hours": cfg.synapse_tagging_window_hours,
+                "ltp_enabled": cfg.synapse_ltp_enabled,
+                "tagging_enabled": cfg.synapse_tagging_enabled,
+                "association_enabled": cfg.synapse_association_enabled,
+                "log_retrievals": cfg.synapse_log_retrievals,
                 "consolidation_candidates": len(candidates),
                 "consolidation_details": candidates[:10],  # 上位10件のみ
+                "log_stats": log_stats,
             }
     except Exception:
         status_dict["synapse_enabled"] = False

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -21,7 +21,7 @@ import sys
 import json
 import logging
 import hashlib
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from .config import MempalaceConfig
 from .version import __version__
@@ -30,6 +30,11 @@ from .palace_graph import traverse, find_tunnels, graph_stats
 import chromadb
 
 from .knowledge_graph import KnowledgeGraph
+from .synapse import (
+    SYNAPSE_MARK_METADATA_KEY,
+    SYNAPSE_MARK_NEW,
+    build_soft_archive_proposal,
+)
 
 _kg = KnowledgeGraph()
 
@@ -60,6 +65,70 @@ def _no_palace():
 # ==================== READ TOOLS ====================
 
 
+def _parse_iso_utc(s: str):
+    """Parse ISO8601 metadata timestamps to timezone-aware UTC."""
+    try:
+        t = s.strip()
+        if t.endswith("Z"):
+            t = t[:-1] + "+00:00"
+        dt = datetime.fromisoformat(t)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except (ValueError, TypeError, OSError, AttributeError):
+        return None
+
+
+def _count_synaptic_tagging_window_drawers(metas: list, window_hours: float) -> int:
+    """Drawers with synapse_mark=new still inside the tagging boost window (by filed_at)."""
+    now = datetime.now(timezone.utc)
+    n = 0
+    for m in metas:
+        if m.get(SYNAPSE_MARK_METADATA_KEY) != SYNAPSE_MARK_NEW:
+            continue
+        fa = m.get("filed_at")
+        if not fa:
+            continue
+        dt = _parse_iso_utc(fa)
+        if dt is None:
+            continue
+        hours = (now - dt).total_seconds() / 3600.0
+        if 0 <= hours < float(window_hours):
+            n += 1
+    return n
+
+
+def _enrich_consolidation_candidates(col, candidates: list, cfg) -> list:
+    """Add wing/room from Chroma and optional soft-archive proposals (#336)."""
+    if not col or not candidates:
+        return []
+    ids = [c["drawer_id"] for c in candidates[:50]]
+    idm = {}
+    try:
+        got = col.get(ids=ids, include=["metadatas"])
+        idm = dict(zip(got["ids"], got["metadatas"]))
+    except Exception:
+        pass
+    out = []
+    for c in candidates[:50]:
+        d = dict(c)
+        m = idm.get(c["drawer_id"]) or {}
+        w = m.get("wing", "unknown")
+        r = m.get("room", "unknown")
+        d["wing"] = w
+        d["room"] = r
+        d[SYNAPSE_MARK_METADATA_KEY] = m.get(SYNAPSE_MARK_METADATA_KEY)
+        if cfg.synapse_soft_archive_suggestions_enabled:
+            d["soft_archive_proposal"] = build_soft_archive_proposal(
+                w,
+                r,
+                target_wing=cfg.synapse_soft_archive_target_wing,
+                inactive_days=cfg.synapse_consolidation_inactive_days,
+            )
+        out.append(d)
+    return out
+
+
 def tool_status():
     col = _get_collection()
     if not col:
@@ -67,6 +136,7 @@ def tool_status():
     count = col.count()
     wings = {}
     rooms = {}
+    all_meta = []
     try:
         all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
         for m in all_meta:
@@ -75,7 +145,7 @@ def tool_status():
             wings[w] = wings.get(w, 0) + 1
             rooms[r] = rooms.get(r, 0) + 1
     except Exception:
-        pass
+        all_meta = []
     status_dict = {
         "total_drawers": count,
         "wings": wings,
@@ -98,10 +168,15 @@ def tool_status():
                 window_days=cfg.synapse_ltp_window_days,
                 ltp_max_boost=cfg.synapse_ltp_max_boost,
             )
-            candidates = synapse_db.get_consolidation_candidates(inactive_days=180)
+            inactive = cfg.synapse_consolidation_inactive_days
+            candidates = synapse_db.get_consolidation_candidates(inactive_days=inactive)
+            enriched = _enrich_consolidation_candidates(col, candidates, cfg)
             log_stats = synapse_db.get_log_stats()
             co_pairs = synapse_db.get_top_co_pairs(15)
             co_clusters = synapse_db.get_co_occurrence_clusters(40, 10)
+            tagging_window_n = _count_synaptic_tagging_window_drawers(
+                all_meta, cfg.synapse_tagging_window_hours
+            )
             status_dict["synapse"] = {
                 "ltp_enabled": cfg.synapse_ltp_enabled,
                 "tagging_enabled": cfg.synapse_tagging_enabled,
@@ -117,8 +192,19 @@ def tool_status():
                 "log_stats": log_stats,
                 "co_retrieval_top_pairs": co_pairs,
                 "co_occurrence_clusters": co_clusters,
+                "consolidation_inactive_days": inactive,
                 "consolidation_candidates": len(candidates),
-                "consolidation_details": candidates[:10],
+                "consolidation_details": enriched[:10],
+                "phase3": {
+                    "synaptic_mark_metadata_key": SYNAPSE_MARK_METADATA_KEY,
+                    "synaptic_mark_new_value": SYNAPSE_MARK_NEW,
+                    "drawers_in_synaptic_tagging_window": tagging_window_n,
+                    "soft_archive": {
+                        "suggestions_enabled": cfg.synapse_soft_archive_suggestions_enabled,
+                        "target_wing": cfg.synapse_soft_archive_target_wing,
+                        "related_issue": "#336",
+                    },
+                },
             }
     except Exception:
         status_dict["synapse_enabled"] = False
@@ -317,6 +403,7 @@ def tool_add_drawer(
                     "chunk_index": 0,
                     "added_by": added_by,
                     "filed_at": datetime.now().isoformat(),
+                    SYNAPSE_MARK_METADATA_KEY: SYNAPSE_MARK_NEW,
                 }
             ],
         )

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -76,7 +76,7 @@ def tool_status():
             rooms[r] = rooms.get(r, 0) + 1
     except Exception:
         pass
-    return {
+    status_dict = {
         "total_drawers": count,
         "wings": wings,
         "rooms": rooms,
@@ -84,6 +84,26 @@ def tool_status():
         "protocol": PALACE_PROTOCOL,
         "aaak_dialect": AAAK_SPEC,
     }
+    palace_path = _config.palace_path
+    # Synapse status
+    try:
+        cfg = MempalaceConfig()
+        status_dict["synapse_enabled"] = cfg.synapse_enabled
+        if cfg.synapse_enabled:
+            from .synapse import SynapseDB
+
+            synapse_db = SynapseDB(palace_path)
+            synapse_db.refresh_stats(window_days=cfg.synapse_ltp_window_days)
+            candidates = synapse_db.get_consolidation_candidates(inactive_days=180)
+            status_dict["synapse"] = {
+                "ltp_window_days": cfg.synapse_ltp_window_days,
+                "tagging_window_hours": cfg.synapse_tagging_window_hours,
+                "consolidation_candidates": len(candidates),
+                "consolidation_details": candidates[:10],  # 上位10件のみ
+            }
+    except Exception:
+        status_dict["synapse_enabled"] = False
+    return status_dict
 
 
 # ── AAAK Dialect Spec ─────────────────────────────────────────────────────────

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -100,10 +100,14 @@ def tool_status():
             )
             candidates = synapse_db.get_consolidation_candidates(inactive_days=180)
             log_stats = synapse_db.get_log_stats()
+            co_pairs = synapse_db.get_top_co_pairs(15)
+            co_clusters = synapse_db.get_co_occurrence_clusters(40, 10)
             status_dict["synapse"] = {
                 "ltp_enabled": cfg.synapse_ltp_enabled,
                 "tagging_enabled": cfg.synapse_tagging_enabled,
                 "association_enabled": cfg.synapse_association_enabled,
+                "association_max_boost": cfg.synapse_association_max_boost,
+                "association_coefficient": cfg.synapse_association_coefficient,
                 "log_retrievals": cfg.synapse_log_retrievals,
                 "ltp_window_days": cfg.synapse_ltp_window_days,
                 "ltp_max_boost": cfg.synapse_ltp_max_boost,
@@ -111,6 +115,8 @@ def tool_status():
                 "tagging_max_boost": cfg.synapse_tagging_max_boost,
                 "log_retention_days": cfg.synapse_log_retention_days,
                 "log_stats": log_stats,
+                "co_retrieval_top_pairs": co_pairs,
+                "co_occurrence_clusters": co_clusters,
                 "consolidation_candidates": len(candidates),
                 "consolidation_details": candidates[:10],
             }

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -25,6 +25,7 @@ import logging
 import hashlib
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Optional
 
 from .config import MempalaceConfig, sanitize_name, sanitize_content
 from .version import __version__
@@ -205,7 +206,7 @@ def _enrich_consolidation_candidates(col, candidates: list, cfg) -> list:
     return out
 
 
-def tool_status():
+def tool_status(consolidation_wing: str = None):
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -245,7 +246,9 @@ def tool_status():
                 ltp_max_boost=cfg.synapse_ltp_max_boost,
             )
             inactive = cfg.synapse_consolidation_inactive_days
-            candidates = synapse_db.get_consolidation_candidates(inactive_days=inactive)
+            candidates = synapse_db.get_consolidation_candidates(
+                inactive_days=inactive, wing=consolidation_wing
+            )
             enriched = _enrich_consolidation_candidates(col, candidates, cfg)
             log_stats = synapse_db.get_log_stats()
             co_pairs = synapse_db.get_top_co_pairs(15)
@@ -371,13 +374,22 @@ def tool_get_taxonomy():
     return {"taxonomy": taxonomy}
 
 
-def tool_search(query: str, limit: int = 5, wing: str = None, room: str = None):
+def tool_search(
+    query: str,
+    limit: int = 5,
+    wing: str = None,
+    room: str = None,
+    synapse_ltp_enabled: Optional[bool] = None,
+    synapse_tagging_enabled: Optional[bool] = None,
+):
     return search_memories(
         query,
         palace_path=_config.palace_path,
         wing=wing,
         room=room,
         n_results=limit,
+        synapse_ltp_enabled=synapse_ltp_enabled,
+        synapse_tagging_enabled=synapse_tagging_enabled,
     )
 
 
@@ -716,7 +728,15 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
 TOOLS = {
     "mempalace_status": {
         "description": "Palace overview — total drawers, wing and room counts",
-        "input_schema": {"type": "object", "properties": {}},
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "consolidation_wing": {
+                    "type": "string",
+                    "description": "If set, limit Synapse consolidation candidates to drawer_ids containing this substring (optional)",
+                },
+            },
+        },
         "handler": tool_status,
     },
     "mempalace_list_wings": {
@@ -868,6 +888,14 @@ TOOLS = {
                 "limit": {"type": "integer", "description": "Max results (default 5)"},
                 "wing": {"type": "string", "description": "Filter by wing (optional)"},
                 "room": {"type": "string", "description": "Filter by room (optional)"},
+                "synapse_ltp_enabled": {
+                    "type": "boolean",
+                    "description": "Override LTP axis for this search only (omit = use config default)",
+                },
+                "synapse_tagging_enabled": {
+                    "type": "boolean",
+                    "description": "Override tagging axis for this search only (omit = use config default)",
+                },
             },
             "required": ["query"],
         },

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -428,6 +428,7 @@ def add_drawer(
                     "chunk_index": chunk_index,
                     "added_by": agent,
                     "filed_at": datetime.now().isoformat(),
+                    "synapse_mark": "new",
                 }
             ],
         )

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -171,48 +171,52 @@ def search_memories(
             query_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
             session_id = uuid.uuid4().hex[:16]
 
-            # 結果の drawer_id リストを収集
             hit_drawer_ids = []
             for hit in result["hits"]:
                 drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
                 if drawer_id:
                     hit_drawer_ids.append(drawer_id)
 
-            # LTP スコアを一括取得
-            ltp_scores = synapse_db.get_ltp_scores_batch(
-                hit_drawer_ids,
-                window_days=cfg.synapse_ltp_window_days,
-            )
+            ltp_scores = {}
+            if cfg.synapse_ltp_enabled:
+                ltp_scores = synapse_db.get_ltp_scores_batch(
+                    hit_drawer_ids,
+                    window_days=cfg.synapse_ltp_window_days,
+                    max_boost=cfg.synapse_ltp_max_boost,
+                )
 
-            # 各ヒットに Synapse スコアを付与
             for hit in result["hits"]:
                 drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
                 filed_at = hit.get("metadata", {}).get("filed_at", None)
                 similarity = hit.get("original_similarity", hit.get("similarity", 0.0))
                 decay = hit.get("decay", 1.0)
 
-                synapse_result = synapse_db.calculate_synapse_score(
-                    similarity=similarity,
-                    decay=decay,
-                    drawer_id=drawer_id,
-                    filed_at=filed_at,
-                    ltp_scores=ltp_scores,
-                    window_days=cfg.synapse_ltp_window_days,
+                ltp = ltp_scores.get(drawer_id, 1.0) if cfg.synapse_ltp_enabled else 1.0
+                tagging = (
+                    SynapseDB.calculate_tagging_boost(
+                        filed_at,
+                        cfg.synapse_tagging_window_hours,
+                        cfg.synapse_tagging_max_boost,
+                    )
+                    if cfg.synapse_tagging_enabled
+                    else 1.0
                 )
+                association = 1.0  # Phase 2: cfg.synapse_association_enabled
 
-                hit["synapse_score"] = synapse_result["final_score"]
+                final_score = similarity * decay * ltp * association * tagging
+
+                hit["synapse_score"] = final_score
                 hit["synapse_factors"] = {
-                    "ltp": synapse_result["ltp"],
-                    "association": synapse_result["association"],
-                    "tagging": synapse_result["tagging"],
+                    "ltp": ltp,
+                    "association": association,
+                    "tagging": tagging,
                 }
 
-            # Synapse スコアで再ソート（hits と results は同一リスト）
             result["hits"].sort(key=lambda h: h.get("synapse_score", 0.0), reverse=True)
             result["synapse_enabled"] = True
 
-            # 検索ログを fire-and-forget で記録
-            synapse_db.log_retrieval(hit_drawer_ids, query_hash, session_id)
+            if cfg.synapse_log_retrievals:
+                synapse_db.log_retrieval(hit_drawer_ids, query_hash, session_id)
         else:
             result["synapse_enabled"] = False
     except Exception as e:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -10,6 +10,7 @@ import hashlib
 import logging
 import uuid
 from pathlib import Path
+from typing import Optional
 
 import chromadb
 
@@ -93,12 +94,31 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
 
 
 def search_memories(
-    query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5
+    query: str,
+    palace_path: Optional[str] = None,
+    wing: Optional[str] = None,
+    room: Optional[str] = None,
+    n_results: int = 5,
+    include_archived: bool = False,
+    time_decay: bool = True,
+    synapse_ltp_enabled: Optional[bool] = None,
+    synapse_tagging_enabled: Optional[bool] = None,
+    synapse_association_enabled: Optional[bool] = None,
+    synapse_ltp_window_days: Optional[int] = None,
+    synapse_ltp_max_boost: Optional[float] = None,
+    synapse_tagging_window_hours: Optional[int] = None,
+    synapse_tagging_max_boost: Optional[float] = None,
 ) -> dict:
     """
     Programmatic search — returns a dict instead of printing.
     Used by the MCP server and other callers that need data.
     """
+    from .config import MempalaceConfig
+
+    cfg = MempalaceConfig()
+    if palace_path is None:
+        palace_path = cfg.palace_path
+
     try:
         client = chromadb.PersistentClient(path=palace_path)
         col = client.get_collection("mempalace_drawers")
@@ -117,6 +137,14 @@ def search_memories(
         where = {"wing": wing}
     elif room:
         where = {"room": room}
+
+    if not include_archived and wing is None:
+        aw = cfg.synapse_soft_archive_target_wing
+        excl = {"wing": {"$ne": aw}}
+        if where:
+            where = {"$and": [where, excl]}
+        else:
+            where = excl
 
     try:
         kwargs = {
@@ -161,11 +189,44 @@ def search_memories(
 
     # --- Synapse integration ---
     try:
-        from .config import MempalaceConfig
-
-        cfg = MempalaceConfig()
         if cfg.synapse_enabled:
             from .synapse import SynapseDB
+
+            _ltp_enabled = (
+                synapse_ltp_enabled
+                if synapse_ltp_enabled is not None
+                else cfg.synapse_ltp_enabled
+            )
+            _tagging_enabled = (
+                synapse_tagging_enabled
+                if synapse_tagging_enabled is not None
+                else cfg.synapse_tagging_enabled
+            )
+            _association_enabled = (
+                synapse_association_enabled
+                if synapse_association_enabled is not None
+                else cfg.synapse_association_enabled
+            )
+            _ltp_window_days = (
+                synapse_ltp_window_days
+                if synapse_ltp_window_days is not None
+                else cfg.synapse_ltp_window_days
+            )
+            _ltp_max_boost = (
+                synapse_ltp_max_boost
+                if synapse_ltp_max_boost is not None
+                else cfg.synapse_ltp_max_boost
+            )
+            _tagging_window_hours = (
+                synapse_tagging_window_hours
+                if synapse_tagging_window_hours is not None
+                else cfg.synapse_tagging_window_hours
+            )
+            _tagging_max_boost = (
+                synapse_tagging_max_boost
+                if synapse_tagging_max_boost is not None
+                else cfg.synapse_tagging_max_boost
+            )
 
             synapse_db = SynapseDB(palace_path)
             query_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
@@ -177,58 +238,65 @@ def search_memories(
                 if drawer_id:
                     hit_drawer_ids.append(drawer_id)
 
-            ltp_scores = {}
-            if cfg.synapse_ltp_enabled and hit_drawer_ids:
-                ltp_scores = synapse_db.get_ltp_scores_batch(
-                    hit_drawer_ids,
-                    window_days=cfg.synapse_ltp_window_days,
-                    max_boost=cfg.synapse_ltp_max_boost,
-                )
-
-            assoc_scores = {}
-            if cfg.synapse_association_enabled and hit_drawer_ids:
-                assoc_scores = synapse_db.get_association_scores_batch(
-                    hit_drawer_ids,
-                    max_boost=cfg.synapse_association_max_boost,
-                    coefficient=cfg.synapse_association_coefficient,
-                )
-
-            for hit in result["hits"]:
-                drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
-                filed_at = hit.get("metadata", {}).get("filed_at", None)
-                similarity = hit.get("original_similarity", hit.get("similarity", 0.0))
-                decay = hit.get("decay", 1.0)
-
-                ltp = ltp_scores.get(drawer_id, 1.0) if cfg.synapse_ltp_enabled else 1.0
-                tagging = (
-                    SynapseDB.calculate_tagging_boost(
-                        filed_at,
-                        window_hours=cfg.synapse_tagging_window_hours,
-                        max_boost=cfg.synapse_tagging_max_boost,
+            with synapse_db.connection() as conn:
+                ltp_scores = {}
+                if _ltp_enabled and hit_drawer_ids:
+                    ltp_scores = synapse_db.get_ltp_scores_batch(
+                        hit_drawer_ids,
+                        window_days=_ltp_window_days,
+                        max_boost=_ltp_max_boost,
+                        conn=conn,
                     )
-                    if cfg.synapse_tagging_enabled
-                    else 1.0
+
+                assoc_scores = {}
+                if _association_enabled and hit_drawer_ids:
+                    assoc_scores = synapse_db.get_association_scores_batch(
+                        hit_drawer_ids,
+                        max_boost=cfg.synapse_association_max_boost,
+                        coefficient=cfg.synapse_association_coefficient,
+                        conn=conn,
+                    )
+
+                for hit in result["hits"]:
+                    drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
+                    filed_at = hit.get("metadata", {}).get("filed_at", None)
+                    similarity = hit.get("original_similarity", hit.get("similarity", 0.0))
+                    decay = 1.0 if not time_decay else hit.get("decay", 1.0)
+
+                    ltp = ltp_scores.get(drawer_id, 1.0) if _ltp_enabled else 1.0
+                    tagging = (
+                        SynapseDB.calculate_tagging_boost(
+                            filed_at,
+                            window_hours=_tagging_window_hours,
+                            max_boost=_tagging_max_boost,
+                        )
+                        if _tagging_enabled
+                        else 1.0
+                    )
+                    association = (
+                        assoc_scores.get(drawer_id, 1.0)
+                        if _association_enabled
+                        else 1.0
+                    )
+
+                    final_score = similarity * decay * ltp * association * tagging
+
+                    hit["synapse_score"] = final_score
+                    hit["synapse_factors"] = {
+                        "ltp": ltp,
+                        "association": association,
+                        "tagging": tagging,
+                    }
+
+                result["hits"].sort(
+                    key=lambda h: h.get("synapse_score", 0.0), reverse=True
                 )
-                association = (
-                    assoc_scores.get(drawer_id, 1.0)
-                    if cfg.synapse_association_enabled
-                    else 1.0
-                )
+                result["synapse_enabled"] = True
 
-                final_score = similarity * decay * ltp * association * tagging
-
-                hit["synapse_score"] = final_score
-                hit["synapse_factors"] = {
-                    "ltp": ltp,
-                    "association": association,
-                    "tagging": tagging,
-                }
-
-            result["hits"].sort(key=lambda h: h.get("synapse_score", 0.0), reverse=True)
-            result["synapse_enabled"] = True
-
-            if cfg.synapse_log_retrievals and hit_drawer_ids:
-                synapse_db.log_retrieval(hit_drawer_ids, query_hash, session_id)
+                if cfg.synapse_log_retrievals and hit_drawer_ids:
+                    synapse_db.log_retrieval(
+                        hit_drawer_ids, query_hash, session_id, conn=conn
+                    )
         else:
             result["synapse_enabled"] = False
     except Exception as e:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -185,6 +185,14 @@ def search_memories(
                     max_boost=cfg.synapse_ltp_max_boost,
                 )
 
+            assoc_scores = {}
+            if cfg.synapse_association_enabled and hit_drawer_ids:
+                assoc_scores = synapse_db.get_association_scores_batch(
+                    hit_drawer_ids,
+                    max_boost=cfg.synapse_association_max_boost,
+                    coefficient=cfg.synapse_association_coefficient,
+                )
+
             for hit in result["hits"]:
                 drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
                 filed_at = hit.get("metadata", {}).get("filed_at", None)
@@ -201,7 +209,11 @@ def search_memories(
                     if cfg.synapse_tagging_enabled
                     else 1.0
                 )
-                association = 1.0  # Phase 2: cfg.synapse_association_enabled
+                association = (
+                    assoc_scores.get(drawer_id, 1.0)
+                    if cfg.synapse_association_enabled
+                    else 1.0
+                )
 
                 final_score = similarity * decay * ltp * association * tagging
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -6,7 +6,9 @@ Semantic search against the palace.
 Returns verbatim text — the actual words, never summaries.
 """
 
+import hashlib
 import logging
+import uuid
 from pathlib import Path
 
 import chromadb
@@ -132,11 +134,16 @@ def search_memories(
     docs = results["documents"][0]
     metas = results["metadatas"][0]
     dists = results["distances"][0]
+    ids = results.get("ids", [[]])[0]
 
     hits = []
-    for doc, meta, dist in zip(docs, metas, dists):
+    for i, (doc, meta, dist) in enumerate(zip(docs, metas, dists)):
+        drawer_id = ids[i] if i < len(ids) else ""
+        meta = meta or {}
         hits.append(
             {
+                "id": drawer_id,
+                "metadata": meta,
                 "text": doc,
                 "wing": meta.get("wing", "unknown"),
                 "room": meta.get("room", "unknown"),
@@ -145,8 +152,71 @@ def search_memories(
             }
         )
 
-    return {
+    result = {
         "query": query,
         "filters": {"wing": wing, "room": room},
         "results": hits,
+        "hits": hits,
     }
+
+    # --- Synapse integration ---
+    try:
+        from .config import MempalaceConfig
+
+        cfg = MempalaceConfig()
+        if cfg.synapse_enabled:
+            from .synapse import SynapseDB
+
+            synapse_db = SynapseDB(palace_path)
+            query_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
+            session_id = uuid.uuid4().hex[:16]
+
+            # 結果の drawer_id リストを収集
+            hit_drawer_ids = []
+            for hit in result["hits"]:
+                drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
+                if drawer_id:
+                    hit_drawer_ids.append(drawer_id)
+
+            # LTP スコアを一括取得
+            ltp_scores = synapse_db.get_ltp_scores_batch(
+                hit_drawer_ids,
+                window_days=cfg.synapse_ltp_window_days,
+            )
+
+            # 各ヒットに Synapse スコアを付与
+            for hit in result["hits"]:
+                drawer_id = hit.get("metadata", {}).get("drawer_id", hit.get("id", ""))
+                filed_at = hit.get("metadata", {}).get("filed_at", None)
+                similarity = hit.get("original_similarity", hit.get("similarity", 0.0))
+                decay = hit.get("decay", 1.0)
+
+                synapse_result = synapse_db.calculate_synapse_score(
+                    similarity=similarity,
+                    decay=decay,
+                    drawer_id=drawer_id,
+                    filed_at=filed_at,
+                    ltp_scores=ltp_scores,
+                    window_days=cfg.synapse_ltp_window_days,
+                )
+
+                hit["synapse_score"] = synapse_result["final_score"]
+                hit["synapse_factors"] = {
+                    "ltp": synapse_result["ltp"],
+                    "association": synapse_result["association"],
+                    "tagging": synapse_result["tagging"],
+                }
+
+            # Synapse スコアで再ソート（hits と results は同一リスト）
+            result["hits"].sort(key=lambda h: h.get("synapse_score", 0.0), reverse=True)
+            result["synapse_enabled"] = True
+
+            # 検索ログを fire-and-forget で記録
+            synapse_db.log_retrieval(hit_drawer_ids, query_hash, session_id)
+        else:
+            result["synapse_enabled"] = False
+    except Exception as e:
+        logger.warning("Synapse scoring skipped: %s", e)
+        result["synapse_enabled"] = False
+
+    return result

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -178,7 +178,7 @@ def search_memories(
                     hit_drawer_ids.append(drawer_id)
 
             ltp_scores = {}
-            if cfg.synapse_ltp_enabled:
+            if cfg.synapse_ltp_enabled and hit_drawer_ids:
                 ltp_scores = synapse_db.get_ltp_scores_batch(
                     hit_drawer_ids,
                     window_days=cfg.synapse_ltp_window_days,
@@ -195,8 +195,8 @@ def search_memories(
                 tagging = (
                     SynapseDB.calculate_tagging_boost(
                         filed_at,
-                        cfg.synapse_tagging_window_hours,
-                        cfg.synapse_tagging_max_boost,
+                        window_hours=cfg.synapse_tagging_window_hours,
+                        max_boost=cfg.synapse_tagging_max_boost,
                     )
                     if cfg.synapse_tagging_enabled
                     else 1.0
@@ -215,7 +215,7 @@ def search_memories(
             result["hits"].sort(key=lambda h: h.get("synapse_score", 0.0), reverse=True)
             result["synapse_enabled"] = True
 
-            if cfg.synapse_log_retrievals:
+            if cfg.synapse_log_retrievals and hit_drawer_ids:
                 synapse_db.log_retrieval(hit_drawer_ids, query_hash, session_id)
         else:
             result["synapse_enabled"] = False

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -294,9 +294,14 @@ def search_memories(
                 result["synapse_enabled"] = True
 
                 if cfg.synapse_log_retrievals and hit_drawer_ids:
-                    synapse_db.log_retrieval(
-                        hit_drawer_ids, query_hash, session_id, conn=conn
-                    )
+                    try:
+                        synapse_db.log_retrieval(
+                            hit_drawer_ids, query_hash, session_id, conn=conn
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Synapse log_retrieval failed (non-fatal): %s", e
+                        )
         else:
             result["synapse_enabled"] = False
     except Exception as e:

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -12,7 +12,13 @@ DEFAULT_LTP_MAX_BOOST = 2.0
 DEFAULT_LTP_COEFFICIENT = 0.3
 DEFAULT_TAGGING_WINDOW_HOURS = 24
 DEFAULT_TAGGING_MAX_BOOST = 1.5
+DEFAULT_ASSOCIATION_MAX_BOOST = 1.5
+DEFAULT_ASSOCIATION_COEFFICIENT = 0.15
 SYNAPSE_DB_NAME = "synapse.sqlite3"
+
+
+def _canonical_pair(a: str, b: str) -> tuple[str, str]:
+    return (a, b) if a < b else (b, a)
 
 
 def _utc_now_iso() -> str:
@@ -67,6 +73,11 @@ class SynapseDB:
                     PRIMARY KEY (drawer_a, drawer_b)
                 );
 
+                CREATE INDEX IF NOT EXISTS idx_co_retrieval_drawer_a
+                    ON co_retrieval(drawer_a);
+                CREATE INDEX IF NOT EXISTS idx_co_retrieval_drawer_b
+                    ON co_retrieval(drawer_b);
+
                 CREATE TABLE IF NOT EXISTS synapse_stats (
                     drawer_id TEXT PRIMARY KEY,
                     total_retrievals INTEGER NOT NULL DEFAULT 0,
@@ -103,6 +114,176 @@ class SynapseDB:
                 conn.close()
         except Exception as e:
             logger.warning("log_retrieval failed: %s", e)
+        else:
+            try:
+                self._record_co_retrieval_pairs(drawer_ids, retrieved_at)
+            except Exception as e:
+                logger.warning("co_retrieval pair update failed: %s", e)
+
+    def _record_co_retrieval_pairs(self, drawer_ids: list[str], retrieved_at: str) -> None:
+        """同一検索結果内の drawer ペアごとに co_count を増分する。"""
+        uniq = sorted(set(drawer_ids))
+        if len(uniq) < 2:
+            return
+        conn = sqlite3.connect(self.db_path)
+        try:
+            for i in range(len(uniq)):
+                for j in range(i + 1, len(uniq)):
+                    a, b = _canonical_pair(uniq[i], uniq[j])
+                    conn.execute(
+                        """
+                        INSERT INTO co_retrieval (drawer_a, drawer_b, co_count, last_co_retrieved)
+                        VALUES (?, ?, 1, ?)
+                        ON CONFLICT(drawer_a, drawer_b) DO UPDATE SET
+                            co_count = co_count + 1,
+                            last_co_retrieved = excluded.last_co_retrieved
+                        """,
+                        (a, b, retrieved_at),
+                    )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def rebuild_co_retrieval_from_log(self) -> int:
+        """
+        retrieval_log を集計して co_retrieval を一括再構築する。
+        ログ削除後や整合性修復用。挿入した行数を返す。
+        """
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("DELETE FROM co_retrieval")
+            conn.execute(
+                """
+                INSERT INTO co_retrieval (drawer_a, drawer_b, co_count, last_co_retrieved)
+                SELECT
+                    d1.drawer_id AS drawer_a,
+                    d2.drawer_id AS drawer_b,
+                    COUNT(DISTINCT d1.session_id) AS co_count,
+                    MAX(d1.retrieved_at) AS last_co_retrieved
+                FROM retrieval_log d1
+                INNER JOIN retrieval_log d2
+                    ON d1.session_id = d2.session_id
+                    AND d1.drawer_id < d2.drawer_id
+                GROUP BY d1.drawer_id, d2.drawer_id
+                """
+            )
+            conn.commit()
+            cur = conn.execute("SELECT COUNT(*) FROM co_retrieval")
+            n = int(cur.fetchone()[0])
+            return n
+        finally:
+            conn.close()
+
+    def get_association_scores_batch(
+        self,
+        drawer_ids: list[str],
+        max_boost: float = DEFAULT_ASSOCIATION_MAX_BOOST,
+        coefficient: float = DEFAULT_ASSOCIATION_COEFFICIENT,
+    ) -> dict[str, float]:
+        """
+        同一検索結果の drawer 集合について、co_retrieval の共起強度から association を計算する。
+        各 drawer について、ヒット集合内の他 drawer との co_count 合計を用いる。
+        """
+        uniq = list(dict.fromkeys([d for d in drawer_ids if d]))
+        out: dict[str, float] = {d: 1.0 for d in uniq}
+        if len(uniq) < 2:
+            return out
+        conn = sqlite3.connect(self.db_path)
+        try:
+            ph = ",".join("?" * len(uniq))
+            cur = conn.execute(
+                f"SELECT drawer_a, drawer_b, co_count FROM co_retrieval "
+                f"WHERE drawer_a IN ({ph}) AND drawer_b IN ({ph})",
+                (*uniq, *uniq),
+            )
+            edge: dict[tuple[str, str], int] = {}
+            for a, b, c in cur.fetchall():
+                edge[(a, b)] = int(c)
+        finally:
+            conn.close()
+        for d in uniq:
+            total = 0
+            for o in uniq:
+                if o == d:
+                    continue
+                ca, cb = _canonical_pair(d, o)
+                total += edge.get((ca, cb), 0)
+            if total == 0:
+                out[d] = 1.0
+            else:
+                raw = 1.0 + math.log(1 + total) * coefficient
+                out[d] = _clamp(raw, 1.0, max_boost)
+        return out
+
+    def get_top_co_pairs(self, limit: int = 20) -> list[dict[str, Any]]:
+        """共起回数の多いペアを返す。"""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute(
+                "SELECT drawer_a, drawer_b, co_count, last_co_retrieved FROM co_retrieval "
+                "ORDER BY co_count DESC, last_co_retrieved DESC LIMIT ?",
+                (limit,),
+            )
+            return [
+                {
+                    "drawer_a": r[0],
+                    "drawer_b": r[1],
+                    "co_count": int(r[2]),
+                    "last_co_retrieved": r[3],
+                }
+                for r in cur.fetchall()
+            ]
+        finally:
+            conn.close()
+
+    def get_co_occurrence_clusters(
+        self, max_edges: int = 40, max_clusters: int = 12
+    ) -> list[dict[str, Any]]:
+        """
+        強い共起ペアから無向グラフを張り、連結成分をクラスタとして返す。
+        """
+        top = self.get_top_co_pairs(max_edges)
+        if not top:
+            return []
+
+        parent: dict[str, str] = {}
+
+        def find(x: str) -> str:
+            if x not in parent:
+                parent[x] = x
+            if parent[x] != x:
+                parent[x] = find(parent[x])
+            return parent[x]
+
+        def union(x: str, y: str) -> None:
+            rx, ry = find(x), find(y)
+            if rx != ry:
+                parent[rx] = ry
+
+        for p in top:
+            union(p["drawer_a"], p["drawer_b"])
+
+        root_nodes: dict[str, set[str]] = {}
+        for p in top:
+            for n in (p["drawer_a"], p["drawer_b"]):
+                r = find(n)
+                root_nodes.setdefault(r, set()).add(n)
+
+        clusters: list[dict[str, Any]] = []
+        for r, drawers in root_nodes.items():
+            if len(drawers) < 2:
+                continue
+            tw = sum(int(p["co_count"]) for p in top if find(p["drawer_a"]) == r)
+            clusters.append(
+                {
+                    "drawers": sorted(drawers),
+                    "total_co_weight": tw,
+                    "size": len(drawers),
+                }
+            )
+
+        clusters.sort(key=lambda c: (-c["total_co_weight"], -c["size"]))
+        return clusters[:max_clusters]
 
     def get_ltp_score(
         self,
@@ -216,11 +397,11 @@ class SynapseDB:
         ltp_max_boost: float = DEFAULT_LTP_MAX_BOOST,
         tagging_window_hours: int = DEFAULT_TAGGING_WINDOW_HOURS,
         tagging_max_boost: float = DEFAULT_TAGGING_MAX_BOOST,
+        association_scores: Optional[dict[str, float]] = None,
     ) -> dict[str, Any]:
         """
         最終スコアを計算して返す。
-        final_score = similarity * decay * ltp * tagging
-        (Phase 1 では association は 1.0 固定)
+        final_score = similarity * decay * ltp * association * tagging
 
         戻り値:
         {
@@ -228,7 +409,7 @@ class SynapseDB:
             "similarity": float,
             "decay": float,
             "ltp": float,
-            "association": 1.0,
+            "association": float,
             "tagging": float
         }
         """
@@ -241,7 +422,10 @@ class SynapseDB:
             window_hours=tagging_window_hours,
             max_boost=tagging_max_boost,
         )
-        association = 1.0
+        if association_scores is not None:
+            association = association_scores.get(drawer_id, 1.0)
+        else:
+            association = 1.0
         final_score = similarity * decay * ltp * tagging * association
         return {
             "final_score": final_score,
@@ -275,8 +459,15 @@ class SynapseDB:
         except Exception as e:
             logger.warning("VACUUM failed: %s", e)
         if deleted is None or deleted < 0:
-            return 0
-        return int(deleted)
+            deleted = 0
+        else:
+            deleted = int(deleted)
+        if deleted > 0:
+            try:
+                self.rebuild_co_retrieval_from_log()
+            except Exception as e:
+                logger.warning("rebuild_co_retrieval_from_log after cleanup failed: %s", e)
+        return deleted
 
     def get_log_stats(self) -> dict[str, Any]:
         """ログの統計情報を返す。"""

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -1,0 +1,313 @@
+import logging
+import math
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LTP_WINDOW_DAYS = 30
+DEFAULT_LTP_MAX_BOOST = 2.0
+DEFAULT_LTP_COEFFICIENT = 0.3
+DEFAULT_TAGGING_WINDOW_HOURS = 24
+DEFAULT_TAGGING_MAX_BOOST = 1.5
+SYNAPSE_DB_NAME = "synapse.sqlite3"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _clamp(x: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, x))
+
+
+class SynapseDB:
+    """Manages the synapse.sqlite3 database for retrieval logging and scoring."""
+
+    def __init__(self, palace_path: str):
+        """
+        palace_path: palace のルートディレクトリ（knowledge_graph.sqlite3 と同階層）
+        synapse.sqlite3 が存在しなければ作成し、テーブルを初期化する。
+        WAL モードを有効にする。
+        """
+        self.db_path = os.path.join(palace_path, SYNAPSE_DB_NAME)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA busy_timeout=5000;")
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS retrieval_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    drawer_id TEXT NOT NULL,
+                    retrieved_at TEXT NOT NULL,
+                    query_hash TEXT NOT NULL,
+                    session_id TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_retrieval_log_drawer
+                    ON retrieval_log(drawer_id);
+
+                CREATE INDEX IF NOT EXISTS idx_retrieval_log_session
+                    ON retrieval_log(session_id);
+
+                CREATE INDEX IF NOT EXISTS idx_retrieval_log_retrieved_at
+                    ON retrieval_log(retrieved_at);
+
+                CREATE TABLE IF NOT EXISTS co_retrieval (
+                    drawer_a TEXT NOT NULL,
+                    drawer_b TEXT NOT NULL,
+                    co_count INTEGER NOT NULL DEFAULT 0,
+                    last_co_retrieved TEXT NOT NULL,
+                    PRIMARY KEY (drawer_a, drawer_b)
+                );
+
+                CREATE TABLE IF NOT EXISTS synapse_stats (
+                    drawer_id TEXT PRIMARY KEY,
+                    total_retrievals INTEGER NOT NULL DEFAULT 0,
+                    recent_density REAL NOT NULL DEFAULT 0.0,
+                    ltp_score REAL NOT NULL DEFAULT 1.0,
+                    last_updated TEXT NOT NULL
+                );
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def log_retrieval(self, drawer_ids: list[str], query_hash: str, session_id: str):
+        """
+        検索結果に含まれた drawer_id のリストを retrieval_log に記録する。
+        - retrieved_at: UTC ISO 8601 形式
+        - fire-and-forget: 例外が発生してもログ出力のみで呼び出し元に伝播しない
+        """
+        if not drawer_ids:
+            return
+        try:
+            retrieved_at = _utc_now_iso()
+            rows = [(did, retrieved_at, query_hash, session_id) for did in drawer_ids]
+            conn = sqlite3.connect(self.db_path)
+            try:
+                conn.executemany(
+                    "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) "
+                    "VALUES (?, ?, ?, ?)",
+                    rows,
+                )
+                conn.commit()
+            finally:
+                conn.close()
+        except Exception as e:
+            logger.warning("log_retrieval failed: %s", e)
+
+    def get_ltp_score(self, drawer_id: str, window_days: int = DEFAULT_LTP_WINDOW_DAYS) -> float:
+        """
+        直近 window_days 日間の retrieval_log から drawer_id の検索回数を集計し、
+        LTP スコアを計算して返す。
+        ltp = clamp(1.0 + log(1 + recent_count) * LTP_COEFFICIENT, 1.0, LTP_MAX_BOOST)
+        retrieval_log にエントリがなければ 1.0 を返す。
+        """
+        cutoff_dt = datetime.now(timezone.utc) - timedelta(days=window_days)
+        cutoff = cutoff_dt.isoformat()
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM retrieval_log WHERE drawer_id = ? AND retrieved_at >= ?",
+                (drawer_id, cutoff),
+            )
+            row = cur.fetchone()
+            recent_count = int(row[0]) if row else 0
+        finally:
+            conn.close()
+
+        if recent_count == 0:
+            return 1.0
+        raw = 1.0 + math.log(1 + recent_count) * DEFAULT_LTP_COEFFICIENT
+        return _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+
+    def get_ltp_scores_batch(
+        self, drawer_ids: list[str], window_days: int = DEFAULT_LTP_WINDOW_DAYS
+    ) -> dict[str, float]:
+        """
+        複数の drawer_id に対する LTP スコアを一括取得する。
+        N+1 クエリを避けるため、IN 句で一括集計する。
+        戻り値: {drawer_id: ltp_score}。ログにない drawer_id は 1.0。
+        """
+        out: dict[str, float] = {did: 1.0 for did in drawer_ids}
+        if not drawer_ids:
+            return out
+        cutoff_dt = datetime.now(timezone.utc) - timedelta(days=window_days)
+        cutoff = cutoff_dt.isoformat()
+        placeholders = ",".join("?" * len(drawer_ids))
+        sql = (
+            f"SELECT drawer_id, COUNT(*) as cnt FROM retrieval_log "
+            f"WHERE drawer_id IN ({placeholders}) AND retrieved_at >= ? GROUP BY drawer_id"
+        )
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute(sql, (*drawer_ids, cutoff))
+            for drawer_id, cnt in cur.fetchall():
+                recent_count = int(cnt)
+                if recent_count == 0:
+                    out[drawer_id] = 1.0
+                else:
+                    raw = 1.0 + math.log(1 + recent_count) * DEFAULT_LTP_COEFFICIENT
+                    out[drawer_id] = _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+        finally:
+            conn.close()
+        return out
+
+    @staticmethod
+    def calculate_tagging_boost(
+        filed_at: Optional[str], window_hours: int = DEFAULT_TAGGING_WINDOW_HOURS
+    ) -> float:
+        """
+        filed_at（ISO 8601 文字列）から現在までの経過時間を計算し、
+        tagging boost を返す。
+        - 24h 以内: 1.0 + 0.5 * (1.0 - hours / window_hours)
+        - 24h 超: 1.0
+        - filed_at が None またはパース失敗: 1.0
+        """
+        if filed_at is None:
+            return 1.0
+        try:
+            s = filed_at.strip()
+            if s.endswith("Z"):
+                s = s[:-1] + "+00:00"
+            filed = datetime.fromisoformat(s)
+            if filed.tzinfo is None:
+                filed = filed.replace(tzinfo=timezone.utc)
+            now = datetime.now(timezone.utc)
+            delta = now - filed.astimezone(timezone.utc)
+            hours = delta.total_seconds() / 3600.0
+        except (ValueError, TypeError, OSError):
+            return 1.0
+
+        if hours >= float(window_hours):
+            return 1.0
+        if hours < 0:
+            hours = 0.0
+        boost = 1.0 + 0.5 * (1.0 - hours / float(window_hours))
+        return _clamp(boost, 1.0, DEFAULT_TAGGING_MAX_BOOST)
+
+    def calculate_synapse_score(
+        self,
+        similarity: float,
+        decay: float,
+        drawer_id: str,
+        filed_at: Optional[str],
+        ltp_scores: Optional[dict[str, float]] = None,
+        window_days: int = DEFAULT_LTP_WINDOW_DAYS,
+    ) -> dict[str, Any]:
+        """
+        最終スコアを計算して返す。
+        final_score = similarity * decay * ltp * tagging
+        (Phase 1 では association は 1.0 固定)
+
+        戻り値:
+        {
+            "final_score": float,
+            "similarity": float,
+            "decay": float,
+            "ltp": float,
+            "association": 1.0,
+            "tagging": float
+        }
+        """
+        if ltp_scores is not None:
+            ltp = ltp_scores.get(drawer_id, 1.0)
+        else:
+            ltp = self.get_ltp_score(drawer_id, window_days)
+        tagging = self.calculate_tagging_boost(filed_at)
+        association = 1.0
+        final_score = similarity * decay * ltp * tagging * association
+        return {
+            "final_score": final_score,
+            "similarity": similarity,
+            "decay": decay,
+            "ltp": ltp,
+            "association": association,
+            "tagging": tagging,
+        }
+
+    def refresh_stats(self, window_days: int = DEFAULT_LTP_WINDOW_DAYS) -> None:
+        """
+        synapse_stats テーブルを retrieval_log から再計算して更新する。
+        mempalace status や明示的なリフレッシュ時に呼ばれる。
+        """
+        cutoff_dt = datetime.now(timezone.utc) - timedelta(days=window_days)
+        cutoff = cutoff_dt.isoformat()
+        now_iso = _utc_now_iso()
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute(
+                "SELECT drawer_id, COUNT(*) FROM retrieval_log GROUP BY drawer_id"
+            )
+            totals = {row[0]: int(row[1]) for row in cur.fetchall()}
+            cur = conn.execute(
+                "SELECT drawer_id, COUNT(*) FROM retrieval_log WHERE retrieved_at >= ? "
+                "GROUP BY drawer_id",
+                (cutoff,),
+            )
+            recent = {row[0]: int(row[1]) for row in cur.fetchall()}
+            for drawer_id, total_retrievals in totals.items():
+                rc = recent.get(drawer_id, 0)
+                recent_density = rc / float(max(1, window_days))
+                if rc == 0:
+                    ltp_score = 1.0
+                else:
+                    raw = 1.0 + math.log(1 + rc) * DEFAULT_LTP_COEFFICIENT
+                    ltp_score = _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+                conn.execute(
+                    "INSERT OR REPLACE INTO synapse_stats "
+                    "(drawer_id, total_retrievals, recent_density, ltp_score, last_updated) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (drawer_id, total_retrievals, recent_density, ltp_score, now_iso),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def get_consolidation_candidates(self, inactive_days: int = 180) -> list[dict]:
+        """
+        inactive_days 以上検索されていない drawer_id のリストを返す。
+        戻り値: [{"drawer_id": str, "last_retrieved_at": str, "days_inactive": int}]
+        """
+        now = datetime.now(timezone.utc)
+        cutoff = (now - timedelta(days=inactive_days)).isoformat()
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute(
+                "SELECT drawer_id, MAX(retrieved_at) AS last_at FROM retrieval_log "
+                "GROUP BY drawer_id HAVING MAX(retrieved_at) < ?",
+                (cutoff,),
+            )
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+
+        out: list[dict] = []
+        for drawer_id, last_at in rows:
+            try:
+                s = last_at.strip()
+                if s.endswith("Z"):
+                    s = s[:-1] + "+00:00"
+                last_dt = datetime.fromisoformat(s)
+                if last_dt.tzinfo is None:
+                    last_dt = last_dt.replace(tzinfo=timezone.utc)
+                last_dt = last_dt.astimezone(timezone.utc)
+                days_inactive = max(0, (now - last_dt).days)
+            except (ValueError, TypeError, AttributeError):
+                days_inactive = inactive_days
+            out.append(
+                {
+                    "drawer_id": drawer_id,
+                    "last_retrieved_at": last_at,
+                    "days_inactive": days_inactive,
+                }
+            )
+        return out

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -16,6 +16,12 @@ DEFAULT_ASSOCIATION_MAX_BOOST = 1.5
 DEFAULT_ASSOCIATION_COEFFICIENT = 0.15
 SYNAPSE_DB_NAME = "synapse.sqlite3"
 
+# Chroma drawer metadata — Phase 3 synaptic marking for newly filed drawers
+SYNAPSE_MARK_METADATA_KEY = "synapse_mark"
+SYNAPSE_MARK_NEW = "new"
+
+SOFT_ARCHIVE_ISSUE_REF = "#336"
+
 
 def _canonical_pair(a: str, b: str) -> tuple[str, str]:
     return (a, b) if a < b else (b, a)
@@ -27,6 +33,29 @@ def _utc_now_iso() -> str:
 
 def _clamp(x: float, lo: float, hi: float) -> float:
     return max(lo, min(hi, x))
+
+
+def build_soft_archive_proposal(
+    wing: str,
+    room: str,
+    *,
+    target_wing: str = "archive",
+    inactive_days: int = 180,
+) -> dict[str, Any]:
+    """
+    Soft-archive nudge for consolidation candidates (#336).
+    Does not move data — surfaces suggested wing/room for a future soft-archive wing.
+    """
+    safe_w = (wing or "unknown").replace(" ", "_")
+    safe_r = (room or "unknown").replace(" ", "_")
+    return {
+        "reason": "inactive_beyond_consolidation_window",
+        "inactive_days_threshold": inactive_days,
+        "suggested_wing": target_wing,
+        "suggested_room": f"{safe_w}__{safe_r}"[:220],
+        "related_issue": SOFT_ARCHIVE_ISSUE_REF,
+        "disclaimer": "Suggestion only — no automatic move; user or agent relocates the drawer.",
+    }
 
 
 class SynapseDB:

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -104,11 +104,16 @@ class SynapseDB:
         except Exception as e:
             logger.warning("log_retrieval failed: %s", e)
 
-    def get_ltp_score(self, drawer_id: str, window_days: int = DEFAULT_LTP_WINDOW_DAYS) -> float:
+    def get_ltp_score(
+        self,
+        drawer_id: str,
+        window_days: int = DEFAULT_LTP_WINDOW_DAYS,
+        max_boost: float = DEFAULT_LTP_MAX_BOOST,
+    ) -> float:
         """
         直近 window_days 日間の retrieval_log から drawer_id の検索回数を集計し、
         LTP スコアを計算して返す。
-        ltp = clamp(1.0 + log(1 + recent_count) * LTP_COEFFICIENT, 1.0, LTP_MAX_BOOST)
+        ltp = clamp(1.0 + log(1 + recent_count) * LTP_COEFFICIENT, 1.0, max_boost)
         retrieval_log にエントリがなければ 1.0 を返す。
         """
         cutoff_dt = datetime.now(timezone.utc) - timedelta(days=window_days)
@@ -127,10 +132,13 @@ class SynapseDB:
         if recent_count == 0:
             return 1.0
         raw = 1.0 + math.log(1 + recent_count) * DEFAULT_LTP_COEFFICIENT
-        return _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+        return _clamp(raw, 1.0, max_boost)
 
     def get_ltp_scores_batch(
-        self, drawer_ids: list[str], window_days: int = DEFAULT_LTP_WINDOW_DAYS
+        self,
+        drawer_ids: list[str],
+        window_days: int = DEFAULT_LTP_WINDOW_DAYS,
+        max_boost: float = DEFAULT_LTP_MAX_BOOST,
     ) -> dict[str, float]:
         """
         複数の drawer_id に対する LTP スコアを一括取得する。
@@ -156,20 +164,22 @@ class SynapseDB:
                     out[drawer_id] = 1.0
                 else:
                     raw = 1.0 + math.log(1 + recent_count) * DEFAULT_LTP_COEFFICIENT
-                    out[drawer_id] = _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+                    out[drawer_id] = _clamp(raw, 1.0, max_boost)
         finally:
             conn.close()
         return out
 
     @staticmethod
     def calculate_tagging_boost(
-        filed_at: Optional[str], window_hours: int = DEFAULT_TAGGING_WINDOW_HOURS
+        filed_at: Optional[str],
+        window_hours: int = DEFAULT_TAGGING_WINDOW_HOURS,
+        max_boost: float = DEFAULT_TAGGING_MAX_BOOST,
     ) -> float:
         """
         filed_at（ISO 8601 文字列）から現在までの経過時間を計算し、
         tagging boost を返す。
-        - 24h 以内: 1.0 + 0.5 * (1.0 - hours / window_hours)
-        - 24h 超: 1.0
+        - 窓内: 1.0 + (max_boost - 1.0) * (1.0 - hours / window_hours)
+        - 窓外: 1.0
         - filed_at が None またはパース失敗: 1.0
         """
         if filed_at is None:
@@ -191,8 +201,9 @@ class SynapseDB:
             return 1.0
         if hours < 0:
             hours = 0.0
-        boost = 1.0 + 0.5 * (1.0 - hours / float(window_hours))
-        return _clamp(boost, 1.0, DEFAULT_TAGGING_MAX_BOOST)
+        amplitude = max_boost - 1.0
+        boost = 1.0 + amplitude * (1.0 - hours / float(window_hours))
+        return _clamp(boost, 1.0, max_boost)
 
     def calculate_synapse_score(
         self,
@@ -202,6 +213,9 @@ class SynapseDB:
         filed_at: Optional[str],
         ltp_scores: Optional[dict[str, float]] = None,
         window_days: int = DEFAULT_LTP_WINDOW_DAYS,
+        ltp_max_boost: float = DEFAULT_LTP_MAX_BOOST,
+        tagging_window_hours: int = DEFAULT_TAGGING_WINDOW_HOURS,
+        tagging_max_boost: float = DEFAULT_TAGGING_MAX_BOOST,
     ) -> dict[str, Any]:
         """
         最終スコアを計算して返す。
@@ -221,8 +235,12 @@ class SynapseDB:
         if ltp_scores is not None:
             ltp = ltp_scores.get(drawer_id, 1.0)
         else:
-            ltp = self.get_ltp_score(drawer_id, window_days)
-        tagging = self.calculate_tagging_boost(filed_at)
+            ltp = self.get_ltp_score(drawer_id, window_days, max_boost=ltp_max_boost)
+        tagging = self.calculate_tagging_boost(
+            filed_at,
+            window_hours=tagging_window_hours,
+            max_boost=tagging_max_boost,
+        )
         association = 1.0
         final_score = similarity * decay * ltp * tagging * association
         return {
@@ -234,7 +252,54 @@ class SynapseDB:
             "tagging": tagging,
         }
 
-    def refresh_stats(self, window_days: int = DEFAULT_LTP_WINDOW_DAYS) -> None:
+    def cleanup_old_logs(self, retention_days: int = 90) -> None:
+        """
+        retention_days より古い retrieval_log エントリを削除する。
+        mempalace status 実行時 または synapse refresh 時に呼ばれる。
+        """
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).isoformat()
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("DELETE FROM retrieval_log WHERE retrieved_at < ?", (cutoff,))
+            conn.commit()
+        finally:
+            conn.close()
+        # VACUUM はトランザクション外で実行する
+        conn2 = sqlite3.connect(self.db_path)
+        try:
+            conn2.execute("VACUUM")
+            conn2.commit()
+        finally:
+            conn2.close()
+
+    def get_log_stats(self) -> dict[str, Any]:
+        """
+        ログの統計情報を返す。mempalace_status に表示する。
+        """
+        conn = sqlite3.connect(self.db_path)
+        try:
+            total = conn.execute("SELECT COUNT(*) FROM retrieval_log").fetchone()[0]
+            unique = conn.execute("SELECT COUNT(DISTINCT drawer_id) FROM retrieval_log").fetchone()[0]
+            row = conn.execute(
+                "SELECT MIN(retrieved_at), MAX(retrieved_at) FROM retrieval_log"
+            ).fetchone()
+            oldest, newest = row[0], row[1]
+        finally:
+            conn.close()
+        size_kb = os.path.getsize(self.db_path) / 1024.0
+        return {
+            "total_entries": int(total),
+            "unique_drawers": int(unique),
+            "oldest_entry": oldest,
+            "newest_entry": newest,
+            "db_size_kb": round(size_kb, 2),
+        }
+
+    def refresh_stats(
+        self,
+        window_days: int = DEFAULT_LTP_WINDOW_DAYS,
+        ltp_max_boost: float = DEFAULT_LTP_MAX_BOOST,
+    ) -> None:
         """
         synapse_stats テーブルを retrieval_log から再計算して更新する。
         mempalace status や明示的なリフレッシュ時に呼ばれる。
@@ -261,7 +326,7 @@ class SynapseDB:
                     ltp_score = 1.0
                 else:
                     raw = 1.0 + math.log(1 + rc) * DEFAULT_LTP_COEFFICIENT
-                    ltp_score = _clamp(raw, 1.0, DEFAULT_LTP_MAX_BOOST)
+                    ltp_score = _clamp(raw, 1.0, ltp_max_boost)
                 conn.execute(
                     "INSERT OR REPLACE INTO synapse_stats "
                     "(drawer_id, total_retrievals, recent_density, ltp_score, last_updated) "

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -2,6 +2,7 @@ import logging
 import math
 import os
 import sqlite3
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
@@ -120,7 +121,28 @@ class SynapseDB:
         finally:
             conn.close()
 
-    def log_retrieval(self, drawer_ids: list[str], query_hash: str, session_id: str):
+    @contextmanager
+    def connection(self):
+        """Single search/request: reuse one SQLite connection (WAL, busy timeout)."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA busy_timeout=5000;")
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def log_retrieval(
+        self,
+        drawer_ids: list[str],
+        query_hash: str,
+        session_id: str,
+        conn: Optional[sqlite3.Connection] = None,
+    ):
         """
         検索結果に含まれた drawer_id のリストを retrieval_log に記録する。
         - retrieved_at: UTC ISO 8601 形式
@@ -131,35 +153,43 @@ class SynapseDB:
         try:
             retrieved_at = _utc_now_iso()
             rows = [(did, retrieved_at, query_hash, session_id) for did in drawer_ids]
-            conn = sqlite3.connect(self.db_path)
-            try:
+            if conn is not None:
                 conn.executemany(
                     "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) "
                     "VALUES (?, ?, ?, ?)",
                     rows,
                 )
-                conn.commit()
-            finally:
-                conn.close()
+            else:
+                with self.connection() as c:
+                    c.executemany(
+                        "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) "
+                        "VALUES (?, ?, ?, ?)",
+                        rows,
+                    )
         except Exception as e:
             logger.warning("log_retrieval failed: %s", e)
         else:
             try:
-                self._record_co_retrieval_pairs(drawer_ids, retrieved_at)
+                self._record_co_retrieval_pairs(drawer_ids, retrieved_at, conn=conn)
             except Exception as e:
                 logger.warning("co_retrieval pair update failed: %s", e)
 
-    def _record_co_retrieval_pairs(self, drawer_ids: list[str], retrieved_at: str) -> None:
+    def _record_co_retrieval_pairs(
+        self,
+        drawer_ids: list[str],
+        retrieved_at: str,
+        conn: Optional[sqlite3.Connection] = None,
+    ) -> None:
         """同一検索結果内の drawer ペアごとに co_count を増分する。"""
         uniq = sorted(set(drawer_ids))
         if len(uniq) < 2:
             return
-        conn = sqlite3.connect(self.db_path)
-        try:
+
+        def _run(c: sqlite3.Connection) -> None:
             for i in range(len(uniq)):
                 for j in range(i + 1, len(uniq)):
                     a, b = _canonical_pair(uniq[i], uniq[j])
-                    conn.execute(
+                    c.execute(
                         """
                         INSERT INTO co_retrieval (drawer_a, drawer_b, co_count, last_co_retrieved)
                         VALUES (?, ?, 1, ?)
@@ -169,9 +199,12 @@ class SynapseDB:
                         """,
                         (a, b, retrieved_at),
                     )
-            conn.commit()
-        finally:
-            conn.close()
+
+        if conn is not None:
+            _run(conn)
+        else:
+            with self.connection() as c:
+                _run(c)
 
     def rebuild_co_retrieval_from_log(self) -> int:
         """
@@ -208,6 +241,7 @@ class SynapseDB:
         drawer_ids: list[str],
         max_boost: float = DEFAULT_ASSOCIATION_MAX_BOOST,
         coefficient: float = DEFAULT_ASSOCIATION_COEFFICIENT,
+        conn: Optional[sqlite3.Connection] = None,
     ) -> dict[str, float]:
         """
         同一検索結果の drawer 集合について、co_retrieval の共起強度から association を計算する。
@@ -217,7 +251,10 @@ class SynapseDB:
         out: dict[str, float] = {d: 1.0 for d in uniq}
         if len(uniq) < 2:
             return out
-        conn = sqlite3.connect(self.db_path)
+        own = False
+        if conn is None:
+            conn = sqlite3.connect(self.db_path)
+            own = True
         try:
             ph = ",".join("?" * len(uniq))
             cur = conn.execute(
@@ -229,7 +266,8 @@ class SynapseDB:
             for a, b, c in cur.fetchall():
                 edge[(a, b)] = int(c)
         finally:
-            conn.close()
+            if own:
+                conn.close()
         for d in uniq:
             total = 0
             for o in uniq:
@@ -349,6 +387,7 @@ class SynapseDB:
         drawer_ids: list[str],
         window_days: int = DEFAULT_LTP_WINDOW_DAYS,
         max_boost: float = DEFAULT_LTP_MAX_BOOST,
+        conn: Optional[sqlite3.Connection] = None,
     ) -> dict[str, float]:
         """
         複数の drawer_id に対する LTP スコアを一括取得する。
@@ -365,7 +404,10 @@ class SynapseDB:
             f"SELECT drawer_id, COUNT(*) as cnt FROM retrieval_log "
             f"WHERE drawer_id IN ({placeholders}) AND retrieved_at >= ? GROUP BY drawer_id"
         )
-        conn = sqlite3.connect(self.db_path)
+        own = False
+        if conn is None:
+            conn = sqlite3.connect(self.db_path)
+            own = True
         try:
             cur = conn.execute(sql, (*drawer_ids, cutoff))
             for drawer_id, cnt in cur.fetchall():
@@ -376,7 +418,8 @@ class SynapseDB:
                     raw = 1.0 + math.log(1 + recent_count) * DEFAULT_LTP_COEFFICIENT
                     out[drawer_id] = _clamp(raw, 1.0, max_boost)
         finally:
-            conn.close()
+            if own:
+                conn.close()
         return out
 
     @staticmethod
@@ -471,13 +514,22 @@ class SynapseDB:
         削除件数を返す。
         """
         cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).isoformat()
-        conn = sqlite3.connect(self.db_path)
-        try:
+        deleted = 0
+        with self.connection() as conn:
             cur = conn.execute("DELETE FROM retrieval_log WHERE retrieved_at < ?", (cutoff,))
-            deleted = cur.rowcount
-            conn.commit()
-        finally:
-            conn.close()
+            rc = cur.rowcount
+            if rc is not None and rc >= 0:
+                deleted = int(rc)
+        if deleted > 1000:
+            self._vacuum_database()
+        if deleted > 0:
+            try:
+                self.rebuild_co_retrieval_from_log()
+            except Exception as e:
+                logger.warning("rebuild_co_retrieval_from_log after cleanup failed: %s", e)
+        return deleted
+
+    def _vacuum_database(self) -> None:
         try:
             vacuum_conn = sqlite3.connect(self.db_path)
             try:
@@ -487,16 +539,6 @@ class SynapseDB:
                 vacuum_conn.close()
         except Exception as e:
             logger.warning("VACUUM failed: %s", e)
-        if deleted is None or deleted < 0:
-            deleted = 0
-        else:
-            deleted = int(deleted)
-        if deleted > 0:
-            try:
-                self.rebuild_co_retrieval_from_log()
-            except Exception as e:
-                logger.warning("rebuild_co_retrieval_from_log after cleanup failed: %s", e)
-        return deleted
 
     def get_log_stats(self) -> dict[str, Any]:
         """ログの統計情報を返す。"""
@@ -564,20 +606,32 @@ class SynapseDB:
         finally:
             conn.close()
 
-    def get_consolidation_candidates(self, inactive_days: int = 180) -> list[dict]:
+    def get_consolidation_candidates(
+        self, inactive_days: int = 180, wing: Optional[str] = None
+    ) -> list[dict]:
         """
         inactive_days 以上検索されていない drawer_id のリストを返す。
+        wing が指定されていれば drawer_id に部分一致する行に限定する。
         戻り値: [{"drawer_id": str, "last_retrieved_at": str, "days_inactive": int}]
         """
         now = datetime.now(timezone.utc)
         cutoff = (now - timedelta(days=inactive_days)).isoformat()
+        if wing:
+            sql = (
+                "SELECT drawer_id, MAX(retrieved_at) AS last_at FROM retrieval_log "
+                "WHERE drawer_id LIKE ? "
+                "GROUP BY drawer_id HAVING MAX(retrieved_at) < ?"
+            )
+            params = (f"%{wing}%", cutoff)
+        else:
+            sql = (
+                "SELECT drawer_id, MAX(retrieved_at) AS last_at FROM retrieval_log "
+                "GROUP BY drawer_id HAVING MAX(retrieved_at) < ?"
+            )
+            params = (cutoff,)
         conn = sqlite3.connect(self.db_path)
         try:
-            cur = conn.execute(
-                "SELECT drawer_id, MAX(retrieved_at) AS last_at FROM retrieval_log "
-                "GROUP BY drawer_id HAVING MAX(retrieved_at) < ?",
-                (cutoff,),
-            )
+            cur = conn.execute(sql, params)
             rows = cur.fetchall()
         finally:
             conn.close()

--- a/mempalace/synapse.py
+++ b/mempalace/synapse.py
@@ -252,47 +252,54 @@ class SynapseDB:
             "tagging": tagging,
         }
 
-    def cleanup_old_logs(self, retention_days: int = 90) -> None:
+    def cleanup_old_logs(self, retention_days: int = 90) -> int:
         """
         retention_days より古い retrieval_log エントリを削除する。
-        mempalace status 実行時 または synapse refresh 時に呼ばれる。
+        削除件数を返す。
         """
         cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).isoformat()
         conn = sqlite3.connect(self.db_path)
         try:
-            conn.execute("DELETE FROM retrieval_log WHERE retrieved_at < ?", (cutoff,))
+            cur = conn.execute("DELETE FROM retrieval_log WHERE retrieved_at < ?", (cutoff,))
+            deleted = cur.rowcount
             conn.commit()
         finally:
             conn.close()
-        # VACUUM はトランザクション外で実行する
-        conn2 = sqlite3.connect(self.db_path)
         try:
-            conn2.execute("VACUUM")
-            conn2.commit()
-        finally:
-            conn2.close()
+            vacuum_conn = sqlite3.connect(self.db_path)
+            try:
+                vacuum_conn.execute("VACUUM")
+                vacuum_conn.commit()
+            finally:
+                vacuum_conn.close()
+        except Exception as e:
+            logger.warning("VACUUM failed: %s", e)
+        if deleted is None or deleted < 0:
+            return 0
+        return int(deleted)
 
     def get_log_stats(self) -> dict[str, Any]:
-        """
-        ログの統計情報を返す。mempalace_status に表示する。
-        """
+        """ログの統計情報を返す。"""
         conn = sqlite3.connect(self.db_path)
         try:
-            total = conn.execute("SELECT COUNT(*) FROM retrieval_log").fetchone()[0]
-            unique = conn.execute("SELECT COUNT(DISTINCT drawer_id) FROM retrieval_log").fetchone()[0]
             row = conn.execute(
-                "SELECT MIN(retrieved_at), MAX(retrieved_at) FROM retrieval_log"
+                "SELECT COUNT(*), COUNT(DISTINCT drawer_id), MIN(retrieved_at), MAX(retrieved_at) "
+                "FROM retrieval_log"
             ).fetchone()
-            oldest, newest = row[0], row[1]
+            total, unique, oldest, newest = row
         finally:
             conn.close()
-        size_kb = os.path.getsize(self.db_path) / 1024.0
+        db_size_kb = 0.0
+        try:
+            db_size_kb = round(os.path.getsize(self.db_path) / 1024, 1)
+        except OSError:
+            pass
         return {
-            "total_entries": int(total),
-            "unique_drawers": int(unique),
+            "total_entries": int(total or 0),
+            "unique_drawers": int(unique or 0),
             "oldest_entry": oldest,
             "newest_entry": newest,
-            "db_size_kb": round(size_kb, 2),
+            "db_size_kb": db_size_kb,
         }
 
     def refresh_stats(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -272,7 +272,8 @@ class TestWriteTools:
         assert result["wing"] == "test_wing"
         assert result["room"] == "test_room"
         assert result["drawer_id"].startswith("drawer_test_wing_test_room_")
-        col = _get_collection(palace_path, create=False)
+        _client, col = _get_collection(palace_path, create=False)
+        del _client
         meta = col.get(ids=[result["drawer_id"]], include=["metadatas"])["metadatas"][0]
         assert meta.get("synapse_mark") == "new"
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -208,6 +208,9 @@ class TestWriteTools:
         assert result["wing"] == "test_wing"
         assert result["room"] == "test_room"
         assert result["drawer_id"].startswith("drawer_test_wing_test_room_")
+        col = _get_collection(palace_path, create=False)
+        meta = col.get(ids=[result["drawer_id"]], include=["metadatas"])["metadatas"][0]
+        assert meta.get("synapse_mark") == "new"
 
     def test_add_drawer_duplicate_detection(self, monkeypatch, config, palace_path, kg):
         _patch_mcp_server(monkeypatch, config, palace_path, kg)

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -1,0 +1,230 @@
+"""
+Tests for mempalace.synapse — SynapseDB retrieval logging and scoring.
+"""
+
+import os
+import shutil
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from mempalace.synapse import DEFAULT_LTP_WINDOW_DAYS, SynapseDB
+
+
+@pytest.fixture
+def tmp_palace():
+    d = tempfile.mkdtemp(prefix="mempalace_synapse_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+# --- SynapseDB 初期化 ---
+
+
+def test_init_creates_db(tmp_palace):
+    SynapseDB(tmp_palace)
+    assert os.path.isfile(os.path.join(tmp_palace, "synapse.sqlite3"))
+
+
+def test_init_creates_tables(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    conn = sqlite3.connect(db.db_path)
+    try:
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        )
+        names = {row[0] for row in cur.fetchall()}
+    finally:
+        conn.close()
+    assert "co_retrieval" in names
+    assert "retrieval_log" in names
+    assert "synapse_stats" in names
+
+
+def test_init_idempotent(tmp_palace):
+    SynapseDB(tmp_palace)
+    SynapseDB(tmp_palace)
+
+
+# --- retrieval_log ---
+
+
+def test_log_retrieval_single(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["drawer_a"], "qh", "sess")
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM retrieval_log").fetchone()[0]
+        row = conn.execute("SELECT drawer_id FROM retrieval_log LIMIT 1").fetchone()
+    finally:
+        conn.close()
+    assert n == 1
+    assert row[0] == "drawer_a"
+
+
+def test_log_retrieval_batch(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    ids = [f"d{i}" for i in range(5)]
+    db.log_retrieval(ids, "qh", "sess")
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM retrieval_log").fetchone()[0]
+    finally:
+        conn.close()
+    assert n == 5
+
+
+def test_log_retrieval_empty_list(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval([], "qh", "sess")
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM retrieval_log").fetchone()[0]
+    finally:
+        conn.close()
+    assert n == 0
+
+
+def test_log_retrieval_exception_suppressed(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    with patch("mempalace.synapse.sqlite3.connect", side_effect=sqlite3.OperationalError("readonly")):
+        db.log_retrieval(["a"], "h", "s")
+
+
+# --- LTP スコアリング ---
+
+
+def test_ltp_no_retrievals(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    assert db.get_ltp_score("missing") == 1.0
+
+
+def test_ltp_single_retrieval(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["x"], "q", "s")
+    s = db.get_ltp_score("x")
+    assert 1.0 < s <= 2.0
+
+
+def test_ltp_high_frequency(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    for _ in range(30):
+        db.log_retrieval(["hf"], "q", "s")
+    s = db.get_ltp_score("hf")
+    assert s >= 1.99
+
+
+def test_ltp_clamped_at_max(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    for _ in range(1000):
+        db.log_retrieval(["many"], "q", "s")
+    assert db.get_ltp_score("many") <= 2.0
+
+
+def test_ltp_outside_window(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=DEFAULT_LTP_WINDOW_DAYS + 5)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        conn.execute(
+            "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+            ("old", old, "q", "s"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    assert db.get_ltp_score("old") == 1.0
+
+
+def test_ltp_batch_consistency(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["a", "b"], "q", "s")
+    batch = db.get_ltp_scores_batch(["a", "b", "c"])
+    assert batch["a"] == db.get_ltp_score("a")
+    assert batch["b"] == db.get_ltp_score("b")
+    assert batch["c"] == 1.0
+
+
+# --- Tagging ---
+
+
+def test_tagging_just_filed():
+    t = datetime.now(timezone.utc)
+    boost = SynapseDB.calculate_tagging_boost(t.isoformat())
+    assert abs(boost - 1.5) < 0.02
+
+
+def test_tagging_12_hours():
+    t = (datetime.now(timezone.utc) - timedelta(hours=12)).isoformat()
+    assert abs(SynapseDB.calculate_tagging_boost(t) - 1.25) < 0.01
+
+
+def test_tagging_25_hours():
+    t = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat()
+    assert SynapseDB.calculate_tagging_boost(t) == 1.0
+
+
+def test_tagging_none_filed_at():
+    assert SynapseDB.calculate_tagging_boost(None) == 1.0
+
+
+# --- Synapse スコア合成 ---
+
+
+def test_synapse_score_composition(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    r = db.calculate_synapse_score(
+        similarity=0.8,
+        decay=0.5,
+        drawer_id="d1",
+        filed_at=old,
+        ltp_scores={"d1": 1.5},
+        window_days=DEFAULT_LTP_WINDOW_DAYS,
+    )
+    assert abs(r["final_score"] - 0.6) < 1e-9
+    assert r["association"] == 1.0
+    assert r["similarity"] == 0.8
+    assert r["decay"] == 0.5
+    assert r["ltp"] == 1.5
+    assert r["tagging"] == 1.0
+
+
+# --- Consolidation ---
+
+
+def test_consolidation_candidates_returns_inactive(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=200)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        conn.execute(
+            "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+            ("stale", old, "q", "s"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    cands = db.get_consolidation_candidates(inactive_days=180)
+    ids = {c["drawer_id"] for c in cands}
+    assert "stale" in ids
+
+
+def test_consolidation_candidates_excludes_active(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    recent = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        conn.execute(
+            "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+            ("active", recent, "q", "s"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    cands = db.get_consolidation_candidates(inactive_days=180)
+    ids = {c["drawer_id"] for c in cands}
+    assert "active" not in ids

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -7,11 +7,29 @@ import shutil
 import sqlite3
 import tempfile
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
+from mempalace.searcher import search_memories
 from mempalace.synapse import DEFAULT_LTP_WINDOW_DAYS, SynapseDB
+
+
+def _synapse_cfg(**overrides):
+    base = dict(
+        synapse_enabled=True,
+        synapse_ltp_enabled=True,
+        synapse_tagging_enabled=True,
+        synapse_association_enabled=False,
+        synapse_ltp_window_days=30,
+        synapse_ltp_max_boost=2.0,
+        synapse_tagging_window_hours=24,
+        synapse_tagging_max_boost=1.5,
+        synapse_log_retrievals=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
 
 
 @pytest.fixture
@@ -228,3 +246,54 @@ def test_consolidation_candidates_excludes_active(tmp_palace):
     cands = db.get_consolidation_candidates(inactive_days=180)
     ids = {c["drawer_id"] for c in cands}
     assert "active" not in ids
+
+
+# --- Config axis switches (search_memories integration) ---
+
+
+def test_ltp_disabled_returns_neutral(palace_path, seeded_collection):
+    cfg = _synapse_cfg(synapse_ltp_enabled=False)
+
+    def fake_batch(self, drawer_ids, window_days=30, max_boost=2.0):
+        return {d: 2.0 for d in drawer_ids}
+
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        with patch.object(SynapseDB, "get_ltp_scores_batch", fake_batch):
+            result = search_memories("JWT authentication", palace_path)
+    assert result.get("synapse_enabled") is True
+    for hit in result["hits"]:
+        assert hit["synapse_factors"]["ltp"] == 1.0
+
+
+def test_tagging_disabled_returns_neutral(palace_path, seeded_collection):
+    cfg = _synapse_cfg(synapse_tagging_enabled=False)
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        result = search_memories("JWT authentication", palace_path)
+    assert result.get("synapse_enabled") is True
+    for hit in result["hits"]:
+        assert hit["synapse_factors"]["tagging"] == 1.0
+
+
+# --- Log cleanup ---
+
+
+def test_log_cleanup_removes_old_entries(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    new = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        conn.executemany(
+            "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+            [("a", old, "q", "s"), ("b", new, "q", "s")],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    db.cleanup_old_logs(retention_days=30)
+    conn = sqlite3.connect(db.db_path)
+    try:
+        rows = conn.execute("SELECT drawer_id FROM retrieval_log ORDER BY drawer_id").fetchall()
+    finally:
+        conn.close()
+    assert [r[0] for r in rows] == ["b"]

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -290,7 +290,8 @@ def test_log_cleanup_removes_old_entries(tmp_palace):
         conn.commit()
     finally:
         conn.close()
-    db.cleanup_old_logs(retention_days=30)
+    deleted = db.cleanup_old_logs(retention_days=30)
+    assert deleted == 1
     conn = sqlite3.connect(db.db_path)
     try:
         rows = conn.execute("SELECT drawer_id FROM retrieval_log ORDER BY drawer_id").fetchall()

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -421,6 +421,19 @@ def test_ltp_and_tagging_composition(palace_path, seeded_collection):
     assert abs(hit["synapse_score"] - expected) < 1e-4
 
 
+def test_log_retrieval_failure_does_not_break_search(palace_path, seeded_collection):
+    """log_retrieval が例外を投げても検索は Synapse スコア付きで返る（接続は commit される）。"""
+    cfg = _synapse_cfg(synapse_log_retrievals=True)
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        with patch.object(
+            SynapseDB, "log_retrieval", side_effect=RuntimeError("log failed")
+        ):
+            result = search_memories("JWT authentication", palace_path)
+    assert result.get("synapse_enabled") is True
+    assert len(result.get("hits", [])) >= 1
+    assert all("synapse_score" in h for h in result["hits"])
+
+
 # --- Log cleanup ---
 
 

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -13,7 +13,12 @@ from unittest.mock import patch
 import pytest
 
 from mempalace.searcher import search_memories
-from mempalace.synapse import DEFAULT_LTP_WINDOW_DAYS, SynapseDB
+from mempalace.synapse import (
+    DEFAULT_LTP_WINDOW_DAYS,
+    SYNAPSE_MARK_NEW,
+    build_soft_archive_proposal,
+    SynapseDB,
+)
 
 
 def _synapse_cfg(**overrides):
@@ -28,6 +33,9 @@ def _synapse_cfg(**overrides):
         synapse_tagging_max_boost=1.5,
         synapse_association_max_boost=1.5,
         synapse_association_coefficient=0.15,
+        synapse_consolidation_inactive_days=180,
+        synapse_soft_archive_suggestions_enabled=True,
+        synapse_soft_archive_target_wing="archive",
         synapse_log_retrievals=False,
     )
     base.update(overrides)
@@ -354,3 +362,18 @@ def test_co_occurrence_clusters_merge(tmp_palace):
     clusters = db.get_co_occurrence_clusters(10, 5)
     assert any(len(c["drawers"]) >= 2 for c in clusters)
     assert any("a" in c["drawers"] and "b" in c["drawers"] for c in clusters)
+
+
+# --- Phase 3: synaptic marking + soft-archive nudges ---
+
+
+def test_soft_archive_proposal_shape():
+    p = build_soft_archive_proposal("my wing", "my room", target_wing="archive", inactive_days=180)
+    assert p["suggested_wing"] == "archive"
+    assert "my_wing__my_room" in p["suggested_room"]
+    assert p["related_issue"] == "#336"
+    assert p["reason"] == "inactive_beyond_consolidation_window"
+
+
+def test_synaptic_mark_constant():
+    assert SYNAPSE_MARK_NEW == "new"

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -2,6 +2,7 @@
 Tests for mempalace.synapse — SynapseDB retrieval logging and scoring.
 """
 
+import math
 import os
 import shutil
 import sqlite3
@@ -14,6 +15,7 @@ import pytest
 
 from mempalace.searcher import search_memories
 from mempalace.synapse import (
+    DEFAULT_LTP_COEFFICIENT,
     DEFAULT_LTP_WINDOW_DAYS,
     SYNAPSE_MARK_NEW,
     build_soft_archive_proposal,
@@ -258,13 +260,52 @@ def test_consolidation_candidates_excludes_active(tmp_palace):
     assert "active" not in ids
 
 
+def test_consolidation_candidates_wing_filter(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=200)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        conn.executemany(
+            "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+            [
+                ("drawer_astrophysics_room_x", old, "q", "s"),
+                ("drawer_economics_room_y", old, "q", "s"),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    astro = db.get_consolidation_candidates(inactive_days=180, wing="astrophysics")
+    ids = {c["drawer_id"] for c in astro}
+    assert "drawer_astrophysics_room_x" in ids
+    assert "drawer_economics_room_y" not in ids
+
+
+def test_vacuum_skipped_under_threshold(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    old = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        for i in range(10):
+            conn.execute(
+                "INSERT INTO retrieval_log (drawer_id, retrieved_at, query_hash, session_id) VALUES (?,?,?,?)",
+                (f"d{i}", old, "q", "s"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    with patch.object(SynapseDB, "_vacuum_database") as vac:
+        db.cleanup_old_logs(retention_days=30)
+    vac.assert_not_called()
+
+
 # --- Config axis switches (search_memories integration) ---
 
 
 def test_ltp_disabled_returns_neutral(palace_path, seeded_collection):
     cfg = _synapse_cfg(synapse_ltp_enabled=False)
 
-    def fake_batch(self, drawer_ids, window_days=30, max_boost=2.0):
+    def fake_batch(self, drawer_ids, window_days=30, max_boost=2.0, conn=None):
         return {d: 2.0 for d in drawer_ids}
 
     with patch("mempalace.config.MempalaceConfig", return_value=cfg):
@@ -282,6 +323,102 @@ def test_tagging_disabled_returns_neutral(palace_path, seeded_collection):
     assert result.get("synapse_enabled") is True
     for hit in result["hits"]:
         assert hit["synapse_factors"]["tagging"] == 1.0
+
+
+def test_per_query_ltp_override_true(palace_path, seeded_collection):
+    drawer_id = "drawer_proj_backend_aaa"
+    db = SynapseDB(palace_path)
+    for _ in range(6):
+        db.log_retrieval([drawer_id], "q", "s")
+    cfg = _synapse_cfg(
+        synapse_ltp_enabled=False,
+        synapse_log_retrievals=False,
+    )
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        result = search_memories(
+            "JWT authentication", palace_path, synapse_ltp_enabled=True
+        )
+    assert result.get("synapse_enabled") is True
+    hit = next(h for h in result["hits"] if h.get("id") == drawer_id)
+    assert hit["synapse_factors"]["ltp"] > 1.0
+
+
+def test_per_query_ltp_override_false(palace_path, seeded_collection):
+    def fake_batch(self, drawer_ids, window_days=30, max_boost=2.0, conn=None):
+        return {d: 2.0 for d in drawer_ids}
+
+    cfg = _synapse_cfg(
+        synapse_ltp_enabled=True,
+        synapse_log_retrievals=False,
+    )
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        with patch.object(SynapseDB, "get_ltp_scores_batch", fake_batch):
+            result = search_memories(
+                "JWT authentication", palace_path, synapse_ltp_enabled=False
+            )
+    assert result.get("synapse_enabled") is True
+    for hit in result["hits"]:
+        assert hit["synapse_factors"]["ltp"] == 1.0
+
+
+def test_per_query_tagging_override(palace_path, seeded_collection):
+    drawer_id = "drawer_proj_backend_aaa"
+    now = datetime.now(timezone.utc).isoformat()
+    got = seeded_collection.get(ids=[drawer_id], include=["metadatas"])
+    meta = dict(got["metadatas"][0])
+    meta["filed_at"] = now
+    seeded_collection.update(ids=[drawer_id], metadatas=[meta])
+
+    cfg_on = _synapse_cfg(
+        synapse_tagging_enabled=True,
+        synapse_log_retrievals=False,
+    )
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg_on):
+        r_on = search_memories("JWT authentication", palace_path)
+    hit_on = next(h for h in r_on["hits"] if h.get("id") == drawer_id)
+    assert hit_on["synapse_factors"]["tagging"] > 1.01
+
+    cfg_off = _synapse_cfg(
+        synapse_tagging_enabled=True,
+        synapse_log_retrievals=False,
+    )
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg_off):
+        r_off = search_memories(
+            "JWT authentication", palace_path, synapse_tagging_enabled=False
+        )
+    hit_off = next(h for h in r_off["hits"] if h.get("id") == drawer_id)
+    assert hit_off["synapse_factors"]["tagging"] == 1.0
+
+
+def test_ltp_and_tagging_composition(palace_path, seeded_collection):
+    drawer_id = "drawer_proj_backend_aaa"
+    db = SynapseDB(palace_path)
+    for _ in range(8):
+        db.log_retrieval([drawer_id], "qh", "sess")
+
+    now = datetime.now(timezone.utc).isoformat()
+    got = seeded_collection.get(ids=[drawer_id], include=["metadatas"])
+    meta = dict(got["metadatas"][0])
+    meta["filed_at"] = now
+    seeded_collection.update(ids=[drawer_id], metadatas=[meta])
+
+    cfg = _synapse_cfg(
+        synapse_association_enabled=False,
+        synapse_log_retrievals=False,
+    )
+    with patch("mempalace.config.MempalaceConfig", return_value=cfg):
+        result = search_memories("JWT authentication", palace_path)
+
+    hit = next(h for h in result["hits"] if h.get("id") == drawer_id)
+    ltp_expected = min(
+        2.0,
+        1.0 + math.log(1 + 8) * DEFAULT_LTP_COEFFICIENT,
+    )
+    tagging_expected = SynapseDB.calculate_tagging_boost(now)
+    assert abs(hit["synapse_factors"]["ltp"] - ltp_expected) < 1e-5
+    assert hit["synapse_factors"]["tagging"] > 1.0
+    expected = hit["similarity"] * ltp_expected * tagging_expected
+    assert abs(hit["synapse_score"] - expected) < 1e-4
 
 
 # --- Log cleanup ---

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -26,6 +26,8 @@ def _synapse_cfg(**overrides):
         synapse_ltp_max_boost=2.0,
         synapse_tagging_window_hours=24,
         synapse_tagging_max_boost=1.5,
+        synapse_association_max_boost=1.5,
+        synapse_association_coefficient=0.15,
         synapse_log_retrievals=False,
     )
     base.update(overrides)
@@ -298,3 +300,57 @@ def test_log_cleanup_removes_old_entries(tmp_palace):
     finally:
         conn.close()
     assert [r[0] for r in rows] == ["b"]
+
+
+# --- Phase 2: co_retrieval & association ---
+
+
+def test_co_retrieval_pairs_increment_on_log(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["a", "b", "c"], "q", "s1")
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM co_retrieval").fetchone()[0]
+    finally:
+        conn.close()
+    assert n == 3
+
+
+def test_association_scores_from_co_retrieval(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["a", "b"], "q", "s1")
+    db.log_retrieval(["a", "b"], "q", "s2")
+    scores = db.get_association_scores_batch(["a", "b"], max_boost=2.0, coefficient=0.3)
+    assert scores["a"] > 1.0
+    assert scores["b"] > 1.0
+
+
+def test_rebuild_co_retrieval_matches_incremental(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["x", "y"], "q", "sess")
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n1 = conn.execute(
+            "SELECT co_count FROM co_retrieval WHERE drawer_a='x' AND drawer_b='y'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    db.rebuild_co_retrieval_from_log()
+    conn = sqlite3.connect(db.db_path)
+    try:
+        n2 = conn.execute(
+            "SELECT co_count FROM co_retrieval WHERE drawer_a='x' AND drawer_b='y'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert n1 == n2 == 1
+
+
+def test_co_occurrence_clusters_merge(tmp_palace):
+    db = SynapseDB(tmp_palace)
+    db.log_retrieval(["a", "b"], "q", "s1")
+    db.log_retrieval(["b", "c"], "q", "s2")
+    db.log_retrieval(["a", "c"], "q", "s3")
+    clusters = db.get_co_occurrence_clusters(10, 5)
+    assert any(len(c["drawers"]) >= 2 for c in clusters)
+    assert any("a" in c["drawers"] and "b" in c["drawers"] for c in clusters)


### PR DESCRIPTION
Implements Phase 1 of the Synapse RFC (#441).

## Summary

Adds a biologically-inspired scoring layer that modulates search results beyond pure vector similarity. Synapse composes four independent axes multiplicatively:

```
final_score = similarity × decay × ltp × association × tagging
```

Phase 1 delivers **LTP** (Long-Term Potentiation) and **Synaptic Tagging**. Association is reserved for Phase 2 (returns 1.0).

## What's new

### `mempalace/synapse.py` (new)

`SynapseDB` class backed by `synapse.sqlite3` (WAL mode, alongside `knowledge_graph.sqlite3`):

- **`retrieval_log`** table — records which drawers were returned per search, with `query_hash` and `session_id`
- **LTP scoring** — `get_ltp_score()` / `get_ltp_scores_batch()` compute retrieval density within a rolling window: `clamp(1.0 + ln(1 + recent_count) × 0.3, 1.0, max_boost)`. Drawers accessed frequently in the last N days get boosted; dormant drawers return to 1.0
- **Synaptic Tagging** — `calculate_tagging_boost()` gives newly filed drawers a temporary visibility boost (default 1.5× at filing, decaying to 1.0× over 24 hours)
- **Consolidation candidates** — `get_consolidation_candidates()` surfaces drawers not retrieved in 180+ days as archive suggestions (connects to soft-archive #336)
- **Log management** — `cleanup_old_logs(retention_days)` prunes old entries + VACUUM; `get_log_stats()` returns entry count, unique drawers, date range, DB size

### `mempalace/config.py`

Per-axis configuration via `~/.mempalace/config.json`:

| Key | Default | Description |
|---|---|---|
| `synapse_enabled` | `false` | Master switch. Off = zero impact on existing behavior |
| `synapse_ltp_enabled` | `true` | LTP axis on/off |
| `synapse_tagging_enabled` | `true` | Tagging axis on/off |
| `synapse_association_enabled` | `false` | Association axis (Phase 2) |
| `synapse_ltp_window_days` | `30` | LTP rolling window |
| `synapse_ltp_max_boost` | `2.0` | LTP upper bound |
| `synapse_tagging_window_hours` | `24` | Tagging window |
| `synapse_tagging_max_boost` | `1.5` | Tagging upper bound |
| `synapse_log_retrievals` | `true` | Enable/disable retrieval logging |
| `synapse_log_retention_days` | `90` | Auto-cleanup threshold |

Control hierarchy:
```
synapse_enabled = false → everything off, no logging, no scoring
synapse_enabled = true
  ├── synapse_ltp_enabled = true/false
  ├── synapse_tagging_enabled = true/false
  ├── synapse_association_enabled = true/false (Phase 2)
  └── synapse_log_retrievals = true/false
```

### `mempalace/searcher.py`

After `search_memories()` builds the result list:
1. Collect `drawer_id` from each hit
2. Batch-fetch LTP scores (if axis enabled)
3. Calculate tagging boost per hit (if axis enabled)
4. Compute `final_score = similarity × decay × ltp × association × tagging`
5. Re-sort hits by `synapse_score`
6. Fire-and-forget `log_retrieval()` (if logging enabled)

Entire Synapse block is wrapped in try/except — failure returns unmodified results.

### `mempalace/mcp_server.py`

`tool_status` now reports:
- All axis flags and tuning parameters
- Log statistics (entry count, unique drawers, DB size)
- Consolidation candidates (top 10)
- Runs `cleanup_old_logs` and `refresh_stats` on each status call

## Design decisions

- **Opt-in by default**: `synapse_enabled=false`. Zero impact until the user explicitly enables it.
- **No ChromaDB metadata writes**: retrieval counters live in SQLite to avoid serializing the search hot path (per @CryptoKupo's observation in #331).
- **Fire-and-forget logging**: search response is returned before the log write completes.
- **Per-connection SQLite**: no persistent connection held; each operation opens and closes its own connection for thread safety.
- **Multiplicative composition**: all factors default to 1.0. Disabling any axis has no effect on others.

## Neuroscience mapping

| Brain mechanism | Synapse axis | Status |
|---|---|---|
| Synaptic fatigue | `decay` (PR #337) | Landed |
| Long-Term Potentiation | `ltp` | **This PR** |
| Hebbian association | `association` | Phase 2 |
| Synaptic tagging | `tagging` | **This PR** |
| Memory consolidation | Consolidation candidates | **This PR** |

## Tests

24 new tests in `tests/test_synapse.py`:

- DB initialization (create, tables, idempotent)
- Retrieval logging (single, batch, empty, exception suppression)
- LTP scoring (no retrievals, single, high frequency, clamp, window expiry, batch consistency)
- Tagging (just filed, 12h, 25h, None)
- Score composition (multiplicative verification)
- Consolidation (inactive returned, active excluded)
- Axis switches (LTP disabled, tagging disabled)
- Log management (cleanup removes old, keeps new)
- Status integration

```
tests/test_synapse.py: 24 passed
tests/ (excluding benchmarks): 122 passed, 2 failed
```

The 2 failures are pre-existing Windows-only Chroma file lock issues (`test_convo_mining`, `test_project_mining`) — unrelated to this change.

## Related

- #441 — Synapse RFC (this implements Phase 1)
- #337 — time-decay scoring (Synapse axis 1)
- #336 — soft-archive (connects to consolidation candidates)
- #385 — query sanitizer (prerequisite: clean queries → accurate similarity → meaningful Synapse modulation)
- #331 — @CryptoKupo's retrieval-frequency suggestion (inspiration for LTP)
- #335 — MemPalace-AGI discussion (@fuzzymoomoo's status metadata, retrieval profiles)
