### PR TITLE
refactor(backends/chroma): coerce None metadatas to `{}` at backend boundary (closes #1020)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1404,10 +1404,21 @@ class ChromaCollection(BaseCollection):
         def _none_list_to_empty(outer):
             return [(inner or []) for inner in outer]
 
+        # Coerce individual None metadata dicts to {} at the backend
+        # boundary. ChromaDB 1.5.x can return None inside metadatas[i][j]
+        # even when the write stored a dict — #999, #1013, and other
+        # fixes added per-site `meta = meta or {}` guards scattered
+        # across searcher.py, layers.py, and miner.py to tolerate this.
+        # Handling the coercion once here means every downstream caller
+        # receives a guaranteed list[dict], matching the type contract
+        # QueryResult.metadatas declares.
+        def _coerce_none_metas(outer):
+            return [[(m if m is not None else {}) for m in (inner or [])] for inner in outer]
+
         return QueryResult(
             ids=_none_list_to_empty(ids),
             documents=_none_list_to_empty(documents),
-            metadatas=_none_list_to_empty(metadatas),
+            metadatas=_coerce_none_metas(metadatas),
             distances=_none_list_to_empty(distances),
             embeddings=(
                 [list(inner) for inner in embeddings_raw]
@@ -1461,6 +1472,16 @@ class ChromaCollection(BaseCollection):
             out_docs = out_docs + [""] * (len(out_ids) - len(out_docs))
         if spec.metadatas and len(out_metas) < len(out_ids):
             out_metas = out_metas + [{}] * (len(out_ids) - len(out_metas))
+
+        # Coerce any individual None metadata dict to {} at the backend
+        # boundary. Same rationale as the parallel path in query():
+        # chromadb 1.5.x can return None inside the metadatas list even
+        # when writes stored a dict, and per-site `meta = meta or {}`
+        # guards across #999 / #1013 compensated. Doing this once here
+        # means callers receive a guaranteed list[dict], matching the
+        # type contract GetResult.metadatas declares.
+        if spec.metadatas:
+            out_metas = [(m if m is not None else {}) for m in out_metas]
 
         return GetResult(
             ids=out_ids,

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -141,6 +141,107 @@ def test_chroma_collection_rejects_unknown_where_operator():
         collection.query(query_texts=["q"], where={"$regex": "foo"})
 
 
+def test_chroma_collection_query_coerces_none_metadatas_to_empty_dict():
+    """ChromaDB 1.5.x can return None inside metadatas[i][j] even when
+    the write stored a dict. The backend boundary coerces each None to
+    {} so downstream callers receive a guaranteed list[dict]. Prevents
+    `AttributeError: 'NoneType' object has no attribute 'get'` at every
+    read site (searcher.py, layers.py, miner.status, etc.)."""
+    raw = {
+        "ids": [["a", "b", "c"]],
+        "documents": [["da", "db", "dc"]],
+        "metadatas": [[{"wing": "w1"}, None, {"wing": "w3"}]],
+        "distances": [[0.1, 0.2, 0.3]],
+    }
+    collection = ChromaCollection(_FakeCollection(query_response=raw))
+
+    result = collection.query(query_texts=["q"])
+
+    assert result.metadatas == [[{"wing": "w1"}, {}, {"wing": "w3"}]]
+    # Ids/docs/distances unaffected — their inner None handling is already
+    # covered by the outer-list coercion.
+    assert result.ids == [["a", "b", "c"]]
+    assert result.distances == [[0.1, 0.2, 0.3]]
+
+
+def test_chroma_collection_query_coerces_all_none_inner_metadatas():
+    """Degenerate case: every metadata dict in the batch is None. Each
+    position still yields {} rather than leaving Nones for callers."""
+    raw = {
+        "ids": [["a", "b"]],
+        "documents": [["da", "db"]],
+        "metadatas": [[None, None]],
+        "distances": [[0.1, 0.2]],
+    }
+    collection = ChromaCollection(_FakeCollection(query_response=raw))
+
+    result = collection.query(query_texts=["q"])
+
+    assert result.metadatas == [[{}, {}]]
+
+
+def test_chroma_collection_query_coerces_none_across_multiple_queries():
+    """Two queries in one call, None dicts mixed through both."""
+    raw = {
+        "ids": [["a", "b"], ["c", "d"]],
+        "documents": [["da", "db"], ["dc", "dd"]],
+        "metadatas": [[{"wing": "w1"}, None], [None, {"wing": "w4"}]],
+        "distances": [[0.1, 0.2], [0.3, 0.4]],
+    }
+    collection = ChromaCollection(_FakeCollection(query_response=raw))
+
+    result = collection.query(query_texts=["q1", "q2"])
+
+    assert result.metadatas == [[{"wing": "w1"}, {}], [{}, {"wing": "w4"}]]
+
+
+def test_chroma_collection_get_coerces_none_metadatas_to_empty_dict():
+    """Same None-coercion guarantee on the get() path. Same rationale as
+    query(): callers zip ids with metadatas and reach `.get("wing")`
+    without first checking for None."""
+    raw = {
+        "ids": ["a", "b", "c"],
+        "documents": ["da", "db", "dc"],
+        "metadatas": [{"wing": "w1"}, None, {"wing": "w3"}],
+    }
+    collection = ChromaCollection(_FakeCollection(get_response=raw))
+
+    result = collection.get()
+
+    assert result.metadatas == [{"wing": "w1"}, {}, {"wing": "w3"}]
+
+
+def test_chroma_collection_get_coerces_padding_remains_dict():
+    """Padding short metadata lists to match ids length already uses {}.
+    Regression guard: the new None-coercion step must not convert those
+    padded {} into something else or re-introduce Nones."""
+    raw = {
+        "ids": ["a", "b", "c"],
+        "documents": ["da", "db", "dc"],
+        "metadatas": [{"wing": "w1"}],  # short — needs 2 padded {}
+    }
+    collection = ChromaCollection(_FakeCollection(get_response=raw))
+
+    result = collection.get()
+
+    assert result.metadatas == [{"wing": "w1"}, {}, {}]
+
+
+def test_chroma_collection_get_without_metadatas_requested_stays_empty():
+    """When the caller omits metadatas from include=, the boundary must
+    not fabricate coerced dicts — empty list in, empty list out."""
+    raw = {
+        "ids": ["a"],
+        "documents": ["da"],
+        "metadatas": [{"wing": "w1"}],  # present in raw but not requested
+    }
+    collection = ChromaCollection(_FakeCollection(get_response=raw))
+
+    result = collection.get(include=["documents"])
+
+    assert result.metadatas == []
+
+
 def test_chroma_collection_delegates_writes():
     fake = _FakeCollection()
     collection = ChromaCollection(fake)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -161,6 +161,7 @@ def test_chroma_collection_query_coerces_none_metadatas_to_empty_dict():
     # Ids/docs/distances unaffected — their inner None handling is already
     # covered by the outer-list coercion.
     assert result.ids == [["a", "b", "c"]]
+    assert result.documents == [["da", "db", "dc"]]
     assert result.distances == [[0.1, 0.2, 0.3]]
 
 


### PR DESCRIPTION
## Summary

Fixes #1020. Moves the `None`-metadata coercion out of per-read-site defensive guards (`meta = meta or {}` scattered across `searcher.py`, `layers.py`, `palace_graph.py`, `miner.py`, etc.) and into the single place the typed contract is produced: `ChromaCollection.query()` and `ChromaCollection.get()` in `backends/chroma.py`.

## Why

ChromaDB 1.5.x can return `None` inside the `metadatas` list even when the write stored a dict. Three prior PRs already responded to this:

- **#999** — guards in `searcher.py` (CLI + API + closet-boost), `miner.status()`, and 4 `mcp_server.py` handlers
- **#1013** — guard in `Layer3.search_raw()`
- Various other paths picked up the same defensive pattern organically

That scatter works but violates the typed contract `QueryResult` and `GetResult` declare: both advertise `metadatas: list[dict]`, never `list[Optional[dict]]`. Every call site that forgets the guard is a latent `AttributeError: 'NoneType' object has no attribute 'get'`.

A boundary coercion is the right architectural fix: one place to handle the backend's quirk, downstream code gets the shape its type annotations promise.

## What changed

- `mempalace/backends/chroma.py`: added inner-list None-coercion inside `ChromaCollection.query()` (alongside the existing `_none_list_to_empty` outer coercion) and inside `ChromaCollection.get()` (after the existing `{}`-padding step). The guarantee becomes: whenever `metadatas` is requested, every element is a dict — never `None`.
- `tests/test_backends.py`: +6 tests covering the shapes the production code actually sees.

## What did NOT change

- The existing per-site `meta = meta or {}` guards stay in place as defensive belt-and-suspenders. They're redundant after this coercion but removing them risks regressing any call path that bypasses the typed wrappers. A follow-up cleanup PR can remove them once we're confident nothing else reaches chromadb directly.
- No behavior change on the write side. Writes still get whatever metadata the caller provides; this PR is strictly read-side.
- No change to `QueryResult` / `GetResult` shape. Same fields, same types — just guaranteed honored at the boundary instead of honored-with-asterisks.

## Test plan

- [x] `pytest tests/test_backends.py` — **35 passed** (6 new, 29 existing)
- [x] `pytest tests/` full suite — **1072 passed, 106 deselected**
- [x] `ruff check` on modified files — clean
- [x] `ruff format --check` with pinned 0.4.10 — clean

New test cases specifically target:

| Test | Exercises |
|---|---|
| `test_chroma_collection_query_coerces_none_metadatas_to_empty_dict` | mixed None/dict in a single-query batch |
| `test_chroma_collection_query_coerces_all_none_inner_metadatas` | degenerate: every metadata is None |
| `test_chroma_collection_query_coerces_none_across_multiple_queries` | None dicts spread across two queries in one call |
| `test_chroma_collection_get_coerces_none_metadatas_to_empty_dict` | mixed None/dict on `get()` path |
| `test_chroma_collection_get_coerces_padding_remains_dict` | regression guard: short metas list → `{}` pads stay `{}` |
| `test_chroma_collection_get_without_metadatas_requested_stays_empty` | when metadatas not in `include=`, don't fabricate |

## Context

I'd committed to driving this on #1020 on 2026-04-18; #1021's merge this week cleared the blocker. @bensig — happy to split into two PRs (the coercion itself and a separate guard-removal follow-up) if you'd prefer landing them serially, but as written this PR keeps behavior strictly monotonic: everything that worked before still works, plus one class of latent None-metadata bugs can't fire anymore.