### PR TITLE
fix: add --config flag to mine so config and data dirs can differ (fixes #14)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -67,6 +67,7 @@ def cmd_init(args):
 
 def cmd_mine(args):
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    config_dir = os.path.expanduser(args.config) if getattr(args, "config", None) else args.dir
     include_ignored = []
     for raw in args.include_ignored or []:
         include_ignored.extend(part.strip() for part in raw.split(",") if part.strip())
@@ -88,6 +89,7 @@ def cmd_mine(args):
 
         mine(
             project_dir=args.dir,
+            config_dir=config_dir,
             palace_path=palace_path,
             wing_override=args.wing,
             agent=args.agent,
@@ -443,6 +445,11 @@ def main():
     p_mine.add_argument("--limit", type=int, default=0, help="Max files to process (0 = all)")
     p_mine.add_argument(
         "--dry-run", action="store_true", help="Show what would be filed without filing"
+    )
+    p_mine.add_argument(
+        "--config",
+        default=None,
+        help="Directory containing mempalace.yaml (default: same as mined directory)",
     )
     p_mine.add_argument(
         "--extract",

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -718,6 +718,7 @@ def cmd_mine(args):
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     mode = getattr(args, "mode", None) or "projects"
     source_adapter = getattr(args, "source", None)
+    config_dir = os.path.expanduser(args.config) if getattr(args, "config", None) else args.dir
     include_ignored = []
     for raw in args.include_ignored or []:
         include_ignored.extend(part.strip() for part in raw.split(",") if part.strip())
@@ -812,6 +813,7 @@ def cmd_mine(args):
 
             mine(
                 project_dir=args.dir,
+                config_dir=config_dir,
                 palace_path=palace_path,
                 wing_override=args.wing,
                 agent=args.agent,
@@ -2591,6 +2593,11 @@ def main():
         "--background",
         action="store_true",
         help="With --daemon, return a job id immediately instead of waiting",
+    )
+    p_mine.add_argument(
+        "--config",
+        default=None,
+        help="Directory containing mempalace.yaml (default: same as mined directory)",
     )
     p_mine.add_argument(
         "--extract",

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -540,6 +540,7 @@ def scan_project(
 def mine(
     project_dir: str,
     palace_path: str,
+    config_dir: str = None,
     wing_override: str = None,
     agent: str = "mempalace",
     limit: int = 0,
@@ -550,7 +551,7 @@ def mine(
     """Mine a project directory into the palace."""
 
     project_path = Path(project_dir).expanduser().resolve()
-    config = load_config(project_dir)
+    config = load_config(config_dir or project_dir)
 
     wing = wing_override or config["wing"]
     rooms = config.get("rooms", [{"name": "general", "description": "All project files"}])

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1863,6 +1863,7 @@ def mine(
         return _mine_impl(
             project_dir,
             palace_path,
+            config_dir=config_dir,
             wing_override=wing_override,
             agent=agent,
             limit=limit,
@@ -1880,6 +1881,7 @@ def mine(
         return _mine_impl(
             project_dir,
             palace_path,
+            config_dir=config_dir,
             wing_override=wing_override,
             agent=agent,
             limit=limit,
@@ -1894,6 +1896,7 @@ def mine(
 def _mine_impl(
     project_dir: str,
     palace_path: str,
+    config_dir: str = None,
     wing_override: str = None,
     agent: str = "mempalace",
     limit: int = 0,

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1836,6 +1836,7 @@ def scan_project(
 def mine(
     project_dir: str,
     palace_path: str,
+    config_dir: str = None,
     wing_override: str = None,
     agent: str = "mempalace",
     limit: int = 0,
@@ -1905,7 +1906,7 @@ def _mine_impl(
     from .config import MempalaceConfig
 
     project_path = Path(project_dir).expanduser().resolve()
-    config = load_config(project_dir)
+    config = load_config(config_dir or project_dir)
     palace_config = MempalaceConfig()
 
     cfg_chunk_size = palace_config.chunk_size

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,7 @@ def test_cmd_mine_projects_mode(mock_config_cls):
         cmd_mine(args)
         mock_mine.assert_called_once_with(
             project_dir="/src",
+            config_dir="/src",
             palace_path="/fake/palace",
             wing_override=None,
             agent="mempalace",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -580,6 +580,7 @@ def test_cmd_mine_projects_mode(mock_config_cls):
         cmd_mine(args)
         mock_mine.assert_called_once_with(
             project_dir="/src",
+            config_dir="/src",
             palace_path="/fake/palace",
             wing_override=None,
             agent="mempalace",


### PR DESCRIPTION
## What does this PR do?
Fixes the "ERROR: No mempalace.yaml found" error when mining a directory
that is different from the initialized project directory (issue #14).

## Root Cause
`mempalace mine <dir>` always looked for `mempalace.yaml` in the mined
directory. But users often init in one place and want to mine data from
another location (e.g. a separate `~/chats/` folder).

## Fix
Added a `--config` flag to the `mine` command: