### PR TITLE
feat: add brief retrieval mode for wing/room overviews

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -114,6 +114,14 @@ def cmd_search(args):
         sys.exit(1)
 
 
+def cmd_brief(args):
+    from .searcher import brief
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    result = brief(palace_path=palace_path, wing=args.wing, room=args.room)
+    print(result)
+
+
 def cmd_wakeup(args):
     """Show L0 (identity) + L1 (essential story) — the wake-up context."""
     from .layers import MemoryStack
@@ -458,6 +466,11 @@ def main():
     p_search.add_argument("--room", default=None, help="Limit to one room")
     p_search.add_argument("--results", type=int, default=5, help="Number of results")
 
+    p_brief = sub.add_parser("brief", help="Condensed overview of a wing or room")
+    p_brief.add_argument("--wing", default=None, help="Wing to summarize")
+    p_brief.add_argument("--room", default=None, help="Room to summarize")
+    p_brief.add_argument("--palace", default=None, help="Palace path")
+
     # compress
     p_compress = sub.add_parser(
         "compress", help="Compress drawers using AAAK Dialect (~30x reduction)"
@@ -580,6 +593,7 @@ def main():
         "mine": cmd_mine,
         "split": cmd_split,
         "search": cmd_search,
+        "brief": cmd_brief,
         "mcp": cmd_mcp,
         "compress": cmd_compress,
         "wake-up": cmd_wakeup,

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1580,6 +1580,14 @@ def cmd_search(args):
         sys.exit(1)
 
 
+def cmd_brief(args):
+    from .searcher import brief
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    result = brief(palace_path=palace_path, wing=args.wing, room=args.room)
+    print(result)
+
+
 def cmd_wakeup(args):
     """Show L0 (identity) + L1 (essential story) — the wake-up context."""
     from .layers import MemoryStack
@@ -3422,6 +3430,11 @@ def main():
         help="Only drawers filed strictly before this ISO date/datetime (exclusive)",
     )
 
