### PR TITLE
feat(plugin): add mempalace-remote — SSH-proxied palace for remote clients

### DIFF
--- a/.claude-plugin-remote/.mcp.json
+++ b/.claude-plugin-remote/.mcp.json
@@ -1,6 +1,5 @@
 {
   "mempalace": {
-    "command": "ssh",
-    "args": ["--", "${MEMPALACE_REMOTE_HOST}", "${MEMPALACE_REMOTE_MCP_BIN:-mempalace-mcp}"]
+    "command": "${CLAUDE_PLUGIN_ROOT}/bin/mempalace-mcp-ssh.sh"
   }
 }

--- a/.claude-plugin-remote/.mcp.json
+++ b/.claude-plugin-remote/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mempalace": {
     "command": "ssh",
-    "args": ["${MEMPALACE_REMOTE_HOST}", "mempalace-mcp"]
+    "args": ["${MEMPALACE_REMOTE_HOST}", "${MEMPALACE_REMOTE_MCP_BIN:-mempalace-mcp}"]
   }
 }

--- a/.claude-plugin-remote/.mcp.json
+++ b/.claude-plugin-remote/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mempalace": {
     "command": "ssh",
-    "args": ["${MEMPALACE_REMOTE_HOST}", "${MEMPALACE_REMOTE_MCP_BIN:-mempalace-mcp}"]
+    "args": ["--", "${MEMPALACE_REMOTE_HOST}", "${MEMPALACE_REMOTE_MCP_BIN:-mempalace-mcp}"]
   }
 }

--- a/.claude-plugin-remote/.mcp.json
+++ b/.claude-plugin-remote/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "mempalace": {
+    "command": "ssh",
+    "args": ["${MEMPALACE_REMOTE_HOST}", "mempalace-mcp"]
+  }
+}

--- a/.claude-plugin-remote/README.md
+++ b/.claude-plugin-remote/README.md
@@ -18,7 +18,7 @@ The default `mempalace` plugin runs the MCP server and auto-save hooks against a
 
 ## Prerequisites
 
-1. **mempalace installed on the central host** with both `mempalace` and `mempalace-mcp` available on the host's non-interactive SSH `PATH`. See "PATH gotcha" below.
+1. **mempalace installed on the central host.**
 2. **Passwordless SSH key** from client to host. `ssh $HOST true` must succeed without prompts.
 3. **`MEMPALACE_REMOTE_HOST`** env var set in the environment Claude Code launches in (e.g. `~/.bashrc`, `~/.zshrc`, or systemd unit env).
 
@@ -37,6 +37,14 @@ export MEMPALACE_REMOTE_HOST=raindance   # or whatever host alias from ~/.ssh/co
 
 Restart Claude Code. The MCP server should connect, and Stop / PreCompact hooks fire automatically.
 
+## Configuration
+
+| Env var | Required | Default | Description |
+|---|---|---|---|
+| `MEMPALACE_REMOTE_HOST` | yes | — | SSH target — alias from `~/.ssh/config` or fully qualified hostname |
+| `MEMPALACE_REMOTE_BIN` | no | `mempalace` | Path to the `mempalace` CLI on the remote (used by Stop / PreCompact hooks) |
+| `MEMPALACE_REMOTE_MCP_BIN` | no | `mempalace-mcp` | Path to the `mempalace-mcp` server on the remote (used by the MCP client) |
+
 ## Strongly recommended: SSH ControlMaster
 
 Every MCP tool call and every hook fire spawns a fresh `ssh` process. Without connection multiplexing, each pays 200–500 ms of TCP+auth overhead — adding up to seconds per session. Add to client `~/.ssh/config`:
@@ -52,9 +60,16 @@ After this, the second and subsequent SSH calls reuse the master connection (~10
 
 ## PATH gotcha
 
-`ssh host command` runs `command` in a **non-interactive, non-login** shell. On most Linux setups, that shell's `PATH` does **not** include `~/.local/bin` (where `pip install --user` and `pipx` put their binaries). If `mempalace` and `mempalace-mcp` are only on PATH for your interactive shell, the SSH calls will fail with `command not found`.
+`ssh host command` runs `command` in a **non-interactive, non-login** shell. On most Linux setups, that shell's `PATH` does **not** include `~/.local/bin` (where `pip install --user` and `pipx` put their binaries). If `mempalace` and `mempalace-mcp` are only on PATH for your interactive shell, the SSH calls fail with `command not found`.
 
-Fixes, in order of preference:
+The simplest fix is to point the plugin at the full paths on the remote:
+
+```sh
+export MEMPALACE_REMOTE_BIN=/home/youruser/.local/bin/mempalace
+export MEMPALACE_REMOTE_MCP_BIN=/home/youruser/.local/bin/mempalace-mcp
+```
+
+Other options:
 
 1. Install mempalace system-wide on the host so the binaries land in `/usr/local/bin` or `/usr/bin`.
 2. Symlink the binaries into a system PATH directory:

--- a/.claude-plugin-remote/README.md
+++ b/.claude-plugin-remote/README.md
@@ -86,6 +86,12 @@ Don't enable both plugins on the same machine. Both register an MCP server named
 - Central host that owns the palace → `mempalace`
 - Remote client that uses the host's palace → `mempalace-remote`
 
+## Windows clients
+
+The MCP wrapper (`bin/mempalace-mcp-ssh.sh`) and the hook scripts are bash. Windows doesn't ship bash, so install Git Bash or WSL and make sure `bash` is on the PATH that Claude Code launches in. Without it, the MCP server fails to start and the auto-save hooks silently no-op.
+
+OpenSSH client ships with Windows 10+ (1809), so once `bash` is available the SSH plumbing works.
+
 ## Limitations
 
 - If the central host is unreachable, MCP tool calls fail and hooks log SSH errors after every assistant turn. There's no offline cache or queue.

--- a/.claude-plugin-remote/README.md
+++ b/.claude-plugin-remote/README.md
@@ -32,7 +32,7 @@ claude /plugin install mempalace-remote@mempalace
 Then set the host:
 
 ```sh
-export MEMPALACE_REMOTE_HOST=raindance   # or whatever host alias from ~/.ssh/config
+export MEMPALACE_REMOTE_HOST=palace-host   # alias from ~/.ssh/config or hostname
 ```
 
 Restart Claude Code. The MCP server should connect, and Stop / PreCompact hooks fire automatically.
@@ -45,12 +45,12 @@ Restart Claude Code. The MCP server should connect, and Stop / PreCompact hooks 
 | `MEMPALACE_REMOTE_BIN` | no | `mempalace` | Path to the `mempalace` CLI on the remote (used by Stop / PreCompact hooks) |
 | `MEMPALACE_REMOTE_MCP_BIN` | no | `mempalace-mcp` | Path to the `mempalace-mcp` server on the remote (used by the MCP client) |
 
-## Strongly recommended: SSH ControlMaster
+## Optional: SSH ControlMaster
 
-Every MCP tool call and every hook fire spawns a fresh `ssh` process. Without connection multiplexing, each pays 200–500 ms of TCP+auth overhead — adding up to seconds per session. Add to client `~/.ssh/config`:
+Every MCP tool call and every hook fire spawns a fresh `ssh` process. Without connection multiplexing, each pays 200–500 ms of TCP+auth overhead — adding up to seconds per session under heavy use. Add to client `~/.ssh/config`:
 
 ```
-Host raindance
+Host palace-host
     ControlMaster auto
     ControlPath ~/.ssh/cm-%r@%h:%p
     ControlPersist 10m

--- a/.claude-plugin-remote/README.md
+++ b/.claude-plugin-remote/README.md
@@ -1,0 +1,78 @@
+# mempalace-remote
+
+Use a MemPalace install on a **central host** from a **remote client** machine, over SSH.
+
+The default `mempalace` plugin runs the MCP server and auto-save hooks against a local mempalace install. On a remote machine that doesn't have mempalace installed (or shouldn't have its own palace), `mempalace-remote` proxies the same MCP tools and Stop / PreCompact hooks to a host that does, so all clients share one canonical palace.
+
+## How it works
+
+```
+┌─────────────────┐     SSH      ┌─────────────────────┐
+│  Remote client  │  ─────────▶  │  Central host       │
+│  (this plugin)  │              │  mempalace + palace │
+└─────────────────┘              └─────────────────────┘
+```
+
+- **MCP server** — Claude Code spawns `ssh $MEMPALACE_REMOTE_HOST mempalace-mcp`. The MCP stdin/stdout JSON-RPC stream rides the SSH channel transparently.
+- **Stop / PreCompact hooks** — fire on the client, pipe the Claude Code hook JSON to `ssh $MEMPALACE_REMOTE_HOST mempalace hook run --hook {stop,precompact} --harness claude-code` on the host.
+
+## Prerequisites
+
+1. **mempalace installed on the central host** with both `mempalace` and `mempalace-mcp` available on the host's non-interactive SSH `PATH`. See "PATH gotcha" below.
+2. **Passwordless SSH key** from client to host. `ssh $HOST true` must succeed without prompts.
+3. **`MEMPALACE_REMOTE_HOST`** env var set in the environment Claude Code launches in (e.g. `~/.bashrc`, `~/.zshrc`, or systemd unit env).
+
+## Install
+
+```sh
+claude /plugin marketplace add MemPalace/mempalace
+claude /plugin install mempalace-remote@mempalace
+```
+
+Then set the host:
+
+```sh
+export MEMPALACE_REMOTE_HOST=raindance   # or whatever host alias from ~/.ssh/config
+```
+
+Restart Claude Code. The MCP server should connect, and Stop / PreCompact hooks fire automatically.
+
+## Strongly recommended: SSH ControlMaster
+
+Every MCP tool call and every hook fire spawns a fresh `ssh` process. Without connection multiplexing, each pays 200–500 ms of TCP+auth overhead — adding up to seconds per session. Add to client `~/.ssh/config`:
+
+```
+Host raindance
+    ControlMaster auto
+    ControlPath ~/.ssh/cm-%r@%h:%p
+    ControlPersist 10m
+```
+
+After this, the second and subsequent SSH calls reuse the master connection (~10 ms overhead).
+
+## PATH gotcha
+
+`ssh host command` runs `command` in a **non-interactive, non-login** shell. On most Linux setups, that shell's `PATH` does **not** include `~/.local/bin` (where `pip install --user` and `pipx` put their binaries). If `mempalace` and `mempalace-mcp` are only on PATH for your interactive shell, the SSH calls will fail with `command not found`.
+
+Fixes, in order of preference:
+
+1. Install mempalace system-wide on the host so the binaries land in `/usr/local/bin` or `/usr/bin`.
+2. Symlink the binaries into a system PATH directory:
+   ```sh
+   sudo ln -s ~/.local/bin/mempalace /usr/local/bin/mempalace
+   sudo ln -s ~/.local/bin/mempalace-mcp /usr/local/bin/mempalace-mcp
+   ```
+3. Use `~/.ssh/environment` on the host (requires `PermitUserEnvironment yes` in `/etc/ssh/sshd_config`).
+
+## Coexistence with the `mempalace` plugin
+
+Don't enable both plugins on the same machine. Both register an MCP server named `mempalace`, and the second one to load will silently shadow the first. Choose one:
+
+- Central host that owns the palace → `mempalace`
+- Remote client that uses the host's palace → `mempalace-remote`
+
+## Limitations
+
+- If the central host is unreachable, MCP tool calls fail and hooks log SSH errors after every assistant turn. There's no offline cache or queue.
+- Only `claude-code` harness wired today. The same hook scripts could be templated for `codex` if needed.
+- `MEMPALACE_REMOTE_HOST` must be a host alias that works from the SSH context Claude Code spawns in. If your terminal SSH config diverges from the GUI launchd / systemd context, expand to a fully qualified hostname.

--- a/.claude-plugin-remote/README.md
+++ b/.claude-plugin-remote/README.md
@@ -1,5 +1,22 @@
 # mempalace-remote
 
+> [!CAUTION]
+> ## ⚠ DO NOT USE — known-broken architecture
+>
+> This plugin's design **amplifies** a known palace-destruction class in MemPalace rather than mitigating it. Empirically demonstrated against a real ~100K-drawer palace; see upstream issues [#1533](https://github.com/MemPalace/mempalace/issues/1533) and [#1545](https://github.com/MemPalace/mempalace/issues/1545).
+>
+> **Why it's broken.** This plugin still spawns a fresh `mempalace-mcp` process on the central host every time a Claude Code session opens. With multiple remote clients (and/or local sessions on the central host) running in parallel, the central host ends up with N concurrent `mempalace.mcp_server` processes — exactly the multi-writer race that destroys ChromaDB HNSW state under sustained multi-session use:
+>
+> 1. ChromaDB's `quarantine_stale_hnsw()` fires on every fresh `make_client()` cold-start. Any new Claude Code session anywhere in the fleet can silently invalidate all other live MCP-server processes' in-memory state.
+> 2. Once invalidated, the next write from any "stale" process persists its outdated view over the on-disk segment files, zeroing `data_level0.bin` / deleting `index_metadata.pickle`.
+> 3. Steady-state Claude Code use with multiple long-running sessions is sufficient to trigger this. No rebuild, no manual swap, no operator action required.
+>
+> Adding SSH proxies on top of this architecture doesn't help — it just gives more clients a way to spawn yet more concurrent MCP processes on the central host.
+>
+> **What to use instead.** A single-process gateway that owns the palace and serves all clients via HTTP/MCP. [`rboarescu/palace-daemon`](https://github.com/rboarescu/palace-daemon) is one such implementation (systemd service, semaphore-based concurrency control, single-writer guarantees). The MemPalace project itself may eventually grow this pattern (see [HttpChromaBackend + Postgres KG, #1337](https://github.com/MemPalace/mempalace/pull/1337) for a related effort).
+>
+> This PR (#1190) is left open as the documentation of *what doesn't work and why* — converting to draft until the architecture is reworked or replaced.
+
 Use a MemPalace install on a **central host** from a **remote client** machine, over SSH.
 
 The default `mempalace` plugin runs the MCP server and auto-save hooks against a local mempalace install. On a remote machine that doesn't have mempalace installed (or shouldn't have its own palace), `mempalace-remote` proxies the same MCP tools and Stop / PreCompact hooks to a host that does, so all clients share one canonical palace.

--- a/.claude-plugin-remote/bin/mempalace-mcp-ssh.sh
+++ b/.claude-plugin-remote/bin/mempalace-mcp-ssh.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# MemPalace remote MCP server — SSH-wraps to the host's mempalace-mcp
+HOST="${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}"
+MCP_BIN="${MEMPALACE_REMOTE_MCP_BIN:-mempalace-mcp}"
+
+[[ "$HOST" =~ ^[A-Za-z0-9_./@-]+$ ]] || { echo "MemPalace: MEMPALACE_REMOTE_HOST has unsafe characters" >&2; exit 1; }
+[[ "$MCP_BIN" =~ ^[A-Za-z0-9_./-]+$ ]] || { echo "MemPalace: MEMPALACE_REMOTE_MCP_BIN has unsafe characters" >&2; exit 1; }
+
+exec ssh -- "$HOST" "$MCP_BIN"

--- a/.claude-plugin-remote/hooks/hooks.json
+++ b/.claude-plugin-remote/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "description": "MemPalace remote auto-save and pre-compact hooks (SSH-proxied)",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/mempal-stop-hook.sh"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/mempal-precompact-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude-plugin-remote/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin-remote/hooks/mempal-precompact-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# MemPalace remote PreCompact hook — SSH-wraps to the host's mempalace CLI
+INPUT=$(cat)
+echo "$INPUT" | ssh "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "mempalace hook run --hook precompact --harness claude-code"

--- a/.claude-plugin-remote/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin-remote/hooks/mempal-precompact-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # MemPalace remote PreCompact hook — SSH-wraps to the host's mempalace CLI
 INPUT=$(cat)
-echo "$INPUT" | ssh "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "${MEMPALACE_REMOTE_BIN:-mempalace} hook run --hook precompact --harness claude-code"
+echo "$INPUT" | ssh -- "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "${MEMPALACE_REMOTE_BIN:-mempalace} hook run --hook precompact --harness claude-code"

--- a/.claude-plugin-remote/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin-remote/hooks/mempal-precompact-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # MemPalace remote PreCompact hook — SSH-wraps to the host's mempalace CLI
 INPUT=$(cat)
-echo "$INPUT" | ssh "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "mempalace hook run --hook precompact --harness claude-code"
+echo "$INPUT" | ssh "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "${MEMPALACE_REMOTE_BIN:-mempalace} hook run --hook precompact --harness claude-code"

--- a/.claude-plugin-remote/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin-remote/hooks/mempal-precompact-hook.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 # MemPalace remote PreCompact hook — SSH-wraps to the host's mempalace CLI
+HOST="${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}"
+BIN="${MEMPALACE_REMOTE_BIN:-mempalace}"
+
+[[ "$HOST" =~ ^[A-Za-z0-9_./@-]+$ ]] || { echo "MemPalace: MEMPALACE_REMOTE_HOST has unsafe characters" >&2; exit 1; }
+[[ "$BIN" =~ ^[A-Za-z0-9_./-]+$ ]] || { echo "MemPalace: MEMPALACE_REMOTE_BIN has unsafe characters" >&2; exit 1; }
+
 INPUT=$(cat)
-echo "$INPUT" | ssh -- "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "${MEMPALACE_REMOTE_BIN:-mempalace} hook run --hook precompact --harness claude-code"
+echo "$INPUT" | ssh -- "$HOST" "$BIN hook run --hook precompact --harness claude-code"

--- a/.claude-plugin-remote/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin-remote/hooks/mempal-stop-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # MemPalace remote Stop hook — SSH-wraps to the host's mempalace CLI
 INPUT=$(cat)
-echo "$INPUT" | ssh "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "mempalace hook run --hook stop --harness claude-code"
+echo "$INPUT" | ssh "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "${MEMPALACE_REMOTE_BIN:-mempalace} hook run --hook stop --harness claude-code"

--- a/.claude-plugin-remote/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin-remote/hooks/mempal-stop-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# MemPalace remote Stop hook — SSH-wraps to the host's mempalace CLI
+INPUT=$(cat)
+echo "$INPUT" | ssh "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "mempalace hook run --hook stop --harness claude-code"

--- a/.claude-plugin-remote/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin-remote/hooks/mempal-stop-hook.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 # MemPalace remote Stop hook — SSH-wraps to the host's mempalace CLI
+HOST="${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}"
+BIN="${MEMPALACE_REMOTE_BIN:-mempalace}"
+
+[[ "$HOST" =~ ^[A-Za-z0-9_./@-]+$ ]] || { echo "MemPalace: MEMPALACE_REMOTE_HOST has unsafe characters" >&2; exit 1; }
+[[ "$BIN" =~ ^[A-Za-z0-9_./-]+$ ]] || { echo "MemPalace: MEMPALACE_REMOTE_BIN has unsafe characters" >&2; exit 1; }
+
 INPUT=$(cat)
-echo "$INPUT" | ssh -- "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "${MEMPALACE_REMOTE_BIN:-mempalace} hook run --hook stop --harness claude-code"
+echo "$INPUT" | ssh -- "$HOST" "$BIN hook run --hook stop --harness claude-code"

--- a/.claude-plugin-remote/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin-remote/hooks/mempal-stop-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # MemPalace remote Stop hook — SSH-wraps to the host's mempalace CLI
 INPUT=$(cat)
-echo "$INPUT" | ssh "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "${MEMPALACE_REMOTE_BIN:-mempalace} hook run --hook stop --harness claude-code"
+echo "$INPUT" | ssh -- "${MEMPALACE_REMOTE_HOST:?MEMPALACE_REMOTE_HOST must be set in env}" "${MEMPALACE_REMOTE_BIN:-mempalace} hook run --hook stop --harness claude-code"

--- a/.claude-plugin-remote/plugin.json
+++ b/.claude-plugin-remote/plugin.json
@@ -10,7 +10,7 @@
   "mcpServers": {
     "mempalace": {
       "command": "ssh",
-      "args": ["${MEMPALACE_REMOTE_HOST}", "mempalace-mcp"]
+      "args": ["${MEMPALACE_REMOTE_HOST}", "${MEMPALACE_REMOTE_MCP_BIN:-mempalace-mcp}"]
     }
   },
   "keywords": [

--- a/.claude-plugin-remote/plugin.json
+++ b/.claude-plugin-remote/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "mempalace-remote",
+  "version": "0.1.0",
+  "description": "Use a MemPalace install on a remote host over SSH. Same MCP tools and auto-save hooks as the mempalace plugin, but proxied to a central palace instead of running locally.",
+  "author": {
+    "name": "messelink"
+  },
+  "license": "MIT",
+  "commands": [],
+  "mcpServers": {
+    "mempalace": {
+      "command": "ssh",
+      "args": ["${MEMPALACE_REMOTE_HOST}", "mempalace-mcp"]
+    }
+  },
+  "keywords": [
+    "memory",
+    "ai",
+    "mcp",
+    "ssh",
+    "remote",
+    "palace"
+  ],
+  "repository": "https://github.com/MemPalace/mempalace"
+}

--- a/.claude-plugin-remote/plugin.json
+++ b/.claude-plugin-remote/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace-remote",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Use a MemPalace install on a remote host over SSH. Same MCP tools and auto-save hooks as the mempalace plugin, but proxied to a central palace instead of running locally.",
   "author": {
     "name": "messelink"

--- a/.claude-plugin-remote/plugin.json
+++ b/.claude-plugin-remote/plugin.json
@@ -9,8 +9,7 @@
   "commands": [],
   "mcpServers": {
     "mempalace": {
-      "command": "ssh",
-      "args": ["--", "${MEMPALACE_REMOTE_HOST}", "${MEMPALACE_REMOTE_MCP_BIN:-mempalace-mcp}"]
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/mempalace-mcp-ssh.sh"
     }
   },
   "keywords": [

--- a/.claude-plugin-remote/plugin.json
+++ b/.claude-plugin-remote/plugin.json
@@ -10,7 +10,7 @@
   "mcpServers": {
     "mempalace": {
       "command": "ssh",
-      "args": ["${MEMPALACE_REMOTE_HOST}", "${MEMPALACE_REMOTE_MCP_BIN:-mempalace-mcp}"]
+      "args": ["--", "${MEMPALACE_REMOTE_HOST}", "${MEMPALACE_REMOTE_MCP_BIN:-mempalace-mcp}"]
     }
   },
   "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       "name": "mempalace-remote",
       "source": "./.claude-plugin-remote",
       "description": "Use a MemPalace install on a remote host over SSH. Same MCP tools and auto-save hooks, proxied to a central palace.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "messelink"
       }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,6 +13,15 @@
       "author": {
         "name": "milla-jovovich"
       }
+    },
+    {
+      "name": "mempalace-remote",
+      "source": "./.claude-plugin-remote",
+      "description": "Use a MemPalace install on a remote host over SSH. Same MCP tools and auto-save hooks, proxied to a central palace.",
+      "version": "0.1.0",
+      "author": {
+        "name": "messelink"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a sibling plugin, `mempalace-remote`, that mirrors the existing `mempalace` plugin's MCP tools and auto-save hooks but proxies them to a **central host over SSH** instead of running locally. Lets a fleet of client machines (VPS, second laptop, dev container, etc.) share one canonical palace without each running its own mempalace install.

The marketplace `plugins` array gains a second entry, so the same `MemPalace/mempalace` repo serves both plugins. Existing users are unaffected — `claude /plugin install mempalace@mempalace` still installs only the local-install variant.

## Why

I run mempalace on a home server and use Claude Code from several other machines. The hand-rolled approach was a pair of `~/.local/bin/{mempalace,mempalace-mcp}` shell wrappers that `ssh ...` to the central install. That works for the MCP server but skips the auto-save Stop and PreCompact hooks entirely, since the upstream plugin's hook scripts call the local `mempalace` CLI directly. Packaging the wrappers + hook proxies as a real plugin makes the central-palace pattern install-and-go for anyone running the same setup.

Discussed (lightly) in #1049 and adjacent threads about non-local mempalace deployments.

## Layout

Mirrors the existing `.claude-plugin/` structure:

```
.claude-plugin-remote/
├── plugin.json                       # plugin manifest
├── .mcp.json                         # ${CLAUDE_PLUGIN_ROOT}/bin/mempalace-mcp-ssh.sh
├── README.md
├── bin/
│   └── mempalace-mcp-ssh.sh          # thin SSH wrapper for the MCP server
└── hooks/
    ├── hooks.json                    # registers Stop + PreCompact
    ├── mempal-stop-hook.sh           # ssh-pipe stdin to remote `mempalace hook run`
    └── mempal-precompact-hook.sh     # same for precompact
```

`.claude-plugin/marketplace.json` gains a single appended entry pointing at `./.claude-plugin-remote`.

## Configuration

| Env var | Required | Default | Description |
|---|---|---|---|
| `MEMPALACE_REMOTE_HOST` | yes | — | SSH target — alias from `~/.ssh/config` or fully qualified hostname |
| `MEMPALACE_REMOTE_BIN` | no | `mempalace` | Path to the `mempalace` CLI on the remote (used by Stop / PreCompact hooks) |
| `MEMPALACE_REMOTE_MCP_BIN` | no | `mempalace-mcp` | Path to the `mempalace-mcp` server on the remote (used by the MCP client) |

The `_BIN` overrides cover the SSH non-interactive PATH gotcha where `~/.local/bin` isn't on PATH for `ssh host command` shells. Bare defaults work for system-wide installs.

## How it works

- **MCP server** — `claude` spawns `${CLAUDE_PLUGIN_ROOT}/bin/mempalace-mcp-ssh.sh`, which validates the env vars and `exec`s `ssh -- $HOST mempalace-mcp`. Stdio JSON-RPC rides the SSH channel transparently — the MCP client doesn't know it's remote.
- **Stop / PreCompact hooks** — fire on the client, validate env vars, pipe Claude Code's hook JSON to `ssh -- $HOST mempalace hook run --hook {stop,precompact} --harness claude-code`. The remote `mempalace` CLI handles all the actual logic; the bash wrapper is intentionally thin.

## Coexistence

Don't enable both `mempalace` and `mempalace-remote` on the same machine — both register an MCP server named `mempalace` and the second one to load shadows the first. The README calls this out.

## Tested

End-to-end test on a real two-machine setup (VPS client → home-server central palace):

- `claude /plugin marketplace add` → `claude /plugin install mempalace-remote@mempalace` → set env vars → restart Claude Code → working
- `mempalace_status` MCP call returned real wing/room counts from the central palace ✓
- Stop hook fired and landed in `~/.mempalace/hook_state/hook.log` on the central host with the correct client session ID ✓
- PreCompact hook (`/compact`) fired and landed in the same log ✓
- Latency: sub-300ms per MCP call without SSH ControlMaster; ControlMaster optional, documented in README.

`claude plugin validate` passes on both `.claude-plugin/plugin.json` and `.claude-plugin-remote/plugin.json`.

## Security

Two issues caught in review and fixed:

- **SSH option-parsing of host** — `MEMPALACE_REMOTE_HOST` is now passed after `--` so a value starting with `-` can't be interpreted as ssh options (e.g. `-oProxyCommand=...` local code execution). Caught by Qodo review.
- **Remote command injection via the `_BIN` env vars** — `MEMPALACE_REMOTE_BIN` and `MEMPALACE_REMOTE_MCP_BIN` are validated against an allow-list regex (`^[A-Za-z0-9_./-]+$`) before being concatenated into the SSH remote command string, blocking the `BIN='...; rm -rf ~ #'` class. The MCP server config goes through the `bin/mempalace-mcp-ssh.sh` wrapper to apply the same defense the JSON config can't express directly.

## Notes for review

- New env vars use the `MEMPALACE_REMOTE_*` namespace; no clash with existing `MEMPAL_*` env vars used by the local plugin.
- The author field on the new marketplace entry is `messelink` (mine). Happy to change to whatever attribution convention you prefer.
- Drift watching: if upstream changes `.claude-plugin/hooks/hooks.json` (e.g. adds SessionStart), the remote variant should mirror the addition. Same protocol, same CLI signature. Adjacent: #1069's proposed consolidation of the legacy `hooks/mempal_*_hook.sh` scripts uses the same thin-wrapper-to-`mempalace hook run` pattern this PR follows.
- Codex variant: not included here — same pattern would work for `.codex-plugin-remote/` if there's interest.