### PR TITLE
docs(hooks): clarify plugin auto-installs hooks; update manual install to use CLI

### DIFF
--- a/website/guide/hooks.md
+++ b/website/guide/hooks.md
@@ -13,33 +13,35 @@ The AI does the actual filing — it knows the conversation context, so it class
 
 ## Install — Claude Code
 
-Add to `.claude/settings.local.json`:
+### Via Plugin (Recommended)
+
+If you installed MemPalace via the Claude Code plugin marketplace, **hooks are registered automatically** — no configuration needed. Verify they're active with the `/hooks` command inside Claude Code.
+
+> **Do not** also add hooks manually to `settings.json` when the plugin is installed — this causes both the Stop and PreCompact hooks to fire twice per event.
+
+### Without Plugin (Manual)
+
+If you installed MemPalace with `pip install` or `uv tool install` but are **not** using the Claude Code plugin, add the following to `~/.claude/settings.json` (user-wide) or `.claude/settings.local.json` (project-scoped):
 
 ```json
 {
   "hooks": {
     "Stop": [{
-      "matcher": "*",
       "hooks": [{
         "type": "command",
-        "command": "/absolute/path/to/hooks/mempal_save_hook.sh",
+        "command": "mempalace hook run --hook stop --harness claude-code",
         "timeout": 30
       }]
     }],
     "PreCompact": [{
       "hooks": [{
         "type": "command",
-        "command": "/absolute/path/to/hooks/mempal_precompact_hook.sh",
+        "command": "mempalace hook run --hook precompact --harness claude-code",
         "timeout": 30
       }]
     }]
   }
 }
-```
-
-Make them executable:
-```bash
-chmod +x hooks/mempal_save_hook.sh hooks/mempal_precompact_hook.sh
 ```
 
 ## Install — Codex CLI
@@ -50,12 +52,12 @@ Add to `.codex/hooks.json`:
 {
   "Stop": [{
     "type": "command",
-    "command": "/absolute/path/to/hooks/mempal_save_hook.sh",
+    "command": "mempalace hook run --hook stop --harness codex",
     "timeout": 30
   }],
   "PreCompact": [{
     "type": "command",
-    "command": "/absolute/path/to/hooks/mempal_precompact_hook.sh",
+    "command": "mempalace hook run --hook precompact --harness codex",
     "timeout": 30
   }]
 }
@@ -63,9 +65,7 @@ Add to `.codex/hooks.json`:
 
 ## Configuration
 
-Edit `mempal_save_hook.sh` to change:
-
-- **`SAVE_INTERVAL=15`** — How many messages between saves. Lower = more frequent, higher = less interruption.
+- **`SAVE_INTERVAL`** — How many messages between saves (default: `15`). Lower = more frequent, higher = less interruption.
 - **`STATE_DIR`** — Where hook state is stored (defaults to `~/.mempalace/hook_state/`)
 - **`MEMPAL_DIR`** — Optional. Set to a conversations directory to auto-run `mempalace mine` on each save trigger.
 


### PR DESCRIPTION
## What does this PR do?

The hooks guide told all users to manually add hooks to `settings.json` using absolute bash script paths. This is wrong in two ways:

1. **Plugin users** don't need to do anything — hooks are registered automatically by the Claude Code plugin runtime (loaded in-memory from `hooks/hooks.json` at session start). Adding manual entries on top causes both Stop and PreCompact hooks to fire twice per event.

2. **Non-plugin users** (pip/uv standalone installs) should use `mempalace hook run` CLI, not absolute paths to internal bash wrapper scripts.

Changes:
- Add **Via Plugin (Recommended)** section — hooks are automatic, with a double-registration warning
- Rename old section to **Without Plugin (Manual)** and update commands to `mempalace hook run --hook stop --harness claude-code`
- Update Codex section to use `mempalace hook run --hook stop --harness codex`
- Remove `matcher` from Stop/PreCompact examples (matchers are for tool-name filtering in PreToolUse/PostToolUse, not event-based hooks)
- Remove instruction to edit bash scripts directly from Configuration section

Related to #408 — the old manual workaround existed partly because earlier versions used `python3 -m mempalace` which silently failed on uv installs. With 3.3.3 using `mempalace hook run`, plugin-managed hooks work correctly.

## How to test

Install via Claude Code plugin marketplace, run `/hooks` — both Stop and PreCompact appear automatically, sourced from `~/.claude/plugins/*/hooks/hooks.json`. Nothing in `settings.json`. Check `~/.mempalace/hook_state/hook.log` to confirm saves fire.

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [ ] No hardcoded paths
- [ ] Linter passes (`ruff check .`)