### PR TITLE
feat: trust_type drawer metadata (mechanical:/human:/llm_judge: prefixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Improvements
 - Optimize entity detection with regex caching and pre-compilation (#828)
 - Extract locked filing block into helper to keep `mine_convos` under C901 complexity
+- **`trust_type` drawer metadata.** New `mempalace.trust_type` module defines a three-way prefix convention for `added_by` strings (`mechanical:<hook>`, `human:<user>`, `llm_judge:<model>`) and parses the high-level category. Both canonical `add_drawer` sites (`miner.add_drawer` and `mcp_server.tool_add_drawer`) auto-populate `trust_type` in drawer metadata when `added_by` carries a recognized prefix, so consumers can filter `where={"trust_type": "human"}` without pattern-matching agent strings downstream. Unrecognized `added_by` values leave `trust_type` unset — legacy callers see no behavior change.
 
 ### Documentation
 - Add `docs/CLOSETS.md` — closet layer overview

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -643,19 +643,26 @@ def tool_add_drawer(
         pass
 
     try:
+        metadata = {
+            "wing": wing,
+            "room": room,
+            "source_file": source_file or "",
+            "chunk_index": 0,
+            "added_by": added_by,
+            "filed_at": datetime.now().isoformat(),
+        }
+        # Auto-populate trust_type when added_by carries a known prefix.
+        # See mempalace.trust_type for the mechanical:/human:/llm_judge:
+        # convention. Unclassified agents leave trust_type unset.
+        from .trust_type import parse_trust_type as _parse_trust_type
+        trust = _parse_trust_type(added_by)
+        if trust:
+            metadata["trust_type"] = trust
+
         col.upsert(
             ids=[drawer_id],
             documents=[content],
-            metadatas=[
-                {
-                    "wing": wing,
-                    "room": room,
-                    "source_file": source_file or "",
-                    "chunk_index": 0,
-                    "added_by": added_by,
-                    "filed_at": datetime.now().isoformat(),
-                }
-            ],
+            metadatas=[metadata],
         )
         _metadata_cache = None
         logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -26,6 +26,7 @@ from .palace import (
     purge_file_closets,
     upsert_closet_lines,
 )
+from .trust_type import parse_trust_type as _parse_trust_type
 
 READABLE_EXTENSIONS = {
     ".txt",
@@ -556,6 +557,13 @@ def add_drawer(
             "filed_at": datetime.now().isoformat(),
             "normalize_version": NORMALIZE_VERSION,
         }
+        # Classify the writer when the agent string carries a known prefix
+        # (mechanical:<hook> / human:<user> / llm_judge:<model>). See
+        # mempalace.trust_type for the full convention. Unrecognized agent
+        # strings leave trust_type unset — existing callers are unaffected.
+        trust = _parse_trust_type(agent)
+        if trust:
+            metadata["trust_type"] = trust
         # Store file mtime so we can detect modifications later.
         try:
             metadata["source_mtime"] = os.path.getmtime(source_file)

--- a/mempalace/trust_type.py
+++ b/mempalace/trust_type.py
@@ -1,0 +1,73 @@
+"""Trust-type parsing for drawer metadata.
+
+A drawer's ``added_by`` field historically has been a free-form agent name
+(e.g. ``"memory-harvest"``, ``"mcp"``, ``"dos-rate-hook"``). Callers that
+want to distinguish automated writes from human-authored writes from
+LLM-summarized content have had to pattern-match against that free-form
+string downstream.
+
+This module defines the three-way prefix convention that callers can opt
+into, and the parser that extracts the high-level category. When a drawer
+is written with an ``added_by`` that carries a recognized prefix, the
+canonical ``add_drawer`` sites (``miner.add_drawer`` and
+``mcp_server.tool_add_drawer``) also write a ``trust_type`` metadata field
+so consumers (ranking, export, fact_check, council workflows) can filter
+without re-parsing strings.
+
+Prefixes:
+
+    mechanical:<hook_name>    automated hook / scheduled job / bridge script
+    human:<user>              human-authored drawer (e.g. direct MCP tool call by the user)
+    llm_judge:<model_id>      LLM-summarized content; provenance points to the summarizer
+
+An ``added_by`` that does not carry one of these prefixes is treated as
+unclassified and ``trust_type`` is left unset. Existing callers are
+unaffected.
+"""
+
+from __future__ import annotations
+
+
+TRUST_TYPE_MECHANICAL = "mechanical"
+TRUST_TYPE_HUMAN = "human"
+TRUST_TYPE_LLM_JUDGE = "llm_judge"
+
+_KNOWN_PREFIXES: tuple[str, ...] = (
+    TRUST_TYPE_MECHANICAL,
+    TRUST_TYPE_HUMAN,
+    TRUST_TYPE_LLM_JUDGE,
+)
+
+
+def parse_trust_type(added_by: str | None) -> str | None:
+    """Parse a trust_type category from an ``added_by`` string.
+
+    Returns one of ``"mechanical"``, ``"human"``, ``"llm_judge"`` when
+    ``added_by`` starts with the corresponding prefix followed by ``":"``
+    and a non-empty specifier. Returns ``None`` otherwise (including for
+    ``None``, empty string, or any unrecognized prefix).
+
+    Examples
+    --------
+    >>> parse_trust_type("mechanical:memory-harvest")
+    'mechanical'
+    >>> parse_trust_type("human:lucas")
+    'human'
+    >>> parse_trust_type("llm_judge:claude-opus-4-7")
+    'llm_judge'
+    >>> parse_trust_type("mcp") is None
+    True
+    >>> parse_trust_type("") is None
+    True
+    >>> parse_trust_type(None) is None
+    True
+    >>> parse_trust_type("mechanical:") is None  # prefix without specifier
+    True
+    """
+    if not added_by or not isinstance(added_by, str):
+        return None
+    for prefix in _KNOWN_PREFIXES:
+        head = prefix + ":"
+        if added_by.startswith(head) and len(added_by) > len(head):
+            return prefix
+    return None

--- a/tests/test_trust_type.py
+++ b/tests/test_trust_type.py
@@ -1,0 +1,68 @@
+"""Tests for mempalace.trust_type — prefix-based agent classification."""
+
+import pytest
+
+from mempalace.trust_type import (
+    TRUST_TYPE_HUMAN,
+    TRUST_TYPE_LLM_JUDGE,
+    TRUST_TYPE_MECHANICAL,
+    parse_trust_type,
+)
+
+
+class TestParseTrustType:
+    def test_mechanical_prefix(self):
+        assert parse_trust_type("mechanical:memory-harvest") == TRUST_TYPE_MECHANICAL
+        assert parse_trust_type("mechanical:dos-rate-hook") == TRUST_TYPE_MECHANICAL
+        assert parse_trust_type("mechanical:a") == TRUST_TYPE_MECHANICAL
+
+    def test_human_prefix(self):
+        assert parse_trust_type("human:lucas") == TRUST_TYPE_HUMAN
+        assert parse_trust_type("human:someone@example.com") == TRUST_TYPE_HUMAN
+
+    def test_llm_judge_prefix(self):
+        assert parse_trust_type("llm_judge:claude-opus-4-7") == TRUST_TYPE_LLM_JUDGE
+        assert parse_trust_type("llm_judge:gpt-4o") == TRUST_TYPE_LLM_JUDGE
+
+    def test_unrecognized_prefix_returns_none(self):
+        # Legacy free-form agent names — no trust_type inferred.
+        assert parse_trust_type("mcp") is None
+        assert parse_trust_type("memory-harvest") is None
+        assert parse_trust_type("dos-rate-hook") is None
+        assert parse_trust_type("sentinel") is None
+
+    def test_prefix_without_specifier_returns_none(self):
+        # Caller set the prefix but didn't name the agent — reject rather
+        # than classify, so malformed writes don't silently inherit a type.
+        assert parse_trust_type("mechanical:") is None
+        assert parse_trust_type("human:") is None
+        assert parse_trust_type("llm_judge:") is None
+
+    def test_similar_but_wrong_prefix(self):
+        # Substring match must be anchored to the start and end with ":".
+        assert parse_trust_type("mechanicalish:name") is None
+        assert parse_trust_type("not-mechanical:name") is None
+        assert parse_trust_type("human-ish:name") is None
+
+    def test_empty_and_none(self):
+        assert parse_trust_type("") is None
+        assert parse_trust_type(None) is None
+
+    def test_non_string_input(self):
+        # Defensive: callers sometimes pass through chromadb metadata which
+        # could be any JSON-serializable value. Treat non-str as unclassified.
+        assert parse_trust_type(123) is None  # type: ignore[arg-type]
+        assert parse_trust_type(["mechanical:x"]) is None  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "added_by,expected",
+        [
+            ("mechanical:memory-harvest", TRUST_TYPE_MECHANICAL),
+            ("human:lucas", TRUST_TYPE_HUMAN),
+            ("llm_judge:claude-opus-4-7", TRUST_TYPE_LLM_JUDGE),
+            ("mcp", None),
+            ("", None),
+        ],
+    )
+    def test_table(self, added_by, expected):
+        assert parse_trust_type(added_by) == expected


### PR DESCRIPTION
## Summary

Adds a three-way prefix convention for the `added_by` drawer metadata field and auto-populates a high-level `trust_type` classifier so downstream consumers can filter without pattern-matching agent strings.

```python
parse_trust_type("mechanical:memory-harvest")   # → "mechanical"
parse_trust_type("human:lucas")                  # → "human"
parse_trust_type("llm_judge:claude-opus-4-7")    # → "llm_judge"
parse_trust_type("mcp")                          # → None (unclassified; legacy caller)
```

Both canonical `add_drawer` sites (`miner.add_drawer` and `mcp_server.tool_add_drawer`) call the parser and, when the prefix is recognized, add `trust_type` to drawer metadata. The field is queryable via the standard ChromaDB `where={"trust_type": "human"}` filter.

## Motivation

Consumers that need to distinguish automated writes from human-authored content from LLM-summarized content today have to either (a) pattern-match free-form `added_by` strings (fragile) or (b) trust every drawer equally (loses signal). Storing the category once at write time lets downstream ranking / export / fact-check / council workflows filter cleanly.

The convention is strictly opt-in — unrecognized `added_by` values (e.g. `"mcp"`, `"memory-harvest"`, `"unknown"`) leave `trust_type` unset, so legacy callers see no behavior change.

## Changes

| File | Change |
|---|---|
| `mempalace/trust_type.py` | New module — parser + three constants |
| `mempalace/miner.py::add_drawer` | Calls parser, populates `trust_type` when recognized |
| `mempalace/mcp_server.py::tool_add_drawer` | Same behavior in MCP write path |
| `tests/test_trust_type.py` | 13 new tests |
| `CHANGELOG.md` | Bullet under existing `[Unreleased] — v3.3.0` Improvements |

## Test plan

- [x] `uv run pytest tests/test_trust_type.py` — 13/13 passing locally
- [x] Prefix detection covers three recognized cases + unrecognized fallback
- [x] Defensive path: non-string input (None, int, list) returns None without raising
- [x] Malformed prefix (`"mechanical:"` with empty specifier) returns None
- [x] Substring-match anchored — `"mechanicalish:name"` rejected
- [x] Backward compatibility: existing callers with free-form `added_by` leave `trust_type` unset

## Notes for reviewers

- No schema migration required — `trust_type` is a new optional metadata key; existing drawers simply don't have it.
- `tool_kg_add` intentionally not modified — this PR scopes `trust_type` to drawer metadata per the underlying use-case (documents, not KG triples).
- The prefix convention was designed with three categories but the parser is open to extension — adding a fourth prefix is a one-line addition to `_KNOWN_PREFIXES`.