### PR TITLE
feat(cli): add `mempalace purge` — delete drawers by wing/room

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -824,6 +824,119 @@ def cmd_migrate_wings(args):
     )
 
 
+def cmd_purge(args):
+    """Delete drawers by wing and/or room.
+
+    Extracts the drawers to *keep*, nukes the palace directory, and
+    re-inserts them into a fresh ChromaDB. This avoids HNSW ghost entries
+    that ChromaDB's in-place ``collection.delete()`` leaves behind, which
+    can cause segfaults on subsequent queries or inserts (see #521 for the
+    underlying hnswlib ``updatePoint`` race on modified-file re-mines).
+
+    Note: ``--room`` without ``--wing`` purges that room across ALL wings.
+
+    Not idempotent — running purge twice on the same criteria will print
+    "No drawers found" the second time. The operation is destructive; the
+    ``--yes`` flag skips the interactive confirmation.
+    """
+    import chromadb
+    import shutil
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    try:
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+    except Exception:
+        print(f"\n  No palace found at {palace_path}")
+        return
+
+    where = {}
+    if args.wing and args.room:
+        where = {"$and": [{"wing": args.wing}, {"room": args.room}]}
+    elif args.wing:
+        where = {"wing": args.wing}
+    elif args.room:
+        where = {"room": args.room}
+    else:
+        print("  Error: specify --wing and/or --room")
+        return
+
+    total = col.count()
+
+    # Count matching drawers
+    match_ids = set()
+    offset = 0
+    while True:
+        batch = col.get(limit=10000, offset=offset, where=where, include=[])
+        if not batch["ids"]:
+            break
+        match_ids.update(batch["ids"])
+        offset += len(batch["ids"])
+
+    if not match_ids:
+        label = f"wing={args.wing}" if args.wing else ""
+        if args.room:
+            label = f"{label} room={args.room}" if label else f"room={args.room}"
+        print(f"\n  No drawers found matching {label}\n")
+        return
+
+    label = f"wing={args.wing}" if args.wing else ""
+    if args.room:
+        label = f"{label} room={args.room}" if label else f"room={args.room}"
+    keep_count = total - len(match_ids)
+    print(f"\n  Found {len(match_ids):,} drawers matching {label}")
+    print(f"  Will keep {keep_count:,} drawers, rebuild index")
+
+    if not args.yes:
+        confirm = input(f"  Purge {len(match_ids):,} drawers? [y/N] ").strip().lower()
+        if confirm not in ("y", "yes"):
+            print("  Aborted.")
+            return
+
+    # Extract drawers to keep (everything NOT matching the filter)
+    print("  Extracting drawers to keep...")
+    keep_ids, keep_docs, keep_metas = [], [], []
+    offset = 0
+    batch_size = 5000
+    while offset < total:
+        batch = col.get(limit=batch_size, offset=offset, include=["documents", "metadatas"])
+        if not batch["ids"]:
+            break
+        for i, doc_id in enumerate(batch["ids"]):
+            if doc_id not in match_ids:
+                keep_ids.append(doc_id)
+                keep_docs.append(batch["documents"][i])
+                keep_metas.append(batch["metadatas"][i])
+        offset += len(batch["ids"])
+    print(f"  Extracted {len(keep_ids):,} drawers to keep")
+
+    # Release client before nuking — ChromaDB holds open file handles
+    # (WAL journal, HNSW mmap) that block rmtree on Windows and some Linux FS.
+    del col, client
+
+    # Nuke and rebuild with clean HNSW index
+    palace_path = palace_path.rstrip(os.sep)
+    print("  Rebuilding palace...")
+    shutil.rmtree(palace_path)
+    os.makedirs(palace_path, mode=0o700)
+
+    new_client = chromadb.PersistentClient(path=palace_path)
+    new_col = new_client.create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
+
+    filed = 0
+    for i in range(0, len(keep_ids), batch_size):
+        end = min(i + batch_size, len(keep_ids))
+        new_col.add(
+            documents=keep_docs[i:end],
+            ids=keep_ids[i:end],
+            metadatas=keep_metas[i:end],
+        )
+        filed += end - i
+        print(f"  Re-filed {filed:,} / {len(keep_ids):,}...", flush=True)
+
+    print(f"\n  Purged {len(match_ids):,} drawers. Remaining: {new_col.count():,}\n")
+
+
 def cmd_status(args):
     from .miner import status
 
