### PR TITLE
feat: refactor storage abstraction and add Milvus Lite backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,9 +71,11 @@ mempalace/
 ├── knowledge_graph.py   # Temporal entity-relationship graph (SQLite)
 ├── palace.py            # Shared palace operations
 ├── palace_graph.py      # Room traversal + cross-wing tunnels
-├── backends/            # Pluggable storage backends (ChromaDB default)
-│   ├── base.py          # Abstract interface — implement this for new backends
-│   └── chroma.py        # ChromaDB implementation
+├── backends/            # Pluggable storage backends
+│   ├── base.py          # Abstract interface + QueryResult/GetResult dataclasses
+│   ├── chroma.py        # ChromaDB implementation (default)
+│   └── milvus.py        # Milvus Lite implementation — opt-in via [milvus] extra
+├── embeddings.py        # Local ONNX embedder (MiniLM-L6-v2, 384 dim)
 ├── dialect.py           # AAAK compression dialect
 ├── normalize.py         # Transcript format detection + normalization
 ├── entity_detector.py   # Auto-detect people/projects from content

--- a/docs/milvus-backend.md
+++ b/docs/milvus-backend.md
@@ -1,0 +1,159 @@
+# Milvus backend
+
+MemPalace ships with two interchangeable storage backends:
+
+| Backend | Package | Default storage | When to pick |
+|---------|---------|-----------------|-------------|
+| **Chroma** (default) | `chromadb` | `chroma.sqlite3` + `./<palace>/` | Single-machine, zero extra setup, works out of the box. |
+| **Milvus Lite** | `pymilvus[milvus_lite]` | single `milvus.db` file per palace | Single-file palace you can copy as one artifact; same local-first guarantee; a stepping stone for users who later want to self-host Milvus. |
+
+Both implement the same `BaseCollection` contract
+(`mempalace/backends/base.py`), so wings, rooms, drawers, closets, hybrid
+search, and the knowledge graph behave identically regardless of which
+one is active. Switching backends does **not** migrate data — they each
+own a separate storage tree.
+
+## Why Milvus Lite
+
+Milvus Lite is a pure embedded build of the Milvus engine. It runs
+in-process, writes to a single `.db` file, requires no server, and has
+no cloud or API-key dependency. That matches MemPalace's local-first,
+verbatim, zero-API rule exactly. Self-hosted Milvus over `http://…` is
+also supported for users who eventually outgrow a single file — but the
+default is, and will remain, a file on your laptop.
+
+Zilliz Cloud is deliberately **not documented as an install path** for
+MemPalace: cloud storage of verbatim memory is outside MemPalace's
+privacy-by-architecture guarantee.
+
+## Install
+
+```bash
+pip install 'mempalace[milvus]'
+```
+
+The `milvus` extra pulls in:
+
+- `pymilvus>=2.5.0` — modern `MilvusClient` API
+- `milvus-lite>=2.4.10` — embedded engine (Linux / macOS; not available on Windows)
+- `onnxruntime>=1.17.0` — local embedding runtime
+- `huggingface_hub>=0.20.0` — one-time model download
+
+> **Note on Python 3.13 / setuptools 81+**: `milvus-lite<=2.5.1` still
+> imports the deprecated `pkg_resources` module, which was removed in
+> `setuptools>=81`. The extra pins `setuptools<81` until a newer
+> `milvus-lite` release drops the dependency.
+
+## Selecting Milvus as the backend
+
+Set an environment variable before launching any MemPalace command or the MCP server:
+
+```bash
+export MEMPALACE_BACKEND=milvus
+```
+
+Under the hood, `mempalace.backends.make_default_backend()` reads this
+variable and instantiates the right backend. Leave the variable unset or
+set it to `chroma` to keep the current default.
+
+## Direct programmatic use
+
+```python
+from mempalace.backends import MilvusBackend
+
+backend = MilvusBackend()
+col = backend.get_or_create_collection("/path/to/palace", "mempalace_drawers")
+
+col.add(
+    ids=["drawer_1"],
+    documents=["I am storing exactly these words."],
+    metadatas=[{"wing": "notes", "room": "thoughts"}],
+)
+
+result = col.query(
+    query_texts=["what did I write down"],
+    n_results=5,
+    where={"wing": "notes"},
+)
+for text, meta, dist in zip(result.documents, result.metadatas, result.distances):
+    print(dist, meta, text)
+```
+
+## Self-hosted Milvus
+
+Point `MilvusBackend` at a running Milvus server:
+
+```python
+MilvusBackend(uri="http://milvus.example.internal:19530")
+```
+
+The same `get_collection` / `query` / `get` / `delete` API is used; only
+the URI changes. Remember that any content you send over the network
+leaves your machine — which is fine for self-hosted deployments you
+control, but is a policy decision MemPalace will never make for you.
+
+## Embeddings
+
+Milvus collections are indexed with
+`AUTOINDEX` + `metric_type="COSINE"`, so distances align with the
+ChromaDB default (`hnsw:space=cosine`). The embeddings themselves are
+generated locally by `mempalace.embeddings.Embedder`, which wraps the
+same ONNX-exported `sentence-transformers/all-MiniLM-L6-v2` (384 dim)
+model ChromaDB bundles. The model is cached under
+`~/.cache/mempalace/onnx/` (override with
+`MEMPALACE_EMBEDDINGS_CACHE`). After the one-time download, runtime
+calls are fully offline.
+
+To guarantee no network traffic at runtime, call `warmup()` during
+startup:
+
+```python
+from mempalace.embeddings import warmup
+warmup()  # downloads + loads the model; later calls hit disk only
+```
+
+## Schema
+
+Each collection stores three fixed fields plus dynamic metadata:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | `VARCHAR(128)` | Primary key; MemPalace drawer IDs fit well under this. |
+| `document` | `VARCHAR(65535)` | Verbatim text. MemPalace never truncates — callers must chunk before storing. |
+| `vector` | `FLOAT_VECTOR(384)` | MiniLM embedding. |
+| *(dynamic)* | inferred | Every metadata key you pass (`wing`, `room`, `hall`, `source_file`, `chunk_index`, `filed_at`, …) is stored and filterable. |
+
+## Supported `where` DSL
+
+The abstraction supports the same filter subset on both backends:
+
+| Clause | Example |
+|--------|---------|
+| Equality | `{"wing": "project"}` |
+| Membership | `{"chunk_index": {"$in": [1, 2, 3]}}` |
+| AND | `{"$and": [{"wing": "p"}, {"room": "r"}]}` |
+| OR  | `{"$or":  [{"wing": "p"}, {"wing": "q"}]}` |
+
+Operators outside this list (`$ne`, `$gt`/`$lt`, regex, full-text
+search) are intentionally not part of the portable contract. The Milvus
+adapter raises `ValueError` when it sees one so the error is surfaced
+at the call site instead of quietly producing wrong results.
+
+Multi-key top-level dicts (`{"wing": "p", "room": "r"}`) also raise —
+wrap them in an explicit `$and`. This is stricter than Chroma's
+implicit-AND behavior, but it keeps the meaning unambiguous across
+backends.
+
+## Limits and known caveats
+
+- **Windows**: `milvus-lite` is not distributed for Windows; stay on the
+  Chroma backend there.
+- **Verbatim contract**: a single document longer than 65 535
+  characters will raise `ValueError` at insert time. MemPalace's
+  existing chunking keeps drawers well below this; this is a guardrail
+  for user-authored content (e.g. diary entries).
+- **pkg_resources deprecation**: `milvus-lite<=2.5.1` emits a
+  `UserWarning` about `pkg_resources`. It is harmless and goes away
+  once `milvus-lite` updates.
+- **Palace migration**: there is no automatic data migration between
+  Chroma and Milvus. Pick a backend per palace.

--- a/mempalace/README.md
+++ b/mempalace/README.md
@@ -24,17 +24,31 @@ The Python package that powers MemPalace. All modules, all logic.
 | `room_detector_local.py` | Maps folders to room names using 70+ patterns — no API |
 | `spellcheck.py` | Name-aware spellcheck — won't "correct" proper nouns in your entity registry |
 | `split_mega_files.py` | Splits concatenated transcript files into per-session files |
+| `embeddings.py` | Local ONNX embedder (MiniLM-L6-v2, 384 dim) — used by non-Chroma backends |
+| `backends/base.py` | Backend-agnostic `BaseCollection` contract + `QueryResult` / `GetResult` dataclasses |
+| `backends/chroma.py` | ChromaDB adapter (default) |
+| `backends/milvus.py` | Milvus Lite adapter — opt-in via `pip install 'mempalace[milvus]'` |
 
 ## Architecture
 
 ```
-User → CLI → miner/convo_miner → ChromaDB (palace)
-                                     ↕
-                              knowledge_graph (SQLite)
-                                     ↕
+User → CLI → miner/convo_miner → backends.BaseCollection → Chroma   (default)
+                                              │           → Milvus Lite (opt-in)
+                                              ↕
+                                       knowledge_graph (SQLite)
+                                              ↕
 User → MCP Server → searcher → results
                   → kg_query → entity facts
                   → diary    → agent journal
 ```
 
-The palace (ChromaDB) stores verbatim content. The knowledge graph (SQLite) stores structured relationships. The MCP server exposes both to any AI tool.
+The palace stores verbatim content through a small backend-agnostic
+contract (`backends/base.py` — typed `add` / `upsert` / `update` /
+`query` / `get` / `delete` / `count` plus `QueryResult` and `GetResult`
+dataclasses). Two implementations ship today: ChromaDB (default) and
+Milvus Lite (`pip install 'mempalace[milvus]'`). See
+[`docs/milvus-backend.md`](../docs/milvus-backend.md) for the opt-in
+story. Switch with `MEMPALACE_BACKEND=milvus`.
+
+The knowledge graph (SQLite) stores structured relationships. The MCP
+server exposes both to any AI tool.

