### PR TITLE
docs: add RELEASING.md with mempalace-mcp pre-release check

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,22 +7,22 @@ Run from the repo root before cutting a release tag.
 ### Verify `mempalace-mcp` entry point alignment
 
 The plugin configs reference `mempalace-mcp` as the MCP server command, which
-resolves to a `console_script` entry point declared in `pyproject.toml`. If
-these disagree, `pip install mempalace` ships a plugin config pointing at a
-binary that was never installed — exactly what broke v3.3.2
-([#1093](https://github.com/MemPalace/mempalace/issues/1093)).
+resolves to a console script declared under `[project.scripts]` in
+`pyproject.toml`. If these disagree, `pip install mempalace` ships a plugin
+config pointing at a binary that was never installed — exactly what broke
+v3.3.2 ([#1093](https://github.com/MemPalace/mempalace/issues/1093)).
 
 ```bash
-grep -rn mempalace-mcp pyproject.toml .claude-plugin .codex-plugin
+grep -r mempalace-mcp pyproject.toml .claude-plugin .codex-plugin
 ```
 
-Expected on a healthy `develop` (post-[#340](https://github.com/MemPalace/mempalace/pull/340)):
+Expected on a healthy `develop` (post-[#340](https://github.com/MemPalace/mempalace/pull/340)) — one line per file:
 
 ```
-pyproject.toml:41:mempalace-mcp = "mempalace.mcp_server:main"
-.claude-plugin/plugin.json:12:      "command": "mempalace-mcp"
-.codex-plugin/plugin.json:24:      "command": "mempalace-mcp"
-.claude-plugin/.mcp.json:3:    "command": "mempalace-mcp"
+pyproject.toml:mempalace-mcp = "mempalace.mcp_server:main"
+.claude-plugin/plugin.json:      "command": "mempalace-mcp"
+.codex-plugin/plugin.json:      "command": "mempalace-mcp"
+.claude-plugin/.mcp.json:    "command": "mempalace-mcp"
 ```
 
 If `pyproject.toml` has no match, **stop** — the entry point is missing and

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,31 @@
+# Releasing MemPalace
+
+## Pre-release checklist
+
+Run from the repo root before cutting a release tag.
+
+### Verify `mempalace-mcp` entry point alignment
+
+The plugin configs reference `mempalace-mcp` as the MCP server command, which
+resolves to a `console_script` entry point declared in `pyproject.toml`. If
+these disagree, `pip install mempalace` ships a plugin config pointing at a
+binary that was never installed — exactly what broke v3.3.2
+([#1093](https://github.com/MemPalace/mempalace/issues/1093)).
+
+```bash
+grep -rn mempalace-mcp pyproject.toml .claude-plugin .codex-plugin
+```
+
+Expected on a healthy `develop` (post-[#340](https://github.com/MemPalace/mempalace/pull/340)):
+
+```
+pyproject.toml:41:mempalace-mcp = "mempalace.mcp_server:main"
+.claude-plugin/plugin.json:12:      "command": "mempalace-mcp"
+.codex-plugin/plugin.json:24:      "command": "mempalace-mcp"
+.claude-plugin/.mcp.json:3:    "command": "mempalace-mcp"
+```
+
+If `pyproject.toml` has no match, **stop** — the entry point is missing and
+any fresh `pip install` will ship a broken plugin config. Investigate whether
+the release branch was cut before
+[#340](https://github.com/MemPalace/mempalace/pull/340) landed on `develop`.


### PR DESCRIPTION
## Summary

Fulfilling the **"Optional: release-checklist addition"** proposal at the bottom of the [#1093 issue body](https://github.com/MemPalace/mempalace/issues/1093), which @bensig accepted on 2026-04-23 (_"yes please on the small PR for docs/RELEASING.md, that one-liner `grep mempalace-mcp pyproject.toml .claude-plugin/plugin.json` would have saved this round"_).

New file at `docs/RELEASING.md` (no existing doc at that path) with a single pre-release grep:

```bash
grep -rn mempalace-mcp pyproject.toml .claude-plugin .codex-plugin
```

If `pyproject.toml` has no match, the `mempalace-mcp` entry point is missing and any fresh `pip install` will ship a `plugin.json` referencing a binary that doesn't exist — exactly the v3.3.2 → #1093 defect.

## Scope note — grep width

The original proposal on #1093 specified `pyproject.toml .claude-plugin/plugin.json` (2 files). This PR expands via `-rn` directory recursion to also cover `.claude-plugin/.mcp.json` and `.codex-plugin/plugin.json`, both of which also reference `mempalace-mcp` by name on `develop`. Same class of regression, different surface — e.g. if a future schema change moves the command reference into `.mcp.json` without updating `pyproject.toml`, the 2-file form would miss it.

Happy to trim back to the literal 2-file form if you'd rather — it's a one-line edit. Defaulted to the broader form because the cognitive cost is identical and the coverage is strictly larger.

## Complementary to mempalace-triage

The [mempalace-triage PR #2](https://github.com/MemPalace/mempalace-triage/pull/2) (merged earlier today) classifies release-blocker **issues** as CRITICAL after they're filed — faster triage. This grep catches the **defect itself** before tagging — prevention. The two don't overlap: dashboard speeds up post-mortem, grep stops the mistake at cut time.

## Test plan

- [x] Grep runs clean on current `upstream/develop` — returns all four expected lines (verified against a fresh `git archive` extract of `upstream/develop`):
      ```
      pyproject.toml:41:mempalace-mcp = "mempalace.mcp_server:main"
      .claude-plugin/plugin.json:12:      "command": "mempalace-mcp"
      .codex-plugin/plugin.json:24:      "command": "mempalace-mcp"
      .claude-plugin/.mcp.json:3:    "command": "mempalace-mcp"
      ```
- [x] Would have flagged the v3.3.2 regression — verified via `git show v3.3.2:pyproject.toml | grep -c mempalace-mcp` returns `0`. The missing line is exactly what the check is designed to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)