@@ -1765,6 +1878,18 @@ def main():
         help="Storage backend (default: config/env/detected/chroma)",
     )
 
+    # purge
+    p_purge = sub.add_parser(
+        "purge",
+        help="Delete drawers by wing and/or room (nuke-and-reinsert to avoid HNSW ghost entries)",
+    )
+    p_purge.add_argument("--wing", help="Wing to purge")
+    p_purge.add_argument("--room", help="Room to purge (across all wings if --wing omitted)")
+    p_purge.add_argument("--palace", help="Path to palace directory (default: from config)")
+    p_purge.add_argument(
+        "--yes", action="store_true", help="Skip interactive confirmation (destructive!)"
+    )
+
     args = parser.parse_args()
     _apply_backend_arg(args)
 
@@ -1810,6 +1935,7 @@ def main():
         "repair-status": cmd_repair_status,
         "migrate": cmd_migrate,
         "migrate-wings": cmd_migrate_wings,
+        "purge": cmd_purge,
         "status": cmd_status,
     }
     dispatch[args.command](args)

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -838,13 +838,21 @@ def cmd_purge(args):
     ``--room`` without ``--wing`` purges that room across ALL wings.
     Not idempotent — running purge twice on the same criteria prints
     "No drawers found" the second time.
+
+    Chroma-only in this release — gated by the same backend guard as
+    ``migrate`` / ``repair`` so a palace on another backend gets a clear
+    message instead of a misleading "No palace found".
     """
     from .backends.chroma import ChromaBackend
     from .migrate import confirm_destructive_action, contains_palace_database
 
+    config = MempalaceConfig()
+    collection_name = config.collection_name
     palace_path = os.path.abspath(
-        os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+        os.path.expanduser(args.palace) if args.palace else config.palace_path
     )
+    if not _maintenance_requires_chroma(palace_path, "purge"):
+        raise SystemExit(2)
 
     if not os.path.isdir(palace_path) or not contains_palace_database(palace_path):
         print(f"\n  No palace found at {palace_path}")
@@ -862,7 +870,7 @@ def cmd_purge(args):
 
     backend = ChromaBackend()
     try:
-        col = backend.get_collection(palace_path, "mempalace_drawers")
+        col = backend.get_collection(palace_path, collection_name)
     except Exception as e:
         print(f"\n  Error reading palace: {e}")
         return

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -827,30 +827,29 @@ def cmd_migrate_wings(args):
 def cmd_purge(args):
     """Delete drawers by wing and/or room.
 
-    Extracts the drawers to *keep*, nukes the palace directory, and
-    re-inserts them into a fresh ChromaDB. This avoids HNSW ghost entries
-    that ChromaDB's in-place ``collection.delete()`` leaves behind, which
-    can cause segfaults on subsequent queries or inserts (see #521 for the
-    underlying hnswlib ``updatePoint`` race on modified-file re-mines).
+    Uses ``collection.delete(where=...)`` — chromadb's filter-delete path
+    doesn't go through ``updatePoint`` / ``repairConnectionsForUpdate``,
+    which is the upsert-only race from #521 that an earlier draft of this
+    command tried to side-step with a nuke-and-rebuild. The simpler path
+    works without losing drawers if the process is interrupted, without
+    re-embedding the survivors under a default model, and without
+    bypassing the backend abstraction.
 
