### PR TITLE
feat: configurable chunk_size, chunk_overlap, min_chunk_size

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -189,6 +189,15 @@ def get_configured_collection_name() -> str:
     return MempalaceConfig().collection_name
 
 
+# Single source of truth for chunking defaults. ``mempalace.miner``
+# imports these so the legacy module-level ``CHUNK_SIZE`` /
+# ``CHUNK_OVERLAP`` / ``MIN_CHUNK_SIZE`` constants stay in sync with
+# ``MempalaceConfig.chunk_*``. Putting them here (not in miner.py) keeps
+# the config layer self-contained and avoids circular imports.
+DEFAULT_CHUNK_SIZE = 800
+DEFAULT_CHUNK_OVERLAP = 100
+DEFAULT_MIN_CHUNK_SIZE = 50
+
 DEFAULT_TOPIC_WINGS = [
     "emotions",
     "consciousness",
@@ -304,20 +313,75 @@ class MempalaceConfig:
         """Mapping of hall names to keyword lists."""
         return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
 
-    @property
-    def chunk_size(self):
-        """Characters per drawer chunk."""
-        return self._file_config.get("chunk_size", 800)
+    def _coerce_config_int(self, key: str, default: int, minimum=None) -> int:
+        """Read an int config value, falling back to ``default`` on bad input.
+
+        Hand-edited ``config.json`` is the most common source of garbage:
+        a string, a bool, a negative number, or a JSON null. None of those
+        should crash mining or hang ``chunk_text()`` — fall back silently
+        to the documented default rather than letting a typo break ingest.
+        """
+        value = self._file_config.get(key, default)
+        if isinstance(value, bool):
+            return default
+        try:
+            if isinstance(value, str):
+                value = value.strip()
+                if not value:
+                    return default
+            value = int(value)
+        except (TypeError, ValueError):
+            return default
+        if minimum is not None and value < minimum:
+            return default
+        return value
+
+    def _validated_chunk_config(self):
+        """Return ``(chunk_size, chunk_overlap, min_chunk_size)`` post-validation.
+
+        Enforces the invariants the miner relies on:
+          * ``chunk_size >= 1``
+          * ``0 <= chunk_overlap < chunk_size`` — equality would loop forever
+          * ``min_chunk_size <= chunk_size`` — otherwise no chunk is ever
+            large enough to file, and ingest silently produces 0 drawers
+
+        Repairs (rather than raises) on violation so a single bad
+        config.json key doesn't take ingest down.
+        """
+        chunk_size = self._coerce_config_int("chunk_size", DEFAULT_CHUNK_SIZE, minimum=1)
+        chunk_overlap = self._coerce_config_int("chunk_overlap", DEFAULT_CHUNK_OVERLAP, minimum=0)
+        min_chunk_size = self._coerce_config_int(
+            "min_chunk_size", DEFAULT_MIN_CHUNK_SIZE, minimum=0
+        )
+
+        if chunk_overlap >= chunk_size:
+            chunk_overlap = (
+                DEFAULT_CHUNK_OVERLAP
+                if DEFAULT_CHUNK_OVERLAP < chunk_size
+                else max(0, chunk_size - 1)
+            )
+
+        if min_chunk_size > chunk_size:
+            min_chunk_size = (
+                DEFAULT_MIN_CHUNK_SIZE if DEFAULT_MIN_CHUNK_SIZE <= chunk_size else chunk_size
+            )
+
+        return chunk_size, chunk_overlap, min_chunk_size
 
     @property
-    def chunk_overlap(self):
-        """Overlap between adjacent chunks."""
-        return self._file_config.get("chunk_overlap", 100)
+    def chunk_size(self) -> int:
+        """Characters per drawer chunk (validated, ``>= 1``)."""
+        return self._validated_chunk_config()[0]
 
     @property
-    def min_chunk_size(self):
-        """Minimum chunk size — skip smaller chunks."""
-        return self._file_config.get("min_chunk_size", 50)
+    def chunk_overlap(self) -> int:
+        """Overlap between adjacent chunks (validated, ``< chunk_size``)."""
+        return self._validated_chunk_config()[1]
+
+    @property
+    def min_chunk_size(self) -> int:
+        """Minimum chunk size — skip smaller chunks (validated, ``<= chunk_size``)."""
+        return self._validated_chunk_config()[2]
 
     @property
     def entity_languages(self):

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -428,6 +428,14 @@ class MempalaceConfig:
         except (OSError, NotImplementedError):
             pass  # Windows doesn't support Unix permissions
         if not self._config_file.exists():
+            # Chunking parameters (chunk_size, chunk_overlap, min_chunk_size)
+            # are intentionally NOT written here — convo_miner.py distinguishes
+            # "user has tuned this" from "user is on defaults" by checking
+            # ``_file_config.get("min_chunk_size") is None``. Writing the
+            # miner.py defaults (50) into config.json breaks that detection
+            # and silently overrides convo_miner's stricter 30-char floor,
+            # dropping legitimate short conversation exchanges. Module-level
+            # defaults already apply correctly when these keys are absent.
             default_config = {
                 "palace_path": DEFAULT_PALACE_PATH,
                 "collection_name": DEFAULT_COLLECTION_NAME,

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -305,6 +305,21 @@ class MempalaceConfig:
         return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
 
     @property
+    def chunk_size(self):
+        """Characters per drawer chunk."""
+        return self._file_config.get("chunk_size", 800)
+
+    @property
+    def chunk_overlap(self):
+        """Overlap between adjacent chunks."""
+        return self._file_config.get("chunk_overlap", 100)
+
+    @property
+    def min_chunk_size(self):
+        """Minimum chunk size — skip smaller chunks."""
+        return self._file_config.get("min_chunk_size", 50)
+
+    @property
     def entity_languages(self):
         """Languages whose entity-detection patterns should be applied.
 

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -109,11 +109,22 @@ def chunk_exchanges(
     Falls back to paragraph chunking if no > markers.
 
     Optional params override module-level defaults when provided.
+
+    Raises ``ValueError`` if ``chunk_size`` is not a positive integer or
+    ``min_chunk_size`` is negative. A non-positive ``chunk_size`` would
+    cause ``_chunk_by_exchange`` below to loop forever — ``content[:0]``
+    is empty, ``content[0:]`` is the whole string, and the remainder
+    never shrinks.
     """
     if chunk_size is None:
         chunk_size = CHUNK_SIZE
     if min_chunk_size is None:
         min_chunk_size = MIN_CHUNK_SIZE
+
+    if chunk_size <= 0:
+        raise ValueError(f"chunk_size must be > 0, got {chunk_size}")
+    if min_chunk_size < 0:
+        raise ValueError(f"min_chunk_size must be >= 0, got {min_chunk_size}")
 
     lines = content.split("\n")
     quote_lines = sum(1 for line in lines if line.strip().startswith(">"))

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -99,25 +99,36 @@ def _register_file(collection, source_file: str, wing: str, agent: str):
 # =============================================================================
 
 
-def chunk_exchanges(content: str) -> list:
+def chunk_exchanges(
+    content: str,
+    chunk_size: int = None,
+    min_chunk_size: int = None,
+) -> list:
     """
     Chunk by exchange pair: one > turn + AI response = one unit.
     Falls back to paragraph chunking if no > markers.
+
+    Optional params override module-level defaults when provided.
     """
+    if chunk_size is None:
+        chunk_size = CHUNK_SIZE
+    if min_chunk_size is None:
+        min_chunk_size = MIN_CHUNK_SIZE
+
     lines = content.split("\n")
     quote_lines = sum(1 for line in lines if line.strip().startswith(">"))
 
     if quote_lines >= 3:
-        return _chunk_by_exchange(lines)
+        return _chunk_by_exchange(lines, chunk_size, min_chunk_size)
     else:
-        return _chunk_by_paragraph(content)
+        return _chunk_by_paragraph(content, min_chunk_size)
 
 
-def _chunk_by_exchange(lines: list) -> list:
+def _chunk_by_exchange(lines: list, chunk_size: int, min_chunk_size: int) -> list:
     """One user turn (>) + the AI response that follows = one or more chunks.
 
     The full AI response is preserved verbatim.  When the combined
-    user-turn + response exceeds CHUNK_SIZE the response is split across
+    user-turn + response exceeds chunk_size the response is split across
     consecutive drawers so nothing is silently discarded.
     """
     chunks = []
@@ -141,20 +152,20 @@ def _chunk_by_exchange(lines: list) -> list:
             ai_response = " ".join(ai_lines)
             content = f"{user_turn}\n{ai_response}" if ai_response else user_turn
 
-            # Split into multiple drawers when the exchange exceeds CHUNK_SIZE
-            if len(content) > CHUNK_SIZE:
+            # Split into multiple drawers when the exchange exceeds chunk_size
+            if len(content) > chunk_size:
                 # First chunk: user turn + as much response as fits
-                first_part = content[:CHUNK_SIZE]
-                if len(first_part.strip()) > MIN_CHUNK_SIZE:
+                first_part = content[:chunk_size]
+                if len(first_part.strip()) > min_chunk_size:
                     chunks.append({"content": first_part, "chunk_index": len(chunks)})
-                # Remaining response in CHUNK_SIZE-sized continuation drawers
-                remainder = content[CHUNK_SIZE:]
+                # Remaining response in chunk_size-sized continuation drawers
+                remainder = content[chunk_size:]
                 while remainder:
-                    part = remainder[:CHUNK_SIZE]
-                    remainder = remainder[CHUNK_SIZE:]
-                    if len(part.strip()) > MIN_CHUNK_SIZE:
+                    part = remainder[:chunk_size]
+                    remainder = remainder[chunk_size:]
+                    if len(part.strip()) > min_chunk_size:
                         chunks.append({"content": part, "chunk_index": len(chunks)})
-            elif len(content.strip()) > MIN_CHUNK_SIZE:
+            elif len(content.strip()) > min_chunk_size:
                 chunks.append(
                     {
                         "content": content,
@@ -167,7 +178,7 @@ def _chunk_by_exchange(lines: list) -> list:
     return chunks
 
 
-def _chunk_by_paragraph(content: str) -> list:
+def _chunk_by_paragraph(content: str, min_chunk_size: int) -> list:
     """Fallback: chunk by paragraph breaks."""
     chunks = []
     paragraphs = [p.strip() for p in content.split("\n\n") if p.strip()]
@@ -177,12 +188,12 @@ def _chunk_by_paragraph(content: str) -> list:
         lines = content.split("\n")
         for i in range(0, len(lines), 25):
             group = "\n".join(lines[i : i + 25]).strip()
-            if len(group) > MIN_CHUNK_SIZE:
+            if len(group) > min_chunk_size:
                 chunks.append({"content": group, "chunk_index": len(chunks)})
         return chunks
 
     for para in paragraphs:
-        if len(para) > MIN_CHUNK_SIZE:
+        if len(para) > min_chunk_size:
             chunks.append({"content": para, "chunk_index": len(chunks)})
 
     return chunks
@@ -393,7 +404,23 @@ def mine_convos(
     extract_mode:
         "exchange" — default exchange-pair chunking (Q+A = one unit)
         "general"  — general extractor: decisions, preferences, milestones, problems, emotions
+
+    Chunking parameters (chunk_size, min_chunk_size) are read from
+    MempalaceConfig so `config.json` governs both this path and the
+    project-file miner in `miner.py`. `min_chunk_size` preserves
+    convo_miner's stricter default (30) when not explicitly set in
+    config.json, so a user who never touches chunking keeps the
+    existing behavior.
     """
+    from .config import MempalaceConfig
+
+    palace_config = MempalaceConfig()
+    cfg_chunk_size = palace_config.chunk_size
+    # Only override convo_miner's MIN_CHUNK_SIZE when the user has set
+    # min_chunk_size explicitly — default MempalaceConfig returns miner.py's
+    # 50, which would drop legitimate short conversation exchanges.
+    raw_min = palace_config._file_config.get("min_chunk_size")
+    cfg_min_chunk_size = raw_min if raw_min is not None else MIN_CHUNK_SIZE
 
     convo_path = Path(convo_dir).expanduser().resolve()
     if not wing:
@@ -438,7 +465,7 @@ def mine_convos(
                 _register_file(collection, source_file, wing, agent)
             continue
 
-        if not content or len(content.strip()) < MIN_CHUNK_SIZE:
+        if not content or len(content.strip()) < cfg_min_chunk_size:
             if not dry_run:
                 _register_file(collection, source_file, wing, agent)
             continue
@@ -450,7 +477,11 @@ def mine_convos(
             chunks = extract_memories(content)
             # Each chunk already has memory_type; use it as the room name
         else:
-            chunks = chunk_exchanges(content)
+            chunks = chunk_exchanges(
+                content,
+                chunk_size=cfg_chunk_size,
+                min_chunk_size=cfg_min_chunk_size,
+            )
 
         if not chunks:
             if not dry_run:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -70,9 +70,16 @@ SKIP_FILENAMES = {
     "yarn.lock",
 }
 
-CHUNK_SIZE = 800  # chars per drawer
-CHUNK_OVERLAP = 100  # overlap between chunks
-MIN_CHUNK_SIZE = 50  # skip tiny chunks
+# Re-export the shared defaults from ``config`` so legacy callers that
+# import ``CHUNK_SIZE`` / ``CHUNK_OVERLAP`` / ``MIN_CHUNK_SIZE`` from
+# ``mempalace.miner`` keep working unchanged. Single source of truth
+# lives in ``config.DEFAULT_CHUNK_*``.
+from .config import (  # noqa: E402  (kept here for the legacy alias)
+    DEFAULT_CHUNK_SIZE as CHUNK_SIZE,
+    DEFAULT_CHUNK_OVERLAP as CHUNK_OVERLAP,
+    DEFAULT_MIN_CHUNK_SIZE as MIN_CHUNK_SIZE,
+)
+
 DRAWER_UPSERT_BATCH_SIZE = 1000
 MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB — skip files larger than this.
 # A single file producing more chunks than this is almost always a generated
@@ -422,6 +429,27 @@ def chunk_text(
         chunk_overlap = CHUNK_OVERLAP
     if min_chunk_size is None:
         min_chunk_size = MIN_CHUNK_SIZE
+
+    # Defensive invariant guard. ``MempalaceConfig.chunk_*`` already
+    # enforces these and falls back to defaults on bad config.json
+    # values, but ``chunk_text`` is a public function — direct callers
+    # (tests, library users, future caller paths) might still pass
+    # values that would loop forever. Fail fast and loud rather than
+    # hang. See review feedback on #1024.
+    if not isinstance(chunk_size, int) or chunk_size <= 0:
+        raise ValueError(f"chunk_size must be a positive int, got {chunk_size!r}")
+    if not isinstance(chunk_overlap, int) or chunk_overlap < 0:
+        raise ValueError(f"chunk_overlap must be a non-negative int, got {chunk_overlap!r}")
+    if chunk_overlap >= chunk_size:
+        # ``start = end - chunk_overlap`` would not advance (or would go
+        # backward) when overlap >= size, producing an infinite loop on
+        # any non-empty input.
+        raise ValueError(
+            f"chunk_overlap ({chunk_overlap}) must be less than chunk_size "
+            f"({chunk_size}); equality or greater would loop forever"
+        )
+    if not isinstance(min_chunk_size, int) or min_chunk_size < 0:
+        raise ValueError(f"min_chunk_size must be a non-negative int, got {min_chunk_size!r}")
 
     # Clean up
     content = content.strip()

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -402,12 +402,27 @@ def detect_room(filepath: Path, content: str, rooms: list, project_path: Path) -
 # =============================================================================
 
 
-def chunk_text(content: str, source_file: str) -> list:
+def chunk_text(
+    content: str,
+    source_file: str,
+    chunk_size: int = None,
+    chunk_overlap: int = None,
+    min_chunk_size: int = None,
+) -> list:
     """
     Split content into drawer-sized chunks.
     Tries to split on paragraph/line boundaries.
     Returns list of {"content": str, "chunk_index": int}
+
+    Optional params override module-level defaults when provided.
     """
+    if chunk_size is None:
+        chunk_size = CHUNK_SIZE
+    if chunk_overlap is None:
+        chunk_overlap = CHUNK_OVERLAP
+    if min_chunk_size is None:
+        min_chunk_size = MIN_CHUNK_SIZE
+
     # Clean up
     content = content.strip()
     if not content:
@@ -418,20 +433,20 @@ def chunk_text(content: str, source_file: str) -> list:
     chunk_index = 0
 
     while start < len(content):
-        end = min(start + CHUNK_SIZE, len(content))
+        end = min(start + chunk_size, len(content))
 
         # Try to break at paragraph boundary
         if end < len(content):
             newline_pos = content.rfind("\n\n", start, end)
-            if newline_pos > start + CHUNK_SIZE // 2:
+            if newline_pos > start + chunk_size // 2:
                 end = newline_pos
             else:
                 newline_pos = content.rfind("\n", start, end)
-                if newline_pos > start + CHUNK_SIZE // 2:
+                if newline_pos > start + chunk_size // 2:
                     end = newline_pos
 
         chunk = content[start:end].strip()
-        if len(chunk) >= MIN_CHUNK_SIZE:
+        if len(chunk) >= min_chunk_size:
             chunks.append(
                 {
                     "content": chunk,
@@ -440,7 +455,7 @@ def chunk_text(content: str, source_file: str) -> list:
             )
             chunk_index += 1
 
-        start = end - CHUNK_OVERLAP if end < len(content) else end
+        start = end - chunk_overlap if end < len(content) else end
 
     return chunks
 
@@ -836,8 +851,12 @@ def process_file(
     agent: str,
     dry_run: bool,
     closets_col=None,
+    chunk_size: int = None,
+    chunk_overlap: int = None,
+    min_chunk_size: int = None,
 ) -> tuple:
     """Read, chunk, route, and file one file. Returns (drawer_count, room_name)."""
+    effective_min = min_chunk_size if min_chunk_size is not None else MIN_CHUNK_SIZE
 
     # Skip if already filed
     source_file = str(filepath)
@@ -850,11 +869,17 @@ def process_file(
         return 0, "general"
 
     content = content.strip()
-    if len(content) < MIN_CHUNK_SIZE:
+    if len(content) < effective_min:
         return 0, "general"
 
     room = detect_room(filepath, content, rooms, project_path)
-    chunks = chunk_text(content, source_file)
+    chunks = chunk_text(
+        content,
+        source_file,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        min_chunk_size=min_chunk_size,
+    )
 
     if len(chunks) > MAX_CHUNKS_PER_FILE:
         print(
@@ -1043,7 +1068,6 @@ def mine(
     prompt) avoids walking the tree twice. When ``None`` (the default),
     ``mine`` walks the tree itself just like before.
     """
-
     if dry_run:
         return _mine_impl(
             project_dir,
@@ -1085,8 +1109,15 @@ def _mine_impl(
     include_ignored: list = None,
     files: list = None,
 ):
+    from .config import MempalaceConfig
+
     project_path = Path(project_dir).expanduser().resolve()
     config = load_config(project_dir)
+    palace_config = MempalaceConfig()
+
+    cfg_chunk_size = palace_config.chunk_size
+    cfg_chunk_overlap = palace_config.chunk_overlap
+    cfg_min_chunk_size = palace_config.min_chunk_size
 
     wing = wing_override or config["wing"]
     rooms = config.get("rooms", [{"name": "general", "description": "All project files"}])
@@ -1143,6 +1174,9 @@ def _mine_impl(
                     agent=agent,
                     dry_run=dry_run,
                     closets_col=closets_col,
+                    chunk_size=cfg_chunk_size,
+                    chunk_overlap=cfg_chunk_overlap,
+                    min_chunk_size=cfg_min_chunk_size,
                 )
             except KeyboardInterrupt:
                 # Re-raise so the outer handler prints the summary; we

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -345,3 +345,144 @@ def test_iso_temporal_error_names_field():
 
 def test_iso_temporal_normalizes_plus_zero_offset_to_z():
     assert sanitize_iso_temporal("2026-05-06T14:23:00+00:00") == "2026-05-06T14:23:00Z"
+
+
+# ── Chunk-config validation ────────────────────────────────────────────
+# Backs the validated chunk_* properties added in #1024. Every property
+# resolves through ``_validated_chunk_config`` which (a) coerces to int
+# (or falls back to the documented default), (b) enforces the invariants
+# ``chunk_text()`` needs (chunk_size >= 1, chunk_overlap < chunk_size,
+# min_chunk_size <= chunk_size). A bad config.json must NEVER hang
+# ingest — repair, don't raise.
+
+
+def _write_config(tmp_path, **values):
+    """Helper: drop a config.json with the given keys into tmp_path."""
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump(values, f)
+    return MempalaceConfig(config_dir=str(tmp_path))
+
+
+def test_chunk_config_defaults_when_unset(tmp_path):
+    """No config.json → documented defaults."""
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.chunk_size == 800
+    assert cfg.chunk_overlap == 100
+    assert cfg.min_chunk_size == 50
+
+
+def test_chunk_config_user_overrides_honored(tmp_path):
+    """Valid file values pass through unchanged."""
+    cfg = _write_config(tmp_path, chunk_size=1200, chunk_overlap=200, min_chunk_size=80)
+    assert cfg.chunk_size == 1200
+    assert cfg.chunk_overlap == 200
+    assert cfg.min_chunk_size == 80
+
+
+def test_chunk_config_string_coerced_to_int(tmp_path):
+    """Hand-edited config can drop quotes around numbers — accept ``"1500"``."""
+    cfg = _write_config(tmp_path, chunk_size="1500", chunk_overlap="50")
+    assert cfg.chunk_size == 1500
+    assert cfg.chunk_overlap == 50
+
+
+def test_chunk_config_garbage_string_falls_back_to_default(tmp_path):
+    cfg = _write_config(tmp_path, chunk_size="not a number")
+    assert cfg.chunk_size == 800  # default, not a crash
+
+
+def test_chunk_config_bool_falls_back_to_default(tmp_path):
+    """``bool`` is a subclass of ``int`` in Python — a JSON ``true``
+    would otherwise coerce to 1 and quietly break ingest. Treat as bad
+    input."""
+    cfg = _write_config(tmp_path, chunk_size=True)
+    assert cfg.chunk_size == 800
+
+
+def test_chunk_config_negative_falls_back(tmp_path):
+    """Negative chunk_size/min_chunk_size violates ``minimum`` and reverts."""
+    cfg = _write_config(tmp_path, chunk_size=-100, min_chunk_size=-5)
+    assert cfg.chunk_size == 800
+    assert cfg.min_chunk_size == 50
+
+
+def test_chunk_config_zero_chunk_size_falls_back(tmp_path):
+    """``chunk_size=0`` would loop forever — must revert to default."""
+    cfg = _write_config(tmp_path, chunk_size=0)
+    assert cfg.chunk_size == 800
+
+
+def test_chunk_config_overlap_at_or_above_size_repaired(tmp_path):
+    """``chunk_overlap >= chunk_size`` is the hang condition; repair to
+    the documented default when the default fits, otherwise to
+    ``chunk_size - 1``."""
+    cfg = _write_config(tmp_path, chunk_size=900, chunk_overlap=900)
+    assert cfg.chunk_size == 900
+    # 100 (default) fits inside 900 → use the default.
+    assert cfg.chunk_overlap == 100
+    assert cfg.chunk_overlap < cfg.chunk_size
+
+
+def test_chunk_config_overlap_repair_when_default_doesnt_fit(tmp_path):
+    """Tiny chunk_size where the default overlap (100) wouldn't fit:
+    repair to ``chunk_size - 1`` instead."""
+    cfg = _write_config(tmp_path, chunk_size=50, chunk_overlap=100)
+    assert cfg.chunk_size == 50
+    assert cfg.chunk_overlap == 49  # max(0, chunk_size - 1)
+    assert cfg.chunk_overlap < cfg.chunk_size
+
+
+def test_chunk_config_min_chunk_size_above_size_repaired(tmp_path):
+    """``min_chunk_size > chunk_size`` would silently produce 0 drawers
+    on every ingest — repair to default if it fits, else clamp to
+    chunk_size."""
+    cfg = _write_config(tmp_path, chunk_size=1000, min_chunk_size=2000)
+    assert cfg.min_chunk_size == 50  # default fits inside 1000
+
+    cfg2 = _write_config(tmp_path, chunk_size=20, min_chunk_size=200)
+    assert cfg2.min_chunk_size == 20  # default (50) > chunk_size, clamp
+
+
+def test_chunk_text_rejects_non_positive_chunk_size():
+    """Direct callers (tests, library users) that pass ``chunk_size <= 0``
+    must hit a clear ValueError, not loop forever."""
+    from mempalace.miner import chunk_text
+
+    with pytest.raises(ValueError, match="chunk_size"):
+        chunk_text("some content", "src.txt", chunk_size=0)
+    with pytest.raises(ValueError, match="chunk_size"):
+        chunk_text("some content", "src.txt", chunk_size=-1)
+
+
+def test_chunk_text_rejects_overlap_at_or_above_size():
+    from mempalace.miner import chunk_text
+
+    with pytest.raises(ValueError, match="chunk_overlap"):
+        chunk_text("some content", "src.txt", chunk_size=100, chunk_overlap=100)
+    with pytest.raises(ValueError, match="chunk_overlap"):
+        chunk_text("some content", "src.txt", chunk_size=100, chunk_overlap=200)
+
+
+def test_chunk_text_rejects_negative_overlap():
+    from mempalace.miner import chunk_text
+
+    with pytest.raises(ValueError, match="chunk_overlap"):
+        chunk_text("some content", "src.txt", chunk_overlap=-1)
+
+
+def test_miner_constants_alias_config_defaults():
+    """Single source of truth: the legacy ``CHUNK_SIZE`` / ``CHUNK_OVERLAP``
+    / ``MIN_CHUNK_SIZE`` re-exports in ``mempalace.miner`` must equal the
+    canonical ``DEFAULT_CHUNK_*`` constants in ``mempalace.config``.
+    Pinned by this test so a future drift would surface as a unit failure.
+    """
+    from mempalace.miner import CHUNK_SIZE, CHUNK_OVERLAP, MIN_CHUNK_SIZE
+    from mempalace.config import (
+        DEFAULT_CHUNK_SIZE,
+        DEFAULT_CHUNK_OVERLAP,
+        DEFAULT_MIN_CHUNK_SIZE,
+    )
+
+    assert CHUNK_SIZE == DEFAULT_CHUNK_SIZE == 800
+    assert CHUNK_OVERLAP == DEFAULT_CHUNK_OVERLAP == 100
+    assert MIN_CHUNK_SIZE == DEFAULT_MIN_CHUNK_SIZE == 50

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -2,6 +2,8 @@
 
 import contextlib
 
+import pytest
+
 from mempalace.convo_miner import (
     _file_chunks_locked,
     chunk_exchanges,
@@ -48,6 +50,39 @@ class TestChunkExchanges:
     def test_short_content_skipped(self):
         chunks = chunk_exchanges("> hi\nbye")
         # Too short to produce chunks (below MIN_CHUNK_SIZE)
+        assert isinstance(chunks, list)
+
+    def test_chunk_size_zero_raises_valueerror(self):
+        """Reject chunk_size == 0 explicitly.
+
+        Without this guard, `_chunk_by_exchange` enters an infinite loop:
+        content[:0] is empty, content[0:] is the whole string, and the
+        remainder never shrinks.
+        """
+        content = (
+            "> What is memory?\nMemory is persistence.\n\n" * 4  # force the split branch
+        )
+        with pytest.raises(ValueError, match="chunk_size must be > 0"):
+            chunk_exchanges(content, chunk_size=0)
+
+    def test_chunk_size_negative_raises_valueerror(self):
+        """Reject chunk_size < 0. Negative slicing would also loop forever
+        (content[:-1] → all but last, remainder[-1:] → last char repeated)."""
+        content = "> hi\nsome response text here that is long enough to chunk\n\n" * 4
+        with pytest.raises(ValueError, match="chunk_size must be > 0"):
+            chunk_exchanges(content, chunk_size=-10)
+
+    def test_min_chunk_size_negative_raises_valueerror(self):
+        """Reject min_chunk_size < 0. A negative threshold silently
+        breaks the `if len(part.strip()) > min_chunk_size` gate — every
+        chunk including empty ones gets appended."""
+        with pytest.raises(ValueError, match="min_chunk_size must be >= 0"):
+            chunk_exchanges("> hi\nbye", min_chunk_size=-1)
+
+    def test_min_chunk_size_zero_allowed(self):
+        """min_chunk_size == 0 is legal — means 'accept any non-empty chunk'."""
+        content = "> What is memory?\nMemory is persistence of information.\n" * 3
+        chunks = chunk_exchanges(content, min_chunk_size=0)
         assert isinstance(chunks, list)
 
     def test_long_ai_response_not_truncated(self):

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -423,7 +423,7 @@ def test_process_file_uses_bounded_upsert_batches(tmp_path, monkeypatch):
     chunks = [{"content": f"chunk {i} " * 20, "chunk_index": i} for i in range(5)]
     col = FakeCol()
     monkeypatch.setattr(miner, "DRAWER_UPSERT_BATCH_SIZE", 2)
-    monkeypatch.setattr(miner, "chunk_text", lambda content, source_file: chunks)
+    monkeypatch.setattr(miner, "chunk_text", lambda content, source_file, **kwargs: chunks)
     monkeypatch.setattr(miner, "detect_hall", lambda content: "code")
     monkeypatch.setattr(miner, "_extract_entities_for_metadata", lambda content: "")
 
@@ -819,7 +819,7 @@ def test_process_file_skips_when_chunks_exceed_max(tmp_path, monkeypatch):
 
     monkeypatch.setattr(miner, "MAX_CHUNKS_PER_FILE", 5)
     over_cap = [{"content": f"chunk {i}", "chunk_index": i} for i in range(7)]
-    monkeypatch.setattr(miner, "chunk_text", lambda content, source_file: over_cap)
+    monkeypatch.setattr(miner, "chunk_text", lambda content, source_file, **kwargs: over_cap)
 
     source = tmp_path / "huge.csv"
     source.write_text("col1,col2\n" + "x,y\n" * 500, encoding="utf-8")


### PR DESCRIPTION
## Why

Chunk sizing in the miner is currently hardcoded via three module-level constants in `mempalace/miner.py`:

```python
CHUNK_SIZE = 800     # chars per drawer
CHUNK_OVERLAP = 100  # overlap between chunks
MIN_CHUNK_SIZE = 50  # skip tiny chunks
```

One size does not fit all. Source material varies enormously — dense source code wants smaller, tighter chunks; prose transcripts and journal entries work better with larger, more overlapping chunks; sparse logs want very small `min_chunk_size` to avoid dropping short but meaningful entries. Users also have different context-window budgets: a palace driving a 200K-token Claude session can afford larger drawers than one driving an 8K local model.

Today the only way to change these values is to edit source and reinstall. This PR makes all three overridable from `~/.mempalace/config.json` without changing defaults.

## What

Adds three new optional keys to `config.json`:

```json
{
  "chunk_size": 1200,
  "chunk_overlap": 150,
  "min_chunk_size": 40
}
```

- **`chunk_size`** (default `800`) — target character count per drawer
- **`chunk_overlap`** (default `100`) — characters shared between adjacent chunks so boundary information is never lost
- **`min_chunk_size`** (default `50`) — files (and tail chunks) smaller than this are skipped

Exposed as `MempalaceConfig` properties:

```python
cfg = MempalaceConfig()
cfg.chunk_size        # 800
cfg.chunk_overlap     # 100
cfg.min_chunk_size    # 50
```

Threaded through the mining path as optional keyword arguments:

```
mine() → reads MempalaceConfig once
      → process_file(..., chunk_size=, chunk_overlap=, min_chunk_size=)
         → chunk_text(..., chunk_size=, chunk_overlap=, min_chunk_size=)
```

`chunk_text()` and `process_file()` keep the module-level constants as fallbacks whenever a parameter is `None`, so **any caller that omits the new kwargs gets identical behavior** to before this PR.

## Backwards compatibility

- Defaults unchanged: `800 / 100 / 50`
- `config.json` keys are optional — missing keys fall through to the same defaults
- `chunk_text(content, source_file)` — the original two-arg signature — still works
- Existing palaces behave byte-for-byte identically until a user explicitly sets a value

## Tests

```
pytest tests/ -q -k "chunk or config"    → 62 passed
pytest tests/ -q -k "miner"              → 48 passed
```

No test changes required — defaults match existing hardcoded values exactly.

## Scope note

The source commit on my fork (`d63ffd4`) bundled three changes:

1. **I6** — configurable chunking (this PR)
2. **I11** — `Layer1.MAX_SCAN=2000` cap on wake-up scan
3. **I12** — `_build_where_filter()` helper extracted in `searcher.py`

Upstream `develop` already contains equivalents of I11 and I12, which made a straight cherry-pick produce tangled conflicts. I reconstructed the chunking slice cleanly on top of `upstream/develop` — I11 and I12 are therefore not in this PR and not needed.

## Test plan

- [x] `pytest -k "chunk or config"` — 62 passed
- [x] `pytest -k "miner"` — 48 passed
- [x] `MempalaceConfig().chunk_size / .chunk_overlap / .min_chunk_size` return `800 / 100 / 50` with no `config.json` present
- [x] Setting `"chunk_size": 1200` in `~/.mempalace/config.json` propagates through `mine() → process_file() → chunk_text()`
- [x] Omitting the new keys preserves default behavior identically