### PR TITLE
fix: add --version flag, use --yes in agent init instructions, document init prerequisite for mine

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -34,6 +34,7 @@ import argparse
 from pathlib import Path
 
 from .config import MempalaceConfig
+from .version import __version__
 
 
 def cmd_init(args):
@@ -398,6 +399,9 @@ def main():
         description="MemPalace — Give your AI a memory. No API key required.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"mempalace {__version__}"
     )
     parser.add_argument(
         "--palace",

--- a/mempalace/instructions/init.md
+++ b/mempalace/instructions/init.md
@@ -41,7 +41,11 @@ before continuing.
 
 ## Step 5: Initialize the palace
 
-Run `mempalace init <dir>` where `<dir>` is the directory from Step 4.
+Run `mempalace init --yes <dir>` where `<dir>` is the directory from Step 4.
+
+The `--yes` flag is required in agent/non-interactive contexts to auto-accept
+detected entities and rooms without prompting. Without it, the command will
+crash with EOFError when stdin is not a terminal.
 
 If this fails, report the error and stop.
 

--- a/mempalace/instructions/mine.md
+++ b/mempalace/instructions/mine.md
@@ -2,6 +2,18 @@
 
 When the user invokes this skill, follow these steps:
 
+## 0. Ensure the palace is initialized
+
+Before mining, the target directory must be initialized with `mempalace init --yes <dir>`.
+Check if a `mempalace.yaml` file exists in the target directory. If not, run init first:
+
+```bash
+mempalace init --yes <dir>
+```
+
+Without this, `mempalace mine` will fail with:
+`ERROR: No mempalace.yaml found in <dir>`
+
 ## 1. Ask what to mine
 
 Ask the user what they want to mine and where the source data is located.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,6 +146,29 @@ def test_cmd_init_with_entities_zero_total(mock_config_cls, tmp_path, capsys):
     assert "No entities detected" in out
 
 
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_init_yes_skips_interactive_prompts(mock_config_cls, tmp_path):
+    """init --yes must not call input(), so agents don't hit EOFError."""
+    fake_files = [tmp_path / "a.txt"]
+    detected = {
+        "people": [{"name": "Alice", "confidence": 0.9, "signals": ["dialogue"]}],
+        "projects": [],
+        "uncertain": [{"name": "Bob", "frequency": 5, "signals": ["appears 5x"]}],
+    }
+    confirmed = {"people": ["Alice"], "projects": []}
+    args = argparse.Namespace(dir=str(tmp_path), yes=True)
+    with (
+        patch("mempalace.entity_detector.scan_for_detection", return_value=fake_files),
+        patch("mempalace.entity_detector.detect_entities", return_value=detected),
+        patch("mempalace.entity_detector.confirm_entities", return_value=confirmed) as mock_confirm,
+        patch("mempalace.room_detector_local.detect_rooms_local"),
+        patch("builtins.open", MagicMock()),
+    ):
+        cmd_init(args)
+        # Verify yes=True was passed through to confirm_entities
+        mock_confirm.assert_called_once_with(detected, yes=True)
+
+
 # ── cmd_mine ───────────────────────────────────────────────────────────
 
 
@@ -264,6 +287,13 @@ def test_cmd_split_all_options():
 
 
 # ── main() argparse dispatch ──────────────────────────────────────────
+
+
+def test_main_version_flag(capsys):
+    with patch("sys.argv", ["mempalace", "--version"]), pytest.raises(SystemExit, match="0"):
+        main()
+    out = capsys.readouterr().out
+    assert "mempalace" in out
 
 
 def test_main_no_args_prints_help(capsys):

--- a/tests/test_instructions_cli.py
+++ b/tests/test_instructions_cli.py
@@ -43,3 +43,17 @@ def test_run_instructions_missing_md_file(capsys, tmp_path):
             assert exc_info.value.code == 1
             captured = capsys.readouterr()
             assert "Instructions file not found" in captured.err
+
+
+def test_init_instructions_use_yes_flag():
+    """init instructions must tell agents to use --yes to avoid EOFError."""
+    content = (INSTRUCTIONS_DIR / "init.md").read_text()
+    assert "--yes" in content
+    assert "mempalace init --yes" in content
+
+
+def test_mine_instructions_mention_init_prerequisite():
+    """mine instructions must mention that init is required first."""
+    content = (INSTRUCTIONS_DIR / "mine.md").read_text()
+    assert "mempalace init" in content
+    assert "mempalace.yaml" in content

--- a/tests/test_instructions_cli.py
+++ b/tests/test_instructions_cli.py
@@ -53,7 +53,7 @@ def test_init_instructions_use_yes_flag():
 
 
 def test_mine_instructions_mention_init_prerequisite():
-    """mine instructions must mention that init is required first."""
+    """mine instructions must mention that init --yes is required first."""
     content = (INSTRUCTIONS_DIR / "mine.md").read_text()
-    assert "mempalace init" in content
+    assert "mempalace init --yes" in content
     assert "mempalace.yaml" in content


### PR DESCRIPTION
## What does this PR do?

Fixes #534. Three issues that break agent-driven use of MemPalace:

### 1. `mempalace --version` crashes (exit 2)

SKILL.md prerequisites tell agents to run `mempalace --version`, but the flag didn't exist:

```
$ mempalace --version
error: unrecognized arguments: --version
```

**Fix:** Added `--version` to the CLI argparser using existing `version.py`.

```
$ mempalace --version
mempalace 3.1.0
```

### 2. `mempalace init` without `--yes` causes EOFError in agent context

When entities are detected, `confirm_entities()` calls `input()` which crashes agents (no stdin):

```
File "entity_detector.py", line 787, in confirm_entities
    if choice == "add" or input("\n  Add any missing? [y/N]: ").strip().lower() == "y":
EOFError: EOF when reading a line
```

**Fix:** Updated `instructions/init.md` Step 5 to use `mempalace init --yes <dir>`. The `--yes` flag already existed (#8) but the agent instructions didn't use it.

### 3. `mempalace mine` fails with no guidance when init hasn't run

```
$ mempalace mine /path/to/dir
ERROR: No mempalace.yaml found in /path/to/dir
Run: mempalace init /path/to/dir
```

Agents following `instructions/mine.md` hit this with no context.

**Fix:** Added Step 0 to `instructions/mine.md` documenting the init prerequisite with the exact error message.

## How to test

```bash
python -m pytest tests/test_cli.py tests/test_instructions_cli.py -v
```

New tests:
- `test_main_version_flag` — verifies `--version` prints version and exits 0
- `test_cmd_init_yes_skips_interactive_prompts` — verifies `yes=True` is passed through to `confirm_entities`
- `test_init_instructions_use_yes_flag` — verifies init.md contains `mempalace init --yes`
- `test_mine_instructions_mention_init_prerequisite` — verifies mine.md mentions `mempalace init` and `mempalace.yaml`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`) — 538 passing
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)