-    Note: ``--room`` without ``--wing`` purges that room across ALL wings.
-
-    Not idempotent — running purge twice on the same criteria will print
-    "No drawers found" the second time. The operation is destructive; the
-    ``--yes`` flag skips the interactive confirmation.
+    ``--room`` without ``--wing`` purges that room across ALL wings.
+    Not idempotent — running purge twice on the same criteria prints
+    "No drawers found" the second time.
     """
-    import chromadb
-    import shutil
+    from .backends.chroma import ChromaBackend
+    from .migrate import confirm_destructive_action, contains_palace_database
 
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
-    try:
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
-    except Exception:
+    palace_path = os.path.abspath(
+        os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    )
+
+    if not os.path.isdir(palace_path) or not contains_palace_database(palace_path):
         print(f"\n  No palace found at {palace_path}")
         return
 
-    where = {}
     if args.wing and args.room:
         where = {"$and": [{"wing": args.wing}, {"room": args.room}]}
     elif args.wing:
@@ -861,80 +860,51 @@ def cmd_purge(args):
         print("  Error: specify --wing and/or --room")
         return
 
-    total = col.count()
+    backend = ChromaBackend()
+    try:
+        col = backend.get_collection(palace_path, "mempalace_drawers")
+    except Exception as e:
+        print(f"\n  Error reading palace: {e}")
+        return
 
-    # Count matching drawers
-    match_ids = set()
-    offset = 0
-    while True:
-        batch = col.get(limit=10000, offset=offset, where=where, include=[])
-        if not batch["ids"]:
-            break
-        match_ids.update(batch["ids"])
-        offset += len(batch["ids"])
+    # Probe match count via a `where=`-filtered get with no payload.
+    # ChromaCollection.get returns the typed result; we only need ids.
+    try:
+        matched = col.get(where=where, include=[])
+    except Exception as e:
+        print(f"\n  Error querying drawers: {e}")
+        return
 
-    if not match_ids:
-        label = f"wing={args.wing}" if args.wing else ""
-        if args.room:
-            label = f"{label} room={args.room}" if label else f"room={args.room}"
+    match_ids = matched.get("ids") if isinstance(matched, dict) else getattr(matched, "ids", [])
+    match_ids = match_ids or []
+    match_count = len(match_ids)
+
+    label_parts = []
+    if args.wing:
+        label_parts.append(f"wing={args.wing}")
+    if args.room:
+        label_parts.append(f"room={args.room}")
+    label = " ".join(label_parts)
+
+    if match_count == 0:
         print(f"\n  No drawers found matching {label}\n")
         return
 
-    label = f"wing={args.wing}" if args.wing else ""
-    if args.room:
-        label = f"{label} room={args.room}" if label else f"room={args.room}"
-    keep_count = total - len(match_ids)
-    print(f"\n  Found {len(match_ids):,} drawers matching {label}")
-    print(f"  Will keep {keep_count:,} drawers, rebuild index")
+    print(f"\n  Found {match_count:,} drawers matching {label}")
 
     if not args.yes:
-        confirm = input(f"  Purge {len(match_ids):,} drawers? [y/N] ").strip().lower()
-        if confirm not in ("y", "yes"):
-            print("  Aborted.")
+        if not confirm_destructive_action(f"Purge of {match_count:,} drawers", palace_path):
             return
 
-    # Extract drawers to keep (everything NOT matching the filter)
-    print("  Extracting drawers to keep...")
-    keep_ids, keep_docs, keep_metas = [], [], []
-    offset = 0
-    batch_size = 5000
-    while offset < total:
-        batch = col.get(limit=batch_size, offset=offset, include=["documents", "metadatas"])
-        if not batch["ids"]:
-            break
-        for i, doc_id in enumerate(batch["ids"]):
-            if doc_id not in match_ids:
-                keep_ids.append(doc_id)
-                keep_docs.append(batch["documents"][i])
-                keep_metas.append(batch["metadatas"][i])
-        offset += len(batch["ids"])
-    print(f"  Extracted {len(keep_ids):,} drawers to keep")
+    print("  Deleting matching drawers...")
+    try:
+        col.delete(where=where)
+    except Exception as e:
+        print(f"\n  Delete failed: {e}\n")
+        return
 
-    # Release client before nuking — ChromaDB holds open file handles
-    # (WAL journal, HNSW mmap) that block rmtree on Windows and some Linux FS.
-    del col, client
-
-    # Nuke and rebuild with clean HNSW index
-    palace_path = palace_path.rstrip(os.sep)
-    print("  Rebuilding palace...")
-    shutil.rmtree(palace_path)
-    os.makedirs(palace_path, mode=0o700)
-
-    new_client = chromadb.PersistentClient(path=palace_path)
-    new_col = new_client.create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
-
-    filed = 0
-    for i in range(0, len(keep_ids), batch_size):
-        end = min(i + batch_size, len(keep_ids))
-        new_col.add(
-            documents=keep_docs[i:end],
-            ids=keep_ids[i:end],
-            metadatas=keep_metas[i:end],
-        )
-        filed += end - i
-        print(f"  Re-filed {filed:,} / {len(keep_ids):,}...", flush=True)
-
-    print(f"\n  Purged {len(match_ids):,} drawers. Remaining: {new_col.count():,}\n")
+    remaining = col.count()
+    print(f"\n  Purged {match_count:,} drawers. Remaining: {remaining:,}\n")
 
 
 def cmd_status(args):
@@ -1881,7 +1851,7 @@ def main():
     # purge
     p_purge = sub.add_parser(
         "purge",
-        help="Delete drawers by wing and/or room (nuke-and-reinsert to avoid HNSW ghost entries)",
+        help="Delete drawers by wing and/or room (filtered delete via chromadb)",
     )
     p_purge.add_argument("--wing", help="Wing to purge")
     p_purge.add_argument("--room", help="Room to purge (across all wings if --wing omitted)")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,6 +214,7 @@ def test_cmd_purge_deletes_via_where_clause(tmp_path):
     args = _make_purge_args(wing="purge-me", palace=str(palace))
     with patch("mempalace.cli.MempalaceConfig") as mock_config_cls:
         mock_config_cls.return_value.palace_path = str(palace)
+        mock_config_cls.return_value.collection_name = "mempalace_drawers"
         cmd_purge(args)
 
     # Re-open through the backend to confirm survivors and that the index

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from mempalace.cli import (
     cmd_init,
     cmd_instructions,
     cmd_mine,
+    cmd_purge,
     cmd_repair,
     cmd_search,
     cmd_split,
@@ -111,6 +112,85 @@ def test_cmd_status_custom_palace(mock_config_cls):
 
         expected = os.path.expanduser("~/my_palace")
         mock_miner.status.assert_called_once_with(palace_path=expected)
+
+
+# ── cmd_purge ──────────────────────────────────────────────────────────
+
+
+def _make_purge_args(**overrides):
+    """Build a Namespace with all purge args set."""
+    defaults = {"palace": None, "wing": None, "room": None, "yes": True}
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_purge_no_palace_found(mock_config_cls, capsys):
+    """Purge prints a clear message when the palace doesn't exist."""
+    mock_config_cls.return_value.palace_path = "/nonexistent/palace"
+    args = _make_purge_args(wing="any")
+    mock_chromadb = MagicMock()
+    mock_chromadb.PersistentClient.side_effect = Exception("no palace")
+    with patch.dict("sys.modules", {"chromadb": mock_chromadb, "shutil": MagicMock()}):
+        cmd_purge(args)
+    out = capsys.readouterr().out
+    assert "No palace found" in out
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_purge_requires_filter(mock_config_cls, capsys):
+    """Purge refuses to run without --wing or --room (no mass-delete safety valve)."""
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = _make_purge_args()  # no wing, no room
+    mock_col = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get_collection.return_value = mock_col
+    mock_chromadb = MagicMock()
+    mock_chromadb.PersistentClient.return_value = mock_client
+    with patch.dict("sys.modules", {"chromadb": mock_chromadb, "shutil": MagicMock()}):
+        cmd_purge(args)
+    out = capsys.readouterr().out
+    assert "Error: specify --wing and/or --room" in out
+    mock_col.count.assert_not_called()  # didn't touch data
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_purge_no_matches(mock_config_cls, capsys):
+    """When the filter matches zero drawers, purge exits cleanly without rebuilding."""
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = _make_purge_args(wing="empty-wing")
+    mock_col = MagicMock()
+    mock_col.count.return_value = 100
+    mock_col.get.return_value = {"ids": []}
+    mock_client = MagicMock()
+    mock_client.get_collection.return_value = mock_col
+    mock_chromadb = MagicMock()
+    mock_chromadb.PersistentClient.return_value = mock_client
+    mock_shutil = MagicMock()
+    with patch.dict("sys.modules", {"chromadb": mock_chromadb, "shutil": mock_shutil}):
+        cmd_purge(args)
+    out = capsys.readouterr().out
+    assert "No drawers found matching" in out
+    mock_shutil.rmtree.assert_not_called()  # nothing to rebuild
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_purge_wing_and_room_uses_and_filter(mock_config_cls):
+    """Purge builds a $and filter when both --wing and --room are set."""
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = _make_purge_args(wing="myproj", room="drafts")
+    mock_col = MagicMock()
+    mock_col.count.return_value = 0
+    mock_col.get.return_value = {"ids": []}
+    mock_client = MagicMock()
+    mock_client.get_collection.return_value = mock_col
+    mock_chromadb = MagicMock()
+    mock_chromadb.PersistentClient.return_value = mock_client
+    with patch.dict("sys.modules", {"chromadb": mock_chromadb, "shutil": MagicMock()}):
+        cmd_purge(args)
+    # First col.get call builds the match-id set, and its `where` should be $and
+    first_call = mock_col.get.call_args_list[0]
+    assert first_call.kwargs["where"] == {"$and": [{"wing": "myproj"}, {"room": "drafts"}]}
 
 
 # ── cmd_search ─────────────────────────────────────────────────────────

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,72 +125,104 @@ def _make_purge_args(**overrides):
 
 
 @patch("mempalace.cli.MempalaceConfig")
