### PR TITLE
docs: remove GitHub Discussions reference from contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ If you're planning a significant change, open an issue first to discuss the appr
 
 - **Discord**: [Join us](https://discord.com/invite/ycTQQCu6kn)
 - **Issues**: Bug reports and feature requests welcome
-- **Discussions**: For questions and ideas
+- **Questions and ideas**: Please use Discord or open an issue while GitHub Discussions are not enabled for this repo
 
 ## License
 


### PR DESCRIPTION
## Summary
- remove the stale GitHub Discussions reference from `CONTRIBUTING.md`
- direct questions and ideas to Discord or Issues while Discussions are disabled
- keep the fix scoped to issue #541 with no code-path changes

## Why
Closes #541. The contributing guide currently points contributors to GitHub Discussions even though Discussions are not enabled for this repository.

## Validation
- `python -m pytest tests/ -v --ignore=tests/benchmarks` ✅ (`567 passed`)
- `ruff check .` ✅
- `ruff format --check .` ⚠️ baseline repo drift in `mempalace/normalize.py` and `mempalace/split_mega_files.py` unrelated to this PR