### PR TITLE
fix(mine): log warning when files exceed MAX_FILE_SIZE (#923)

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -397,15 +397,28 @@ def scan_convos(convo_dir: str) -> list:
                     except OSError:
                         pass
                     continue
+                # Skip files exceeding size limit, or those whose stat() raises
+                # (permission denied, racing delete, broken symlink that
+                # survived the earlier is_symlink check). Both branches log
+                # to stderr to match the SKIP: (symlink) line above; silent
+                # drops at this gate were the original #923 complaint.
                 try:
                     file_size = filepath.stat().st_size
                     if file_size > MAX_FILE_SIZE:
                         print(
                             f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"
-                            f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit"
+                            f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit",
+                            file=sys.stderr,
                         )
                         continue
-                except OSError:
+                except OSError as exc:
+                    # Prefer ``exc.strerror`` so the path isn't duplicated in
+                    # the output (see the matching comment in
+                    # ``miner.scan_project``).
+                    print(
+                        f"  SKIP: {filepath.name} (stat error: {exc.strerror or exc})",
+                        file=sys.stderr,
+                    )
                     continue
                 if not _is_regular_source_file(filepath, convo_path):
                     continue

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -400,8 +400,10 @@ def scan_convos(convo_dir: str) -> list:
                 try:
                     file_size = filepath.stat().st_size
                     if file_size > MAX_FILE_SIZE:
-                        print(f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"
-                              f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit")
+                        print(
+                            f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"
+                            f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit"
+                        )
                         continue
                 except OSError:
                     continue

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -397,6 +397,14 @@ def scan_convos(convo_dir: str) -> list:
                     except OSError:
                         pass
                     continue
+                try:
+                    file_size = filepath.stat().st_size
+                    if file_size > MAX_FILE_SIZE:
+                        print(f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"
+                              f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit")
+                        continue
+                except OSError:
+                    continue
                 if not _is_regular_source_file(filepath, convo_path):
                     continue
                 files.append(filepath)

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1589,16 +1589,30 @@ def scan_project(
                 except OSError:
                     pass
                 continue
-            # Skip files exceeding size limit
+            # Skip files exceeding size limit, or those whose stat() raises
+            # (permission denied, racing delete, broken symlink that survived
+            # the earlier is_symlink check). Both branches log to stderr to
+            # match the SKIP: (symlink) line above; silent drops at this
+            # gate were the original #923 complaint.
             try:
                 file_size = filepath.stat().st_size
                 if file_size > MAX_FILE_SIZE:
                     print(
                         f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"
-                        f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit"
+                        f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit",
+                        file=sys.stderr,
                     )
                     continue
-            except OSError:
+            except OSError as exc:
+                # Prefer ``exc.strerror`` so the path isn't duplicated in the
+                # output (PermissionError stringifies to
+                # ``[Errno 13] Permission denied: '<path>'`` and the path is
+                # already in the SKIP prefix). Falls back to the default repr
+                # when strerror is unset.
+                print(
+                    f"  SKIP: {filepath.name} (stat error: {exc.strerror or exc})",
+                    file=sys.stderr,
+                )
                 continue
             files.append(filepath)
     return files

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1593,8 +1593,10 @@ def scan_project(
             try:
                 file_size = filepath.stat().st_size
                 if file_size > MAX_FILE_SIZE:
-                    print(f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"
-                          f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit")
+                    print(
+                        f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"
+                        f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit"
+                    )
                     continue
             except OSError:
                 continue

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1591,7 +1591,10 @@ def scan_project(
                 continue
             # Skip files exceeding size limit
             try:
-                if filepath.stat().st_size > MAX_FILE_SIZE:
+                file_size = filepath.stat().st_size
+                if file_size > MAX_FILE_SIZE:
+                    print(f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"
+                          f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit")
                     continue
             except OSError:
                 continue

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -431,6 +431,23 @@ class TestScanConvos:
         assert "deep/subdir/nested.jsonl" in err
         assert "(symlink)" in err
 
+    def test_scan_skips_oversized_files(self, tmp_path, capsys, monkeypatch):
+        import mempalace.convo_miner as convo_mod
+
+        monkeypatch.setattr(convo_mod, "MAX_FILE_SIZE", 100)
+
+        (tmp_path / "small.txt").write_text("hello " * 5, encoding="utf-8")
+        (tmp_path / "big.txt").write_text("hello " * 100, encoding="utf-8")
+
+        files = scan_convos(str(tmp_path))
+        names = [f.name for f in files]
+        assert "small.txt" in names
+        assert "big.txt" not in names
+
+        captured = capsys.readouterr()
+        assert "SKIP: big.txt" in captured.out
+        assert "exceeds" in captured.out
+
 
 class TestFileChunksLocked:
     def test_uses_bounded_upsert_batches(self, monkeypatch):

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -432,6 +432,8 @@ class TestScanConvos:
         assert "(symlink)" in err
 
     def test_scan_skips_oversized_files(self, tmp_path, capsys, monkeypatch):
+        import re
+
         import mempalace.convo_miner as convo_mod
 
         monkeypatch.setattr(convo_mod, "MAX_FILE_SIZE", 100)
@@ -444,9 +446,43 @@ class TestScanConvos:
         assert "small.txt" in names
         assert "big.txt" not in names
 
-        captured = capsys.readouterr()
-        assert "SKIP: big.txt" in captured.out
-        assert "exceeds" in captured.out
+        err = capsys.readouterr().err
+        # SKIP message goes to stderr, matching the existing
+        # `SKIP: <rel> (symlink)` line in the same function.
+        assert "SKIP: big.txt" in err
+        # Validate the full template so a drop of the MB suffix or a
+        # regression to bare-substring output trips the test.
+        assert re.search(r"SKIP: big\.txt \(\d+\.\d+ MB\) exceeds \d+ MB limit", err), err
+
+    def test_scan_skips_unreadable_files(self, tmp_path, capsys, monkeypatch):
+        from pathlib import Path
+
+        # .txt is in CONVO_EXTENSIONS so it reaches the size-check gate.
+        (tmp_path / "readable.txt").write_text("hi", encoding="utf-8")
+        unreadable = tmp_path / "unreadable.txt"
+        unreadable.write_text("hi", encoding="utf-8")
+
+        real_stat = Path.stat
+
+        def selective_stat(self, *args, **kwargs):
+            # On Py 3.10+, Path.is_symlink() routes through lstat ->
+            # stat(follow_symlinks=False). Only raise for the follow-symlinks
+            # call that the actual size-check makes, otherwise the test
+            # never reaches the size-check arm we want to exercise.
+            if self.name == "unreadable.txt" and kwargs.get("follow_symlinks", True):
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", selective_stat)
+
+        files = scan_convos(str(tmp_path))
+        names = [f.name for f in files]
+        assert "readable.txt" in names
+        assert "unreadable.txt" not in names
+
+        err = capsys.readouterr().err
+        assert "SKIP: unreadable.txt" in err
+        assert "stat error" in err
 
 
 class TestFileChunksLocked:

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -627,6 +627,8 @@ def test_entity_metadata_matches_known_names_case_insensitively(monkeypatch):
 
 
 def test_scan_project_skips_oversized_files(tmp_path, capsys, monkeypatch):
+    import re
+
     import mempalace.miner as miner_mod
 
     monkeypatch.setattr(miner_mod, "MAX_FILE_SIZE", 100)
@@ -639,9 +641,45 @@ def test_scan_project_skips_oversized_files(tmp_path, capsys, monkeypatch):
     assert "small.py" in names
     assert "big.py" not in names
 
-    captured = capsys.readouterr()
-    assert "SKIP: big.py" in captured.out
-    assert "exceeds" in captured.out
+    err = capsys.readouterr().err
+    # SKIP message goes to stderr, matching the existing
+    # `SKIP: <rel> (symlink)` line in the same function.
+    assert "SKIP: big.py" in err
+    # Validate the full template shape so a regression to bare-substring
+    # output (or a drop of the MB suffix) trips the test instead of
+    # silently passing.
+    assert re.search(r"SKIP: big\.py \(\d+\.\d+ MB\) exceeds \d+ MB limit", err), err
+
+
+def test_scan_project_skips_unreadable_files(tmp_path, capsys, monkeypatch):
+    from pathlib import Path
+
+    # Two real files; the unreadable one will have stat() raise.
+    write_file(tmp_path / "readable.py", "x = 1\n")
+    unreadable = tmp_path / "unreadable.py"
+    write_file(unreadable, "x = 1\n")
+
+    real_stat = Path.stat
+
+    def selective_stat(self, *args, **kwargs):
+        # On Py 3.10+, Path.is_symlink() routes through lstat ->
+        # stat(follow_symlinks=False). Only raise for the follow-symlinks
+        # call that the actual size-check makes, otherwise the test
+        # never reaches the size-check arm we want to exercise.
+        if self.name == "unreadable.py" and kwargs.get("follow_symlinks", True):
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", selective_stat)
+
+    files = scan_project(str(tmp_path))
+    names = [f.name for f in files]
+    assert "readable.py" in names
+    assert "unreadable.py" not in names
+
+    err = capsys.readouterr().err
+    assert "SKIP: unreadable.py" in err
+    assert "stat error" in err
 
 
 def test_file_already_mined_check_mtime():

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -626,6 +626,24 @@ def test_entity_metadata_matches_known_names_case_insensitively(monkeypatch):
     assert "Lumi" in matched_mixed
 
 
+def test_scan_project_skips_oversized_files(tmp_path, capsys, monkeypatch):
+    import mempalace.miner as miner_mod
+
+    monkeypatch.setattr(miner_mod, "MAX_FILE_SIZE", 100)
+
+    write_file(tmp_path / "small.py", "x = 1\n" * 10)
+    write_file(tmp_path / "big.py", "x = 1\n" * 100)
+
+    files = scan_project(str(tmp_path))
+    names = [f.name for f in files]
+    assert "small.py" in names
+    assert "big.py" not in names
+
+    captured = capsys.readouterr()
+    assert "SKIP: big.py" in captured.out
+    assert "exceeds" in captured.out
+
+
 def test_file_already_mined_check_mtime():
     tmpdir = tempfile.mkdtemp()
     try:


### PR DESCRIPTION
## Summary

`mempalace mine` (both default and `--mode convos`) silently drops files at
the 500 MB `MAX_FILE_SIZE` threshold. No log, no counter, exit code 0. The
output is indistinguishable from a directory with no mineable files (the
original #923 complaint).

This PR logs a SKIP line on stderr per dropped file, matching the existing
`SKIP: <rel> (symlink)` stderr convention already present in the same
`scan_project` and `scan_convos` functions.

The `except OSError: continue` arm right below the size check is the same
bug class. A file whose `stat()` raises (permission denied, racing delete,
broken symlink that survived the earlier `is_symlink()` check) also drops
silently. This PR logs that case too.

## Sites covered

| File:line | Skip cause | Stream |
|---|---|---|
| `mempalace/miner.py:1160` | `st_size > MAX_FILE_SIZE` | stderr |
| `mempalace/miner.py:1167` | `stat()` OSError | stderr |
| `mempalace/convo_miner.py:372` | `st_size > MAX_FILE_SIZE` | stderr |
| `mempalace/convo_miner.py:379` | `stat()` OSError | stderr |

Sister site `mempalace/format_miner.py:344` (added in 3.3.6 via #1555)
already logs the same event via `logger.info("skip:too_large ...")` and is
unchanged here. Logging-style consolidation across the three miners is out
of scope for this PR.

Files that survive the walk and skip later in the processing loop (OSError
on `read_text`, content shorter than `MIN_CHUNK_SIZE`) are already counted
in the `Files skipped (already filed or other)` summary bucket. Those are
not the `#923` invisible-drop case. Bucketing the skip reasons by cause is
the same refactor as reporter spec item 2 below and is left out of this PR.

## Reporter spec coverage

#923 listed three asks; this PR addresses the first:

1. Warning per skipped file. Covered (stderr).
2. Distinct counter in the `Done.` summary. Not in this PR. `scan_project`
   filters oversized files out before they reach `mine()`'s
   `files_skipped` accounting; adding a counter would require changing
   the scan return shape (touched by 3 callers). Left for maintainer's
   judgment on whether the warning alone suffices.
3. `--max-file-size` CLI flag. Not in this PR. Reporter listed it as
   "ideally". Same maintainer-judgment note.

## Test plan

- [x] `pytest tests/test_miner.py::test_scan_project_skips_oversized_files`
- [x] `pytest tests/test_miner.py::test_scan_project_skips_unreadable_files`
- [x] `pytest tests/test_convo_miner_unit.py::TestScanConvos::test_scan_skips_oversized_files`
- [x] `pytest tests/test_convo_miner_unit.py::TestScanConvos::test_scan_skips_unreadable_files`
- [x] Full suite passes
- [x] `ruff check .` + `ruff format --check .` clean against ruff 0.15.9
- [x] Binary repro on canonical develop @ `95caf80`: 534 MB
      conversation file under `mempalace mine --dry-run --mode convos`
      is silent on develop (no stderr, no stdout mention, exit 0). On
      this branch the same invocation prints
      `SKIP: bigchat.txt (534.1 MB) exceeds 500 MB limit` on stderr
      only; the mine summary on stdout is identical to develop.

Closes #923