-def test_cmd_purge_no_palace_found(mock_config_cls, capsys):
+def test_cmd_purge_no_palace_found(mock_config_cls, capsys, tmp_path):
     """Purge prints a clear message when the palace doesn't exist."""
-    mock_config_cls.return_value.palace_path = "/nonexistent/palace"
-    args = _make_purge_args(wing="any")
-    mock_chromadb = MagicMock()
-    mock_chromadb.PersistentClient.side_effect = Exception("no palace")
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb, "shutil": MagicMock()}):
-        cmd_purge(args)
+    missing = tmp_path / "nonexistent"
+    mock_config_cls.return_value.palace_path = str(missing)
+    args = _make_purge_args(wing="any", palace=str(missing))
+    cmd_purge(args)
     out = capsys.readouterr().out
     assert "No palace found" in out
 
 
 @patch("mempalace.cli.MempalaceConfig")
-def test_cmd_purge_requires_filter(mock_config_cls, capsys):
+def test_cmd_purge_requires_filter(mock_config_cls, capsys, tmp_path):
     """Purge refuses to run without --wing or --room (no mass-delete safety valve)."""
-    mock_config_cls.return_value.palace_path = "/fake/palace"
-    args = _make_purge_args()  # no wing, no room
-    mock_col = MagicMock()
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-    mock_chromadb = MagicMock()
-    mock_chromadb.PersistentClient.return_value = mock_client
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb, "shutil": MagicMock()}):
-        cmd_purge(args)
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    (palace / "chroma.sqlite3").write_text("")
+    mock_config_cls.return_value.palace_path = str(palace)
+    args = _make_purge_args(palace=str(palace))  # no wing, no room
+    cmd_purge(args)
     out = capsys.readouterr().out
     assert "Error: specify --wing and/or --room" in out
