### PR TITLE
fix(repair): scale HNSW divergence floor with hnsw:sync_threshold

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -372,18 +372,69 @@ def _hnsw_element_count(palace_path: str, segment_id: str) -> Optional[int]:
 
 
 # Divergence threshold: chromadb's HNSW flushes asynchronously, so HNSW
-# typically lags sqlite by up to ``sync_threshold`` (default 1000) records
-# under active write load — that's the *brute-force batch* that hasn't
-# been compacted into HNSW yet, plus the un-persisted tail beyond the
-# last sync. Two synchronization windows worth (2 × sync_threshold = 2000)
-# is a safe steady-state ceiling; anything past that is real divergence,
-# not flush-lag.
+# typically lags sqlite by up to ``sync_threshold`` records under active
+# write load — that's the *brute-force batch* that hasn't been compacted
+# into HNSW yet, plus the un-persisted tail beyond the last sync. Two
+# synchronization windows worth (2 × sync_threshold) is a safe steady-
+# state ceiling; anything past that is real divergence, not flush-lag.
 #
-# The #1222 case was 176 613 missing out of 192 997 (91% gone) — orders
-# of magnitude past 2000. A typical post-mine palace shows a few hundred
-# to ~1000 missing, well under threshold.
-_HNSW_DIVERGENCE_ABSOLUTE = 2000
+# The threshold floor scales with whatever ``hnsw:sync_threshold`` the
+# collection was created with (read via :func:`_read_sync_threshold`).
+# ``_HNSW_DIVERGENCE_FALLBACK_FLOOR`` is the floor used when we can't
+# read the collection metadata (older palaces missing the row, sqlite
+# unreadable). 2000 = 2 × chromadb's default sync_threshold of 1000.
+#
+# Why dynamic: PR #1191 set ``hnsw:sync_threshold = 50_000`` to prevent
+# index bloat, which means flush-lag can grow up to 50K naturally. A
+# fixed 2000 floor would flag every actively-written palace as DIVERGED
+# the moment its queue exceeded 10% of sqlite_count, even though chromadb
+# is behaving correctly. The floor must scale with sync_threshold to
+# distinguish real corruption (#1222 was 176 613 missing of 192 997 —
+# orders of magnitude past 2 × any reasonable sync_threshold) from
+# expected steady-state lag.
+_HNSW_DIVERGENCE_FALLBACK_FLOOR = 2000
 _HNSW_DIVERGENCE_FRACTION = 0.10
+
+
+def _read_sync_threshold(palace_path: str, collection_name: str) -> int:
+    """Return the ``hnsw:sync_threshold`` for a collection, or 1000 default.
+
+    The configured sync_threshold drives chromadb's HNSW flush cadence —
+    larger values mean fewer, bigger flushes (less index-bloat risk per
+    PR #1191) but also larger steady-state lag between
+    ``index_metadata.pickle`` and the live sqlite count. The divergence
+    probe scales its tolerance to ``2 × sync_threshold`` so that lag is
+    not mistaken for corruption.
+
+    Falls back to 1000 (chromadb's own default) if the collection has no
+    explicit setting — matches what older mempalace palaces were created
+    with before PR #1191.
+    """
+    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return 1000
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT cm.int_value
+                FROM collection_metadata cm
+                JOIN collections c ON cm.collection_id = c.id
+                WHERE c.name = ? AND cm.key = 'hnsw:sync_threshold'
+                """,
+                (collection_name,),
+            )
+            row = cur.fetchone()
+            if row and row[0] is not None:
+                return int(row[0])
+            return 1000
+        finally:
+            conn.close()
+    except Exception:
+        logger.debug("_read_sync_threshold failed", exc_info=True)
+        return 1000
 
 
 def hnsw_capacity_status(palace_path: str, collection_name: str = "mempalace_drawers") -> dict:
@@ -431,13 +482,18 @@ def hnsw_capacity_status(palace_path: str, collection_name: str = "mempalace_dra
         hnsw_count = _hnsw_element_count(palace_path, seg_id)
         out["hnsw_count"] = hnsw_count
 
+        sync_threshold = _read_sync_threshold(palace_path, collection_name)
+        # Two synchronization windows worth — see comment above
+        # _HNSW_DIVERGENCE_FALLBACK_FLOOR for the rationale.
+        divergence_floor = max(_HNSW_DIVERGENCE_FALLBACK_FLOOR, 2 * sync_threshold)
+
         if hnsw_count is None:
             # No pickle yet — segment hasn't persisted metadata. Could be
             # fresh-but-unflushed (normal) or interrupted-mid-flush (bad).
             # We can't distinguish without the pickle, so only flag
             # divergence when sqlite holds clearly more than two flush
             # windows worth — same threshold as the with-pickle path.
-            if sqlite_count > _HNSW_DIVERGENCE_ABSOLUTE:
+            if sqlite_count > divergence_floor:
                 out["status"] = "diverged"
                 out["diverged"] = True
                 out["divergence"] = sqlite_count
@@ -452,7 +508,7 @@ def hnsw_capacity_status(palace_path: str, collection_name: str = "mempalace_dra
 
         divergence = sqlite_count - hnsw_count
         out["divergence"] = divergence
-        threshold = max(_HNSW_DIVERGENCE_ABSOLUTE, int(sqlite_count * _HNSW_DIVERGENCE_FRACTION))
+        threshold = max(divergence_floor, int(sqlite_count * _HNSW_DIVERGENCE_FRACTION))
         if divergence > threshold:
             out["status"] = "diverged"
             out["diverged"] = True

--- a/tests/test_hnsw_capacity.py
+++ b/tests/test_hnsw_capacity.py
@@ -28,13 +28,23 @@ COLLECTION = "mempalace_drawers"
 # ── Fixtures ──────────────────────────────────────────────────────────
 
 
-def _seed_chroma_db(palace: str, sqlite_count: int, segment_id: str) -> None:
+def _seed_chroma_db(
+    palace: str,
+    sqlite_count: int,
+    segment_id: str,
+    sync_threshold: int | None = None,
+) -> None:
     """Create a minimal chroma.sqlite3 with one collection + VECTOR segment.
 
     Mirrors the columns the probe queries: ``segments``, ``collections``,