+    p_brief = sub.add_parser("brief", help="Condensed overview of a wing or room")
+    p_brief.add_argument("--wing", default=None, help="Wing to summarize")
+    p_brief.add_argument("--room", default=None, help="Room to summarize")
+    p_brief.add_argument("--palace", default=None, help="Palace path")
+
     # compress
     p_compress = sub.add_parser(
         "compress", help="Compress drawers using AAAK Dialect (~30x reduction)"
@@ -4073,6 +4086,7 @@ def main():
         "search": cmd_search,
         "sweep": cmd_sweep,
         "sync": cmd_sync,
+        "brief": cmd_brief,
         "mcp": cmd_mcp,
         "serve": cmd_serve,
         "compress": cmd_compress,

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -424,7 +424,9 @@ class MemoryStack:
 
         # Parse the L2 output to get individual drawer lines
         lines = raw.split("\n")
-        content_lines = [line.strip() for line in lines if line.strip() and not line.startswith("## ")]
+        content_lines = [
+            line.strip() for line in lines if line.strip() and not line.startswith("## ")
+        ]
 
         # Deduplicate: skip lines with >70% overlap with already-seen content
         seen = []

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -415,6 +415,52 @@ class MemoryStack:
         """Deep L3 semantic search."""
         return self.l3.search(query, wing=wing, room=room, n_results=n_results)
 
+    def brief(self, wing: str = None, room: str = None, n_results: int = 20) -> str:
+        """Compressed overview of a wing/room - deduplicated top drawers."""
+        # Use L2 to get drawers but with more results for broader coverage
+        raw = self.l2.retrieve(wing=wing, room=room, n_results=n_results)
+        if raw.startswith("No "):
+            return raw
+
+        # Parse the L2 output to get individual drawer lines
+        lines = raw.split("\n")
+        content_lines = [line.strip() for line in lines if line.strip() and not line.startswith("## ")]
+
+        # Deduplicate: skip lines with >70% overlap with already-seen content
+        seen = []
+        unique = []
+        for line in content_lines:
+            words = set(line.lower().split())
+            is_dupe = False
+            for prev_words in seen:
+                if len(words & prev_words) > 0.7 * max(len(words), len(prev_words), 1):
+                    is_dupe = True
+                    break
+            if not is_dupe:
+                unique.append(line)
+                seen.append(words)
+
+        # Format as brief overview
+        label_parts = []
+        if wing:
+            label_parts.append(f"wing={wing}")
+        if room:
+            label_parts.append(f"room={room}")
+        label = ", ".join(label_parts) if label_parts else "all"
+
+        header = f"## Brief - {label} ({len(unique)} topics)"
+        # Truncate to ~2000 chars total
+        result_lines = [header]
+        total = len(header)
+        for line in unique:
+            if total + len(line) > 2000:
+                result_lines.append("  ...")
+                break
+            result_lines.append(line)
+            total += len(line)
+
+        return "\n".join(result_lines)
+
     def status(self) -> dict:
         """Status of all layers."""
         result = {

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -419,7 +419,7 @@ class MemoryStack:
         """Compressed overview of a wing/room - deduplicated top drawers."""
         # Use L2 to get drawers but with more results for broader coverage
         raw = self.l2.retrieve(wing=wing, room=room, n_results=n_results)
-        if raw.startswith("No "):
+        if raw.startswith("No ") or raw.startswith("Retrieval error"):
             return raw
 
         # Parse the L2 output to get individual drawer lines

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -430,6 +430,52 @@ class MemoryStack:
         """Deep L3 semantic search."""
         return self.l3.search(query, wing=wing, room=room, n_results=n_results)
 
+    def brief(self, wing: str = None, room: str = None, n_results: int = 20) -> str:
+        """Compressed overview of a wing/room - deduplicated top drawers."""
+        # Use L2 to get drawers but with more results for broader coverage
+        raw = self.l2.retrieve(wing=wing, room=room, n_results=n_results)
+        if raw.startswith("No "):
+            return raw
+
+        # Parse the L2 output to get individual drawer lines
+        lines = raw.split("\n")
+        content_lines = [line.strip() for line in lines if line.strip() and not line.startswith("## ")]
+
+        # Deduplicate: skip lines with >70% overlap with already-seen content
+        seen = []
+        unique = []
+        for line in content_lines:
+            words = set(line.lower().split())
+            is_dupe = False
+            for prev_words in seen:
+                if len(words & prev_words) > 0.7 * max(len(words), len(prev_words), 1):
+                    is_dupe = True
+                    break
+            if not is_dupe:
+                unique.append(line)
+                seen.append(words)
+
+        # Format as brief overview
+        label_parts = []
+        if wing:
+            label_parts.append(f"wing={wing}")
+        if room:
+            label_parts.append(f"room={room}")
+        label = ", ".join(label_parts) if label_parts else "all"
+
+        header = f"## Brief - {label} ({len(unique)} topics)"
+        # Truncate to ~2000 chars total
+        result_lines = [header]
+        total = len(header)
+        for line in unique:
+            if total + len(line) > 2000:
+                result_lines.append("  ...")
+                break
+            result_lines.append(line)
+            total += len(line)
+
+        return "\n".join(result_lines)
+
     def status(self) -> dict:
         """Status of all layers."""
         result = {

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -434,7 +434,7 @@ class MemoryStack:
         """Compressed overview of a wing/room - deduplicated top drawers."""
         # Use L2 to get drawers but with more results for broader coverage
         raw = self.l2.retrieve(wing=wing, room=room, n_results=n_results)
-        if raw.startswith("No "):
+        if raw.startswith("No ") or raw.startswith("Retrieval error"):
             return raw
 
         # Parse the L2 output to get individual drawer lines

--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -439,7 +439,9 @@ class MemoryStack:
 
         # Parse the L2 output to get individual drawer lines
         lines = raw.split("\n")
-        content_lines = [line.strip() for line in lines if line.strip() and not line.startswith("## ")]
+        content_lines = [
+            line.strip() for line in lines if line.strip() and not line.startswith("## ")
+        ]
 
         # Deduplicate: skip lines with >70% overlap with already-seen content
         seen = []

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -150,3 +150,11 @@ def search_memories(
         "filters": {"wing": wing, "room": room},
         "results": hits,
     }
+
+
+def brief(palace_path: str, wing: str = None, room: str = None):
+    """Brief overview of a wing/room - deduplicated top drawers."""
+    from mempalace.layers import MemoryStack
+
+    stack = MemoryStack(palace_path=palace_path)
+    return stack.brief(wing=wing, room=room)

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -2216,6 +2216,14 @@ def search_memories(
     )
 
 
+def brief(palace_path: str, wing: str = None, room: str = None):
+    """Brief overview of a wing/room - deduplicated top drawers."""
+    from mempalace.layers import MemoryStack
+
+    stack = MemoryStack(palace_path=palace_path)
+    return stack.brief(wing=wing, room=room)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Virtual line numbering — read-time grid for drawers (3.3.6).
 #

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mempalace.searcher import SearchError, search, search_memories
+from mempalace.searcher import SearchError, brief, search, search_memories
 
 
 # ── search_memories (API) ──────────────────────────────────────────────
@@ -51,6 +51,12 @@ class TestSearchMemories:
         assert "source_file" in hit
         assert "similarity" in hit
         assert isinstance(hit["similarity"], float)
+
+    def test_brief(self, palace_path, seeded_collection):
+        """Brief returns a deduplicated overview."""
+        result = brief(palace_path=palace_path)
+        assert "Brief" in result
+        assert "topics" in result
 
     def test_search_memories_query_error(self):
         """search_memories returns error dict when query raises."""

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -58,6 +58,30 @@ class TestSearchMemories:
         assert "Brief" in result
         assert "topics" in result
 
+    def test_brief_empty_palace(self, palace_path, collection):
+        """Brief surfaces the L2 'no drawers' message instead of crashing."""
+        result = brief(palace_path=palace_path)
+        assert result.startswith("No ")
+
+    def test_brief_dedupes_near_identical_drawers(self, palace_path, collection):
+        """Brief collapses drawers whose summary lines overlap heavily."""
+        collection.add(
+            ids=["dup_a", "dup_b", "distinct_c"],
+            documents=[
+                "The authentication module uses JWT tokens for session management.",
+                "The authentication module uses JWT tokens for session management.",
+                "Database migrations are handled by Alembic with PostgreSQL 15.",
+            ],
+            metadatas=[
+                {"wing": "project", "room": "backend", "source_file": "auth_a.py"},
+                {"wing": "project", "room": "backend", "source_file": "auth_b.py"},
+                {"wing": "project", "room": "backend", "source_file": "db.py"},
+            ],
+        )
+        result = brief(palace_path=palace_path, wing="project")
+        assert result.count("authentication module uses JWT") == 1
+        assert "Database migrations" in result
+
     def test_search_memories_query_error(self):
         """search_memories returns error dict when query raises."""
         mock_col = MagicMock()

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -197,6 +197,30 @@ class TestSearchMemories:
         assert "Brief" in result
         assert "topics" in result
 
+    def test_brief_empty_palace(self, palace_path, collection):
+        """Brief surfaces the L2 'no drawers' message instead of crashing."""
+        result = brief(palace_path=palace_path)
+        assert result.startswith("No ")
+
+    def test_brief_dedupes_near_identical_drawers(self, palace_path, collection):
+        """Brief collapses drawers whose summary lines overlap heavily."""
+        collection.add(
+            ids=["dup_a", "dup_b", "distinct_c"],
+            documents=[
+                "The authentication module uses JWT tokens for session management.",
+                "The authentication module uses JWT tokens for session management.",
+                "Database migrations are handled by Alembic with PostgreSQL 15.",
+            ],
+            metadatas=[
+                {"wing": "project", "room": "backend", "source_file": "auth_a.py"},
+                {"wing": "project", "room": "backend", "source_file": "auth_b.py"},
+                {"wing": "project", "room": "backend", "source_file": "db.py"},
+            ],
+        )
+        result = brief(palace_path=palace_path, wing="project")
+        assert result.count("authentication module uses JWT") == 1
+        assert "Database migrations" in result
+
     def test_search_memories_query_error(self):
         """search_memories returns error dict when query raises."""
         mock_col = MagicMock()

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -17,6 +17,7 @@ from mempalace.backends import BackendMismatchError
 from mempalace.searcher import (
     SearchError,
     _result_drawer_id,
+    brief,
     build_where_filter,
     get_collection,
     search,
@@ -189,6 +190,12 @@ class TestSearchMemories:
             result = search_memories("test", "/fake/path")
         hit = result["results"][0]
         assert hit["created_at"] == "unknown"
+
+    def test_brief(self, palace_path, seeded_collection):
+        """Brief returns a deduplicated overview."""
+        result = brief(palace_path=palace_path)
+        assert "Brief" in result
+        assert "topics" in result
 
     def test_search_memories_query_error(self):
         """search_memories returns error dict when query raises."""


### PR DESCRIPTION
Reopens #174 (closed for merge conflicts) — rebased onto current `develop` and conflicts resolved.

## What does this PR do?

Adds a `brief()` retrieval mode that returns a deduplicated, truncated overview of a wing or room's contents. Complements the existing `recall()` (raw L2 retrieval) and `search()` (semantic L3 search) with a "catch me up" mode.

How it works:
- Fetches top 20 drawers via L2
- Deduplicates using 70% word-overlap threshold
- Caps output at ~2000 chars
- Formats with topic count header

Available via:
- `MemoryStack.brief(wing=..., room=...)` in Python
- `searcher.brief()` wrapper
- `mempalace brief --wing X --room Y` CLI subcommand

Closes #73.

## Rebase notes (3.8.0 review)

Rebased onto `develop` @ `639c69a`. The branch was 257 commits behind; it is now current.

One conflict, in `tests/test_searcher.py` — the `mempalace.searcher` import list. `develop` had added `_result_drawer_id` and this branch adds `brief`; both were kept. The earlier `mempalace/cli.py` dispatch-table conflict no longer occurs on `develop`.

**Dropped commit:** the previous head carried `fix: drop closet distance cap - align with main's boost-never-gate design`, which deleted `CLOSET_DISTANCE_CAP` from `search_memories()`. That commit has been dropped, for three reasons:

1. It is unrelated to `brief()` — it changes hybrid drawer/closet search scoring.
2. Its justification was inverted. It cited 8e446f9 ("closets boost, never gate") as having removed the cap, but 8e446f9 is the commit that *introduced* `CLOSET_DISTANCE_CAP`, and both `main` and `develop` still carry it today.
3. It applied cleanly onto `develop`, so it would have silently reverted a live gate inside a PR titled "add brief retrieval mode" without surfacing a conflict for review.

The full suite passes both with and without that commit, so nothing in `brief()` depends on it. If the cap removal is still wanted it belongs in its own PR against `develop`. `develop`'s cap is left untouched here.

The diff is now purely additive: 101 insertions, 0 deletions, across 4 files.

## How to test

```bash
# CLI
mempalace brief --wing my_project

# Python
from mempalace.layers import MemoryStack
stack = MemoryStack()
print(stack.brief(wing="my_project"))
```

Or run the tests:
```bash
pytest tests/test_searcher.py -k brief -v
```

## Checklist
- [x] Tests pass (`uv run pytest tests/ --ignore=tests/benchmarks` → 4303 passed, 31 skipped)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
- [x] Formatter passes (`ruff format --check .`)

This contribution was developed with AI assistance (Codex).