-    mock_col.count.assert_not_called()  # didn't touch data
 
 
 @patch("mempalace.cli.MempalaceConfig")
-def test_cmd_purge_no_matches(mock_config_cls, capsys):
-    """When the filter matches zero drawers, purge exits cleanly without rebuilding."""
-    mock_config_cls.return_value.palace_path = "/fake/palace"
-    args = _make_purge_args(wing="empty-wing")
+def test_cmd_purge_no_matches(mock_config_cls, capsys, tmp_path):
+    """When the filter matches zero drawers, purge exits cleanly."""
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    (palace / "chroma.sqlite3").write_text("")
+    mock_config_cls.return_value.palace_path = str(palace)
+    args = _make_purge_args(wing="empty-wing", palace=str(palace))
+
     mock_col = MagicMock()
-    mock_col.count.return_value = 100
     mock_col.get.return_value = {"ids": []}
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-    mock_chromadb = MagicMock()
-    mock_chromadb.PersistentClient.return_value = mock_client
-    mock_shutil = MagicMock()
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb, "shutil": mock_shutil}):
+    mock_backend = MagicMock()
+    mock_backend.return_value.get_collection.return_value = mock_col
+    with patch("mempalace.backends.chroma.ChromaBackend", mock_backend):
         cmd_purge(args)
     out = capsys.readouterr().out
     assert "No drawers found matching" in out