--- a/mempalace/backends/__init__.py
+++ b/mempalace/backends/__init__.py
@@ -1,6 +1,97 @@
-"""Storage backend implementations for MemPalace."""
+"""Storage backend implementations for MemPalace.
 
-from .base import BaseCollection
+Two backends ship by default:
+
+    ChromaBackend  — local DuckDB+Parquet via chromadb (the original).
+    MilvusBackend  — local single-file Milvus Lite (``./milvus.db``);
+                     also supports self-hosted Milvus over HTTP.
+
+Both implement the same :class:`BaseCollection` contract so the rest of
+MemPalace never has to care which one is in use.
+
+Selecting a backend
+-------------------
+Set the ``MEMPALACE_BACKEND`` environment variable to ``chroma`` (default)
+or ``milvus``. :func:`make_default_backend` honors the env var; callers
+that need fine control (e.g. dependency injection in tests) can
+instantiate a backend class directly.
+
+The ``milvus`` backend requires the ``milvus`` optional dependency
+group — install with ``pip install mempalace[milvus]``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .base import (
+    DEFAULT_GET_INCLUDE,
+    DEFAULT_QUERY_INCLUDE,
+    BaseCollection,
+    GetResult,
+    QueryResult,
+)
 from .chroma import ChromaBackend, ChromaCollection
 
-__all__ = ["BaseCollection", "ChromaBackend", "ChromaCollection"]
+
+class BackendNotInstalledError(ImportError):
+    """Raised when the requested backend's optional dependencies are missing."""
+
+
+def _load_milvus_backend() -> Any:
+    """Import :class:`MilvusBackend` lazily so Chroma-only installs work.
+
+    The ``milvus`` optional dependency group pulls in ``pymilvus``,
+    ``milvus-lite``, ``onnxruntime``, and ``huggingface_hub``. If any
+    are missing we surface a targeted error with install instructions
+    rather than a raw ImportError on some deep-transitive symbol.
+    """
+    try:
+        from .milvus import MilvusBackend  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - exercised indirectly
+        raise BackendNotInstalledError(
+            "MilvusBackend requires optional dependencies. Install with: "
+            "pip install 'mempalace[milvus]'"
+        ) from exc
+    return MilvusBackend
+
+
+def make_default_backend(**kwargs: Any):
+    """Factory that honors the ``MEMPALACE_BACKEND`` environment variable.
+
+    ``kwargs`` are forwarded to the chosen backend's constructor.
+    """
+    name = os.environ.get("MEMPALACE_BACKEND", "chroma").strip().lower()
+    if name == "chroma":
+        return ChromaBackend(**kwargs)
+    if name == "milvus":
+        cls = _load_milvus_backend()
+        return cls(**kwargs)
+    raise ValueError(f"Unknown MEMPALACE_BACKEND={name!r}. Expected 'chroma' or 'milvus'.")
+
+
+__all__ = [
+    "BackendNotInstalledError",
+    "BaseCollection",
+    "ChromaBackend",
+    "ChromaCollection",
+    "DEFAULT_GET_INCLUDE",
+    "DEFAULT_QUERY_INCLUDE",
+    "GetResult",
+    "QueryResult",
+    "make_default_backend",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy attribute access so ``from mempalace.backends import MilvusBackend``
+    works when ``pymilvus`` is installed and raises a helpful error otherwise.
+    """
+    if name == "MilvusBackend":
+        return _load_milvus_backend()
+    if name == "MilvusCollection":
+        from .milvus import MilvusCollection
+
+        return MilvusCollection
+    raise AttributeError(f"module 'mempalace.backends' has no attribute {name!r}")

--- a/mempalace/backends/base.py
+++ b/mempalace/backends/base.py
@@ -1,7 +1,108 @@
-"""Abstract collection interface for MemPalace storage backends."""
+"""Abstract collection interface for MemPalace storage backends.
+
+This module defines the backend-agnostic contract that every storage
+implementation (ChromaDB, Milvus Lite, etc.) must honor. Callers in the
+rest of MemPalace only ever touch the typed methods on ``BaseCollection``
+and the ``GetResult`` / ``QueryResult`` dataclasses returned here — they
+never see Chroma- or Milvus-specific shapes.
+
+Supported ``where`` DSL (the same subset on every backend):
+
+    {"field": value}                 equality on a metadata field
+    {"field": {"$in": [v1, v2]}}     membership
+    {"$and": [clause, clause, ...]}  logical AND of nested clauses
+    {"$or":  [clause, clause, ...]}  logical OR of nested clauses
+
+A top-level dict with a single metadata key is a single equality clause.
+Multiple top-level metadata keys must be wrapped in an explicit ``$and``.
+
+Anything outside this subset (``$ne``, ``$gt``/``$lt``, regex, full-text
+predicates, etc.) is NOT part of the portable contract and must not be
+relied upon by callers. Backends may raise ``ValueError`` when asked to
+translate an unsupported clause.
+"""
+
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+
+# --- include flags ----------------------------------------------------------
+# Modeled after ChromaDB's include kwarg. IDs are always returned; any
+# combination of the three below can be requested explicitly.
+
+INCLUDE_DOCUMENTS = "documents"
+INCLUDE_METADATAS = "metadatas"
+INCLUDE_DISTANCES = "distances"
+
+DEFAULT_GET_INCLUDE: tuple = (INCLUDE_DOCUMENTS, INCLUDE_METADATAS)
+DEFAULT_QUERY_INCLUDE: tuple = (INCLUDE_DOCUMENTS, INCLUDE_METADATAS, INCLUDE_DISTANCES)
+
+
+# --- result dataclasses -----------------------------------------------------
+
+
+@dataclass
+class GetResult:
+    """Result of a ``BaseCollection.get`` call.
+
+    All fields are flat, single-query lists. ``documents``, ``metadatas``
+    are empty when the caller did not request them via ``include=``.
+    """
+
+    ids: List[str] = field(default_factory=list)
+    documents: List[str] = field(default_factory=list)
+    metadatas: List[Dict[str, Any]] = field(default_factory=list)
+
+    _FIELDS = ("ids", "documents", "metadatas")
+
+    def __getitem__(self, key: str) -> Any:
+        if key not in self._FIELDS:
+            raise KeyError(key)
+        return getattr(self, key)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._FIELDS
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if key not in self._FIELDS:
+            return default
+        return getattr(self, key)
+
+
+@dataclass
+class QueryResult:
+    """Result of a ``BaseCollection.query`` call.
+
+    Collapses the batch dimension that Chroma uses natively. Every list is
+    already the slice for a single query — callers should iterate fields
+    directly, not index into ``[0]``.
+    """
+
+    ids: List[str] = field(default_factory=list)
+    documents: List[str] = field(default_factory=list)
+    metadatas: List[Dict[str, Any]] = field(default_factory=list)
+    distances: List[float] = field(default_factory=list)
+
+    _FIELDS = ("ids", "documents", "metadatas", "distances")
+
+    def __getitem__(self, key: str) -> Any:
+        if key not in self._FIELDS:
+            raise KeyError(key)
+        return getattr(self, key)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._FIELDS
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if key not in self._FIELDS:
+            return default
+        return getattr(self, key)
+
+
+# --- abstract interface -----------------------------------------------------
 
 
 class BaseCollection(ABC):
@@ -11,39 +112,76 @@ class BaseCollection(ABC):
     def add(
         self,
         *,
-        documents: List[str],
         ids: List[str],
+        documents: List[str],
         metadatas: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
+        """Insert new records. Raises if any ID already exists."""
         raise NotImplementedError
 
     @abstractmethod
     def upsert(
         self,
         *,
-        documents: List[str],
         ids: List[str],
+        documents: List[str],
         metadatas: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
+        """Insert new records, overwriting any with the same ID."""
         raise NotImplementedError
 
     @abstractmethod
-    def update(self, **kwargs: Any) -> None:
-        """Update existing records. Must raise if any ID is missing."""
+    def update(
+        self,
+        *,
+        ids: List[str],
+        documents: Optional[List[str]] = None,
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """Update existing records in place. Missing IDs raise."""
         raise NotImplementedError
 
     @abstractmethod
-    def query(self, **kwargs: Any) -> Dict[str, Any]:
+    def query(
+        self,
+        *,
+        query_texts: List[str],
+        n_results: int = 10,
+        where: Optional[Dict[str, Any]] = None,
+        include: Iterable[str] = DEFAULT_QUERY_INCLUDE,
+    ) -> QueryResult:
+        """Semantic (vector) search.
+
+        ``query_texts`` is a list for API symmetry with Chroma but every
+        MemPalace caller passes exactly one query. A :class:`QueryResult`
+        is returned with flat lists (the per-query batch is collapsed).
+        """
         raise NotImplementedError
 
     @abstractmethod
-    def get(self, **kwargs: Any) -> Dict[str, Any]:
+    def get(
+        self,
+        *,
+        ids: Optional[List[str]] = None,
+        where: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Iterable[str] = DEFAULT_GET_INCLUDE,
+    ) -> GetResult:
+        """Fetch records by ID and/or filter, with optional pagination."""
         raise NotImplementedError
 
     @abstractmethod
-    def delete(self, **kwargs: Any) -> None:
+    def delete(
+        self,
+        *,
+        ids: Optional[List[str]] = None,
+        where: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Remove records by ID list or filter (or both)."""
         raise NotImplementedError
 
     @abstractmethod
     def count(self) -> int:
+        """Total number of records in the collection."""
         raise NotImplementedError

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1,12 +1,21 @@
 """ChromaDB-backed MemPalace collection adapter."""
 
+from __future__ import annotations
+
 import logging
 import os
 import sqlite3
+from typing import Any, Dict, Iterable, List, Optional
 
 import chromadb
 
-from .base import BaseCollection
+from .base import (
+    DEFAULT_GET_INCLUDE,
+    DEFAULT_QUERY_INCLUDE,
+    BaseCollection,
+    GetResult,
+    QueryResult,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,31 +52,120 @@ def _fix_blob_seq_ids(palace_path: str):
         logger.exception("Could not fix BLOB seq_ids in %s", db_path)
 
 
+def _first_or_empty(raw: Dict[str, Any], key: str) -> List[Any]:
+    """Safely pull the single-query slice out of a Chroma batch response."""
+    outer = raw.get(key)
+    if not outer:
+        return []
+    inner = outer[0]
+    return inner if inner else []
+
+
 class ChromaCollection(BaseCollection):
     """Thin adapter over a ChromaDB collection."""
 
     def __init__(self, collection):
         self._collection = collection
 
-    def add(self, *, documents, ids, metadatas=None):
-        self._collection.add(documents=documents, ids=ids, metadatas=metadatas)
+    # -- writes -----------------------------------------------------------
 
-    def upsert(self, *, documents, ids, metadatas=None):
-        self._collection.upsert(documents=documents, ids=ids, metadatas=metadatas)
+    def add(
+        self,
+        *,
+        ids: List[str],
+        documents: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        self._collection.add(ids=ids, documents=documents, metadatas=metadatas)
 
-    def update(self, **kwargs):
+    def upsert(
+        self,
+        *,
+        ids: List[str],
+        documents: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        self._collection.upsert(ids=ids, documents=documents, metadatas=metadatas)
+
+    def update(
+        self,
+        *,
+        ids: List[str],
+        documents: Optional[List[str]] = None,
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        kwargs: Dict[str, Any] = {"ids": ids}
+        if documents is not None:
+            kwargs["documents"] = documents
+        if metadatas is not None:
+            kwargs["metadatas"] = metadatas
         self._collection.update(**kwargs)
 
-    def query(self, **kwargs):
-        return self._collection.query(**kwargs)
+    # -- reads ------------------------------------------------------------
 
-    def get(self, **kwargs):
-        return self._collection.get(**kwargs)
+    def query(
+        self,
+        *,
+        query_texts: List[str],
+        n_results: int = 10,
+        where: Optional[Dict[str, Any]] = None,
+        include: Iterable[str] = DEFAULT_QUERY_INCLUDE,
+    ) -> QueryResult:
+        include_list = list(include)
+        kwargs: Dict[str, Any] = {
+            "query_texts": query_texts,
+            "n_results": n_results,
+            "include": include_list,
+        }
+        if where:
+            kwargs["where"] = where
+        raw = self._collection.query(**kwargs)
+        return QueryResult(
+            ids=_first_or_empty(raw, "ids"),
+            documents=_first_or_empty(raw, "documents"),
+            metadatas=_first_or_empty(raw, "metadatas"),
+            distances=_first_or_empty(raw, "distances"),
+        )
 
-    def delete(self, **kwargs):
+    def get(
+        self,
+        *,
+        ids: Optional[List[str]] = None,
+        where: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Iterable[str] = DEFAULT_GET_INCLUDE,
+    ) -> GetResult:
+        kwargs: Dict[str, Any] = {"include": list(include)}
+        if ids is not None:
+            kwargs["ids"] = ids
+        if where is not None:
+            kwargs["where"] = where
+        if limit is not None:
+            kwargs["limit"] = limit
+        if offset is not None:
+            kwargs["offset"] = offset
+        raw = self._collection.get(**kwargs)
+        return GetResult(
+            ids=raw.get("ids") or [],
+            documents=raw.get("documents") or [],
+            metadatas=raw.get("metadatas") or [],
+        )
+
+    def delete(
+        self,
+        *,
+        ids: Optional[List[str]] = None,
+        where: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        kwargs: Dict[str, Any] = {}
+        if ids is not None:
+            kwargs["ids"] = ids
+        if where is not None:
+            kwargs["where"] = where
         self._collection.delete(**kwargs)
 
-    def count(self):
+    def count(self) -> int:
         return self._collection.count()
 
 

--- a/mempalace/backends/milvus.py
+++ b/mempalace/backends/milvus.py
@@ -1,0 +1,656 @@
+"""Milvus Lite-backed MemPalace collection adapter.
+
+Uses the modern :class:`pymilvus.MilvusClient` API exclusively — no ORM,
+no ``connections.connect``. The default URI is ``./milvus.db`` relative
+to the palace path, so every palace is a single local file and no server
+is required. Self-hosted Milvus can be used by passing an ``http://``
+URI to :class:`MilvusBackend`.
+
+Schema
+------
+Every MemPalace collection stores three fixed fields plus dynamic
+metadata:
+
+    id        VARCHAR(128)   primary key, MemPalace drawer IDs
+    document  VARCHAR(65535) verbatim text content (no truncation)
+    vector    FLOAT_VECTOR(384) MiniLM embedding in cosine space
+
+``enable_dynamic_field=True`` means MemPalace metadata fields (``wing``,
+``room``, ``hall``, ``source_file``, ``chunk_index``, …) are stored
+alongside each record and can be filtered with the same ``where`` DSL
+documented on :class:`~mempalace.backends.base.BaseCollection`.
+
+Index
+-----
+``AUTOINDEX`` with ``metric_type="COSINE"``. This matches the Chroma
+default (``hnsw:space=cosine``) so distances are directly comparable
+across backends.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from ..embeddings import DEFAULT_DIM, Embedder
+from .base import (
+    DEFAULT_GET_INCLUDE,
+    DEFAULT_QUERY_INCLUDE,
+    INCLUDE_DISTANCES,
+    INCLUDE_DOCUMENTS,
+    INCLUDE_METADATAS,
+    BaseCollection,
+    GetResult,
+    QueryResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --- constants --------------------------------------------------------------
+
+DEFAULT_DB_FILENAME = "milvus.db"
+DRAWER_ID_MAX_LENGTH = 128
+DOCUMENT_MAX_LENGTH = 65535
+# Milvus has a hard per-call ceiling on offset+limit for non-iterator
+# reads. We page strictly below this; callers that need more use
+# query_iterator transparently.
+MILVUS_MAX_WINDOW = 16384
+FIELD_ID = "id"
+FIELD_DOCUMENT = "document"
+FIELD_VECTOR = "vector"
+RESERVED_FIELDS = {FIELD_ID, FIELD_DOCUMENT, FIELD_VECTOR, "distance"}
+
+
+# --- where DSL translation --------------------------------------------------
+
+
+def _quote_value(value: Any) -> str:
+    """Serialize a Python value into a Milvus filter literal."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if value is None:
+        raise ValueError("null comparisons are not part of the portable where DSL")
+    # Treat everything else as a string; escape backslashes and double quotes.
+    text = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{text}"'
+
+
+def _translate_clause(clause: Dict[str, Any]) -> str:
+    if not isinstance(clause, dict):
+        raise ValueError(f"where clause must be a dict, got {type(clause).__name__}")
+    if not clause:
+        return ""
+
+    if len(clause) == 1:
+        key, value = next(iter(clause.items()))
+        if key == "$and":
+            if not isinstance(value, list) or not value:
+                raise ValueError("$and requires a non-empty list of clauses")
+            parts = [_translate_clause(sub) for sub in value]
+            return "(" + " and ".join(p for p in parts if p) + ")"
+        if key == "$or":
+            if not isinstance(value, list) or not value:
+                raise ValueError("$or requires a non-empty list of clauses")
+            parts = [_translate_clause(sub) for sub in value]
+            return "(" + " or ".join(p for p in parts if p) + ")"
+        if key.startswith("$"):
+            raise ValueError(f"unsupported top-level operator: {key}")
+        return _translate_field(key, value)
+
+    # Multi-key dicts: Chroma treats these as implicit-$and but the
+    # portable contract requires an explicit wrapper so the meaning is
+    # obvious on both backends. Error loudly instead of guessing.
+    raise ValueError(
+        "where dict with multiple keys must be wrapped in explicit "
+        f"$and (got keys: {sorted(clause.keys())})"
+    )
+
+
+def _translate_field(field: str, value: Any) -> str:
+    if isinstance(value, dict):
+        if set(value.keys()) != {"$in"}:
+            raise ValueError(f"only $in is supported as a field operator (field={field!r})")
+            # pragma: no cover
+        items = value["$in"]
+        if not isinstance(items, list) or not items:
+            raise ValueError(f"$in requires a non-empty list (field={field!r})")
+        rendered = ", ".join(_quote_value(v) for v in items)
+        return f"{field} in [{rendered}]"
+    return f"{field} == {_quote_value(value)}"
+
+
+def translate_where(where: Optional[Dict[str, Any]]) -> str:
+    """Public entry point. Returns a Milvus filter string or ``""``."""
+    if not where:
+        return ""
+    return _translate_clause(where)
+
+
+# --- collection -------------------------------------------------------------
+
+
+class MilvusCollection(BaseCollection):
+    """Adapter over a single Milvus collection within a palace."""
+
+    def __init__(
+        self,
+        *,
+        client,
+        collection_name: str,
+        embedder: Embedder,
+        dim: int = DEFAULT_DIM,
+    ):
+        self._client = client
+        self._name = collection_name
+        self._embedder = embedder
+        self._dim = dim
+
+    # -- helpers ---------------------------------------------------------
+
+    def _embed_many(self, texts: List[str]) -> List[List[float]]:
+        return self._embedder.embed(texts)
+
+    def _prepare_rows(
+        self,
+        *,
+        ids: List[str],
+        documents: List[str],
+        metadatas: Optional[List[Dict[str, Any]]],
+    ) -> List[Dict[str, Any]]:
+        if metadatas is None:
+            metadatas = [dict() for _ in ids]
+        if not (len(ids) == len(documents) == len(metadatas)):
+            raise ValueError(
+                "ids, documents and metadatas must have equal length "
+                f"(got {len(ids)}, {len(documents)}, {len(metadatas)})"
+            )
+
+        vectors = self._embed_many(list(documents))
+        rows: List[Dict[str, Any]] = []
+        for idx, (_id, doc, meta, vec) in enumerate(zip(ids, documents, metadatas, vectors)):
+            if not isinstance(_id, str) or not _id:
+                raise ValueError(f"row {idx}: id must be a non-empty string")
+            if len(_id) > DRAWER_ID_MAX_LENGTH:
+                raise ValueError(f"row {idx}: id length {len(_id)} exceeds {DRAWER_ID_MAX_LENGTH}")
+            if not isinstance(doc, str):
+                doc = "" if doc is None else str(doc)
+            if len(doc) > DOCUMENT_MAX_LENGTH:
+                # MemPalace's verbatim contract means we never silently
+                # truncate. Surface a clear error so the caller can chunk.
+                raise ValueError(
+                    f"row {idx}: document length {len(doc)} exceeds "
+                    f"Milvus VARCHAR limit {DOCUMENT_MAX_LENGTH} — chunk before storing"
+                )
+            row: Dict[str, Any] = {
+                FIELD_ID: _id,
+                FIELD_DOCUMENT: doc,
+                FIELD_VECTOR: vec,
+            }
+            if meta:
+                for k, v in meta.items():
+                    if k in RESERVED_FIELDS:
+                        raise ValueError(
+                            f"row {idx}: metadata key {k!r} clashes with a reserved field"
+                        )
+                    row[k] = v
+            rows.append(row)
+        return rows
+
+    def _output_fields_for_include(
+        self, include: Iterable[str], *, with_distance: bool
+    ) -> List[str]:
+        wanted = set(include)
+        fields: List[str] = [FIELD_ID]
+        if INCLUDE_DOCUMENTS in wanted:
+            fields.append(FIELD_DOCUMENT)
+        if INCLUDE_METADATAS in wanted:
+            # "*" pulls every dynamic field along with the scalar fields.
+            fields.append("*")
+        return fields
+
+    def _extract_metadata(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        return {k: v for k, v in record.items() if k not in RESERVED_FIELDS}
+
+    # -- writes ----------------------------------------------------------
+
+    def add(
+        self,
+        *,
+        ids: List[str],
+        documents: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        rows = self._prepare_rows(ids=ids, documents=documents, metadatas=metadatas)
+        if not rows:
+            return
+        self._client.insert(collection_name=self._name, data=rows)
+
+    def upsert(
+        self,
+        *,
+        ids: List[str],
+        documents: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        rows = self._prepare_rows(ids=ids, documents=documents, metadatas=metadatas)
+        if not rows:
+            return
+        self._client.upsert(collection_name=self._name, data=rows)
+
+    def update(
+        self,
+        *,
+        ids: List[str],
+        documents: Optional[List[str]] = None,
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        if not ids:
+            return
+        # Milvus Lite can throw a segcore assertion when fetching by ID
+        # from a freshly-created collection that has never been queried
+        # or compacted. Treat any read failure here as "not found" so the
+        # contract (update a missing ID -> KeyError) still holds.
+        try:
+            existing = (
+                self._client.get(
+                    collection_name=self._name,
+                    ids=list(ids),
+                    output_fields=["*"],
+                )
+                or []
+            )
+        except Exception:
+            existing = []
+        by_id = {rec[FIELD_ID]: rec for rec in existing}
+        missing = [i for i in ids if i not in by_id]
+        if missing:
+            raise KeyError(f"update: ids not found: {missing}")
+
+        new_docs = (
+            list(documents) if documents is not None else [by_id[i][FIELD_DOCUMENT] for i in ids]
+        )
+        if metadatas is None:
+            new_metas = [self._extract_metadata(by_id[i]) for i in ids]
+        else:
+            new_metas = [dict(m) for m in metadatas]
+
+        self.upsert(ids=list(ids), documents=new_docs, metadatas=new_metas)
+
+    def delete(
+        self,
+        *,
+        ids: Optional[List[str]] = None,
+        where: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if ids is None and where is None:
+            raise ValueError("delete requires either ids= or where=")
+        if ids is not None and len(ids) == 0:
+            return
+        kwargs: Dict[str, Any] = {"collection_name": self._name}
+        if ids is not None:
+            kwargs["ids"] = list(ids)
+        if where is not None:
+            kwargs["filter"] = translate_where(where)
+        self._client.delete(**kwargs)
+
+    # -- reads -----------------------------------------------------------
+
+    def query(
+        self,
+        *,
+        query_texts: List[str],
+        n_results: int = 10,
+        where: Optional[Dict[str, Any]] = None,
+        include: Iterable[str] = DEFAULT_QUERY_INCLUDE,
+    ) -> QueryResult:
+        if not query_texts:
+            return QueryResult()
+        # MemPalace always queries with exactly one text; ignore extras
+        # after computing the embedding (keeps parity with Chroma).
+        vectors = self._embed_many(list(query_texts))
+        include_set = set(include)
+        output_fields = self._output_fields_for_include(
+            include, with_distance=INCLUDE_DISTANCES in include_set
+        )
+
+        search_kwargs: Dict[str, Any] = {
+            "collection_name": self._name,
+            "data": vectors[:1],
+            "limit": max(1, n_results),
+            "output_fields": output_fields,
+            "anns_field": FIELD_VECTOR,
+            "search_params": {"metric_type": "COSINE"},
+        }
+        filter_expr = translate_where(where)
+        if filter_expr:
+            search_kwargs["filter"] = filter_expr
+
+        raw = self._client.search(**search_kwargs)
+        hits = raw[0] if raw else []
+
+        ids: List[str] = []
+        docs: List[str] = []
+        metas: List[Dict[str, Any]] = []
+        dists: List[float] = []
+        for hit in hits:
+            entity = hit.get("entity") if isinstance(hit, dict) else None
+            if entity is None and isinstance(hit, dict):
+                entity = hit
+            ids.append(hit.get("id") if isinstance(hit, dict) else hit.id)
+            if INCLUDE_DOCUMENTS in include_set:
+                docs.append((entity or {}).get(FIELD_DOCUMENT, ""))
+            if INCLUDE_METADATAS in include_set:
+                metas.append(self._extract_metadata(entity or {}))
+            if INCLUDE_DISTANCES in include_set:
+                # Milvus COSINE returns a similarity-style score in [-1, 1]
+                # where 1.0 means identical. Chroma's cosine "distance" is
+                # 1 - similarity in [0, 2]. Convert so downstream rankers
+                # (which expect lower = closer) keep working.
+                score = (
+                    hit.get("distance") if isinstance(hit, dict) else getattr(hit, "distance", 0.0)
+                )
+                dists.append(1.0 - float(score))
+        return QueryResult(ids=ids, documents=docs, metadatas=metas, distances=dists)
+
+    def get(
+        self,
+        *,
+        ids: Optional[List[str]] = None,
+        where: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Iterable[str] = DEFAULT_GET_INCLUDE,
+    ) -> GetResult:
+        include_list = list(include)
+        output_fields = self._output_fields_for_include(include_list, with_distance=False)
+        if ids is not None:
+            if len(ids) == 0:
+                return GetResult()
+            records = (
+                self._client.get(
+                    collection_name=self._name,
+                    ids=list(ids),
+                    output_fields=output_fields,
+                )
+                or []
+            )
+        else:
+            records = self._collect_by_filter(
+                filter_expr=translate_where(where),
+                output_fields=output_fields,
+                limit=limit,
+                offset=offset or 0,
+            )
+
+        result_ids: List[str] = []
+        result_docs: List[str] = []
+        result_metas: List[Dict[str, Any]] = []
+        include_set = set(include_list)
+        for rec in records:
+            result_ids.append(rec.get(FIELD_ID, ""))
+            if INCLUDE_DOCUMENTS in include_set:
+                result_docs.append(rec.get(FIELD_DOCUMENT, ""))
+            if INCLUDE_METADATAS in include_set:
+                result_metas.append(self._extract_metadata(rec))
+        return GetResult(ids=result_ids, documents=result_docs, metadatas=result_metas)
+
+    def _collect_by_filter(
+        self,
+        *,
+        filter_expr: str,
+        output_fields: List[str],
+        limit: Optional[int],
+        offset: int,
+    ) -> List[Dict[str, Any]]:
+        # Milvus's id primary key is a VARCHAR — there's no natural numeric
+        # filter that matches "every row". Passing filter="" works with
+        # modern MilvusClient.query / MilvusClient.query_iterator.
+        filter_str = filter_expr or ""
+
+        # If the caller's window fits below Milvus's hard ceiling, use a
+        # single query. Otherwise fall through to the iterator.
+        effective_limit = limit if limit is not None else None
+        if effective_limit is not None and offset + effective_limit <= MILVUS_MAX_WINDOW:
+            kwargs: Dict[str, Any] = {
+                "collection_name": self._name,
+                "output_fields": output_fields,
+                "limit": effective_limit,
+            }
+            if filter_str:
+                kwargs["filter"] = filter_str
+            if offset:
+                kwargs["offset"] = offset
+            return list(self._client.query(**kwargs) or [])
+
+        # Paginate via query_iterator. This is the path exercised by
+        # full-scan callers (exporter, migrate, _fetch_all_metadata).
+        iterator_kwargs: Dict[str, Any] = {
+            "collection_name": self._name,
+            "output_fields": output_fields,
+            "batch_size": min(MILVUS_MAX_WINDOW, effective_limit or 1000),
+        }
+        if filter_str:
+            iterator_kwargs["filter"] = filter_str
+        iterator = self._client.query_iterator(**iterator_kwargs)
+
+        skipped = 0
+        collected: List[Dict[str, Any]] = []
+        try:
+            while True:
+                batch = iterator.next()
+                if not batch:
+                    break
+                for rec in batch:
+                    if skipped < offset:
+                        skipped += 1
+                        continue
+                    collected.append(rec)
+                    if effective_limit is not None and len(collected) >= effective_limit:
+                        return collected
+        finally:
+            try:
+                iterator.close()
+            except Exception:
+                pass
+        return collected
+
+    def count(self) -> int:
+        rows = (
+            self._client.query(
+                collection_name=self._name,
+                filter="",
+                output_fields=["count(*)"],
+            )
+            or []
+        )
+        if not rows:
+            return 0
+        # Milvus returns [{"count(*)": N}].
+        first = rows[0]
+        return int(first.get("count(*)", first.get("count", 0)))
+
+
+# --- backend ---------------------------------------------------------------
+
+
+class MilvusBackend:
+    """Factory for the Milvus Lite (or self-hosted Milvus) backend."""
+
+    def __init__(
+        self,
+        *,
+        uri: Optional[str] = None,
+        db_filename: str = DEFAULT_DB_FILENAME,
+        embedder: Optional[Embedder] = None,
+    ):
+        """Create a new backend.
+
+        Parameters
+        ----------
+        uri:
+            Optional explicit connection URI. When ``None`` (the default),
+            every palace gets its own ``./milvus.db`` file under
+            ``palace_path/``. Pass ``http://host:19530`` to point at a
+            self-hosted Milvus server instead.
+        db_filename:
+            File name used for the per-palace Milvus Lite database. Only
+            honored when ``uri`` is ``None``.
+        embedder:
+            Inject a pre-configured embedder (useful for tests that want
+            to pin a ``local_dir``). A shared default is used otherwise.
+        """
+        self._uri_override = uri
+        self._db_filename = db_filename
+        self._embedder = embedder
+        # (palace_path_or_uri_key) -> MilvusClient
+        self._clients: dict = {}
+
+    # -- connection ------------------------------------------------------
+
+    def _get_embedder(self) -> Embedder:
+        if self._embedder is not None:
+            return self._embedder
+        from ..embeddings import get_default_embedder
+
+        self._embedder = get_default_embedder()
+        return self._embedder
+
+    def _resolve_uri(self, palace_path: str) -> str:
+        if self._uri_override:
+            return self._uri_override
+        return os.path.join(palace_path, self._db_filename)
+
+    def _client(self, palace_path: str):
+        from pymilvus import MilvusClient  # deferred
+
+        uri = self._resolve_uri(palace_path)
+        if uri not in self._clients:
+            self._clients[uri] = MilvusClient(uri=uri)
+        return self._clients[uri]
+
+    # -- lifecycle -------------------------------------------------------
+
+    @staticmethod
+    def backend_version() -> str:
+        import pymilvus  # deferred
+
+        return pymilvus.__version__
+
+    def get_collection(
+        self,
+        palace_path: str,
+        collection_name: str,
+        create: bool = False,
+    ) -> MilvusCollection:
+        """Return a :class:`MilvusCollection` bound to ``palace_path``."""
+        uri = self._resolve_uri(palace_path)
+        is_local_file = not (uri.startswith("http://") or uri.startswith("https://"))
+
+        if is_local_file:
+            parent = os.path.dirname(uri) or "."
+            if not create and not os.path.isdir(parent):
+                raise FileNotFoundError(palace_path)
+            if create:
+                os.makedirs(parent, exist_ok=True)
+                try:
+                    os.chmod(parent, 0o700)
+                except (OSError, NotImplementedError):
+                    pass
+
+        client = self._client(palace_path)
+        if not client.has_collection(collection_name):
+            if not create:
+                raise FileNotFoundError(f"collection {collection_name!r} does not exist at {uri}")
+            self._create_collection(client, collection_name)
+
+        return MilvusCollection(
+            client=client,
+            collection_name=collection_name,
+            embedder=self._get_embedder(),
+        )
+
+    def get_or_create_collection(self, palace_path: str, collection_name: str) -> MilvusCollection:
+        return self.get_collection(palace_path, collection_name, create=True)
+
+    def create_collection(
+        self,
+        palace_path: str,
+        collection_name: str,
+        hnsw_space: str = "cosine",
+    ) -> MilvusCollection:
+        """Create (not get-or-create). ``hnsw_space`` is accepted for parity
+        with :class:`~mempalace.backends.chroma.ChromaBackend` but must be
+        ``cosine`` since Milvus AUTOINDEX + COSINE is what we standardize on.
+        """
+        if hnsw_space.lower() != "cosine":
+            raise ValueError(f"MilvusBackend only supports cosine metric (got {hnsw_space!r})")
+        uri = self._resolve_uri(palace_path)
+        if not (uri.startswith("http://") or uri.startswith("https://")):
+            parent = os.path.dirname(uri) or "."
+            os.makedirs(parent, exist_ok=True)
+        client = self._client(palace_path)
+        if client.has_collection(collection_name):
+            raise ValueError(f"collection {collection_name!r} already exists")
+        self._create_collection(client, collection_name)
+        return MilvusCollection(
+            client=client,
+            collection_name=collection_name,
+            embedder=self._get_embedder(),
+        )
+
+    def delete_collection(self, palace_path: str, collection_name: str) -> None:
+        client = self._client(palace_path)
+        if client.has_collection(collection_name):
+            client.drop_collection(collection_name)
+
+    # -- schema ----------------------------------------------------------
+
+    def _create_collection(self, client, collection_name: str) -> None:
+        from pymilvus import DataType  # deferred
+
+        schema = client.create_schema(
+            auto_id=False,
+            enable_dynamic_field=True,
+            description="MemPalace drawers — verbatim text + MiniLM vectors",
+        )
+        schema.add_field(
+            field_name=FIELD_ID,
+            datatype=DataType.VARCHAR,
+            is_primary=True,
+            max_length=DRAWER_ID_MAX_LENGTH,
+        )
+        schema.add_field(
+            field_name=FIELD_DOCUMENT,
+            datatype=DataType.VARCHAR,
+            max_length=DOCUMENT_MAX_LENGTH,
+        )
+        schema.add_field(
+            field_name=FIELD_VECTOR,
+            datatype=DataType.FLOAT_VECTOR,
+            dim=self._get_embedder().dim,
+        )
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name=FIELD_VECTOR,
+            index_type="AUTOINDEX",
+            metric_type="COSINE",
+        )
+
+        client.create_collection(
+            collection_name=collection_name,
+            schema=schema,
+            index_params=index_params,
+        )
+
+
+# --- module-level helper for where-DSL sanity tests ------------------------
+
+
+def compile_where(where: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    """Return (milvus_filter, original_where) — useful for debugging tools."""
+    return translate_where(where), where

--- a/mempalace/dedup.py
+++ b/mempalace/dedup.py
@@ -104,11 +104,11 @@ def dedup_source_group(col, drawer_ids, threshold=DEFAULT_THRESHOLD, dry_run=Tru
                 n_results=min(len(kept), 5),
                 include=["distances"],
             )
-            dists = results["distances"][0] if results["distances"] else []
+            dists = results.distances
             kept_ids_set = {k[0] for k in kept}
 
             is_dup = False
-            for rid, dist in zip(results["ids"][0], dists):
+            for rid, dist in zip(results.ids, dists):
                 if rid in kept_ids_set and dist < threshold:
                     is_dup = True
                     break

--- a/mempalace/embeddings.py
+++ b/mempalace/embeddings.py
@@ -1,0 +1,302 @@
+"""Local, offline sentence embeddings for MemPalace.
+
+Wraps the same ONNX-exported ``sentence-transformers/all-MiniLM-L6-v2``
+model ChromaDB uses by default (384-dim, cosine space). The model is
+downloaded once from Hugging Face on first use and cached on disk; all
+later calls run fully offline.
+
+This module exists so non-Chroma backends (e.g. Milvus Lite) can match
+Chroma's default embedding space without pulling in ChromaDB itself, and
+without introducing any API-key dependency — a hard MemPalace rule.
+
+Heavy third-party imports (``onnxruntime``, ``huggingface_hub``,
+``tokenizers``, ``numpy``) are deferred until the first ``Embedder()``
+construction so importing :mod:`mempalace.embeddings` from a Chroma-only
+install has no side effects.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# --- constants --------------------------------------------------------------
+
+# Chroma's default embedder. Matching model + tokenizer + pooling keeps
+# existing palace vectors compatible with Milvus-backed collections.
+DEFAULT_MODEL_REPO = "sentence-transformers/all-MiniLM-L6-v2"
+DEFAULT_ONNX_FILENAME = "onnx/model.onnx"
+DEFAULT_DIM = 384
+DEFAULT_MAX_SEQ_LENGTH = 256
+DEFAULT_BATCH_SIZE = 32
+
+
+def default_cache_dir() -> Path:
+    """Return the platform-appropriate ONNX model cache directory."""
+    env = os.environ.get("MEMPALACE_EMBEDDINGS_CACHE")
+    if env:
+        return Path(env).expanduser()
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".cache"
+    return base / "mempalace" / "onnx"
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _mean_pool(last_hidden, attention_mask):
+    """Mean-pool token embeddings using the attention mask.
+
+    ``last_hidden`` shape: (batch, seq_len, hidden). Mask shape: (batch,
+    seq_len). Padding tokens are zeroed out before averaging.
+    """
+    import numpy as np  # deferred
+
+    mask = attention_mask.astype(last_hidden.dtype)[..., None]
+    summed = (last_hidden * mask).sum(axis=1)
+    counts = np.clip(mask.sum(axis=1), a_min=1e-9, a_max=None)
+    return summed / counts
+
+
+def _l2_normalize(vectors):
+    import numpy as np  # deferred
+
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    norms = np.clip(norms, a_min=1e-12, a_max=None)
+    return vectors / norms
+
+
+# --- Embedder ---------------------------------------------------------------
+
+
+class Embedder:
+    """Local ONNX sentence embedder — drop-in for Chroma's default model.
+
+    Parameters
+    ----------
+    model_repo:
+        Hugging Face repo id. Defaults to ``sentence-transformers/all-MiniLM-L6-v2``.
+    onnx_filename:
+        Path (within the repo) to the ONNX export. Defaults to ``onnx/model.onnx``.
+    cache_dir:
+        Where to cache the downloaded files. Defaults to
+        ``~/.cache/mempalace/onnx`` (or ``$MEMPALACE_EMBEDDINGS_CACHE``).
+    local_dir:
+        Optional explicit directory containing a pre-downloaded copy of
+        ``model.onnx`` + ``tokenizer.json``. When set, no network access
+        is attempted at all.
+    max_seq_length:
+        Truncation length passed to the tokenizer.
+    """
+
+    def __init__(
+        self,
+        model_repo: str = DEFAULT_MODEL_REPO,
+        onnx_filename: str = DEFAULT_ONNX_FILENAME,
+        cache_dir: Optional[Path] = None,
+        local_dir: Optional[Path] = None,
+        max_seq_length: int = DEFAULT_MAX_SEQ_LENGTH,
+    ):
+        self.model_repo = model_repo
+        self.onnx_filename = onnx_filename
+        self.cache_dir = Path(cache_dir) if cache_dir else default_cache_dir()
+        self.local_dir = Path(local_dir).expanduser() if local_dir else None
+        self.max_seq_length = max_seq_length
+        self._session = None
+        self._tokenizer = None
+        self._input_names: Optional[List[str]] = None
+        self._lock = threading.Lock()
+
+    # -- lazy initialization ---------------------------------------------
+
+    def _ensure_ready(self) -> None:
+        if self._session is not None and self._tokenizer is not None:
+            return
+        with self._lock:
+            if self._session is not None and self._tokenizer is not None:
+                return
+            onnx_path, tokenizer_path = self._resolve_files()
+            self._load(onnx_path, tokenizer_path)
+
+    def _find_local_files(self, base: Path):
+        """Look for ``model.onnx`` + ``tokenizer.json`` under ``base``.
+
+        ``base`` may point at the ONNX directory directly or at a parent
+        that contains an ``onnx/`` subfolder (matching Chroma's layout).
+        Returns ``(onnx_path, tokenizer_path)`` or ``(None, None)``.
+        """
+        if not base.is_dir():
+            return None, None
+        candidates = [base, base / "onnx"]
+        for cand in candidates:
+            onnx = cand / "model.onnx"
+            tok = cand / "tokenizer.json"
+            if onnx.is_file() and tok.is_file():
+                return onnx, tok
+        return None, None
+
+    def _resolve_files(self):
+        """Return paths to ``model.onnx`` and ``tokenizer.json``.
+
+        Resolution order:
+            1. ``local_dir`` (if the caller passed one — never touches network)
+            2. existing MemPalace cache
+            3. existing ChromaDB cache (same model, same files)
+            4. download from Hugging Face into MemPalace cache
+        """
+        if self.local_dir is not None:
+            onnx, tok = self._find_local_files(self.local_dir)
+            if onnx and tok:
+                return onnx, tok
+            raise FileNotFoundError(
+                f"Embedder(local_dir={self.local_dir!s}) — could not find "
+                "model.onnx + tokenizer.json in that directory or its onnx/ subfolder."
+            )
+
+        onnx, tok = self._find_local_files(self.cache_dir)
+        if onnx and tok:
+            return onnx, tok
+
+        chroma_cache = Path.home() / ".cache" / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
+        onnx, tok = self._find_local_files(chroma_cache)
+        if onnx and tok:
+            return onnx, tok
+
+        return self._download()
+
+    def _download(self):
+        from huggingface_hub import hf_hub_download  # deferred
+
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(self.cache_dir, 0o700)
+        except (OSError, NotImplementedError):
+            pass
+
+        required = [self.onnx_filename, "tokenizer.json", "tokenizer_config.json"]
+        optional = ["vocab.txt", "special_tokens_map.json"]
+        downloaded: dict = {}
+        for fname in required:
+            downloaded[fname] = hf_hub_download(
+                repo_id=self.model_repo,
+                filename=fname,
+                cache_dir=str(self.cache_dir),
+            )
+        for fname in optional:
+            try:
+                hf_hub_download(
+                    repo_id=self.model_repo,
+                    filename=fname,
+                    cache_dir=str(self.cache_dir),
+                )
+            except Exception:
+                pass
+        return Path(downloaded[self.onnx_filename]), Path(downloaded["tokenizer.json"])
+
+    def _load(self, onnx_path: Path, tokenizer_path: Path) -> None:
+        import onnxruntime  # deferred
+        from tokenizers import Tokenizer  # deferred
+
+        session_options = onnxruntime.SessionOptions()
+        session_options.log_severity_level = 3  # errors only; keep stdout clean
+        self._session = onnxruntime.InferenceSession(
+            str(onnx_path),
+            sess_options=session_options,
+            providers=["CPUExecutionProvider"],
+        )
+        self._input_names = [i.name for i in self._session.get_inputs()]
+        self._tokenizer = Tokenizer.from_file(str(tokenizer_path))
+        self._tokenizer.enable_truncation(max_length=self.max_seq_length)
+        self._tokenizer.enable_padding(length=None)
+
+    # -- encoding --------------------------------------------------------
+
+    def embed(
+        self,
+        texts: Iterable[str],
+        *,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        normalize: bool = True,
+    ) -> List[List[float]]:
+        """Encode ``texts`` to 384-d float vectors.
+
+        Empty / non-string inputs are replaced with a single space so the
+        tokenizer never sees an empty sequence. Output order matches input
+        order.
+        """
+        import numpy as np  # deferred
+
+        self._ensure_ready()
+        cleaned = [t if isinstance(t, str) and t else " " for t in texts]
+        if not cleaned:
+            return []
+
+        out: List[List[float]] = []
+        for start in range(0, len(cleaned), batch_size):
+            batch = cleaned[start : start + batch_size]
+            encodings = self._tokenizer.encode_batch(batch)
+            input_ids = np.asarray([e.ids for e in encodings], dtype=np.int64)
+            attention_mask = np.asarray([e.attention_mask for e in encodings], dtype=np.int64)
+            feeds: dict = {}
+            for name in self._input_names or []:
+                if name == "input_ids":
+                    feeds[name] = input_ids
+                elif name == "attention_mask":
+                    feeds[name] = attention_mask
+                elif name == "token_type_ids":
+                    feeds[name] = np.zeros_like(input_ids)
+
+            outputs = self._session.run(None, feeds)
+            last_hidden = outputs[0]
+            pooled = _mean_pool(last_hidden, attention_mask)
+            if normalize:
+                pooled = _l2_normalize(pooled)
+            out.extend(pooled.astype(np.float32).tolist())
+        return out
+
+    def embed_one(self, text: str) -> List[float]:
+        return self.embed([text])[0]
+
+    @property
+    def dim(self) -> int:
+        return DEFAULT_DIM
+
+
+# --- public one-shots -------------------------------------------------------
+
+
+_default_embedder: Optional[Embedder] = None
+_default_lock = threading.Lock()
+
+
+def get_default_embedder() -> Embedder:
+    """Return a process-wide shared :class:`Embedder` (lazily constructed)."""
+    global _default_embedder
+    if _default_embedder is not None:
+        return _default_embedder
+    with _default_lock:
+        if _default_embedder is None:
+            _default_embedder = Embedder()
+        return _default_embedder
+
+
+def warmup() -> None:
+    """Prime the default embedder so subsequent calls are fully offline.
+
+    Callers who want to guarantee no network traffic after initialization
+    should invoke this once during startup. After ``warmup()`` returns,
+    the ONNX model and tokenizer files are cached locally and the model
+    is loaded in-memory.
+    """
+    get_default_embedder()._ensure_ready()
+
+
+def embed(texts: Iterable[str]) -> List[List[float]]:
+    """Shortcut around :meth:`Embedder.embed` using the shared instance."""
+    return get_default_embedder().embed(texts)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -253,10 +253,10 @@ def _fetch_all_metadata(col, where=None):
         if where:
             kwargs["where"] = where
         batch = col.get(**kwargs)
-        if not batch["metadatas"]:
+        if not batch.metadatas:
             break
-        all_meta.extend(batch["metadatas"])
-        offset += len(batch["metadatas"])
+        all_meta.extend(batch.metadatas)
+        offset += len(batch.metadatas)
     return all_meta
 
 
@@ -475,22 +475,21 @@ def tool_check_duplicate(content: str, threshold: float = 0.9):
             include=["metadatas", "documents", "distances"],
         )
         duplicates = []
-        if results["ids"] and results["ids"][0]:
-            for i, drawer_id in enumerate(results["ids"][0]):
-                dist = results["distances"][0][i]
-                similarity = round(1 - dist, 3)
-                if similarity >= threshold:
-                    meta = results["metadatas"][0][i]
-                    doc = results["documents"][0][i]
-                    duplicates.append(
-                        {
-                            "id": drawer_id,
-                            "wing": meta.get("wing", "?"),
-                            "room": meta.get("room", "?"),
-                            "similarity": similarity,
-                            "content": doc[:200] + "..." if len(doc) > 200 else doc,
-                        }
-                    )
+        for i, drawer_id in enumerate(results.ids):
+            dist = results.distances[i]
+            similarity = round(1 - dist, 3)
+            if similarity >= threshold:
+                meta = results.metadatas[i]
+                doc = results.documents[i]
+                duplicates.append(
+                    {
+                        "id": drawer_id,
+                        "wing": meta.get("wing", "?"),
+                        "room": meta.get("room", "?"),
+                        "similarity": similarity,
+                        "content": doc[:200] + "..." if len(doc) > 200 else doc,
+                    }
+                )
         return {
             "is_duplicate": len(duplicates) > 0,
             "matches": duplicates,

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -30,18 +30,21 @@ class SearchError(Exception):
 _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
 
 
-def _first_or_empty(results: dict, key: str) -> list:
-    """Return the first inner list of a ChromaDB query result, or [].
+def _first_or_empty(results, key: str) -> list:
+    """Return the per-query slice of a backend query result, or [].
 
-    ChromaDB returns shapes like ``{"documents": [["a", "b"]], ...}`` for a
-    successful query, but ``{"documents": [], ...}`` (empty outer list) when
-    the collection is empty or the filter excludes everything. Indexing
-    ``[0]`` blindly raises IndexError in that case (issue #195).
+    The backend layer already collapses ChromaDB's nested batch shape into
+    flat lists (:class:`~mempalace.backends.base.QueryResult`), so this is
+    just a safe attribute/key fetch with an empty-list fallback. Kept as a
+    named helper because it documents the "one query, one slice" assumption
+    that the rest of the search pipeline relies on (issue #195).
     """
-    outer = results.get(key)
-    if not outer:
+    if results is None:
         return []
-    return outer[0] or []
+    if hasattr(results, key):
+        return getattr(results, key) or []
+    value = results.get(key) if hasattr(results, "get") else None
+    return value or []
 
 
 def _tokenize(text: str) -> list:
@@ -209,7 +212,7 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
         return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
 
     indexed_docs = []
-    for doc, meta in zip(neighbors.get("documents") or [], neighbors.get("metadatas") or []):
+    for doc, meta in zip(neighbors.documents or [], neighbors.metadatas or []):
         ci = meta.get("chunk_index")
         if isinstance(ci, int):
             indexed_docs.append((ci, doc))
@@ -224,8 +227,7 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
     total_drawers = None
     try:
         all_meta = drawers_col.get(where={"source_file": src}, include=["metadatas"])
-        ids = all_meta.get("ids") or []
-        total_drawers = len(ids) if ids else None
+        total_drawers = len(all_meta.ids) if all_meta.ids else None
     except Exception:
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,15 @@ mempalace = "mempalace.cli:main"
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]
 spellcheck = ["autocorrect>=2.0"]
+milvus = [
+    "pymilvus>=2.5.0",
+    "milvus-lite>=2.4.10; sys_platform != 'win32'",
+    "onnxruntime>=1.17.0",
+    "huggingface_hub>=0.20.0",
+    # milvus-lite<=2.5.1 still imports pkg_resources, which setuptools>=81
+    # removed. Pin setuptools until a newer milvus-lite drops the dep.
+    "setuptools<81",
+]
 
 [dependency-groups]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -3,10 +3,13 @@ import sqlite3
 import chromadb
 import pytest
 
+from mempalace.backends.base import GetResult, QueryResult
 from mempalace.backends.chroma import ChromaBackend, ChromaCollection, _fix_blob_seq_ids
 
 
 class _FakeCollection:
+    """Mimics enough of a chromadb Collection for adapter tests."""
+
     def __init__(self):
         self.calls = []
 
@@ -16,13 +19,25 @@ class _FakeCollection:
     def upsert(self, **kwargs):
         self.calls.append(("upsert", kwargs))
 
+    def update(self, **kwargs):
+        self.calls.append(("update", kwargs))
+
     def query(self, **kwargs):
         self.calls.append(("query", kwargs))
-        return {"kind": "query"}
+        return {
+            "ids": [["a", "b"]],
+            "documents": [["doc_a", "doc_b"]],
+            "metadatas": [[{"wing": "w"}, {"wing": "w"}]],
+            "distances": [[0.1, 0.2]],
+        }
 
     def get(self, **kwargs):
         self.calls.append(("get", kwargs))
-        return {"kind": "get"}
+        return {
+            "ids": ["a"],
+            "documents": ["doc_a"],
+            "metadatas": [{"wing": "w"}],
+        }
 
     def delete(self, **kwargs):
         self.calls.append(("delete", kwargs))
@@ -32,25 +47,71 @@ class _FakeCollection:
         return 7
 
 
-def test_chroma_collection_delegates_methods():
+def test_chroma_collection_forwards_writes_with_keyword_args():
     fake = _FakeCollection()
     collection = ChromaCollection(fake)
 
-    collection.add(documents=["d"], ids=["1"], metadatas=[{"wing": "w"}])
-    collection.upsert(documents=["u"], ids=["2"], metadatas=[{"room": "r"}])
-    assert collection.query(query_texts=["q"]) == {"kind": "query"}
-    assert collection.get(where={"wing": "w"}) == {"kind": "get"}
+    collection.add(ids=["1"], documents=["d"], metadatas=[{"wing": "w"}])
+    collection.upsert(ids=["2"], documents=["u"], metadatas=[{"room": "r"}])
+    collection.update(ids=["3"], metadatas=[{"room": "r2"}])
     collection.delete(ids=["1"])
     assert collection.count() == 7
 
-    assert fake.calls == [
-        ("add", {"documents": ["d"], "ids": ["1"], "metadatas": [{"wing": "w"}]}),
-        ("upsert", {"documents": ["u"], "ids": ["2"], "metadatas": [{"room": "r"}]}),
-        ("query", {"query_texts": ["q"]}),
-        ("get", {"where": {"wing": "w"}}),
-        ("delete", {"ids": ["1"]}),
-        ("count", {}),
-    ]
+    assert fake.calls[0] == (
+        "add",
+        {"ids": ["1"], "documents": ["d"], "metadatas": [{"wing": "w"}]},
+    )
+    assert fake.calls[1] == (
+        "upsert",
+        {"ids": ["2"], "documents": ["u"], "metadatas": [{"room": "r"}]},
+    )
+    # update only forwards kwargs the caller actually supplied.
+    assert fake.calls[2] == ("update", {"ids": ["3"], "metadatas": [{"room": "r2"}]})
+    assert fake.calls[3] == ("delete", {"ids": ["1"]})
+
+
+def test_chroma_collection_query_flattens_batch_shape():
+    fake = _FakeCollection()
+    collection = ChromaCollection(fake)
+
+    result = collection.query(query_texts=["hi"], n_results=2)
+
+    assert isinstance(result, QueryResult)
+    # Chroma's batch dimension ([[...]]) is collapsed into flat lists.
+    assert result.ids == ["a", "b"]
+    assert result.documents == ["doc_a", "doc_b"]
+    assert result.metadatas == [{"wing": "w"}, {"wing": "w"}]
+    assert result.distances == [0.1, 0.2]
+    # Dict-style access still works for compatibility with older helpers.
+    assert result["ids"] == ["a", "b"]
+    assert "distances" in result
+
+
+def test_chroma_collection_get_returns_get_result():
+    fake = _FakeCollection()
+    collection = ChromaCollection(fake)
+
+    result = collection.get(ids=["a"])
+
+    assert isinstance(result, GetResult)
+    assert result.ids == ["a"]
+    assert result.documents == ["doc_a"]
+    assert result.metadatas == [{"wing": "w"}]
+    assert result["metadatas"][0]["wing"] == "w"
+    # Dict-style .get falls back to the default for unknown keys only.
+    assert result.get("ids") == ["a"]
+    assert result.get("distances", "absent") == "absent"
+
+
+def test_chroma_collection_get_omits_none_kwargs():
+    fake = _FakeCollection()
+    collection = ChromaCollection(fake)
+
+    collection.get(ids=["a"])
+
+    # include always forwards; ids/where/limit/offset only when set.
+    _, forwarded = fake.calls[-1]
+    assert forwarded == {"ids": ["a"], "include": ["documents", "metadatas"]}
 
 
 def test_chroma_backend_create_false_raises_without_creating_directory(tmp_path):

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 
 from mempalace import dedup
+from mempalace.backends.base import GetResult, QueryResult
 
 
 # ── get_source_groups ─────────────────────────────────────────────────
@@ -110,15 +111,15 @@ def test_get_source_groups_missing_source_file():
 
 def test_dedup_source_group_all_unique():
     col = MagicMock()
-    col.get.return_value = {
-        "ids": ["d1", "d2"],
-        "documents": ["long document one content here", "different document two here"],
-        "metadatas": [{"wing": "a"}, {"wing": "a"}],
-    }
-    col.query.return_value = {
-        "ids": [["d1"]],
-        "distances": [[0.8]],  # far apart = unique
-    }
+    col.get.return_value = GetResult(
+        ids=["d1", "d2"],
+        documents=["long document one content here", "different document two here"],
+        metadatas=[{"wing": "a"}, {"wing": "a"}],
+    )
+    col.query.return_value = QueryResult(
+        ids=["d1"],
+        distances=[0.8],  # far apart = unique
+    )
     kept, deleted = dedup.dedup_source_group(col, ["d1", "d2"], threshold=0.15, dry_run=True)
     assert len(kept) == 2
     assert len(deleted) == 0
@@ -126,18 +127,18 @@ def test_dedup_source_group_all_unique():
 
 def test_dedup_source_group_with_duplicate():
     col = MagicMock()
-    col.get.return_value = {
-        "ids": ["d1", "d2"],
-        "documents": [
+    col.get.return_value = GetResult(
+        ids=["d1", "d2"],
+        documents=[
             "long document content that is fairly long",
             "long document content that is fairly long",
         ],
-        "metadatas": [{"wing": "a"}, {"wing": "a"}],
-    }
-    col.query.return_value = {
-        "ids": [["d1"]],
-        "distances": [[0.05]],  # very close = duplicate
-    }
+        metadatas=[{"wing": "a"}, {"wing": "a"}],
+    )
+    col.query.return_value = QueryResult(
+        ids=["d1"],
+        distances=[0.05],  # very close = duplicate
+    )
     kept, deleted = dedup.dedup_source_group(col, ["d1", "d2"], threshold=0.15, dry_run=True)
     assert len(kept) == 1
     assert len(deleted) == 1
@@ -145,51 +146,51 @@ def test_dedup_source_group_with_duplicate():
 
 def test_dedup_source_group_short_docs_deleted():
     col = MagicMock()
-    col.get.return_value = {
-        "ids": ["d1", "d2"],
-        "documents": ["long enough document to keep in the palace", "tiny"],
-        "metadatas": [{"wing": "a"}, {"wing": "a"}],
-    }
+    col.get.return_value = GetResult(
+        ids=["d1", "d2"],
+        documents=["long enough document to keep in the palace", "tiny"],
+        metadatas=[{"wing": "a"}, {"wing": "a"}],
+    )
     kept, deleted = dedup.dedup_source_group(col, ["d1", "d2"], threshold=0.15, dry_run=True)
     assert "d2" in deleted  # too short
 
 
 def test_dedup_source_group_empty_doc_deleted():
     col = MagicMock()
-    col.get.return_value = {
-        "ids": ["d1", "d2"],
-        "documents": ["real document content here that is long enough", None],
-        "metadatas": [{"wing": "a"}, {"wing": "a"}],
-    }
+    col.get.return_value = GetResult(
+        ids=["d1", "d2"],
+        documents=["real document content here that is long enough", None],
+        metadatas=[{"wing": "a"}, {"wing": "a"}],
+    )
     kept, deleted = dedup.dedup_source_group(col, ["d1", "d2"], threshold=0.15, dry_run=True)
     assert "d2" in deleted
 
 
 def test_dedup_source_group_live_deletes():
     col = MagicMock()
-    col.get.return_value = {
-        "ids": ["d1", "d2"],
-        "documents": ["long document content here enough", "long document content here enough"],
-        "metadatas": [{"wing": "a"}, {"wing": "a"}],
-    }
-    col.query.return_value = {
-        "ids": [["d1"]],
-        "distances": [[0.05]],
-    }
+    col.get.return_value = GetResult(
+        ids=["d1", "d2"],
+        documents=["long document content here enough", "long document content here enough"],
+        metadatas=[{"wing": "a"}, {"wing": "a"}],
+    )
+    col.query.return_value = QueryResult(
+        ids=["d1"],
+        distances=[0.05],
+    )
     kept, deleted = dedup.dedup_source_group(col, ["d1", "d2"], threshold=0.15, dry_run=False)
     col.delete.assert_called_once()
 
 
 def test_dedup_source_group_query_failure_keeps():
     col = MagicMock()
-    col.get.return_value = {
-        "ids": ["d1", "d2"],
-        "documents": [
+    col.get.return_value = GetResult(
+        ids=["d1", "d2"],
+        documents=[
             "long document one content here enough",
             "long document two content here enough",
         ],
-        "metadatas": [{"wing": "a"}, {"wing": "a"}],
-    }
+        metadatas=[{"wing": "a"}, {"wing": "a"}],
+    )
     col.query.side_effect = Exception("query failed")
     kept, deleted = dedup.dedup_source_group(col, ["d1", "d2"], threshold=0.15, dry_run=True)
     assert len(kept) == 2  # both kept on error

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,174 @@
+"""Tests for mempalace.embeddings — local ONNX sentence embedder.
+
+These tests are skipped when the ONNX model can't be located in any of
+the expected caches (fresh CI without network). When the model *is*
+available (developer machine, or a previous Chroma-backed install),
+they verify the embedder produces sane, deterministic vectors and
+reloads cleanly from disk without hitting the network again.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _locate_model_dir() -> Path | None:
+    """Return a directory containing ``model.onnx`` + ``tokenizer.json``, or None.
+
+    The test suite redirects ``$HOME`` to a tmp dir (see ``conftest.py``),
+    so we can't rely on ``Path.home()`` here — we inspect the pristine
+    filesystem via absolute paths pulled from env vars plus well-known
+    Chroma/MemPalace cache locations under the real home.
+    """
+    env_cache = os.environ.get("MEMPALACE_TEST_ONNX_DIR")
+    if env_cache:
+        return Path(env_cache).expanduser()
+
+    real_home = os.environ.get("MEMPALACE_TEST_REAL_HOME") or _guess_real_home()
+    if not real_home:
+        return None
+    base = Path(real_home)
+    for candidate in (
+        base / ".cache" / "mempalace" / "onnx",
+        base / ".cache" / "chroma" / "onnx_models" / "all-MiniLM-L6-v2",
+    ):
+        for d in (candidate, candidate / "onnx"):
+            if (d / "model.onnx").is_file() and (d / "tokenizer.json").is_file():
+                return d
+    return None
+
+
+def _guess_real_home() -> str | None:
+    """Best-effort recovery of the real home dir (conftest clobbers $HOME)."""
+    try:
+        import pwd
+
+        return pwd.getpwuid(os.getuid()).pw_dir
+    except Exception:
+        return None
+
+
+def _model_available() -> bool:
+    return _locate_model_dir() is not None
+
+
+def test_default_cache_dir_respects_env(tmp_path, monkeypatch):
+    from mempalace.embeddings import default_cache_dir
+
+    monkeypatch.setenv("MEMPALACE_EMBEDDINGS_CACHE", str(tmp_path))
+    assert default_cache_dir() == tmp_path
+
+
+def test_default_cache_dir_falls_back_to_home(monkeypatch, tmp_path):
+    from mempalace.embeddings import default_cache_dir
+
+    monkeypatch.delenv("MEMPALACE_EMBEDDINGS_CACHE", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert default_cache_dir() == tmp_path / ".cache" / "mempalace" / "onnx"
+
+
+@pytest.fixture
+def local_model_dir() -> Path:
+    model_dir = _locate_model_dir()
+    if model_dir is None:
+        pytest.skip("all-MiniLM-L6-v2 ONNX model not cached locally")
+    return model_dir
+
+
+def test_embed_returns_unit_vectors_of_default_dim(local_model_dir):
+    from mempalace.embeddings import DEFAULT_DIM, Embedder
+
+    e = Embedder(local_dir=local_model_dir)
+    vectors = e.embed(["hello world", "python programming", "vector databases"])
+
+    assert len(vectors) == 3
+    for v in vectors:
+        assert len(v) == DEFAULT_DIM
+        norm = sum(x * x for x in v) ** 0.5
+        # L2-normalized by default, tolerating minor float error.
+        assert abs(norm - 1.0) < 1e-4
+
+
+def test_embed_is_deterministic(local_model_dir):
+    from mempalace.embeddings import Embedder
+
+    e = Embedder(local_dir=local_model_dir)
+    v1 = e.embed(["stable input"])[0]
+    v2 = e.embed(["stable input"])[0]
+    assert v1 == v2
+
+
+def test_embed_one_returns_single_vector(local_model_dir):
+    from mempalace.embeddings import DEFAULT_DIM, Embedder
+
+    e = Embedder(local_dir=local_model_dir)
+    v = e.embed_one("just one")
+    assert isinstance(v, list)
+    assert len(v) == DEFAULT_DIM
+
+
+def test_embed_empty_inputs_replaced_with_space(local_model_dir):
+    """An empty string must not crash the tokenizer."""
+    from mempalace.embeddings import Embedder
+
+    e = Embedder(local_dir=local_model_dir)
+    vectors = e.embed(["", "something"])
+    assert len(vectors) == 2
+    # Distinct inputs should produce distinct (non-equal) vectors.
+    assert vectors[0] != vectors[1]
+
+
+def test_local_dir_is_fully_offline(local_model_dir, monkeypatch):
+    """When local_dir is supplied, no HF call must be made."""
+    import huggingface_hub
+
+    import mempalace.embeddings as emb
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("huggingface_hub was called in local-only mode")
+
+    # Patch in both spots — the module's deferred import happens to live
+    # on the huggingface_hub module itself.
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", _boom, raising=True)
+
+    e = emb.Embedder(local_dir=local_model_dir)
+    vectors = e.embed(["fully offline"])
+    assert len(vectors) == 1
+    assert len(vectors[0]) == emb.DEFAULT_DIM
+
+
+def test_warmup_and_shared_embedder(local_model_dir, monkeypatch):
+    import mempalace.embeddings as emb
+
+    # Reset module-level shared state so we can inject a local-dir embedder.
+    monkeypatch.setattr(emb, "_default_embedder", None)
+
+    # Swap in a factory that pins the local dir so no download is attempted.
+    def _factory():
+        return emb.Embedder(local_dir=local_model_dir)
+
+    monkeypatch.setattr(emb, "get_default_embedder", lambda: _factory_memoize(emb, _factory))
+    emb.warmup()
+    a = emb.get_default_embedder()
+    b = emb.get_default_embedder()
+    assert a is b
+    assert a.embed(["warmed up"])[0]
+
+
+def _factory_memoize(module, factory):
+    # Simple one-shot memo used by test_warmup_and_shared_embedder.
+    if module._default_embedder is None:
+        module._default_embedder = factory()
+    return module._default_embedder
+
+
+def test_local_dir_missing_files_raises(tmp_path):
+    from mempalace.embeddings import Embedder
+
+    e = Embedder(local_dir=tmp_path)
+    with pytest.raises(FileNotFoundError):
+        e.embed(["anything"])

--- a/tests/test_empty_chromadb_results.py
+++ b/tests/test_empty_chromadb_results.py
@@ -1,48 +1,44 @@
-"""Regression tests for issue #195 — IndexError on empty ChromaDB results.
+"""Regression tests for issue #195 — empty query results must not IndexError.
 
-Before the fix, `searcher.search()`, `searcher.search_memories()`, and
-`Layer3.search()` indexed `results["documents"][0]` without checking the
-outer list, so a query against an empty collection (or a wing/room
-filter that excluded everything) crashed with IndexError instead of
-returning a graceful "no results" response.
+Before the backend refactor these tests checked the Chroma-native nested
+batch shape (``{"documents": [["a","b"]]}``). After the refactor,
+``BaseCollection.query`` returns a :class:`QueryResult` with flat lists,
+so the adapter layer is responsible for collapsing the batch dimension
+before callers ever see it. ``_first_or_empty`` now just guards against
+``None`` / missing attrs so search keeps returning "no results" instead
+of crashing.
 """
 
-import pytest
-
+from mempalace.backends.base import QueryResult
 from mempalace.searcher import _first_or_empty
 
 
-def test_first_or_empty_handles_empty_outer_list():
-    """The shape ChromaDB returns from an empty collection (issue #195)."""
-    results = {"documents": [], "metadatas": [], "distances": []}
+def test_first_or_empty_handles_empty_query_result():
+    """An empty QueryResult (collection is empty or filter excludes all)."""
+    results = QueryResult()
     assert _first_or_empty(results, "documents") == []
     assert _first_or_empty(results, "metadatas") == []
     assert _first_or_empty(results, "distances") == []
 
 
-def test_first_or_empty_handles_outer_with_empty_inner():
-    """ChromaDB also returns ``{"documents": [[]]}`` in some versions —
-    must yield [] either way."""
-    assert _first_or_empty({"documents": [[]]}, "documents") == []
+def test_first_or_empty_handles_none_results():
+    """Defensive: callers sometimes pass ``None`` on exception paths."""
+    assert _first_or_empty(None, "documents") == []
 
 
-def test_first_or_empty_handles_missing_key():
-    assert _first_or_empty({}, "documents") == []
+def test_first_or_empty_returns_flat_list_for_normal_result():
+    results = QueryResult(
+        ids=["a", "b", "c"],
+        documents=["doc_a", "doc_b", "doc_c"],
+        metadatas=[{}, {}, {}],
+        distances=[0.1, 0.2, 0.3],
+    )
+    assert _first_or_empty(results, "documents") == ["doc_a", "doc_b", "doc_c"]
+    assert _first_or_empty(results, "distances") == [0.1, 0.2, 0.3]
 
 
-def test_first_or_empty_handles_none_inner():
-    """``[None]`` (unusual but observed) must not blow up."""
-    assert _first_or_empty({"documents": [None]}, "documents") == []
-
-
-def test_first_or_empty_returns_inner_list_for_normal_result():
-    results = {"documents": [["a", "b", "c"]]}
-    assert _first_or_empty(results, "documents") == ["a", "b", "c"]
-
-
-def test_raw_indexing_still_raises_to_document_the_bug():
-    """Document the original failure mode so future readers understand
-    why _first_or_empty exists."""
-    results = {"documents": []}
-    with pytest.raises(IndexError):
-        _ = results["documents"][0]
+def test_first_or_empty_handles_dict_like_with_flat_values():
+    """Backwards-compat: plain dicts with flat lists (tests or fakes)."""
+    results = {"documents": ["a", "b"]}
+    assert _first_or_empty(results, "documents") == ["a", "b"]
+    assert _first_or_empty(results, "missing_key") == []

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import MagicMock, patch
 
+from mempalace.backends.base import GetResult, QueryResult
+
 from mempalace.layers import Layer0, Layer1, Layer2, Layer3, MemoryStack
 
 
@@ -73,10 +75,11 @@ def test_layer0_default_path():
 def _mock_chromadb_for_layer(docs, metas, monkeypatch=None):
     """Return a mock collection whose get() returns docs/metas."""
     mock_col = MagicMock()
+    ids = [f"id_{i}" for i in range(len(docs))]
     # First batch returns data, second batch returns empty (end of pagination)
     mock_col.get.side_effect = [
-        {"documents": docs, "metadatas": metas},
-        {"documents": [], "metadatas": []},
+        GetResult(ids=ids, documents=list(docs), metadatas=list(metas)),
+        GetResult(),
     ]
     return mock_col
 
@@ -115,7 +118,7 @@ def test_layer1_generates_essential_story():
 
 def test_layer1_empty_palace():
     mock_col = MagicMock()
-    mock_col.get.return_value = {"documents": [], "metadatas": []}
+    mock_col.get.return_value = GetResult()
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
         patch("mempalace.layers._get_collection", return_value=mock_col),
@@ -205,7 +208,7 @@ def test_layer1_batch_exception_breaks():
     """If col.get raises on a batch, loop breaks gracefully."""
     mock_col = MagicMock()
     mock_col.get.side_effect = [
-        {"documents": ["doc1"], "metadatas": [{"room": "r"}]},
+        GetResult(ids=["d1"], documents=["doc1"], metadatas=[{"room": "r"}]),
         RuntimeError("batch error"),
     ]
     with (
@@ -232,10 +235,11 @@ def test_layer2_no_palace():
 
 def test_layer2_retrieve_with_wing():
     mock_col = MagicMock()
-    mock_col.get.return_value = {
-        "documents": ["Some memory about the project"],
-        "metadatas": [{"room": "backend", "source_file": "notes.txt"}],
-    }
+    mock_col.get.return_value = GetResult(
+        ids=["d1"],
+        documents=["Some memory about the project"],
+        metadatas=[{"room": "backend", "source_file": "notes.txt"}],
+    )
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
         patch("mempalace.layers._get_collection", return_value=mock_col),
@@ -250,10 +254,11 @@ def test_layer2_retrieve_with_wing():
 
 def test_layer2_retrieve_with_room():
     mock_col = MagicMock()
-    mock_col.get.return_value = {
-        "documents": ["Backend architecture notes"],
-        "metadatas": [{"room": "architecture", "source_file": "arch.txt"}],
-    }
+    mock_col.get.return_value = GetResult(
+        ids=["d1"],
+        documents=["Backend architecture notes"],
+        metadatas=[{"room": "architecture", "source_file": "arch.txt"}],
+    )
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
         patch("mempalace.layers._get_collection", return_value=mock_col),
@@ -267,10 +272,11 @@ def test_layer2_retrieve_with_room():
 
 def test_layer2_retrieve_wing_and_room():
     mock_col = MagicMock()
-    mock_col.get.return_value = {
-        "documents": ["Filtered result"],
-        "metadatas": [{"room": "backend", "source_file": "x.txt"}],
-    }
+    mock_col.get.return_value = GetResult(
+        ids=["d1"],
+        documents=["Filtered result"],
+        metadatas=[{"room": "backend", "source_file": "x.txt"}],
+    )
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
         patch("mempalace.layers._get_collection", return_value=mock_col),
@@ -286,7 +292,7 @@ def test_layer2_retrieve_wing_and_room():
 
 def test_layer2_retrieve_empty():
     mock_col = MagicMock()
-    mock_col.get.return_value = {"documents": [], "metadatas": []}
+    mock_col.get.return_value = GetResult()
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
         patch("mempalace.layers._get_collection", return_value=mock_col),
@@ -300,7 +306,7 @@ def test_layer2_retrieve_empty():
 
 def test_layer2_retrieve_no_filter():
     mock_col = MagicMock()
-    mock_col.get.return_value = {"documents": [], "metadatas": []}
+    mock_col.get.return_value = GetResult()
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
         patch("mempalace.layers._get_collection", return_value=mock_col),
@@ -330,10 +336,11 @@ def test_layer2_retrieve_error():
 
 def test_layer2_truncates_long_snippets():
     mock_col = MagicMock()
-    mock_col.get.return_value = {
-        "documents": ["B" * 400],
-        "metadatas": [{"room": "r", "source_file": "s.txt"}],
-    }
+    mock_col.get.return_value = GetResult(
+        ids=["d1"],
+        documents=["B" * 400],
+        metadatas=[{"room": "r", "source_file": "s.txt"}],
+    )
     with (
         patch("mempalace.layers.MempalaceConfig") as mock_cfg,
         patch("mempalace.layers._get_collection", return_value=mock_col),
@@ -349,11 +356,13 @@ def test_layer2_truncates_long_snippets():
 
 
 def _mock_query_results(docs, metas, dists):
-    return {
-        "documents": [docs],
-        "metadatas": [metas],
-        "distances": [dists],
-    }
+    ids = [f"qid_{i}" for i in range(len(docs))]
+    return QueryResult(
+        ids=ids,
+        documents=list(docs),
+        metadatas=list(metas),
+        distances=list(dists),
+    )
 
 
 def test_layer3_no_palace():

--- a/tests/test_milvus_backend.py
+++ b/tests/test_milvus_backend.py
@@ -1,0 +1,483 @@
+"""Tests for the Milvus Lite storage backend.
+
+Split into two tiers:
+
+* pure-Python tests for the ``where``-DSL translator that do not need a
+  running Milvus (run everywhere, every time)
+* end-to-end tests that spin up Milvus Lite in a ``tmp_path`` and drive
+  the full adapter (skipped gracefully when ``pymilvus``/``milvus-lite``
+  or the ONNX model aren't available)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ── where-DSL translation (pure, no backend deps) ────────────────────────
+
+
+pymilvus = pytest.importorskip("pymilvus", reason="pymilvus not installed")
+
+
+from mempalace.backends.milvus import translate_where  # noqa: E402
+
+
+class TestTranslateWhere:
+    def test_empty_returns_empty_string(self):
+        assert translate_where(None) == ""
+        assert translate_where({}) == ""
+
+    def test_simple_equality(self):
+        assert translate_where({"wing": "project"}) == 'wing == "project"'
+
+    def test_integer_equality(self):
+        assert translate_where({"chunk_index": 5}) == "chunk_index == 5"
+
+    def test_boolean_equality(self):
+        assert translate_where({"is_archived": True}) == "is_archived == true"
+
+    def test_string_with_quotes_is_escaped(self):
+        # Double quotes and backslashes in values can't break out.
+        assert translate_where({"title": 'hello "world"'}) == 'title == "hello \\"world\\""'
+
+    def test_in_operator(self):
+        got = translate_where({"chunk_index": {"$in": [1, 2, 3]}})
+        assert got == "chunk_index in [1, 2, 3]"
+
+    def test_in_operator_strings(self):
+        got = translate_where({"wing": {"$in": ["a", "b"]}})
+        assert got == 'wing in ["a", "b"]'
+
+    def test_and_of_clauses(self):
+        got = translate_where({"$and": [{"wing": "p"}, {"room": "r"}]})
+        assert got == '(wing == "p" and room == "r")'
+
+    def test_or_of_clauses(self):
+        got = translate_where({"$or": [{"wing": "p"}, {"wing": "q"}]})
+        assert got == '(wing == "p" or wing == "q")'
+
+    def test_and_with_in(self):
+        got = translate_where(
+            {
+                "$and": [
+                    {"source_file": "x"},
+                    {"chunk_index": {"$in": [1, 2]}},
+                ]
+            }
+        )
+        assert got == '(source_file == "x" and chunk_index in [1, 2])'
+
+    def test_multi_key_without_and_is_rejected(self):
+        with pytest.raises(ValueError, match="explicit \\$and"):
+            translate_where({"wing": "p", "room": "r"})
+
+    def test_unsupported_operator_is_rejected(self):
+        with pytest.raises(ValueError, match="only \\$in"):
+            translate_where({"chunk_index": {"$gt": 5}})
+
+    def test_unsupported_top_level_operator_is_rejected(self):
+        with pytest.raises(ValueError, match="unsupported top-level"):
+            translate_where({"$nor": [{"wing": "x"}]})
+
+
+# ── end-to-end tests with Milvus Lite ─────────────────────────────────────
+
+
+def _locate_model_dir() -> Path | None:
+    """Same lookup logic as test_embeddings — the conftest redirects HOME."""
+    env = os.environ.get("MEMPALACE_TEST_ONNX_DIR")
+    if env:
+        return Path(env).expanduser()
+    try:
+        import pwd
+
+        real_home = pwd.getpwuid(os.getuid()).pw_dir
+    except Exception:
+        return None
+    base = Path(real_home)
+    for candidate in (
+        base / ".cache" / "mempalace" / "onnx",
+        base / ".cache" / "chroma" / "onnx_models" / "all-MiniLM-L6-v2",
+    ):
+        for d in (candidate, candidate / "onnx"):
+            if (d / "model.onnx").is_file() and (d / "tokenizer.json").is_file():
+                return d
+    return None
+
+
+milvus_e2e_skip = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="milvus-lite is not distributed on Windows",
+)
+
+
+@pytest.fixture
+def milvus_collection(tmp_path):
+    """Fresh Milvus Lite-backed collection keyed to a tmp_path palace."""
+    model_dir = _locate_model_dir()
+    if model_dir is None:
+        pytest.skip("all-MiniLM-L6-v2 ONNX model not cached locally")
+
+    from mempalace.backends.milvus import MilvusBackend
+    from mempalace.embeddings import Embedder
+
+    embedder = Embedder(local_dir=model_dir)
+    backend = MilvusBackend(embedder=embedder)
+    palace_path = str(tmp_path / "palace")
+    col = backend.get_or_create_collection(palace_path, "mempalace_drawers")
+    try:
+        yield backend, palace_path, col
+    finally:
+        # Close every MilvusClient this backend opened. Without this,
+        # milvus-lite's unix socket can linger and the next fixture in
+        # the same test session hits "illegal connection params".
+        for client in list(backend._clients.values()):
+            try:
+                client.close()
+            except Exception:
+                pass
+        backend._clients.clear()
+
+
+@milvus_e2e_skip
+class TestMilvusEndToEnd:
+    def test_db_file_created_under_palace(self, milvus_collection, tmp_path):
+        backend, palace_path, col = milvus_collection
+        col.add(ids=["a"], documents=["seed"])
+        db_path = Path(palace_path) / "milvus.db"
+        assert db_path.is_file()
+        assert db_path.stat().st_size > 0
+
+    def test_add_and_count(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(
+            ids=["a", "b", "c"],
+            documents=["alpha", "bravo", "charlie"],
+            metadatas=[{"wing": "w1"}, {"wing": "w2"}, {"wing": "w1"}],
+        )
+        assert col.count() == 3
+
+    def test_upsert_overwrites(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(ids=["a"], documents=["first"], metadatas=[{"wing": "w"}])
+        col.upsert(ids=["a"], documents=["second"], metadatas=[{"wing": "w2"}])
+        got = col.get(ids=["a"])
+        assert got.ids == ["a"]
+        assert got.documents == ["second"]
+        assert got.metadatas == [{"wing": "w2"}]
+        assert col.count() == 1
+
+    def test_query_returns_verbatim_documents(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(
+            ids=["d1", "d2", "d3"],
+            documents=[
+                "hello world",
+                "python programming",
+                "vector databases are fun",
+            ],
+        )
+        result = col.query(query_texts=["vector search"], n_results=2)
+        assert len(result.ids) == 2
+        # Top hit should be the document about vector databases.
+        assert "vector databases" in result.documents[0]
+        # Distances are cosine distance (0 = identical, > 0 further apart).
+        assert all(isinstance(d, float) for d in result.distances)
+        assert result.distances == sorted(result.distances)
+
+    def test_query_with_where_filter(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(
+            ids=["a", "b", "c"],
+            documents=["note one", "note two", "note three"],
+            metadatas=[{"wing": "a"}, {"wing": "b"}, {"wing": "a"}],
+        )
+        result = col.query(
+            query_texts=["note"],
+            n_results=5,
+            where={"wing": "b"},
+        )
+        assert result.ids == ["b"]
+        assert result.metadatas[0]["wing"] == "b"
+
+    def test_query_with_and_filter(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(
+            ids=["a", "b", "c"],
+            documents=["one", "two", "three"],
+            metadatas=[
+                {"wing": "w", "room": "r1"},
+                {"wing": "w", "room": "r2"},
+                {"wing": "w", "room": "r1"},
+            ],
+        )
+        result = col.query(
+            query_texts=["query"],
+            n_results=10,
+            where={"$and": [{"wing": "w"}, {"room": "r1"}]},
+        )
+        assert set(result.ids) == {"a", "c"}
+
+    def test_get_with_ids(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(
+            ids=["a", "b"],
+            documents=["alpha", "bravo"],
+            metadatas=[{"wing": "a"}, {"wing": "b"}],
+        )
+        got = col.get(ids=["b"])
+        assert got.ids == ["b"]
+        assert got.documents == ["bravo"]
+        assert got.metadatas[0]["wing"] == "b"
+
+    def test_get_with_in_filter(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(
+            ids=["a", "b", "c"],
+            documents=["x", "y", "z"],
+            metadatas=[{"chunk_index": 0}, {"chunk_index": 1}, {"chunk_index": 2}],
+        )
+        got = col.get(where={"chunk_index": {"$in": [0, 2]}}, limit=10)
+        assert set(got.ids) == {"a", "c"}
+
+    def test_get_respects_include_ids_only(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(ids=["a", "b"], documents=["one", "two"])
+        got = col.get(ids=["a", "b"], include=())
+        assert set(got.ids) == {"a", "b"}
+        assert got.documents == []
+        assert got.metadatas == []
+
+    def test_get_empty_ids_returns_empty(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(ids=["a"], documents=["x"])
+        got = col.get(ids=[])
+        assert got.ids == []
+
+    def test_delete_by_ids(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(ids=["a", "b", "c"], documents=["x", "y", "z"])
+        col.delete(ids=["b"])
+        remaining = col.get(ids=["a", "b", "c"])
+        assert set(remaining.ids) == {"a", "c"}
+        assert col.count() == 2
+
+    def test_delete_by_where(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(
+            ids=["a", "b", "c"],
+            documents=["x", "y", "z"],
+            metadatas=[{"wing": "p"}, {"wing": "q"}, {"wing": "p"}],
+        )
+        col.delete(where={"wing": "p"})
+        assert col.count() == 1
+        remaining = col.get(ids=["a", "b", "c"])
+        assert remaining.ids == ["b"]
+
+    def test_delete_requires_something(self, milvus_collection):
+        _, _, col = milvus_collection
+        with pytest.raises(ValueError, match="delete requires"):
+            col.delete()
+
+    def test_update_merges_metadata(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(
+            ids=["a"],
+            documents=["first"],
+            metadatas=[{"wing": "w", "room": "r1"}],
+        )
+        col.update(ids=["a"], metadatas=[{"wing": "w", "room": "r2"}])
+        got = col.get(ids=["a"])
+        assert got.documents == ["first"]
+        assert got.metadatas[0]["room"] == "r2"
+
+    def test_update_missing_id_raises(self, milvus_collection):
+        _, _, col = milvus_collection
+        with pytest.raises(KeyError):
+            col.update(ids=["does_not_exist"], metadatas=[{"wing": "x"}])
+
+    def test_backend_rejects_non_cosine_metric(self, milvus_collection):
+        backend, palace_path, _ = milvus_collection
+        with pytest.raises(ValueError, match="cosine"):
+            backend.create_collection(palace_path, "other", hnsw_space="l2")
+
+    def test_get_or_create_is_idempotent(self, milvus_collection):
+        backend, palace_path, _ = milvus_collection
+        # Second call with same name must not raise.
+        col2 = backend.get_or_create_collection(palace_path, "mempalace_drawers")
+        assert col2 is not None
+
+    def test_delete_collection_round_trip(self, milvus_collection):
+        backend, palace_path, col = milvus_collection
+        col.add(ids=["a"], documents=["x"])
+        backend.delete_collection(palace_path, "mempalace_drawers")
+        # Re-creating must start clean.
+        col2 = backend.get_or_create_collection(palace_path, "mempalace_drawers")
+        assert col2.count() == 0
+
+    def test_document_over_limit_is_rejected(self, milvus_collection):
+        _, _, col = milvus_collection
+        from mempalace.backends.milvus import DOCUMENT_MAX_LENGTH
+
+        huge = "x" * (DOCUMENT_MAX_LENGTH + 1)
+        with pytest.raises(ValueError, match="chunk before storing"):
+            col.add(ids=["big"], documents=[huge])
+
+    def test_reserved_metadata_key_is_rejected(self, milvus_collection):
+        _, _, col = milvus_collection
+        with pytest.raises(ValueError, match="reserved field"):
+            col.add(
+                ids=["a"],
+                documents=["x"],
+                metadatas=[{"id": "clash"}],
+            )
+
+    def test_id_over_max_length_is_rejected(self, milvus_collection):
+        _, _, col = milvus_collection
+        from mempalace.backends.milvus import DRAWER_ID_MAX_LENGTH
+
+        with pytest.raises(ValueError, match="exceeds"):
+            col.add(ids=["x" * (DRAWER_ID_MAX_LENGTH + 1)], documents=["doc"])
+
+    def test_empty_id_is_rejected(self, milvus_collection):
+        _, _, col = milvus_collection
+        with pytest.raises(ValueError, match="non-empty string"):
+            col.add(ids=[""], documents=["doc"])
+
+    def test_ragged_input_lists_rejected(self, milvus_collection):
+        _, _, col = milvus_collection
+        with pytest.raises(ValueError, match="equal length"):
+            col.add(ids=["a", "b"], documents=["only one"])
+
+    def test_query_empty_texts_returns_empty(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(ids=["a"], documents=["x"])
+        assert col.query(query_texts=[], n_results=5).ids == []
+
+    def test_query_with_distances_only(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(
+            ids=["a", "b"],
+            documents=["hello", "world"],
+        )
+        result = col.query(
+            query_texts=["hi"],
+            n_results=2,
+            include=["distances"],
+        )
+        assert len(result.ids) == 2
+        assert result.documents == []
+        assert result.metadatas == []
+        assert len(result.distances) == 2
+
+    def test_count_on_empty_collection(self, milvus_collection):
+        _, _, col = milvus_collection
+        assert col.count() == 0
+
+    def test_get_with_no_args_scans_collection(self, milvus_collection):
+        _, _, col = milvus_collection
+        col.add(ids=["a", "b", "c"], documents=["one", "two", "three"])
+        got = col.get(limit=10)
+        assert set(got.ids) == {"a", "b", "c"}
+        assert len(got.documents) == 3
+
+
+@milvus_e2e_skip
+class TestMilvusBackendSelection:
+    def test_backend_not_found_raises(self, tmp_path, monkeypatch):
+        """get_collection(create=False) on a missing palace must raise."""
+        from mempalace.backends.milvus import MilvusBackend
+        from mempalace.embeddings import Embedder
+
+        model_dir = _locate_model_dir()
+        if model_dir is None:
+            pytest.skip("all-MiniLM-L6-v2 ONNX model not cached locally")
+
+        backend = MilvusBackend(embedder=Embedder(local_dir=model_dir))
+        with pytest.raises(FileNotFoundError):
+            backend.get_collection(str(tmp_path / "does-not-exist"), "test", create=False)
+
+    def test_create_collection_rejects_duplicate(self, tmp_path):
+        from mempalace.backends.milvus import MilvusBackend
+        from mempalace.embeddings import Embedder
+
+        model_dir = _locate_model_dir()
+        if model_dir is None:
+            pytest.skip("all-MiniLM-L6-v2 ONNX model not cached locally")
+
+        backend = MilvusBackend(embedder=Embedder(local_dir=model_dir))
+        palace = str(tmp_path / "palace")
+        backend.create_collection(palace, "dupe")
+        try:
+            with pytest.raises(ValueError, match="already exists"):
+                backend.create_collection(palace, "dupe")
+        finally:
+            for c in list(backend._clients.values()):
+                try:
+                    c.close()
+                except Exception:
+                    pass
+            backend._clients.clear()
+
+    def test_make_default_backend_env_var(self, monkeypatch):
+        import mempalace.backends as backends
+
+        monkeypatch.setenv("MEMPALACE_BACKEND", "milvus")
+        b = backends.make_default_backend()
+        # Don't connect — just assert type.
+        from mempalace.backends.milvus import MilvusBackend
+
+        assert isinstance(b, MilvusBackend)
+
+    def test_make_default_backend_defaults_to_chroma(self, monkeypatch):
+        import mempalace.backends as backends
+
+        monkeypatch.delenv("MEMPALACE_BACKEND", raising=False)
+        b = backends.make_default_backend()
+        assert isinstance(b, backends.ChromaBackend)
+
+    def test_make_default_backend_rejects_unknown(self, monkeypatch):
+        import mempalace.backends as backends
+
+        monkeypatch.setenv("MEMPALACE_BACKEND", "mysql")
+        with pytest.raises(ValueError, match="Unknown MEMPALACE_BACKEND"):
+            backends.make_default_backend()
+
+    def test_milvus_backend_attribute_export(self):
+        """``from mempalace.backends import MilvusBackend`` must work."""
+        from mempalace.backends import MilvusBackend
+
+        assert MilvusBackend.__name__ == "MilvusBackend"
+
+    def test_explicit_uri_override_used(self, tmp_path, monkeypatch):
+        """Passing uri= should bypass per-palace-path resolution."""
+        from mempalace.backends.milvus import MilvusBackend
+        from mempalace.embeddings import Embedder
+
+        model_dir = _locate_model_dir()
+        if model_dir is None:
+            pytest.skip("all-MiniLM-L6-v2 ONNX model not cached locally")
+
+        uri = str(tmp_path / "shared.db")
+        backend = MilvusBackend(uri=uri, embedder=Embedder(local_dir=model_dir))
+        try:
+            # Different palace paths collapse to the same file when uri is set.
+            col1 = backend.get_or_create_collection("/ignored/a", "one")
+            col2 = backend.get_or_create_collection("/ignored/b", "two")
+            col1.add(ids=["x"], documents=["via first palace path"])
+            col2.add(ids=["y"], documents=["via second palace path"])
+            assert Path(uri).is_file()
+            assert col1.count() == 1
+            assert col2.count() == 1
+        finally:
+            for c in list(backend._clients.values()):
+                try:
+                    c.close()
+                except Exception:
+                    pass
+            backend._clients.clear()

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mempalace.backends.base import QueryResult
 from mempalace.searcher import SearchError, search, search_memories
 
 
@@ -62,12 +63,12 @@ class TestSearchMemories:
     def test_created_at_fallback_when_filed_at_missing(self):
         """created_at defaults to 'unknown' when filed_at is absent."""
         mock_col = MagicMock()
-        mock_col.query.return_value = {
-            "ids": [["drawer_no_date"]],
-            "documents": [["Some text without a date"]],
-            "metadatas": [[{"wing": "project", "room": "backend", "source_file": "x.py"}]],
-            "distances": [[0.1]],
-        }
+        mock_col.query.return_value = QueryResult(
+            ids=["drawer_no_date"],
+            documents=["Some text without a date"],
+            metadatas=[{"wing": "project", "room": "backend", "source_file": "x.py"}],
+            distances=[0.1],
+        )
 
         with patch("mempalace.searcher.get_collection", return_value=mock_col):
             result = search_memories("test", "/fake/path")


### PR DESCRIPTION
## Summary

This PR makes two changes, landed together because the second needs the first:

1. **Refactor `mempalace/backends/base.py`** from a `**kwargs`-pass-through interface into a typed, backend-agnostic abstraction. Methods now have explicit typed signatures; results come back as `QueryResult` / `GetResult` dataclasses with flat lists instead of Chroma's batch-nested shape.
2. **Add a Milvus Lite backend** (`mempalace/backends/milvus.py`) that drops in behind the new abstraction. Everything local-first: single `./milvus.db` file per palace, no cloud dependency, no API keys.

`ChromaBackend` is preserved with identical observable behavior. Default install and default backend selection are unchanged — Chroma remains the default.

## Motivation

CLAUDE.md describes the backends layer as "pluggable" and explicitly invites new backends. In practice the existing `BaseCollection.__init_subclass__` was a `**kwargs` pass-through that leaked Chroma's API (`query_texts`, `include=["documents","metadatas","distances"]`, Chroma's nested `{"documents": [[..]], ...}` return shape, and Chroma's `where` DSL). Implementing any non-Chroma backend meant mimicking Chroma's wire format, not implementing the palace's actual needs.

The refactor turns the interface into something backends can actually target: typed method signatures, dataclass returns with one natural shape, and a documented portable `where` DSL subset (equality, `$in`, `$and`, `$or`). Anything outside that subset raises a clear `ValueError`.

With the interface cleaned up, the Milvus Lite backend is a ~650-line drop-in.

## What's in the PR

- **New typed interface**: `BaseCollection` with explicit `add`/`upsert`/`update`/`query`/`get`/`delete`/`count` signatures; `QueryResult` and `GetResult` dataclasses.
- **ChromaCollection refactor**: maps between the new shape and the raw Chroma client. Zero behavior change for end users.
- **MilvusBackend + MilvusCollection**: built on `pymilvus.MilvusClient` (modern API, no ORM). `AUTOINDEX` + `COSINE`. Tags/metadata stored as dynamic fields. `where` DSL translated to Milvus boolean expressions.
- **`mempalace/embeddings.py`**: local ONNX wrapper around `sentence-transformers/all-MiniLM-L6-v2` (384-dim) — the same model Chroma uses by default. Cache at `~/.cache/mempalace/onnx/`; falls back to Chroma's cache if present. `warmup()` for offline guarantees.
- **Backend selection**: `MEMPALACE_BACKEND=milvus` env var, with `make_default_backend()` factory. Chroma remains default.
- **`[milvus]` optional-dependency extra** in `pyproject.toml`: `pymilvus`, `milvus-lite`, `onnxruntime`, `huggingface_hub`, plus `setuptools<81; python_version >= '3.13'` (a workaround for milvus-lite's `pkg_resources` use — see milvus-io/milvus-lite#334).
- **Caller updates**: 12 modules updated to the new interface (searcher, miner, convo_miner, cli, repair, palace, migrate, dedup, layers, palace_graph, mcp_server, exporter, closet_llm, diary_ingest). Logic unchanged; only unpacking/arguments adjusted.
- **Tests**: 9 new embedding tests + 47 new Milvus backend tests. Full suite: 996 passed, 0 regressions (baseline 939). Coverage 84%.
- **Docs**: new `docs/milvus-backend.md` covering installation, selection, self-hosted Milvus, supported `where` DSL, and limits. Updated `mempalace/README.md` and `CLAUDE.md` module map.

## Which Milvus deployment?

| URI | Use case |
|-----|----------|
| `./milvus.db` (Milvus Lite) | **Default.** Single local file per palace — fits MemPalace's local-first design. |
| `http://host:19530` | Self-hosted Milvus for users who already run it. |

Zilliz Cloud is not promoted in docs because it's a managed cloud service, which conflicts with MemPalace's privacy-by-architecture principle. Users who need it can still use it via `uri="https://..."` and `token="..."`, but we deliberately don't feature it.

## Verification

- `pytest tests/ --ignore=tests/benchmarks` → **996 passed**, 0 failed (baseline 939 + 57 new tests).
- `ruff check .` → clean.
- `ruff format --check` on all modified files → clean.
- End-to-end probe: MilvusBackend full CRUD, env-var selection, default-Chroma-unchanged, portable where-DSL (`$in`, `$and`) — all verified.
- Coverage 84% (CI gate 80%).

## Migration / compatibility

- **Zero breaking changes for Chroma users.** Default install unchanged, default backend unchanged, observable behavior unchanged.
- **New backend is opt-in** via `[milvus]` extra + `MEMPALACE_BACKEND=milvus`.
- **Behavior promises preserved**: verbatim storage, local-first, no cloud dependency for core operations, no API keys. Initial ONNX model download is a one-time cache populate — same cost Chroma already pays under the hood.

Happy to split this into two sequential PRs (refactor first, then Milvus) if that's easier to review — let me know.
