### PR TITLE
fix(knowledge_graph): backfill NULL metadata on duplicate add_triple

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -296,11 +296,41 @@ class KnowledgeGraph:
 
                 # Check for existing identical triple
                 existing = conn.execute(
-                    "SELECT id FROM triples WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
+                    "SELECT id, valid_from, confidence, source_closet, source_file, "
+                    "source_drawer_id, adapter_name "
+                    "FROM triples WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
                     (sub_id, pred, obj_id),
                 ).fetchone()
                 if existing:
-                    return existing["id"]  # Already exists and still valid
+                    # Idempotent write preserving the original id, but with
+                    # NULL-field backfill so a later adapter can add provenance
+                    # (RFC 002 §5.5) or a start date that the first writer did
+                    # not know. Non-NULL fields are never overwritten — explicit
+                    # invalidate() is the only path to change settled values.
+                    # Confidence is the one exception: a strictly higher value
+                    # replaces a weaker one so stronger evidence wins.
+                    updates = []
+                    params = []
+                    for col, new_val, old_val in (
+                        ("valid_from", valid_from, existing["valid_from"]),
+                        ("source_closet", source_closet, existing["source_closet"]),
+                        ("source_file", source_file, existing["source_file"]),
+                        ("source_drawer_id", source_drawer_id, existing["source_drawer_id"]),
+                        ("adapter_name", adapter_name, existing["adapter_name"]),
+                    ):
+                        if old_val is None and new_val is not None:
+                            updates.append(f"{col} = ?")
+                            params.append(new_val)
+                    if confidence > (existing["confidence"] or 0):
+                        updates.append("confidence = ?")
+                        params.append(confidence)
+                    if updates:
+                        params.append(existing["id"])
+                        conn.execute(
+                            f"UPDATE triples SET {', '.join(updates)} WHERE id = ?",
+                            params,
+                        )
+                    return existing["id"]
 
                 triple_id = f"t_{sub_id}_{pred}_{obj_id}_{hashlib.sha256(f'{valid_from}{datetime.now().isoformat()}'.encode()).hexdigest()[:12]}"
                 conn.execute(

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -309,11 +309,41 @@ class KnowledgeGraph:
 
                 # Check for existing identical triple
                 existing = conn.execute(
-                    "SELECT id FROM triples WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
+                    "SELECT id, valid_from, confidence, source_closet, source_file, "
+                    "source_drawer_id, adapter_name "
+                    "FROM triples WHERE subject=? AND predicate=? AND object=? AND valid_to IS NULL",
                     (sub_id, pred, obj_id),
                 ).fetchone()
                 if existing:
-                    return existing["id"]  # Already exists and still valid
+                    # Idempotent write preserving the original id, but with
+                    # NULL-field backfill so a later adapter can add provenance
+                    # (RFC 002 §5.5) or a start date that the first writer did
+                    # not know. Non-NULL fields are never overwritten — explicit
+                    # invalidate() is the only path to change settled values.
+                    # Confidence is the one exception: a strictly higher value
+                    # replaces a weaker one so stronger evidence wins.
+                    updates = []
+                    params = []
+                    for col, new_val, old_val in (
+                        ("valid_from", valid_from, existing["valid_from"]),
+                        ("source_closet", source_closet, existing["source_closet"]),
+                        ("source_file", source_file, existing["source_file"]),
+                        ("source_drawer_id", source_drawer_id, existing["source_drawer_id"]),
+                        ("adapter_name", adapter_name, existing["adapter_name"]),
+                    ):
+                        if old_val is None and new_val is not None:
+                            updates.append(f"{col} = ?")
+                            params.append(new_val)
+                    if confidence > (existing["confidence"] or 0):
+                        updates.append("confidence = ?")
+                        params.append(confidence)
+                    if updates:
+                        params.append(existing["id"])
+                        conn.execute(
+                            f"UPDATE triples SET {', '.join(updates)} WHERE id = ?",
+                            params,
+                        )
+                    return existing["id"]
 
                 triple_id = make_triple_id(
                     sub_id, pred, obj_id, valid_from, datetime.now().isoformat()

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -97,7 +97,7 @@ class TestTripleOperations:
         assert facts[0]["valid_from"] == "2015-04-01"
 
     def test_duplicate_add_backfills_null_provenance(self, kg):
-        """RFC 002 §5.5 provenance fields must backfill on a later add."""
+        """corpus-origin provenance fields backfill when supplied on a later add_triple call."""
         tid = kg.add_triple("Alice", "works_at", "Acme")
         kg.add_triple(
             "Alice",

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -81,6 +81,69 @@ class TestTripleOperations:
         tid2 = kg.add_triple("Alice", "knew", "Bob", valid_to="2026-03-01")
         assert tid2.startswith("t_alice_knew_bob_")
 
+    def test_duplicate_add_backfills_null_valid_from(self, kg):
+        """Re-adding an existing triple with a new valid_from must populate it.
+
+        Common adapter pattern: a bare ingest establishes the relationship,
+        a later adapter discovers the start date. The second call previously
+        returned the existing id and silently dropped the new valid_from.
+        """
+        kg.add_triple("Max", "child_of", "Alice")
+        kg.add_triple("Max", "child_of", "Alice", valid_from="2015-04-01")
+        facts = [
+            f for f in kg.query_entity("Max", direction="outgoing") if f["predicate"] == "child_of"
+        ]
+        assert len(facts) == 1
+        assert facts[0]["valid_from"] == "2015-04-01"
+
+    def test_duplicate_add_backfills_null_provenance(self, kg):
+        """RFC 002 §5.5 provenance fields must backfill on a later add."""
+        tid = kg.add_triple("Alice", "works_at", "Acme")
+        kg.add_triple(
+            "Alice",
+            "works_at",
+            "Acme",
+            source_closet="projects/acme.md",
+            source_file="projects/acme.md",
+            source_drawer_id="d_abc123",
+            adapter_name="project-miner",
+        )
+        conn = kg._conn()
+        row = conn.execute(
+            "SELECT source_closet, source_file, source_drawer_id, adapter_name "
+            "FROM triples WHERE id = ?",
+            (tid,),
+        ).fetchone()
+        assert row["source_closet"] == "projects/acme.md"
+        assert row["source_file"] == "projects/acme.md"
+        assert row["source_drawer_id"] == "d_abc123"
+        assert row["adapter_name"] == "project-miner"
+
+    def test_duplicate_add_does_not_overwrite_existing_metadata(self, kg):
+        """Backfill must never clobber data that is already populated.
+
+        If the first write set valid_from=2015 and a later call passes
+        valid_from=2020, we keep 2015 — explicit invalidation is the only
+        path to change an existing start date.
+        """
+        tid = kg.add_triple("Max", "child_of", "Alice", valid_from="2015-04-01")
+        kg.add_triple("Max", "child_of", "Alice", valid_from="2020-01-01")
+        conn = kg._conn()
+        row = conn.execute("SELECT valid_from FROM triples WHERE id = ?", (tid,)).fetchone()
+        assert row["valid_from"] == "2015-04-01"
+
+    def test_duplicate_add_upgrades_confidence_only_when_higher(self, kg):
+        """Confidence is monotonically non-decreasing — later evidence that
+        is at least as strong wins, weaker evidence never downgrades."""
+        tid = kg.add_triple("Max", "does", "swimming", confidence=0.6)
+        kg.add_triple("Max", "does", "swimming", confidence=0.4)  # weaker, ignored
+        conn = kg._conn()
+        row = conn.execute("SELECT confidence FROM triples WHERE id = ?", (tid,)).fetchone()
+        assert row["confidence"] == 0.6
+        kg.add_triple("Max", "does", "swimming", confidence=0.9)  # stronger, wins
+        row = conn.execute("SELECT confidence FROM triples WHERE id = ?", (tid,)).fetchone()
+        assert row["confidence"] == 0.9
+
 
 class TestQueries:
     def test_query_outgoing(self, seeded_kg):


### PR DESCRIPTION
## What and Why

When `add_triple()` is called a second time with the same `(subject, predicate, object)` and the existing triple is still open (`valid_to IS NULL`), every new metadata value — `valid_from`, `source_closet`, `source_file`, `source_drawer_id`, `adapter_name`, `confidence` — was silently dropped:

```python
if existing:
    return existing["id"]  # Already exists and still valid
```

This breaks the **Incremental-only** principle from [CLAUDE.md](https://github.com/MemPalace/mempalace/blob/develop/CLAUDE.md#design-principles): a later pass with better information should be additive, never a silent no-op. It is the exact "a later adapter refines what an earlier one did not know" pattern the RFC 002 §5.5 provenance fields (`source_drawer_id`, `adapter_name`) were designed to support.

[CONTRIBUTING.md](https://github.com/MemPalace/mempalace/blob/develop/CONTRIBUTING.md#good-first-issues) explicitly calls out `knowledge_graph.py` as an area where coverage is wanted.

## Root Cause

[`mempalace/knowledge_graph.py:189-196`](https://github.com/MemPalace/mempalace/blob/develop/mempalace/knowledge_graph.py#L189)

## Change Summary

Policy for re-adding an existing open triple — preserves idempotency, adds provenance plumbing:

- **Backfill** NULL fields when a new non-NULL value is provided
- **Never overwrite** an already-populated field — `invalidate()` remains the only path to change settled values
- **Confidence** is the one exception: a strictly higher value replaces a weaker one so stronger evidence wins; weaker evidence is ignored (confidence is monotonically non-decreasing)
- The returned id is unchanged — idempotent contract preserved

## Reproduction

```python
from mempalace.knowledge_graph import KnowledgeGraph
kg = KnowledgeGraph(db_path=":memory:")

# Adapter 1 discovers the relationship, knows no start date:
tid = kg.add_triple("Max", "child_of", "Alice")

# Adapter 2 later finds the start date:
kg.add_triple("Max", "child_of", "Alice", valid_from="2015-04-01")

facts = kg.query_entity("Max", direction="outgoing")
print([f["valid_from"] for f in facts if f["predicate"] == "child_of"])
```

**Before this PR:** `[None]`
**After this PR:** `['2015-04-01']`

## Test Plan

Four regression tests covering every branch of the new policy:

- [x] `test_duplicate_add_backfills_null_valid_from` — NULL date gets filled
- [x] `test_duplicate_add_backfills_null_provenance` — RFC 002 provenance fields roundtrip
- [x] `test_duplicate_add_does_not_overwrite_existing_metadata` — locks the "never clobber" rule
- [x] `test_duplicate_add_upgrades_confidence_only_when_higher` — stronger evidence wins, weaker is ignored
- [x] Existing `test_duplicate_triple_returns_existing_id` and `test_invalidated_triple_allows_re_add` still pass — idempotent contract intact
- [x] `pytest tests/ --ignore=tests/benchmarks` — 1070/1070 pass, no downstream regressions
- [x] `ruff check` / `ruff format --check` — clean

## Out of scope

Audit surfaced two adjacent correctness concerns I left for follow-up PRs to keep this one surgical:

1. No validation that `valid_from <= valid_to` on input
2. Lex comparison on mixed-precision timestamps in `query_*(as_of=...)` (e.g. `'2025-10-01'` vs `'2025'`)

Happy to file them separately if this direction is welcome.