-    mock_shutil.rmtree.assert_not_called()  # nothing to rebuild
+    mock_col.delete.assert_not_called()
 
 
 @patch("mempalace.cli.MempalaceConfig")
-def test_cmd_purge_wing_and_room_uses_and_filter(mock_config_cls):
+def test_cmd_purge_wing_and_room_uses_and_filter(mock_config_cls, tmp_path):
     """Purge builds a $and filter when both --wing and --room are set."""
-    mock_config_cls.return_value.palace_path = "/fake/palace"
-    args = _make_purge_args(wing="myproj", room="drafts")
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    (palace / "chroma.sqlite3").write_text("")
+    mock_config_cls.return_value.palace_path = str(palace)
+    args = _make_purge_args(wing="myproj", room="drafts", palace=str(palace))
+
     mock_col = MagicMock()
-    mock_col.count.return_value = 0
     mock_col.get.return_value = {"ids": []}
-    mock_client = MagicMock()
-    mock_client.get_collection.return_value = mock_col
-    mock_chromadb = MagicMock()
-    mock_chromadb.PersistentClient.return_value = mock_client
-    with patch.dict("sys.modules", {"chromadb": mock_chromadb, "shutil": MagicMock()}):
+    mock_backend = MagicMock()
+    mock_backend.return_value.get_collection.return_value = mock_col
+    with patch("mempalace.backends.chroma.ChromaBackend", mock_backend):
         cmd_purge(args)
-    # First col.get call builds the match-id set, and its `where` should be $and
     first_call = mock_col.get.call_args_list[0]
     assert first_call.kwargs["where"] == {"$and": [{"wing": "myproj"}, {"room": "drafts"}]}