-    ``embeddings``, ``embedding_metadata``. Schema matches chromadb
-    1.5.x; column types are kept loose because we read with COUNT(*) and
-    SELECT key, *_value rather than driver-specific casts.
+    ``collection_metadata``, ``embeddings``, ``embedding_metadata``.
+    Schema matches chromadb 1.5.x; column types are kept loose because
+    we read with COUNT(*) and SELECT key, *_value rather than driver-
+    specific casts.
+
+    When ``sync_threshold`` is supplied, an ``hnsw:sync_threshold`` row
+    is added to ``collection_metadata`` so the divergence floor scales
+    accordingly. Omit to model an older palace that pre-dates PR #1191.
     """
     db_path = os.path.join(palace, "chroma.sqlite3")
     conn = sqlite3.connect(db_path)
@@ -44,6 +54,15 @@ def _seed_chroma_db(palace: str, sqlite_count: int, segment_id: str) -> None:
             CREATE TABLE collections (
                 id TEXT PRIMARY KEY,
                 name TEXT NOT NULL
+            );
+            CREATE TABLE collection_metadata (
+                collection_id TEXT REFERENCES collections(id) ON DELETE CASCADE,
+                key TEXT NOT NULL,
+                str_value TEXT,
+                int_value INTEGER,
+                float_value REAL,
+                bool_value INTEGER,
+                PRIMARY KEY (collection_id, key)
             );
             CREATE TABLE segments (
                 id TEXT PRIMARY KEY,
@@ -73,6 +92,12 @@ def _seed_chroma_db(palace: str, sqlite_count: int, segment_id: str) -> None:
         col_id = "col-test"
         meta_seg = "seg-meta"
         conn.execute("INSERT INTO collections (id, name) VALUES (?, ?)", (col_id, COLLECTION))
+        if sync_threshold is not None:
+            conn.execute(
+                """INSERT INTO collection_metadata (collection_id, key, int_value)
+                   VALUES (?, 'hnsw:sync_threshold', ?)""",
+                (col_id, sync_threshold),
+            )
         conn.execute(
             "INSERT INTO segments (id, collection, scope) VALUES (?, ?, 'VECTOR')",
             (segment_id, col_id),
@@ -227,6 +252,78 @@ def test_capacity_status_quiet_for_empty_palace(tmp_path):
     info = hnsw_capacity_status(str(tmp_path), COLLECTION)
     assert info["diverged"] is False
     assert info["status"] == "unknown"
+
+
+# ── Divergence threshold scales with hnsw:sync_threshold ───────────────
+
+
+def test_capacity_status_tolerates_lag_under_large_sync_threshold(tmp_path):
+    """Regression for the PR #1191 / PR #1227 conflict.
+
+    Palaces created via mempalace's _HNSW_BLOAT_GUARD (sync_threshold=
+    50_000) naturally accumulate up to ~50K queued entries between
+    flushes. The pickle-vs-sqlite probe must scale its tolerance to
+    ``2 × sync_threshold`` so this expected lag is not flagged as
+    corruption — otherwise vector search disables for ~80% of the
+    write cycle on any actively-mined ≥100K palace.
+    """
+    seg = "seg-bloat-guard"
+    _seed_chroma_db(str(tmp_path), sqlite_count=100_000, segment_id=seg, sync_threshold=50_000)
+    _write_pickle(str(tmp_path), seg, hnsw_count=50_000)
+    info = hnsw_capacity_status(str(tmp_path), COLLECTION)
+    # 50K divergence is exactly one flush window — well within 2× = 100K.
+    assert info["diverged"] is False, info["message"]
+    assert info["status"] == "ok"
+    assert info["divergence"] == 50_000
+
+
+def test_capacity_status_still_flags_real_corruption_under_large_sync(tmp_path):
+    """The dynamic floor must still catch genuine #1222-style corruption.
+
+    sqlite at 200K with HNSW frozen at 16K is the original #1222 shape —
+    any reasonable threshold should flag it, regardless of whether the
+    collection was created with sync_threshold=1000 or 50_000.
+    """
+    seg = "seg-1222-with-bloat-guard"
+    _seed_chroma_db(str(tmp_path), sqlite_count=200_000, segment_id=seg, sync_threshold=50_000)
+    _write_pickle(str(tmp_path), seg, hnsw_count=16_384)
+    info = hnsw_capacity_status(str(tmp_path), COLLECTION)
+    # 183,616 missing — far past 2 × 50K = 100K floor and 10% of 200K = 20K.
+    assert info["diverged"] is True
+    assert info["status"] == "diverged"
+    assert info["divergence"] == 183_616
+
+
+def test_capacity_status_default_threshold_when_no_sync_metadata(tmp_path):
+    """Older palaces without ``hnsw:sync_threshold`` fall back to 2000 floor.
+
+    Pre-PR-#1191 collections only carry ``hnsw:space``. The probe must
+    use chromadb's own default sync_threshold of 1000 → floor of 2000,
+    matching pre-fix behavior.
+    """
+    seg = "seg-legacy"
+    # No sync_threshold supplied — collection_metadata stays empty.
+    _seed_chroma_db(str(tmp_path), sqlite_count=10_000, segment_id=seg)
+    _write_pickle(str(tmp_path), seg, hnsw_count=7_500)
+    info = hnsw_capacity_status(str(tmp_path), COLLECTION)
+    # 2,500 divergence > max(2000 floor, 10% of 10K = 1000) → DIVERGED
+    assert info["diverged"] is True
+    assert info["divergence"] == 2_500
+
+
+def test_unflushed_path_also_uses_dynamic_floor(tmp_path):
+    """The never-flushed branch must scale with sync_threshold too.
+
+    A 30K-drawer collection under sync_threshold=50_000 hasn't reached
+    its first flush yet — pickle is absent. Pre-fix this would flag
+    DIVERGED (30K > fixed 2000 floor); post-fix the 30K stays under
+    the dynamic 100K floor.
+    """
+    seg = "seg-preflush-large"
+    _seed_chroma_db(str(tmp_path), sqlite_count=30_000, segment_id=seg, sync_threshold=50_000)
+    info = hnsw_capacity_status(str(tmp_path), COLLECTION)
+    assert info["hnsw_count"] is None
+    assert info["diverged"] is False, info["message"]
 
 
 # ── BM25-only sqlite fallback ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

The capacity probe added in #1227 hardcoded a 2,000-row floor for the "DIVERGED" decision. The comment justifying that number explicitly tied it to chromadb's default `sync_threshold` of 1,000:

> Two synchronization windows worth (2 × sync_threshold = 2000) is a safe steady-state ceiling

#1191 then set `hnsw:sync_threshold = 50_000` via `_HNSW_BLOAT_GUARD` (to prevent index bloat) **without updating the divergence floor to track**. The two changes shipped about a week apart and the dependency wasn't caught.

## Symptom

Any palace created via `ChromaBackend.create_collection` after #1191 carries `hnsw:sync_threshold=50_000` in `collection_metadata`. ChromaDB then naturally accumulates up to 50,000 entries in its WAL (`embeddings_queue`) between HNSW flushes — that's by design. The on-disk `index_metadata.pickle` only updates at flush time, so between flushes:

- `sqlite_count` grows with every write
- `hnsw_count` (read from the pickle) stays frozen until the next flush
- Divergence climbs from 0 → ~50K → flush → back to 0 → repeat

With the 2,000 floor, the divergence threshold becomes `max(2000, 10% × sqlite_count)`. For a 100K-drawer palace that's 10,000 — and the queue crosses 10K maybe a fifth of the way through every 50K-write cycle. Result: **the MCP server (`mcp_server._refresh_vector_disabled_flag`) routes vector search to the BM25 fallback and disables duplicate detection for ~80% of the write cycle on any actively-mined ≥100K palace**, even though chromadb is behaving correctly.

Concretely on a 100K-drawer palace I just rebuilt:

```
$ mempalace repair-status
  [drawers]
    sqlite count:   98,176
    hnsw count:     50,000
    divergence:     48,176
    status:         DIVERGED
    note:           HNSW index holds 50,000 elements but sqlite has 98,176
                    embeddings — 48,176 drawers (49%) are invisible to vector
                    search. Run `mempalace repair` to rebuild.
```

The "49% invisible" framing is misleading: those 48,176 drawers are queued for the next HNSW flush, not corrupt. ChromaDB's WAL replay surfaces them on every fresh open — `count()` returns the full 98,176, and a CLI `mempalace search` returns hybrid (cosine + BM25) results across the full set. The MCP server's stricter guardrail is what disables vector search.

## Fix

Read the configured `hnsw:sync_threshold` from `collection_metadata` per palace and scale the floor to `2 × sync_threshold`. The 10% relative term, the unflushed-pickle branch, and the original #1222 detection capability are unchanged.

```python
sync_threshold = _read_sync_threshold(palace_path, collection_name)
divergence_floor = max(_HNSW_DIVERGENCE_FALLBACK_FLOOR, 2 * sync_threshold)
threshold = max(divergence_floor, int(sqlite_count * _HNSW_DIVERGENCE_FRACTION))
```

A 91%-missing-of-192,997 palace (the actual #1222 reproducer) still trips, regardless of whether the collection was created with `sync_threshold=1000` or `50000`.

## Behavior summary

| Collection's `hnsw:sync_threshold` | Floor (after fix) | Floor (before) |
|---|---|---|
| Missing (legacy palace from before #1191) | 2,000  | 2,000 (unchanged) |
| 1,000 (chromadb default)                  | 2,000  | 2,000 (unchanged) |
| 50,000 (`_HNSW_BLOAT_GUARD`)              | 100,000 | 2,000 (the bug) |

## Tests

Four new tests in `tests/test_hnsw_capacity.py`:

- `test_capacity_status_tolerates_lag_under_large_sync_threshold` — regression for the #1191/#1227 conflict: 100K sqlite + 50K HNSW + `sync_threshold=50_000` → `OK`. (Pre-fix: would flag DIVERGED.)
- `test_capacity_status_still_flags_real_corruption_under_large_sync` — #1222-shape (200K sqlite + 16K HNSW) on a `sync_threshold=50_000` collection still trips correctly.
- `test_capacity_status_default_threshold_when_no_sync_metadata` — legacy palaces without the metadata row use the 2,000 fallback floor (no behavior change).
- `test_unflushed_path_also_uses_dynamic_floor` — the never-flushed branch (no pickle yet) also scales: a 30K-drawer collection under `sync_threshold=50_000` is no longer flagged DIVERGED before its first flush.

`_seed_chroma_db` in the test fixture grew an optional `sync_threshold` parameter that, when provided, seeds an `hnsw:sync_threshold` row into a new `collection_metadata` table. All 18 pre-existing tests in `test_hnsw_capacity.py` continue to pass; the broader `test_backends.py` (45 tests) shows no regressions.

## Related

- #1191 — the PR that set `_HNSW_BLOAT_GUARD` with `sync_threshold=50_000`
- #1227 — the PR that added the capacity divergence detection (and the hardcoded 2,000 floor this PR makes dynamic)
- #1222 — the original failure mode the divergence detection was added to catch (still detected after this fix)