### PR TITLE
fix(knowledge_graph): bound the WAL to reduce multi-writer corruption window

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -118,6 +118,14 @@ class KnowledgeGraph:
         if self._connection is None:
             self._connection = sqlite3.connect(self.db_path, timeout=10, check_same_thread=False)
             self._connection.execute("PRAGMA journal_mode=WAL")
+            # Bound the WAL: checkpoint every 100 pages (default 1000) and cap
+            # the journal file at 10 MB. When the MCP server is hosted behind
+            # multiple concurrent stdio clients (one mempalace-mcp child per
+            # editor / Claude Code session), a long-deferred checkpoint under
+            # write pressure is a known SQLite corruption window. Bounding the
+            # WAL keeps the blast radius small and recovery cheap.
+            self._connection.execute("PRAGMA wal_autocheckpoint=100")
+            self._connection.execute("PRAGMA journal_size_limit=10485760")
             self._connection.row_factory = sqlite3.Row
         return self._connection
 


### PR DESCRIPTION
## Summary

Add `PRAGMA wal_autocheckpoint=100` and `PRAGMA journal_size_limit=10485760` to the canonical `KnowledgeGraph._conn()` site, alongside the existing `PRAGMA journal_mode=WAL`. SQLite's default `wal_autocheckpoint=1000` is far too relaxed for the multi-writer MCP hosting pattern.

## Why

When the MCP server is hosted behind multiple concurrent stdio clients (the standard pattern in editor / Claude Code setups, where each session spawns its own `mempalace-mcp` child holding a separate SQLite connection), the WAL grows unbounded between checkpoints. With several writers active, a long-deferred checkpoint becomes a known SQLite corruption window: any abrupt termination during the merge can leave btree pages malformed.

This was observed in the field on 2026-05-05 — an `integrity_check` on a production KG returned a string of:

\`\`\`
Tree 4 page 131: btreeInitPage() returns error code 11
Tree 4 page 129: btreeInitPage() returns error code 11
Tree 4 page 125: btreeInitPage() returns error code 11
... (many more)
\`\`\`

…after the WAL had grown without checkpoint for ~2.5 hours under 6 concurrent stdio writers. Recovery via \`sqlite3 .recover\` succeeded (214 entities + 179 triples + 1227 lost_and_found rows), but the corruption was preventable.

## What the two PRAGMAs do

- \`wal_autocheckpoint=100\` — checkpoint every 100 WAL pages instead of 1000. The WAL never accumulates more than ~100 pages of unmerged writes.
- \`journal_size_limit=10485760\` — cap the journal file size at 10 MB. A stuck checkpoint can't balloon the file beyond that.

Both are tunable per-deployment if needed; these defaults are reasonable for multi-writer hosting and harmless for single-writer use.

## Test plan

- [x] Verified locally — fresh \`KnowledgeGraph._conn()\` reports \`journal_mode=wal\`, \`wal_autocheckpoint=100\`, \`journal_size_limit=10485760\`
- [x] Existing tests still pass (no behavior change for single-writer use; PRAGMAs are advisory bounds)
- [ ] No deterministic regression test added — corruption-under-contention is timing-dependent and not amenable to unit testing. The PRAGMAs are observable via \`PRAGMA\` query, which is what \`_conn()\` uses to set them.

## Related

- 2026-05-05 incident transcript & recovery procedure: corruption window was ~2.5 h of WAL accumulation under 6 concurrent \`mempalace-mcp\` stdio clients.