### PR TITLE
feat(llm): add claude-code provider (#1193)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -308,6 +308,18 @@ def cmd_init(args):
     if not getattr(args, "no_llm", False):
         provider_name = getattr(args, "llm_provider", "ollama") or "ollama"
         provider_model = getattr(args, "llm_model", "gemma4:e4b") or "gemma4:e4b"
+        # Friendly hint when claude-code is paired with the Ollama-shaped
+        # default model. claude -p rejects "gemma4:e4b" as an unknown
+        # Anthropic model with a confusing error; surface what the user
+        # likely meant and continue (they may have set the same value
+        # explicitly on purpose).
+        if provider_name == "claude-code" and provider_model == "gemma4:e4b":
+            print(
+                "  Hint: --llm-model defaults to 'gemma4:e4b' (Ollama). "
+                "claude-code expects an Anthropic model name like "
+                "'claude-haiku-4-5'. Pass --llm-model claude-haiku-4-5 to silence.",
+                file=sys.stderr,
+            )
         try:
             candidate = get_provider(
                 name=provider_name,

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1804,20 +1804,30 @@ def main():
     p_init.add_argument(
         "--llm-provider",
         default="ollama",
-        choices=["ollama", "openai-compat", "anthropic"],
-        help="LLM provider (default: ollama). Pass --no-llm to disable LLM-assisted refinement entirely.",
+        choices=["ollama", "openai-compat", "anthropic", "claude-code"],
+        help=(
+            "LLM provider (default: ollama). Pass --no-llm to disable LLM-assisted "
+            "refinement entirely. claude-code routes through the local `claude` CLI "
+            "using your Claude Pro/Max subscription (run `claude auth login` first); "
+            "no API key needed."
+        ),
     )
     p_init.add_argument(
         "--llm-model",
         default="gemma4:e4b",
-        help="Model name for the chosen provider (default: gemma4:e4b for Ollama).",
+        help=(
+            "Model name for the chosen provider (default: gemma4:e4b for Ollama). "
+            "For claude-code, pass an Anthropic model name "
+            "such as claude-haiku-4-5."
+        ),
     )
     p_init.add_argument(
         "--llm-endpoint",
         default=None,
         help=(
             "Provider endpoint URL. Default for Ollama: http://localhost:11434. "
-            "Required for openai-compat."
+            "Required for openai-compat. Ignored for claude-code (auth comes "
+            "from the local CLI)."
         ),
     )
     p_init.add_argument(
@@ -1825,7 +1835,8 @@ def main():
         default=None,
         help=(
             "API key for the provider. For anthropic, defaults to $ANTHROPIC_API_KEY; "
-            "for openai-compat, defaults to $OPENAI_API_KEY."
+            "for openai-compat, defaults to $OPENAI_API_KEY. "
+            "Ignored for claude-code (auth comes from `claude auth login`)."
         ),
     )
     p_init.add_argument(

--- a/mempalace/llm_client.py
+++ b/mempalace/llm_client.py
@@ -485,13 +485,21 @@ class ClaudeCodeProvider(LLMProvider):
         # Override the URL-based default in the base class.
         return True
 
+    # Only the credential-bearing ANTHROPIC_* vars get stripped. Configuration
+    # vars like ANTHROPIC_BASE_URL (corporate proxy / custom endpoint) must
+    # pass through so users behind an internal gateway keep working. A broad
+    # prefix-strip would break those deployments without warning.
+    _SUBPROCESS_ENV_STRIP = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+
     def _subprocess_env(self) -> dict:
-        # Strip ANTHROPIC_* env vars before spawning `claude -p`. If the user
-        # has ANTHROPIC_API_KEY exported in their shell, the CLI may fall
-        # back to API-key auth and bill the API account instead of the
-        # subscription this provider is built around. Removing the vars
-        # forces OAuth / keychain auth, which is the documented path.
-        return {k: v for k, v in os.environ.items() if not k.upper().startswith("ANTHROPIC_")}
+        # Strip credential env vars before spawning `claude -p`. If the user
+        # has ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN exported in their
+        # shell, the CLI may fall back to API-key auth and bill the API
+        # account instead of the subscription this provider is built
+        # around. Removing them forces OAuth / keychain auth, which is the
+        # documented path. Other ANTHROPIC_* (BASE_URL, etc.) are passed
+        # through.
+        return {k: v for k, v in os.environ.items() if k.upper() not in self._SUBPROCESS_ENV_STRIP}
 
     def check_available(self) -> tuple[bool, str]:
         binary = shutil.which("claude")

--- a/mempalace/llm_client.py
+++ b/mempalace/llm_client.py
@@ -1,7 +1,7 @@
 """
 llm_client.py — Minimal provider abstraction for LLM-assisted entity refinement.
 
-Three providers cover the useful space:
+Four providers cover the useful space:
 
 - ``ollama`` (default): local models via http://localhost:11434. Works fully
   offline. Honors MemPalace's "zero-API required" principle.
@@ -10,21 +10,29 @@ Three providers cover the useful space:
   Together, and most self-hosted setups.
 - ``anthropic``: the official Messages API. Opt-in for users who want Haiku
   quality without setting up a local model.
+- ``claude-code``: the local ``claude`` CLI binary. Routes through the user's
+  existing Claude Pro/Max subscription via ``claude auth login`` -- no API
+  key required. Subprocess-based, zero new pip deps. Subject to Anthropic
+  policy on subscription use from third-party tools.
 
 All providers expose the same ``classify(system, user, json_mode)`` method and
-the same ``check_available()`` probe. No external SDK dependencies — stdlib
-``urllib`` only.
+the same ``check_available()`` probe. No external SDK dependencies -- stdlib
+``urllib`` plus ``subprocess`` (for ``claude-code``) only.
 
 JSON mode matters here: we always ask for structured output. Providers
 differ on how to request it (Ollama: ``format: json``; OpenAI-compat:
-``response_format``; Anthropic: prompt-level instruction) and this module
-normalizes that away from the caller.
+``response_format``; Anthropic: prompt-level instruction; claude-code:
+prompt-level instruction) and this module normalizes that away from the
+caller.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
+import tempfile
 from dataclasses import dataclass
 from typing import Optional
 from urllib.error import HTTPError, URLError
@@ -436,6 +444,118 @@ class AnthropicProvider(LLMProvider):
         return LLMResponse(text=text, model=self.model, provider=self.name, raw=data)
 
 
+# ==================== CLAUDE CODE (CLI subprocess) ====================
+
+
+class ClaudeCodeProvider(LLMProvider):
+    """Routes through the local ``claude`` CLI binary using subscription auth.
+
+    Auth happens once via ``claude auth login`` (stored in the user's keychain
+    by Claude Code itself); we shell out to ``claude -p`` for each call. No
+    API key, no new pip dependencies -- the CLI itself is the bundled
+    transport.
+
+    Going direct via ``subprocess`` rather than the ``claude-agent-sdk``
+    Python wrapper is deliberate: the SDK is async-only, requires
+    Python >= 3.10 (we still support 3.9), and itself spawns the same binary.
+    Skipping the wrapper avoids a dependency and an asyncio bridge.
+
+    Subscription use from third-party harnesses is governed by Anthropic's
+    policy, which has changed in 2026. The ``claude -p`` CLI invocation
+    pattern is currently sanctioned for first-party tools but may be
+    restricted later; ``check_available()`` will surface auth errors at that
+    point so callers can fall back.
+    """
+
+    name = "claude-code"
+    DEFAULT_MODEL = "claude-haiku-4-5"
+
+    def __init__(
+        self,
+        model: str,
+        timeout: int = 120,
+        **_: object,  # endpoint/api_key ignored -- auth comes from `claude auth login`
+    ):
+        super().__init__(model=model, timeout=timeout)
+
+    def check_available(self) -> tuple[bool, str]:
+        binary = shutil.which("claude")
+        if not binary:
+            return (
+                False,
+                "`claude` CLI not found in PATH. "
+                "Install Claude Code: https://claude.com/product/claude-code",
+            )
+        try:
+            r = subprocess.run(
+                ["claude", "auth", "status", "--text"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            return False, f"`claude auth status` failed: {e}"
+        if r.returncode != 0:
+            return (
+                False,
+                "Not authenticated. Run `claude auth login` to use your Claude subscription.",
+            )
+        return True, "ok"
+
+    def classify(self, system: str, user: str, json_mode: bool = True) -> LLMResponse:
+        sys_prompt = system
+        if json_mode:
+            sys_prompt += "\n\nRespond with valid JSON only, no prose."
+        # `--bare` would skip hooks, plugins, CLAUDE.md auto-discovery, but it
+        # also forces claude to use ANTHROPIC_API_KEY only and ignore OAuth /
+        # keychain. That defeats this provider's whole point (subscription
+        # auth), so we omit it. To keep the surrounding context minimal we
+        # invoke from a temp cwd so claude does not pick up a project-level
+        # CLAUDE.md it does not need.
+        #
+        # System prompt is prepended to stdin instead of being passed via
+        # `--system-prompt` argv. argv is visible to other local users via
+        # `ps` / /proc/*/cmdline, and the prompt can carry sensitive context
+        # (entity names, project paths). The SYSTEM/USER framing is a
+        # convention `claude -p` follows reliably for classification tasks.
+        cmd = [
+            "claude",
+            "-p",
+            "--no-session-persistence",  # don't pollute Claude Code session history
+            "--output-format",
+            "json",
+            "--model",
+            self.model,
+        ]
+        combined_input = f"SYSTEM:\n{sys_prompt}\n\nUSER:\n{user}"
+        try:
+            r = subprocess.run(
+                cmd,
+                input=combined_input,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                cwd=tempfile.gettempdir(),
+            )
+        except subprocess.TimeoutExpired as e:
+            raise LLMError(f"`claude -p` timed out after {self.timeout}s") from e
+        except OSError as e:
+            raise LLMError(f"`claude -p` failed to spawn: {e}") from e
+        if r.returncode != 0:
+            stderr = (r.stderr or "").strip()[:500]
+            raise LLMError(f"`claude -p` exited {r.returncode}: {stderr or 'no stderr'}")
+        try:
+            envelope = json.loads(r.stdout)
+        except json.JSONDecodeError as e:
+            raise LLMError(f"`claude -p` returned non-JSON envelope: {e}") from e
+        # `--output-format json` returns:
+        # {"type":"result","result":"<text>","total_cost_usd":...,...}
+        text = envelope.get("result", "")
+        if not text:
+            raise LLMError(f"`claude -p` returned empty result: {envelope}")
+        return LLMResponse(text=text, model=self.model, provider=self.name, raw=envelope)
+
+
 # ==================== FACTORY ====================
 
 
@@ -443,6 +563,7 @@ PROVIDERS: dict[str, type[LLMProvider]] = {
     "ollama": OllamaProvider,
     "openai-compat": OpenAICompatProvider,
     "anthropic": AnthropicProvider,
+    "claude-code": ClaudeCodeProvider,
 }
 
 

--- a/mempalace/llm_client.py
+++ b/mempalace/llm_client.py
@@ -478,6 +478,21 @@ class ClaudeCodeProvider(LLMProvider):
     ):
         super().__init__(model=model, timeout=timeout)
 
+    @property
+    def is_external_service(self) -> bool:
+        # The CLI binary runs locally but routes every classify call to
+        # Anthropic's hosted models, so user content does leave the machine.
+        # Override the URL-based default in the base class.
+        return True
+
+    def _subprocess_env(self) -> dict:
+        # Strip ANTHROPIC_* env vars before spawning `claude -p`. If the user
+        # has ANTHROPIC_API_KEY exported in their shell, the CLI may fall
+        # back to API-key auth and bill the API account instead of the
+        # subscription this provider is built around. Removing the vars
+        # forces OAuth / keychain auth, which is the documented path.
+        return {k: v for k, v in os.environ.items() if not k.upper().startswith("ANTHROPIC_")}
+
     def check_available(self) -> tuple[bool, str]:
         binary = shutil.which("claude")
         if not binary:
@@ -488,12 +503,15 @@ class ClaudeCodeProvider(LLMProvider):
             )
         try:
             r = subprocess.run(
-                ["claude", "auth", "status", "--text"],
+                [binary, "auth", "status", "--text"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
+                env=self._subprocess_env(),
             )
-        except (subprocess.TimeoutExpired, OSError) as e:
+        except (subprocess.SubprocessError, OSError) as e:
             return False, f"`claude auth status` failed: {e}"
         if r.returncode != 0:
             return (
@@ -506,6 +524,9 @@ class ClaudeCodeProvider(LLMProvider):
         sys_prompt = system
         if json_mode:
             sys_prompt += "\n\nRespond with valid JSON only, no prose."
+        binary = shutil.which("claude")
+        if not binary:
+            raise LLMError("`claude` CLI not found in PATH")
         # `--bare` would skip hooks, plugins, CLAUDE.md auto-discovery, but it
         # also forces claude to use ANTHROPIC_API_KEY only and ignore OAuth /
         # keychain. That defeats this provider's whole point (subscription
@@ -513,13 +534,13 @@ class ClaudeCodeProvider(LLMProvider):
         # invoke from a temp cwd so claude does not pick up a project-level
         # CLAUDE.md it does not need.
         #
-        # System prompt is prepended to stdin instead of being passed via
-        # `--system-prompt` argv. argv is visible to other local users via
-        # `ps` / /proc/*/cmdline, and the prompt can carry sensitive context
-        # (entity names, project paths). The SYSTEM/USER framing is a
-        # convention `claude -p` follows reliably for classification tasks.
+        # System and user content go through stdin (not argv) so they are
+        # not visible to other local users via `ps` / /proc/*/cmdline, and
+        # to keep prompt-injection surface narrow we frame them with XML-
+        # like tags rather than literal "SYSTEM:" / "USER:" markers a
+        # malicious drawer could spoof.
         cmd = [
-            "claude",
+            binary,
             "-p",
             "--no-session-persistence",  # don't pollute Claude Code session history
             "--output-format",
@@ -527,15 +548,18 @@ class ClaudeCodeProvider(LLMProvider):
             "--model",
             self.model,
         ]
-        combined_input = f"SYSTEM:\n{sys_prompt}\n\nUSER:\n{user}"
+        combined_input = f"<system>\n{sys_prompt}\n</system>\n<user>\n{user}\n</user>"
         try:
             r = subprocess.run(
                 cmd,
                 input=combined_input,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=self.timeout,
                 cwd=tempfile.gettempdir(),
+                env=self._subprocess_env(),
             )
         except subprocess.TimeoutExpired as e:
             raise LLMError(f"`claude -p` timed out after {self.timeout}s") from e
@@ -547,7 +571,10 @@ class ClaudeCodeProvider(LLMProvider):
         try:
             envelope = json.loads(r.stdout)
         except json.JSONDecodeError as e:
-            raise LLMError(f"`claude -p` returned non-JSON envelope: {e}") from e
+            stdout_excerpt = (r.stdout or "").strip()[:200]
+            raise LLMError(
+                f"`claude -p` returned non-JSON envelope: {e}; stdout={stdout_excerpt!r}"
+            ) from e
         # `--output-format json` returns:
         # {"type":"result","result":"<text>","total_cost_usd":...,...}
         text = envelope.get("result", "")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,6 +178,80 @@ def test_cmd_hook_session_end_calls_run_hook():
 
 
 @patch("mempalace.cli.MempalaceConfig")
+def test_cmd_init_hints_when_claude_code_paired_with_ollama_default_model(
+    mock_config_cls, tmp_path, capsys
+):
+    """When --llm-provider is claude-code but --llm-model stays at the
+    Ollama-shaped default ``gemma4:e4b``, cmd_init must print a one-line
+    hint pointing at a real Anthropic model. Without this, claude -p
+    rejects the call with a confusing model-not-found error and the user
+    has no idea why."""
+
+    args = argparse.Namespace(
+        dir=str(tmp_path),
+        yes=True,
+        no_llm=False,
+        llm_provider="claude-code",
+        llm_model="gemma4:e4b",
+        llm_endpoint=None,
+        llm_api_key=None,
+        accept_external_llm=False,
+        palace=None,
+        lang=None,
+    )
+
+    bad_provider = MagicMock()
+    bad_provider.check_available.return_value = (False, "no claude binary")
+
+    with (
+        patch("mempalace.cli.get_provider", return_value=bad_provider),
+        patch("mempalace.entity_detector.scan_for_detection", return_value=[]),
+        patch("mempalace.room_detector_local.detect_rooms_local"),
+        patch("mempalace.cli._maybe_run_mine_after_init"),
+    ):
+        cmd_init(args)
+
+    err = capsys.readouterr().err
+    assert "claude-code expects an Anthropic model name" in err
+    assert "claude-haiku-4-5" in err
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_init_no_hint_when_claude_code_with_explicit_anthropic_model(
+    mock_config_cls, tmp_path, capsys
+):
+    """No hint when the user explicitly picked an Anthropic model name --
+    the trap is the silent default, not the explicit pairing."""
+
+    args = argparse.Namespace(
+        dir=str(tmp_path),
+        yes=True,
+        no_llm=False,
+        llm_provider="claude-code",
+        llm_model="claude-haiku-4-5",
+        llm_endpoint=None,
+        llm_api_key=None,
+        accept_external_llm=False,
+        palace=None,
+        lang=None,
+    )
+
+    bad_provider = MagicMock()
+    bad_provider.check_available.return_value = (False, "no claude binary")
+
+    with (
+        patch("mempalace.cli.get_provider", return_value=bad_provider),
+        patch("mempalace.entity_detector.scan_for_detection", return_value=[]),
+        patch("mempalace.room_detector_local.detect_rooms_local"),
+        patch("mempalace.cli._maybe_run_mine_after_init"),
+    ):
+        cmd_init(args)
+
+    err = capsys.readouterr().err
+    assert "claude-haiku-4-5" not in err or "Hint" not in err
+
+
+@patch("mempalace.cli.MempalaceConfig")
 def test_cmd_init_no_entities(mock_config_cls, tmp_path):
     args = argparse.Namespace(dir=str(tmp_path), yes=True)
     with (

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,17 +1,22 @@
 """Tests for mempalace.llm_client.
 
-HTTP is mocked throughout — these tests do not require a running Ollama
-or network access. Live-provider smoke tests live outside the unit-test
-suite.
+HTTP and subprocess are mocked throughout — these tests do not require a
+running Ollama, network access, or the ``claude`` CLI binary. Live-provider
+smoke tests live outside the unit-test suite (see
+``test_claude_code_real_invocation`` for the gated integration probe).
 """
 
 import json
+import os
+import subprocess
+import tempfile
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 from mempalace.llm_client import (
     AnthropicProvider,
+    ClaudeCodeProvider,
     LLMError,
     OllamaProvider,
     OpenAICompatProvider,
@@ -39,6 +44,12 @@ def test_get_provider_anthropic():
     p = get_provider("anthropic", "claude-haiku", api_key="sk-xxx")
     assert isinstance(p, AnthropicProvider)
     assert p.api_key == "sk-xxx"
+
+
+def test_get_provider_claude_code():
+    p = get_provider("claude-code", "claude-haiku-4-5")
+    assert isinstance(p, ClaudeCodeProvider)
+    assert p.model == "claude-haiku-4-5"
 
 
 def test_get_provider_unknown_raises():
@@ -483,3 +494,199 @@ def test_ollama_api_key_source_is_none():
     p = OllamaProvider(model="gemma4:e4b")
     assert p.api_key is None
     assert p.api_key_source is None
+
+
+# ── ClaudeCodeProvider ──────────────────────────────────────────────────
+
+
+def _mock_completed(returncode: int, stdout: str = "", stderr: str = ""):
+    """Build a fake subprocess.CompletedProcess for patching subprocess.run."""
+    cp = MagicMock(spec=subprocess.CompletedProcess)
+    cp.returncode = returncode
+    cp.stdout = stdout
+    cp.stderr = stderr
+    return cp
+
+
+def _claude_envelope(result_text: str, cost: float = 0.0007) -> str:
+    """Build the JSON envelope `claude -p --output-format json` returns."""
+    return json.dumps(
+        {
+            "type": "result",
+            "result": result_text,
+            "total_cost_usd": cost,
+            "duration_ms": 1234,
+        }
+    )
+
+
+def test_claude_code_check_available_binary_missing():
+    with patch("mempalace.llm_client.shutil.which", return_value=None):
+        p = ClaudeCodeProvider(model="claude-haiku-4-5")
+        ok, msg = p.check_available()
+    assert not ok
+    assert "`claude` CLI not found" in msg
+
+
+def test_claude_code_check_available_not_authenticated():
+    with patch("mempalace.llm_client.shutil.which", return_value="/usr/local/bin/claude"):
+        with patch(
+            "mempalace.llm_client.subprocess.run",
+            return_value=_mock_completed(1, stdout="", stderr="not logged in"),
+        ):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5")
+            ok, msg = p.check_available()
+    assert not ok
+    assert "Run `claude auth login`" in msg
+
+
+def test_claude_code_check_available_ready():
+    with patch("mempalace.llm_client.shutil.which", return_value="/usr/local/bin/claude"):
+        with patch(
+            "mempalace.llm_client.subprocess.run",
+            return_value=_mock_completed(0, stdout="logged in as user@example.com"),
+        ):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5")
+            ok, msg = p.check_available()
+    assert ok
+    assert msg == "ok"
+
+
+def test_claude_code_classify_command_line():
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return _mock_completed(0, stdout=_claude_envelope('{"ok": true}'))
+
+    with patch("mempalace.llm_client.subprocess.run", side_effect=fake_run):
+        p = ClaudeCodeProvider(model="claude-haiku-4-5", timeout=99)
+        p.classify("system text", "user text", json_mode=True)
+
+    assert captured["cmd"][0] == "claude"
+    assert "-p" in captured["cmd"]
+    # `--bare` is intentionally NOT passed: it would force ANTHROPIC_API_KEY
+    # auth and disable OAuth / keychain, defeating the subscription path.
+    assert "--bare" not in captured["cmd"]
+    assert "--no-session-persistence" in captured["cmd"]
+    assert "--output-format" in captured["cmd"]
+    assert "json" in captured["cmd"]
+    assert "--model" in captured["cmd"]
+    assert "claude-haiku-4-5" in captured["cmd"]
+    # System prompt MUST NOT be in argv -- argv is visible to other local
+    # users via `ps` / /proc/*/cmdline and may carry sensitive context.
+    assert "--system-prompt" not in captured["cmd"]
+    assert "system text" not in captured["cmd"]
+    # System + user are framed in stdin instead. json_mode appends a
+    # JSON-only directive to the system block.
+    stdin_input = captured["kwargs"]["input"]
+    assert stdin_input.startswith("SYSTEM:\nsystem text")
+    assert "JSON only" in stdin_input
+    assert "\n\nUSER:\nuser text" in stdin_input
+    assert captured["kwargs"]["timeout"] == 99
+    # cwd must be a temp dir so claude does not pick up a project-level CLAUDE.md
+    assert captured["kwargs"]["cwd"] == tempfile.gettempdir()
+
+
+def test_claude_code_classify_json_mode_off_keeps_system_clean():
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return _mock_completed(0, stdout=_claude_envelope("plain text reply"))
+
+    with patch("mempalace.llm_client.subprocess.run", side_effect=fake_run):
+        p = ClaudeCodeProvider(model="claude-haiku-4-5")
+        resp = p.classify("system text", "user", json_mode=False)
+
+    # No JSON-only directive appended when json_mode=False; raw system
+    # text appears verbatim in the stdin SYSTEM block (not in argv).
+    assert "--system-prompt" not in captured["cmd"]
+    assert captured["kwargs"]["input"] == "SYSTEM:\nsystem text\n\nUSER:\nuser"
+    assert resp.text == "plain text reply"
+
+
+def test_claude_code_classify_parses_envelope():
+    with patch(
+        "mempalace.llm_client.subprocess.run",
+        return_value=_mock_completed(0, stdout=_claude_envelope("classified")),
+    ):
+        p = ClaudeCodeProvider(model="claude-haiku-4-5")
+        resp = p.classify("s", "u")
+
+    assert resp.text == "classified"
+    assert resp.provider == "claude-code"
+    assert resp.model == "claude-haiku-4-5"
+    assert resp.raw["total_cost_usd"] == pytest.approx(0.0007)
+
+
+def test_claude_code_classify_timeout_raises_llm_error():
+    with patch(
+        "mempalace.llm_client.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["claude"], timeout=1),
+    ):
+        p = ClaudeCodeProvider(model="claude-haiku-4-5", timeout=1)
+        with pytest.raises(LLMError, match="timed out after 1s"):
+            p.classify("s", "u")
+
+
+def test_claude_code_classify_spawn_failure_raises_llm_error():
+    with patch(
+        "mempalace.llm_client.subprocess.run",
+        side_effect=FileNotFoundError("no such file: claude"),
+    ):
+        p = ClaudeCodeProvider(model="claude-haiku-4-5")
+        with pytest.raises(LLMError, match="failed to spawn"):
+            p.classify("s", "u")
+
+
+def test_claude_code_classify_nonzero_raises_llm_error():
+    with patch(
+        "mempalace.llm_client.subprocess.run",
+        return_value=_mock_completed(1, stdout="", stderr="boom: bad model"),
+    ):
+        p = ClaudeCodeProvider(model="claude-haiku-4-5")
+        with pytest.raises(LLMError, match=r"`claude -p` exited 1: boom"):
+            p.classify("s", "u")
+
+
+def test_claude_code_classify_malformed_json_raises_llm_error():
+    with patch(
+        "mempalace.llm_client.subprocess.run",
+        return_value=_mock_completed(0, stdout="not valid json"),
+    ):
+        p = ClaudeCodeProvider(model="claude-haiku-4-5")
+        with pytest.raises(LLMError, match="non-JSON envelope"):
+            p.classify("s", "u")
+
+
+def test_claude_code_classify_empty_result_raises_llm_error():
+    with patch(
+        "mempalace.llm_client.subprocess.run",
+        return_value=_mock_completed(0, stdout=_claude_envelope("")),
+    ):
+        p = ClaudeCodeProvider(model="claude-haiku-4-5")
+        with pytest.raises(LLMError, match="empty result"):
+            p.classify("s", "u")
+
+
+@pytest.mark.skipif(
+    os.environ.get("MEMPAL_TEST_CLAUDE_CLI") != "1",
+    reason="set MEMPAL_TEST_CLAUDE_CLI=1 to run live `claude -p` integration test",
+)
+def test_claude_code_real_invocation():
+    """End-to-end probe: spawns the real `claude` binary if available + authenticated."""
+    p = ClaudeCodeProvider(model="claude-haiku-4-5")
+    ok, msg = p.check_available()
+    if not ok:
+        pytest.skip(f"`claude` not ready: {msg}")
+    resp = p.classify(
+        "Reply with a single short JSON object.",
+        'Reply with {"hello": "world"} and nothing else.',
+        json_mode=True,
+    )
+    assert resp.provider == "claude-code"
+    assert resp.text  # non-empty
+    assert resp.raw.get("type") == "result"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -625,7 +625,7 @@ def test_claude_code_classify_json_mode_off_keeps_system_clean():
     assert resp.text == "plain text reply"
 
 
-def test_claude_code_strips_anthropic_env_vars(monkeypatch):
+def test_claude_code_strips_anthropic_credential_env_vars(monkeypatch):
     captured = {}
 
     def fake_run(cmd, **kwargs):
@@ -634,7 +634,10 @@ def test_claude_code_strips_anthropic_env_vars(monkeypatch):
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
     monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-test")
-    monkeypatch.setenv("anthropic_other", "lower")  # case-insensitive prefix scrub
+    monkeypatch.setenv("anthropic_api_key", "sk-lower")  # case-insensitive match
+    # ANTHROPIC_BASE_URL is configuration, not credentials -- a corporate
+    # proxy / internal gateway needs it to survive into the subprocess.
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://anthropic.internal.corp/api")
     monkeypatch.setenv("UNRELATED_VAR", "kept")
 
     with patch("mempalace.llm_client.shutil.which", return_value=_FAKE_CLAUDE_BIN):
@@ -644,11 +647,16 @@ def test_claude_code_strips_anthropic_env_vars(monkeypatch):
 
     env = captured["env"]
     assert env is not None
-    # ANTHROPIC_* in any case is stripped so claude -p can't fall back to
-    # API-key auth and bill the API account instead of the subscription.
+    # API_KEY / AUTH_TOKEN (credential-bearing) get stripped so claude -p
+    # can't fall back to API-key auth and bill the API account instead of
+    # the subscription. Case-insensitive match guards against a lowercased
+    # export that would otherwise sneak through.
     assert "ANTHROPIC_API_KEY" not in env
     assert "ANTHROPIC_AUTH_TOKEN" not in env
-    assert "anthropic_other" not in env
+    assert "anthropic_api_key" not in env
+    # Configuration vars (BASE_URL etc.) MUST pass through so corporate-proxy
+    # users keep their custom endpoint routing.
+    assert env.get("ANTHROPIC_BASE_URL") == "https://anthropic.internal.corp/api"
     # Unrelated env vars must still pass through.
     assert env.get("UNRELATED_VAR") == "kept"
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -552,6 +552,9 @@ def test_claude_code_check_available_ready():
     assert msg == "ok"
 
 
+_FAKE_CLAUDE_BIN = "/usr/local/bin/claude"
+
+
 def test_claude_code_classify_command_line():
     captured = {}
 
@@ -560,11 +563,15 @@ def test_claude_code_classify_command_line():
         captured["kwargs"] = kwargs
         return _mock_completed(0, stdout=_claude_envelope('{"ok": true}'))
 
-    with patch("mempalace.llm_client.subprocess.run", side_effect=fake_run):
-        p = ClaudeCodeProvider(model="claude-haiku-4-5", timeout=99)
-        p.classify("system text", "user text", json_mode=True)
+    with patch("mempalace.llm_client.shutil.which", return_value=_FAKE_CLAUDE_BIN):
+        with patch("mempalace.llm_client.subprocess.run", side_effect=fake_run):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5", timeout=99)
+            p.classify("system text", "user text", json_mode=True)
 
-    assert captured["cmd"][0] == "claude"
+    # cmd[0] is the resolved absolute path from shutil.which, not a bare
+    # "claude" literal -- avoids a TOCTOU between check_available and
+    # classify if PATH changes between calls.
+    assert captured["cmd"][0] == _FAKE_CLAUDE_BIN
     assert "-p" in captured["cmd"]
     # `--bare` is intentionally NOT passed: it would force ANTHROPIC_API_KEY
     # auth and disable OAuth / keychain, defeating the subscription path.
@@ -578,15 +585,22 @@ def test_claude_code_classify_command_line():
     # users via `ps` / /proc/*/cmdline and may carry sensitive context.
     assert "--system-prompt" not in captured["cmd"]
     assert "system text" not in captured["cmd"]
-    # System + user are framed in stdin instead. json_mode appends a
-    # JSON-only directive to the system block.
+    # System + user are framed in stdin with XML-like tags so a malicious
+    # drawer cannot spoof the boundary with literal "SYSTEM:" / "USER:"
+    # markers. json_mode appends a JSON-only directive inside the <system>
+    # block.
     stdin_input = captured["kwargs"]["input"]
-    assert stdin_input.startswith("SYSTEM:\nsystem text")
+    assert stdin_input.startswith("<system>\nsystem text")
     assert "JSON only" in stdin_input
-    assert "\n\nUSER:\nuser text" in stdin_input
+    assert "</system>\n<user>\nuser text\n</user>" in stdin_input
+    assert "SYSTEM:" not in stdin_input
+    assert "USER:" not in stdin_input
     assert captured["kwargs"]["timeout"] == 99
     # cwd must be a temp dir so claude does not pick up a project-level CLAUDE.md
     assert captured["kwargs"]["cwd"] == tempfile.gettempdir()
+    # Explicit UTF-8 decoding so Windows cp1252 locale does not mojibake the
+    # JSON envelope.
+    assert captured["kwargs"]["encoding"] == "utf-8"
 
 
 def test_claude_code_classify_json_mode_off_keeps_system_clean():
@@ -597,24 +611,64 @@ def test_claude_code_classify_json_mode_off_keeps_system_clean():
         captured["kwargs"] = kwargs
         return _mock_completed(0, stdout=_claude_envelope("plain text reply"))
 
-    with patch("mempalace.llm_client.subprocess.run", side_effect=fake_run):
-        p = ClaudeCodeProvider(model="claude-haiku-4-5")
-        resp = p.classify("system text", "user", json_mode=False)
+    with patch("mempalace.llm_client.shutil.which", return_value=_FAKE_CLAUDE_BIN):
+        with patch("mempalace.llm_client.subprocess.run", side_effect=fake_run):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5")
+            resp = p.classify("system text", "user", json_mode=False)
 
     # No JSON-only directive appended when json_mode=False; raw system
-    # text appears verbatim in the stdin SYSTEM block (not in argv).
+    # text appears verbatim inside the <system> block (not in argv).
     assert "--system-prompt" not in captured["cmd"]
-    assert captured["kwargs"]["input"] == "SYSTEM:\nsystem text\n\nUSER:\nuser"
+    assert captured["kwargs"]["input"] == (
+        "<system>\nsystem text\n</system>\n<user>\nuser\n</user>"
+    )
     assert resp.text == "plain text reply"
 
 
+def test_claude_code_strips_anthropic_env_vars(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return _mock_completed(0, stdout=_claude_envelope("ok"))
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-test")
+    monkeypatch.setenv("anthropic_other", "lower")  # case-insensitive prefix scrub
+    monkeypatch.setenv("UNRELATED_VAR", "kept")
+
+    with patch("mempalace.llm_client.shutil.which", return_value=_FAKE_CLAUDE_BIN):
+        with patch("mempalace.llm_client.subprocess.run", side_effect=fake_run):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5")
+            p.classify("s", "u")
+
+    env = captured["env"]
+    assert env is not None
+    # ANTHROPIC_* in any case is stripped so claude -p can't fall back to
+    # API-key auth and bill the API account instead of the subscription.
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+    assert "anthropic_other" not in env
+    # Unrelated env vars must still pass through.
+    assert env.get("UNRELATED_VAR") == "kept"
+
+
+def test_claude_code_is_external_service_true():
+    # claude-code routes user content to Anthropic's hosted models via the
+    # local CLI binary, so the privacy gate (#1224) must treat it as
+    # external regardless of the URL-based base-class default.
+    p = ClaudeCodeProvider(model="claude-haiku-4-5")
+    assert p.is_external_service is True
+
+
 def test_claude_code_classify_parses_envelope():
-    with patch(
-        "mempalace.llm_client.subprocess.run",
-        return_value=_mock_completed(0, stdout=_claude_envelope("classified")),
-    ):
-        p = ClaudeCodeProvider(model="claude-haiku-4-5")
-        resp = p.classify("s", "u")
+    with patch("mempalace.llm_client.shutil.which", return_value=_FAKE_CLAUDE_BIN):
+        with patch(
+            "mempalace.llm_client.subprocess.run",
+            return_value=_mock_completed(0, stdout=_claude_envelope("classified")),
+        ):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5")
+            resp = p.classify("s", "u")
 
     assert resp.text == "classified"
     assert resp.provider == "claude-code"
@@ -623,53 +677,68 @@ def test_claude_code_classify_parses_envelope():
 
 
 def test_claude_code_classify_timeout_raises_llm_error():
-    with patch(
-        "mempalace.llm_client.subprocess.run",
-        side_effect=subprocess.TimeoutExpired(cmd=["claude"], timeout=1),
-    ):
-        p = ClaudeCodeProvider(model="claude-haiku-4-5", timeout=1)
-        with pytest.raises(LLMError, match="timed out after 1s"):
-            p.classify("s", "u")
+    with patch("mempalace.llm_client.shutil.which", return_value=_FAKE_CLAUDE_BIN):
+        with patch(
+            "mempalace.llm_client.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["claude"], timeout=1),
+        ):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5", timeout=1)
+            with pytest.raises(LLMError, match="timed out after 1s"):
+                p.classify("s", "u")
 
 
 def test_claude_code_classify_spawn_failure_raises_llm_error():
-    with patch(
-        "mempalace.llm_client.subprocess.run",
-        side_effect=FileNotFoundError("no such file: claude"),
-    ):
+    with patch("mempalace.llm_client.shutil.which", return_value=_FAKE_CLAUDE_BIN):
+        with patch(
+            "mempalace.llm_client.subprocess.run",
+            side_effect=FileNotFoundError("no such file: claude"),
+        ):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5")
+            with pytest.raises(LLMError, match="failed to spawn"):
+                p.classify("s", "u")
+
+
+def test_claude_code_classify_binary_missing_raises_llm_error():
+    # If the binary disappears between provider construction and classify,
+    # surface a clear LLMError rather than letting subprocess raise an
+    # opaque FileNotFoundError later.
+    with patch("mempalace.llm_client.shutil.which", return_value=None):
         p = ClaudeCodeProvider(model="claude-haiku-4-5")
-        with pytest.raises(LLMError, match="failed to spawn"):
+        with pytest.raises(LLMError, match="not found in PATH"):
             p.classify("s", "u")
 
 
 def test_claude_code_classify_nonzero_raises_llm_error():
-    with patch(
-        "mempalace.llm_client.subprocess.run",
-        return_value=_mock_completed(1, stdout="", stderr="boom: bad model"),
-    ):
-        p = ClaudeCodeProvider(model="claude-haiku-4-5")
-        with pytest.raises(LLMError, match=r"`claude -p` exited 1: boom"):
-            p.classify("s", "u")
+    with patch("mempalace.llm_client.shutil.which", return_value=_FAKE_CLAUDE_BIN):
+        with patch(
+            "mempalace.llm_client.subprocess.run",
+            return_value=_mock_completed(1, stdout="", stderr="boom: bad model"),
+        ):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5")
+            with pytest.raises(LLMError, match=r"`claude -p` exited 1: boom"):
+                p.classify("s", "u")
 
 
 def test_claude_code_classify_malformed_json_raises_llm_error():
-    with patch(
-        "mempalace.llm_client.subprocess.run",
-        return_value=_mock_completed(0, stdout="not valid json"),
-    ):
-        p = ClaudeCodeProvider(model="claude-haiku-4-5")
-        with pytest.raises(LLMError, match="non-JSON envelope"):
-            p.classify("s", "u")
+    with patch("mempalace.llm_client.shutil.which", return_value=_FAKE_CLAUDE_BIN):
+        with patch(
+            "mempalace.llm_client.subprocess.run",
+            return_value=_mock_completed(0, stdout="not valid json"),
+        ):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5")
+            with pytest.raises(LLMError, match="non-JSON envelope"):
+                p.classify("s", "u")
 
 
 def test_claude_code_classify_empty_result_raises_llm_error():
-    with patch(
-        "mempalace.llm_client.subprocess.run",
-        return_value=_mock_completed(0, stdout=_claude_envelope("")),
-    ):
-        p = ClaudeCodeProvider(model="claude-haiku-4-5")
-        with pytest.raises(LLMError, match="empty result"):
-            p.classify("s", "u")
+    with patch("mempalace.llm_client.shutil.which", return_value=_FAKE_CLAUDE_BIN):
+        with patch(
+            "mempalace.llm_client.subprocess.run",
+            return_value=_mock_completed(0, stdout=_claude_envelope("")),
+        ):
+            p = ClaudeCodeProvider(model="claude-haiku-4-5")
+            with pytest.raises(LLMError, match="empty result"):
+                p.classify("s", "u")
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

Adds a `claude-code` LLM provider in `mempalace/llm_client.py` that routes through the local `claude` CLI binary using the user's Claude Pro/Max subscription via `claude auth login`. Mirrors the existing `OllamaProvider` / `OpenAICompatProvider` / `AnthropicProvider` shape so `mempalace init --llm --llm-provider claude-code --llm-model claude-haiku-4-5` works with no API key.

Closes #1193.

## How it works

```
claude -p \
    --no-session-persistence \
    --output-format json \
    --model <model>
```

System prompt + user prompt go through **stdin**, framed with XML-like tags:

```
<system>
{system_prompt + JSON-only directive when json_mode=True}
</system>
<user>
{user_prompt}
</user>
```

`cwd=tempfile.gettempdir()` so claude does not pick up a project-level `CLAUDE.md`. Auth flows through `claude auth login` (OAuth / keychain). The resolved binary path comes from `shutil.which("claude")` (not the bare `"claude"` literal) so a PATH change between `check_available()` and `classify()` does not introduce a TOCTOU.

`check_available()` runs `claude auth status --text` and surfaces a friendly error pointing at `claude auth login` if not authenticated.

## Hardening

- **System prompt off argv.** The first version passed the system prompt via `--system-prompt <text>`. argv is visible to other local users via `ps` / `/proc/*/cmdline`, and the prompt can carry sensitive context (entity names, project paths). Moving system content to stdin keeps that surface zero. The `<system>/<user>` XML framing replaces literal `SYSTEM:` / `USER:` markers a malicious drawer could spoof to inject a second system prompt.
- **Credential env scrub.** `_subprocess_env()` strips `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` before spawning `claude -p`. If the user has either exported in their shell, the CLI may fall back to API-key auth and bill the API account instead of the subscription this provider is built around. Removing the credentials forces OAuth / keychain auth, which is the documented path. Configuration vars (`ANTHROPIC_BASE_URL` for corporate-proxy / internal-gateway routing, etc.) pass through so users behind a custom endpoint keep working.
- **External-service flag.** `is_external_service` is overridden to `True`. The base class default is URL-based and would treat this provider as local because `endpoint=None`, but every classify call routes user content to Anthropic-hosted models. The override makes the privacy-warning gate (#1224) fire for `claude-code` the same way it does for the `anthropic` provider.
- **Friendly UX hint** when `--llm-provider claude-code` is paired with the Ollama-shaped default `--llm-model gemma4:e4b`. `cmd_init` prints a one-line stderr nudge pointing at `claude-haiku-4-5` and continues -- the hint is informational, not blocking.

## Why subprocess and not `claude-agent-sdk`

The Anthropic-published Python SDK was the obvious alternative; subprocess won on every axis for our use case:

| Criterion | `subprocess.run(['claude', '-p', ...])` | `claude-agent-sdk` |
|---|---|---|
| Pip dependency | none (stdlib) | `claude-agent-sdk` + `anyio` |
| Python floor | matches current `>=3.9` | bumps to `>=3.10` |
| API surface | sync, matches existing providers | async-only, needs asyncio bridge |
| Auth path | `claude auth login` (CLI keychain) | same (SDK delegates to the CLI) |
| Maintenance | pin claude CLI flags | pin SDK API + CLI flags |

The SDK is a thin wrapper around the same `claude` binary the user already has. Going direct keeps `llm_client.py`'s zero-SDK style intact and does not raise the Python floor.

## Why `--bare` is NOT used

`claude --bare` would skip hooks, plugins, and CLAUDE.md auto-discovery for clean isolation. From `claude --help`:

> `--bare`: ... Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper via --settings (OAuth and keychain are never read).

That defeats the point of a subscription provider. We omit it and reduce ambient noise via `cwd=tempfile.gettempdir()` and `--no-session-persistence` instead.

## Subscription policy fragility

This provider is fully opt-in: `--llm` is opt-in, and within that `--llm-provider claude-code` is opt-in. Default `init` path remains zero-API.

Anthropic blocked OAuth-token-replay through third-party harnesses on April 4, 2026; `claude -p` invocation from third-party tools was subsequently sanctioned for first-party CLI binaries. That sanction may change. If it does, `check_available()` will return `(False, ...)` from the post-policy `claude auth status` failure, surfacing a clear error before any classify call. Existing `llm_refine.py` callers can fall through to a different provider.

Documented in the provider docstring so future readers know this path is best-effort.

## Failure modes

All raise `LLMError` like the other providers:

- `claude` binary missing -> `check_available()` returns `(False, "not found in PATH")`; `classify()` raises `LLMError("`claude` CLI not found in PATH")` if the binary disappears between provider construction and classify
- Not logged in -> `check_available()` returns `(False, "Run `claude auth login`...")`
- `claude -p` timeout -> `LLMError("`claude -p` timed out after Ns")`
- Spawn failure (`OSError`) -> `LLMError("failed to spawn")`
- Non-zero exit -> `LLMError` with `stderr[:500]`
- Malformed JSON envelope -> `LLMError("non-JSON envelope")` with `stdout[:200]` excerpt for debugging
- Empty `result` field -> `LLMError("empty result")`

## Tests

16 new tests in `tests/test_llm_client.py`: 1 factory-dispatch test, 13 unit tests covering `check_available()` and `classify()` paths (mocking `subprocess.run` and/or `shutil.which`) plus the hardening hooks (env strip, `is_external_service`, binary missing), and 1 gated integration test `test_claude_code_real_invocation` that runs a live `claude -p` round-trip when `MEMPAL_TEST_CLAUDE_CLI=1` is set (skipped by default; CI has no authenticated user). `tests/test_cli.py` adds 2 tests pinning the `gemma4:e4b`-with-claude-code stderr hint behaviour. Local pytest: 108 passed + 1 skipped, ruff clean.

## Out of scope

- Benchmark scripts (`benchmarks/longmemeval_bench.py`, `benchmarks/locomo_bench.py`) `--llm-backend claude-code`. Benchmarks are excluded from the package tests and have their own argparse layer (`--llm-backend [anthropic, ollama]`); plumbing claude-code through the rerank/refine call sites is a parallel concern. Happy to do it as a follow-up if useful.
- `mempalace config set llm.provider ...` persistence (planned under #1149 follow-ups).
- Optimizing CLAUDE.md auto-discovery overhead. First call pays a one-time cache-miss; subsequent calls hit Anthropic's prompt cache and are cheap. If real users hit this on tiny corpora we can revisit.

---

_Body reflects the landed code: the system prompt goes to stdin (not `--system-prompt` argv), framed with `<system>/<user>` XML; `ANTHROPIC_*` credential env vars are stripped before spawning; `is_external_service` is overridden to `True` so the privacy gate fires; the env strip is narrowed to `ANTHROPIC_API_KEY` + `ANTHROPIC_AUTH_TOKEN` only (configuration vars like `ANTHROPIC_BASE_URL` pass through for corporate-proxy users); and `cmd_init` prints a hint when `claude-code` is paired with the Ollama default model._

