### PR TITLE
fix: skip tool_result messages in save hook exchange count

### DIFF
--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -252,10 +252,15 @@ with open(sys.argv[1]) as f:
                 # Skip system/command messages
                 if isinstance(content, str) and '<command-message>' in content:
                     continue
-                # Skip tool results (role: "user" but not human input)
-                if isinstance(content, list) and all(
-                    isinstance(b, dict) and b.get('type') == 'tool_result'
-                    for b in content
+                # Skip empty content lists or tool-result-only messages
+                # (role: "user" but not human input). all([]) is vacuously
+                # True, so the empty case must be guarded explicitly.
+                if isinstance(content, list) and (
+                    not content
+                    or all(
+                        isinstance(b, dict) and b.get('type') == 'tool_result'
+                        for b in content
+                    )
                 ):
                     continue
                 count += 1

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -249,7 +249,16 @@ with open(sys.argv[1]) as f:
             msg = entry.get('message', {})
             if isinstance(msg, dict) and msg.get('role') == 'user':
                 content = msg.get('content', '')
+                # Skip system/command messages
                 if isinstance(content, str) and '<command-message>' in content:
+                    continue
+                # Skip tool results — Claude Code sends these as role: "user"
+                # with content blocks of type "tool_result", but they aren't
+                # human input. Safe no-op for other LLMs that use role: "tool".
+                if isinstance(content, list) and all(
+                    isinstance(b, dict) and b.get('type') == 'tool_result'
+                    for b in content
+                ):
                     continue
                 count += 1
         except:

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -252,9 +252,7 @@ with open(sys.argv[1]) as f:
                 # Skip system/command messages
                 if isinstance(content, str) and '<command-message>' in content:
                     continue
-                # Skip tool results — Claude Code sends these as role: "user"
-                # with content blocks of type "tool_result", but they aren't
-                # human input. Safe no-op for other LLMs that use role: "tool".
+                # Skip tool results (role: "user" but not human input)
                 if isinstance(content, list) and all(
                     isinstance(b, dict) and b.get('type') == 'tool_result'
                     for b in content

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -162,8 +162,18 @@ def _count_human_messages(transcript_path: str) -> int:
                             if "<command-message>" in content:
                                 continue
                         elif isinstance(content, list):
+                            # Skip tool results — Claude Code sends these as
+                            # role: "user" with content blocks of type
+                            # "tool_result", but they aren't human input.
+                            # Safe no-op for LLMs that use role: "tool".
+                            if all(
+                                isinstance(b, dict) and b.get("type") == "tool_result"
+                                for b in content
+                            ):
+                                continue
                             text = " ".join(
-                                b.get("text", "") for b in content if isinstance(b, dict)
+                                b.get("text", "")
+                                for b in content if isinstance(b, dict)
                             )
                             if "<command-message>" in text:
                                 continue
@@ -921,7 +931,9 @@ def hook_stop(data: dict, harness: str):
 
     since_last = exchange_count - last_save
 
-    _log(f"Session {session_id}: {exchange_count} exchanges, {since_last} since last save")
+    _log(
+        f"Session {session_id}: {exchange_count} exchanges, {since_last} since last save"
+    )
 
     if since_last >= SAVE_INTERVAL and exchange_count > 0:
         _log(f"TRIGGERING SAVE at exchange {exchange_count}")

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -162,6 +162,9 @@ def _count_human_messages(transcript_path: str) -> int:
                             if "<command-message>" in content:
                                 continue
                         elif isinstance(content, list):
+                            # Skip empty content lists — no human input.
+                            if not content:
+                                continue
                             # Skip tool results (role: "user" but not human input)
                             if all(
                                 isinstance(b, dict) and b.get("type") == "tool_result"

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -169,8 +169,7 @@ def _count_human_messages(transcript_path: str) -> int:
                             ):
                                 continue
                             text = " ".join(
-                                b.get("text", "")
-                                for b in content if isinstance(b, dict)
+                                b.get("text", "") for b in content if isinstance(b, dict)
                             )
                             if "<command-message>" in text:
                                 continue
@@ -928,9 +927,7 @@ def hook_stop(data: dict, harness: str):
 
     since_last = exchange_count - last_save
 
-    _log(
-        f"Session {session_id}: {exchange_count} exchanges, {since_last} since last save"
-    )
+    _log(f"Session {session_id}: {exchange_count} exchanges, {since_last} since last save")
 
     if since_last >= SAVE_INTERVAL and exchange_count > 0:
         _log(f"TRIGGERING SAVE at exchange {exchange_count}")

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -162,10 +162,7 @@ def _count_human_messages(transcript_path: str) -> int:
                             if "<command-message>" in content:
                                 continue
                         elif isinstance(content, list):
-                            # Skip tool results — Claude Code sends these as
-                            # role: "user" with content blocks of type
-                            # "tool_result", but they aren't human input.
-                            # Safe no-op for LLMs that use role: "tool".
+                            # Skip tool results (role: "user" but not human input)
                             if all(
                                 isinstance(b, dict) and b.get("type") == "tool_result"
                                 for b in content

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -259,6 +259,24 @@ def test_count_mixed_content_not_skipped(tmp_path):
     assert _count_human_messages(str(transcript)) == 1
 
 
+def test_count_skips_empty_content_list(tmp_path):
+    """Messages with content=[] are not human input.
+
+    Regression: ``all([])`` is vacuously True, which previously caused
+    empty-content user messages to slip past the tool_result guard and be
+    counted as human exchanges, undercounting the save trigger.
+    """
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            {"message": {"role": "user", "content": []}},
+            {"message": {"role": "user", "content": "real human message"}},
+        ],
+    )
+    assert _count_human_messages(str(transcript)) == 1
+
+
 def test_count_missing_file():
     assert _count_human_messages("/nonexistent/path.jsonl") == 0
 

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -202,6 +202,60 @@ def test_count_handles_list_content(tmp_path):
     assert _count_human_messages(str(transcript)) == 1
 
 
+def test_count_skips_tool_results(tmp_path):
+    """Tool results arrive as role: 'user' but should not count as human messages."""
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            {"message": {"role": "user", "content": "real human message"}},
+            {
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu_1",
+                            "content": "file contents",
+                        },
+                    ],
+                }
+            },
+            {
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "tu_2", "content": "ok"},
+                        {"type": "tool_result", "tool_use_id": "tu_3", "content": "ok"},
+                    ],
+                }
+            },
+            {"message": {"role": "user", "content": "another real message"}},
+        ],
+    )
+    assert _count_human_messages(str(transcript)) == 2
+
+
+def test_count_mixed_content_not_skipped(tmp_path):
+    """Messages with both tool_result and text blocks should still count."""
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            {
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "tu_1", "content": "ok"},
+                        {"type": "text", "text": "and here is my follow-up"},
+                    ],
+                }
+            },
+        ],
+    )
+    assert _count_human_messages(str(transcript)) == 1
+
+
 def test_count_missing_file():
     assert _count_human_messages("/nonexistent/path.jsonl") == 0
 

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -245,6 +245,9 @@ def test_count_mixed_content_not_skipped(tmp_path):
             {
                 "message": {
                     "role": "user",
+                    # Mixed content: a tool_result block alongside a text block.
+                    # The text block means a human actually typed something, so
+                    # this message should still count as a human exchange.
                     "content": [
                         {"type": "tool_result", "tool_use_id": "tu_1", "content": "ok"},
                         {"type": "text", "text": "and here is my follow-up"},


### PR DESCRIPTION
Closes #549

## Summary

- Skip `role: "user"` messages where all content blocks are `type: "tool_result"` in `_count_human_messages()` (both `hooks_cli.py` and the inline Python in `mempal_save_hook.sh`)
- Claude Code sends tool results as `role: "user"`, inflating the exchange count ~2.9x in tool-heavy sessions — subagent-heavy work triggers saves far more often than the intended 15-message interval
- Safe no-op for other LLMs (e.g. OpenAI-compatible) that use `role: "tool"` for tool results

## Related

- #316 targets the same bug but modifies `hooks_cli.py` with a different approach — this PR also fixes the inline Python in `mempal_save_hook.sh`
- #347 / #373 address a separate Codex transcript counting issue

## Test plan

- [x] Added `test_count_skips_tool_results` — verifies single and multi-block tool_result messages are skipped
- [x] Added `test_count_mixed_content_not_skipped` — verifies messages with both tool_result and text blocks still count
- [x] All 34 tests pass