+
+
+def test_cmd_purge_deletes_via_where_clause(tmp_path):
+    """End-to-end: purge filters via collection.delete(where=...) — preserves
+    embedding function, no rmtree, no rebuild. Regression for igorls' #1087
+    review concerns 1, 2, 3."""
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    # Real chromadb palace via the backend so the embedding function is
+    # whatever the backend resolves (the actual concern from the review).
+    from mempalace.backends.chroma import ChromaBackend
+
+    backend = ChromaBackend()
+    col = backend.get_collection(str(palace), "mempalace_drawers", create=True)
+    col.add(
+        ids=["k1", "k2", "p1", "p2"],
+        documents=["keep one", "keep two", "purge one", "purge two"],
+        metadatas=[
+            {"wing": "keep", "room": "r"},
+            {"wing": "keep", "room": "r"},
+            {"wing": "purge-me", "room": "r"},
+            {"wing": "purge-me", "room": "r"},
+        ],
+    )
+    assert col.count() == 4
+
+    args = _make_purge_args(wing="purge-me", palace=str(palace))
+    with patch("mempalace.cli.MempalaceConfig") as mock_config_cls:
+        mock_config_cls.return_value.palace_path = str(palace)
+        cmd_purge(args)
+
+    # Re-open through the backend to confirm survivors and that the index
+    # still works (no nuke, embedding function intact).
+    col2 = backend.get_collection(str(palace), "mempalace_drawers", create=False)
+    assert col2.count() == 2
+    surviving = col2.get(include=["metadatas"])
+    surviving_ids = surviving.get("ids") if isinstance(surviving, dict) else surviving.ids
+    assert set(surviving_ids) == {"k1", "k2"}
 
 
 # ── cmd_search ─────────────────────────────────────────────────────────

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,6 +225,68 @@ def test_cmd_purge_deletes_via_where_clause(tmp_path):
     assert set(surviving_ids) == {"k1", "k2"}
 
 
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_purge_interactive_abort_leaves_data_intact(mock_config_cls, capsys, tmp_path):
+    """yes=False + the user types anything other than 'y'/'yes' → no delete.
+
+    The custom input() prompt was retired in #1087's rewrite in favor of
+    confirm_destructive_action() (mempalace/migrate.py); this test
+    exercises the interactive branch end-to-end via patched input() and
+    asserts both the operator-visible message and that .delete() was
+    never called.
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    (palace / "chroma.sqlite3").write_text("")
+    mock_config_cls.return_value.palace_path = str(palace)
+    args = _make_purge_args(wing="purge-me", palace=str(palace), yes=False)
+
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"ids": ["d1", "d2"]}
+    mock_backend = MagicMock()
+    mock_backend.return_value.get_collection.return_value = mock_col
+
+    with (
+        patch("mempalace.backends.chroma.ChromaBackend", mock_backend),
+        patch("builtins.input", return_value="n"),
+    ):
+        cmd_purge(args)
+
+    out = capsys.readouterr().out
+    assert "Aborted" in out, f"abort message missing: {out!r}"
+    mock_col.delete.assert_not_called()
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_purge_eof_on_confirm_aborts_safely(mock_config_cls, capsys, tmp_path):
+    """yes=False + EOF on stdin (non-interactive call) → abort, not crash.
+
+    Closes the EOFError concern — purge piped from a non-tty (CI, cron,
+    `< /dev/null`) used to raise an unhandled exception. Now
+    confirm_destructive_action catches EOFError and aborts cleanly.
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    (palace / "chroma.sqlite3").write_text("")
+    mock_config_cls.return_value.palace_path = str(palace)
+    args = _make_purge_args(wing="purge-me", palace=str(palace), yes=False)
+
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"ids": ["d1"]}
+    mock_backend = MagicMock()
+    mock_backend.return_value.get_collection.return_value = mock_col
+
+    with (
+        patch("mempalace.backends.chroma.ChromaBackend", mock_backend),
+        patch("builtins.input", side_effect=EOFError),
+    ):
+        cmd_purge(args)
+
+    out = capsys.readouterr().out
+    assert "Aborted" in out
+    mock_col.delete.assert_not_called()
+
+
 # ── cmd_search ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds a destructive CLI command that removes drawers matching a wing and/or room filter. Example usage:

```bash
mempalace purge --wing old-project                # nuke everything in one wing
mempalace purge --wing big-wing --room drafts     # just that room in that wing
mempalace purge --room _registry --yes            # cross-wing by room, skip confirm
```

