### PR TITLE
fix: replace hardcoded limit=10000 with dynamic col.count() in navigation tools

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -144,7 +144,7 @@ def tool_status():
     wings = {}
     rooms = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
+        all_meta = col.get(include=["metadatas"], limit=max(col.count(), 1))["metadatas"]
         for m in all_meta:
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
@@ -201,7 +201,7 @@ def tool_list_wings():
         return _no_palace()
     wings = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
+        all_meta = col.get(include=["metadatas"], limit=max(col.count(), 1))["metadatas"]
         for m in all_meta:
             w = m.get("wing", "unknown")
             wings[w] = wings.get(w, 0) + 1
@@ -216,7 +216,7 @@ def tool_list_rooms(wing: str = None):
         return _no_palace()
     rooms = {}
     try:
-        kwargs = {"include": ["metadatas"], "limit": 10000}
+        kwargs = {"include": ["metadatas"], "limit": max(col.count(), 1)}
         if wing:
             kwargs["where"] = {"wing": wing}
         all_meta = col.get(**kwargs)["metadatas"]
@@ -234,7 +234,7 @@ def tool_get_taxonomy():
         return _no_palace()
     taxonomy = {}
     try:
-        all_meta = col.get(include=["metadatas"], limit=10000)["metadatas"]
+        all_meta = col.get(include=["metadatas"], limit=max(col.count(), 1))["metadatas"]
         for m in all_meta:
             w = m.get("wing", "unknown")
             r = m.get("room", "unknown")
@@ -554,7 +554,7 @@ def tool_diary_read(agent_name: str, last_n: int = 10):
         results = col.get(
             where={"$and": [{"wing": wing}, {"room": "diary"}]},
             include=["documents", "metadatas"],
-            limit=10000,
+            limit=max(col.count(), 1),
         )
 
         if not results["ids"]:


### PR DESCRIPTION
## Problem

Navigation tools (`tool_status`, `tool_list_wings`, `tool_list_rooms`, `tool_get_taxonomy`, `tool_diary_read`) use `col.get(include=["metadatas"], limit=10000)` to scan metadata. Palaces with more than 10,000 drawers silently lose wings and rooms from the response.

**Observed behavior:** A palace with 16,003 drawers across 3 wings returns only the first 10,000 entries (1 wing) from `mempalace_status` and `mempalace_list_wings`. The other 2 wings (6,003 drawers) are invisible in navigation tools.

**Search is NOT affected** — `mempalace_search` uses ChromaDB's vector query which has no such limit.

## Fix

Replace `limit=10000` with `limit=max(col.count(), 1)` in all 5 affected functions. This scales the limit dynamically with the actual collection size, following the [ChromaDB batch iteration pattern](https://cookbook.chromadb.dev/core/collections/).

The `max(..., 1)` guard handles the edge case of an empty collection where `col.count()` returns 0.

## Testing

Verified on a production palace with 16,003 drawers across 3 wings:
- Before: `mempalace_list_wings` → `{"sos_app": 10000}`
- After: `mempalace_list_wings` → `{"sos_app": 12585, "sos_medical_ai": 2553, "sos_playbooks": 865}`

## Files Changed

- `mempalace/mcp_server.py` — 5 occurrences of `limit=10000` replaced with `limit=max(col.count(), 1)`