### PR TITLE
feat(hooks): configurable save_interval via config + env var

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -295,6 +295,25 @@ class MempalaceConfig:
         return self._file_config.get("hooks", {}).get("silent_save", True)
 
     @property
+    def hooks_save_interval(self) -> int:
+        """Number of exchanges between auto-save prompts. 0 = disabled.
+
+        Config: {"hooks": {"save_interval": 30}}
+        Env var (takes precedence): MEMPALACE_HOOKS_SAVE_INTERVAL=30
+        """
+        env_val = os.environ.get("MEMPALACE_HOOKS_SAVE_INTERVAL", "").strip()
+        if env_val:
+            try:
+                return max(0, int(env_val))
+            except ValueError:
+                pass
+        val = self._file_config.get("hooks", {}).get("save_interval", 15)
+        try:
+            return max(0, int(val))
+        except (TypeError, ValueError):
+            return 15
+
+    @property
     def hook_desktop_toast(self):
         """Whether the stop hook shows a desktop notification via notify-send."""
         return self._file_config.get("hooks", {}).get("desktop_toast", False)

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -596,7 +596,17 @@ def hook_stop(data: dict, harness: str):
 
     _log(f"Session {session_id}: {exchange_count} exchanges, {since_last} since last save")
 
-    if since_last >= SAVE_INTERVAL and exchange_count > 0:
+    try:
+        from .config import MempalaceConfig
+        save_interval = int(MempalaceConfig().hooks_save_interval)
+    except Exception:
+        save_interval = SAVE_INTERVAL
+
+    if save_interval == 0:
+        _output({})
+        return
+
+    if since_last >= save_interval and exchange_count > 0:
         _log(f"TRIGGERING SAVE at exchange {exchange_count}")
 
         # Read hook settings from config


### PR DESCRIPTION
## 😤 The problem

The stop hook fires every **15 messages**. Always. No way to change it without editing source code or uninstalling the plugin.

For long coding sessions this is fine. For a quick 3-message task it is noise. For a CI/automation context it is a blocker.

## ✅ What this does

Makes the interval configurable — via config file or env var:

```json
// ~/.mempalace/config.json
{"hooks": {"save_interval": 30}}
```

```bash
# Or via env var (takes precedence)
MEMPALACE_HOOKS_SAVE_INTERVAL=30   # save every 30 messages
MEMPALACE_HOOKS_SAVE_INTERVAL=0    # disable stop hook entirely
```

**Priority:** env var > config file > default (15)

Setting `save_interval: 0` disables the stop hook without uninstalling it. Negative values are clamped to 0.

## 🔑 Key design decision

`save_interval` controls **only** the stop hook. The precompact hook is independent (see PR #1346). Disabling periodic saves does not disable the last-chance save before context compression.

## 🧪 Tests

All 104 existing hook and config tests pass.

```
python -m pytest tests/test_hooks_cli.py tests/test_config.py -q
104 passed
```

Closes #494.