Users currently have no clean way to delete drawers by scope. This closes that gap.

## Why the implementation is "nuke-and-reinsert" rather than `collection.delete()`

The obvious implementation is `collection.delete(where=...)`. That path triggers hnswlib's internal `updatePoint` → `repairConnectionsForUpdate`, which — on macOS ARM64 with Python 3.13 + chromadb 0.6.3 — has a thread-safety bug that dereferences dangling pointers and kills the process with `EXC_BAD_ACCESS`. See **#521** (@StefanKremen, 2026-04-13) for the reproducer.

**To be clear, this PR does NOT fix #521.** The miner's modified-file re-mine path still hits the same bug on every edit, because it also delete-then-inserts. Fixing that is a separate, larger effort (possibly a hnswlib or chroma-core upstream fix, or a structural change to make re-mines rebuild rather than mutate).

This PR just avoids the bug for the one new operation we're adding, using a pattern that sidesteps `updatePoint` entirely:

1. Extract drawers to keep (the ones NOT matching the filter).
2. Release ChromaDB handles.
3. `shutil.rmtree(palace_path)`.
4. Create a fresh `PersistentClient` + `create_collection` at the same path.
5. Re-insert the keeps in batches.

The tradeoff: a full rebuild. On a 100K-drawer palace, that's a few minutes of embedding computation (if the embedding fn is re-run — chromadb caches) and disk I/O. Given that `purge` is an explicit user-initiated destructive op, not a hot path, the cost is acceptable. The alternative (`collection.delete()` + SIGSEGV) is not.

## What's in the diff

- `mempalace/cli.py` — `cmd_purge` function (~112 lines), argparse block, dispatch entry. `+125/-0`.
- `tests/test_cli.py` — 4 tests mocking `chromadb` + `shutil` at module-import time:
  1. No palace found → clean error message.
  2. No `--wing` or `--room` → refuses to run (no mass-delete safety valve).
  3. Filter matches zero drawers → exit cleanly, don't rebuild.
  4. Both `--wing` and `--room` → builds the `$and` composite filter.
  `+81/-0`.

All tests mock at the `sys.modules` layer because `chromadb` and `shutil` are imported lazily inside `cmd_purge`. Full `tests/test_cli.py` suite: 46 passed.

## Interface design — open to feedback

This is the first destructive command in the CLI. A few defaults I chose without strong conviction — happy to change any of these based on maintainer preference:

- **`--wing` and/or `--room` is required.** Running `mempalace purge` with no flags just prints `Error: specify --wing and/or --room` and returns. Deliberate: there's no "purge everything" mode, because that's `rm -rf ~/.mempalace/palace`.
- **`--room` without `--wing` purges across all wings.** Makes it possible to, e.g., delete every `_registry` room. Open to the alternative: require `--wing` alongside `--room` (safer, but less useful).
- **Interactive confirmation by default, `--yes` to skip.** Mirrors `--yes` on `init` and `migrate`.
- **No `--dry-run` yet.** Could add one that prints "would purge N drawers, would keep M" without actually doing the rebuild. Let me know if that's worth the extra code.

## Test plan

- [x] `mempalace purge --help` renders clean help block.
- [x] `ruff check` + `ruff format --check` clean (with pinned 0.4.10 per upstream CI).
- [x] `pytest tests/test_cli.py` — 46 passed (4 new).

## Context

Running this implementation in production on a 165K-drawer fork palace since 2026-04-10 — used it to purge accidentally-mined test content and polluted conversation wings. The nuke-and-reinsert path has cleanly purged at wing-granularity (~10K-drawer wings) and room-granularity (~5K-drawer rooms) without a single `EXC_BAD_ACCESS` over that period. With in-place `collection.delete()`, the same operations reliably crashed within the first few hundred deletes.


Closes #848.