### PR TITLE
fix(hooks): restore precompact save nudge with opt-in two-phase block (refs #858)

### DIFF
--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -8,8 +8,11 @@
 # context about what was discussed. This hook forces one final save of
 # EVERYTHING before that happens.
 #
-# Unlike the save hook (which triggers every N exchanges), this ALWAYS
-# blocks — because compaction is always worth saving before.
+# Unlike the save hook (which triggers every N exchanges), the precompact
+# hook fires exactly once: right before /compact. By default it nudges the
+# model to save (via stderr) and returns {} so compaction proceeds. Set
+# MEMPAL_BLOCK_COMPACT=1 to opt into a two-phase hard-block (block once,
+# allow the retry) for users who want a forced save-before-compact pause.
 #
 # === INSTALL ===
 # Add to .claude/settings.local.json:
@@ -37,8 +40,16 @@
 # Claude Code sends JSON on stdin with:
 #   session_id — unique session identifier
 #
-# We always return decision: "block" with a reason telling the AI
-# to save everything. After the AI saves, compaction proceeds normally.
+# Default behavior: print a save nudge to stderr (which Claude Code surfaces
+# to the model) and return {} so compaction is not blocked. This restores
+# the safety nudge that PR #885 dropped without re-introducing the
+# unconditional block from #858 (which had no escape path).
+#
+# Opt-in hard-block: export MEMPAL_BLOCK_COMPACT=1 to use the two-phase
+# behavior — the first /compact attempt this session blocks with the nudge
+# as the reason, the next attempt clears the per-session flag and allows
+# compaction. This gives users who want a forced save-before-compact pause
+# a way to do that without footgunning themselves.
 #
 # === MEMPALACE CLI ===
 # This repo uses: mempalace mine <dir>
@@ -75,6 +86,27 @@ if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
     mempalace mine "$MEMPAL_DIR" >> "$STATE_DIR/hook.log" 2>&1
 fi
 
-# Silent: return empty JSON to not block. "decision": "allow" is invalid —
-# only "block" or {} are recognized.
+NUDGE="MemPalace: compaction imminent. If you have unsaved topics, decisions, quotes, code, or important context from this session, save them via your memory system NOW. After compaction, detailed context is lost."
+
+# Opt-in hard-block (MEMPAL_BLOCK_COMPACT=1) — two-phase: block once per
+# session, then allow on the next attempt. The per-session flag prevents
+# the original #858 footgun where the unconditional block had no escape.
+if [ "${MEMPAL_BLOCK_COMPACT:-0}" = "1" ]; then
+    BLOCKED_FLAG="$STATE_DIR/${SESSION_ID}_blocked_compact"
+    if [ -f "$BLOCKED_FLAG" ]; then
+        rm -f "$BLOCKED_FLAG"
+        echo '{}'
+        exit 0
+    fi
+    touch "$BLOCKED_FLAG"
+    NUDGE="$NUDGE" "$MEMPAL_PYTHON_BIN" -c '
+import json, os
+print(json.dumps({"decision": "block", "reason": os.environ["NUDGE"]}))
+'
+    exit 0
+fi
+
+# Default: print nudge to stderr (Claude Code surfaces it to the model)
+# and return {} so compaction proceeds.
+echo "$NUDGE" >&2
 echo '{}'


### PR DESCRIPTION
## Summary

Follow-up to #858 / #885. Issue #858 reported that the precompact hook hard-blocked `/compact` with no escape. PR #885 fixed the symptom by always returning `{}` — but dropped the save nudge entirely, so the model now gets no signal that compaction is imminent. This PR restores the nudge without re-introducing the original footgun.

## What changed

- **Default (warn-only, issue #858 Option 3):** the hook prints the nudge to stderr (Claude Code surfaces hook stderr to the model) and returns `{}`. Compaction still proceeds; the model just sees the nudge first. Strict superset of the post-#885 behavior.
- **Opt-in (`MEMPAL_BLOCK_COMPACT=1`, issue #858 Option 2):** two-phase hard-block. First `/compact` this session blocks with the nudge as the reason; the next attempt clears a per-session flag at `\$STATE_DIR/\${SESSION_ID}_blocked_compact` and lets compaction proceed. Gives users a forced save-before-compact pause without re-creating the #858 footgun (the original block had no escape).
- Stale header comments at lines 11–12 and 40–41 (which still claimed the hook "ALWAYS blocks") are updated to describe the actual behavior.

Mirrors the `MEMPAL_VERBOSE` opt-in pattern already used by `mempal_save_hook.sh`.

## Why not just leave it as `echo '{}'`

The hook header in `mempal_precompact_hook.sh` describes its purpose as a *safety net* — \"forces one final save of EVERYTHING before [compaction]\". After #885, there's no save signal at all: the hook does its background `mempalace mine` (only if `MEMPAL_DIR` is set, which is empty by default) and exits silent. The model never learns compaction is about to happen.

Restoring a model-visible nudge re-establishes the documented purpose; routing it through stderr (rather than a `decision: block`) keeps `/compact` non-blocking for the default case.

## Test plan

- [x] `bash -n hooks/mempal_precompact_hook.sh` — syntax OK
- [x] Default mode: stdin `{\"session_id\":\"X\"}` → stdout `{}`, stderr contains nudge, exit 0
- [x] `MEMPAL_BLOCK_COMPACT=1` first call: stdout `{\"decision\":\"block\",\"reason\":\"…\"}`, flag file created
- [x] `MEMPAL_BLOCK_COMPACT=1` second call: stdout `{}`, flag file removed
- [ ] Verify in a real Claude Code session that stderr nudge surfaces to the model

## Refs

- #858 (original bug — closed but the underlying safety nudge is gone post-fix)
- #885 (the previous fix that over-corrected)