### PR TITLE
fix: add cache invalidation and error logging to add_drawer

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -105,6 +105,13 @@ _client_cache = None
 _collection_cache = None
 
 
+def _invalidate_cache():
+    """Reset client and collection caches so the next call reconnects."""
+    global _client_cache, _collection_cache
+    _client_cache = None
+    _collection_cache = None
+
+
 def _get_client():
     """Return a singleton ChromaDB PersistentClient."""
     global _client_cache
@@ -123,7 +130,9 @@ def _get_collection(create=False):
         elif _collection_cache is None:
             _collection_cache = client.get_collection(_config.collection_name)
         return _collection_cache
-    except Exception:
+    except Exception as e:
+        logger.error(f"Failed to get collection: {e}")
+        _invalidate_cache()
         return None
 
 
@@ -176,7 +185,7 @@ def tool_status():
     return result
 
 
-# ── AAAK Dialect Spec ─────────────────────────────────────────────────────────
+# ── AAAK Dialect Spec ─────────────────────────────────────────────────────────────────
 # Included in status response so the AI learns it on first wake-up call.
 # Also available via mempalace_get_aaak_spec tool.
 
@@ -434,8 +443,13 @@ def tool_add_drawer(
         existing = col.get(ids=[drawer_id])
         if existing and existing["ids"]:
             return {"success": True, "reason": "already_exists", "drawer_id": drawer_id}
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"Idempotency check failed for {drawer_id}: {e}")
+        # Invalidate cache and re-acquire collection before upsert attempt
+        _invalidate_cache()
+        col = _get_collection(create=True)
+        if not col:
+            return {"success": False, "error": f"Collection unavailable after reconnect: {e}"}
 
     try:
         col.upsert(
@@ -455,6 +469,8 @@ def tool_add_drawer(
         logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")
         return {"success": True, "drawer_id": drawer_id, "wing": wing, "room": room}
     except Exception as e:
+        logger.exception(f"Failed to upsert drawer {drawer_id}")
+        _invalidate_cache()
         return {"success": False, "error": str(e)}
 
 


### PR DESCRIPTION
## Problem\n\n`tool_add_drawer()` silently fails when the ChromaDB connection becomes stale (e.g., after a database restart, concurrent access, or transient I/O error). The root cause is threefold:\n\n1. **`_get_collection()` swallows exceptions silently** — returns `None` without logging or resetting the cached client, so subsequent calls keep reusing the dead reference.\n2. **Idempotency check uses bare `except: pass`** — if `col.get()` fails due to a stale connection, the error is silently ignored and the function proceeds to `upsert()` with the same broken collection handle.\n3. **`upsert()` exception is caught but never logged** — returns `{\"success\": False, \"error\": str(e)}` without any `logger` call, making it impossible to diagnose failures from server logs.\n\n## Fix\n\n### Added `_invalidate_cache()` helper\nCentralizes cache reset logic for `_client_cache` and `_collection_cache`.\n\n### `_get_collection()` — log and invalidate on failure\n```python\nexcept Exception as e:\n    logger.error(f\"Failed to get collection: {e}\")\n    _invalidate_cache()\n    return None\n```\n\n### `tool_add_drawer()` — idempotency check recovery\n```python\nexcept Exception as e:\n    logger.warning(f\"Idempotency check failed for {drawer_id}: {e}\")\n    _invalidate_cache()\n    col = _get_collection(create=True)\n    if not col:\n        return {\"success\": False, \"error\": f\"Collection unavailable after reconnect: {e}\"}\n```\n\n### `tool_add_drawer()` — upsert exception logging\n```python\nexcept Exception as e:\n    logger.exception(f\"Failed to upsert drawer {drawer_id}\")\n    _invalidate_cache()\n    return {\"success\": False, \"error\": str(e)}\n```\n\n## Testing\n\n- Verified ChromaDB write layer is healthy via direct `PersistentClient` test (upsert + get + delete)\n- Verified `tool_add_drawer()` and `tool_delete_drawer()` work end-to-end after the fix\n- Palace has 14,822 drawers, no data loss\n\n## Impact\n\n- **No breaking changes** — only adds logging and cache invalidation to existing error paths\n- **Self-healing** — stale connections are now automatically recovered on next call\n- **Debuggable** — all write failures now produce actionable log output via `logger`"