### PR TITLE
fix(benchmarks): UTF-8 encoding + ASCII print chrome on Windows for the 3 sibling runners

### DIFF
--- a/benchmarks/convomem_bench.py
+++ b/benchmarks/convomem_bench.py
@@ -70,13 +70,13 @@ def download_evidence_file(category, subpath, cache_dir):
     os.makedirs(os.path.dirname(cache_path), exist_ok=True)
 
     if os.path.exists(cache_path):
-        with open(cache_path) as f:
+        with open(cache_path, encoding="utf-8") as f:
             return json.load(f)
 
     print(f"    Downloading: {category}/{subpath}...")
     try:
         urllib.request.urlretrieve(url, cache_path)
-        with open(cache_path) as f:
+        with open(cache_path, encoding="utf-8") as f:
             return json.load(f)
     except Exception as e:
         print(f"    Failed to download {url}: {e}")
@@ -89,7 +89,7 @@ def discover_files(category, cache_dir):
     cache_path = os.path.join(cache_dir, f"{category}_filelist.json")
 
     if os.path.exists(cache_path):
-        with open(cache_path) as f:
+        with open(cache_path, encoding="utf-8") as f:
             return json.load(f)
 
     try:
@@ -100,7 +100,7 @@ def discover_files(category, cache_dir):
                 f["path"].split(f"{category}/")[1] for f in files if f["path"].endswith(".json")
             ]
             os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-            with open(cache_path, "w") as f:
+            with open(cache_path, "w", encoding="utf-8") as f:
                 json.dump(paths, f)
             return paths
     except Exception as e:
@@ -236,13 +236,13 @@ def run_benchmark(categories, limit_per_cat, top_k, mode, cache_dir, out_file):
     print(f"  Limit/cat:   {limit_per_cat}")
     print(f"  Top-k:       {top_k}")
     print(f"  Mode:        {mode}")
-    print(f"{'─' * 60}")
+    print(f"{'-' * 60}")
     print("\n  Loading data from HuggingFace...\n")
 
     items = load_evidence_items(categories, limit_per_cat, cache_dir)
 
     print(f"\n  Total items: {len(items)}")
-    print(f"{'─' * 60}\n")
+    print(f"{'-' * 60}\n")
 
     all_recall = []
     per_category = defaultdict(list)
@@ -302,7 +302,7 @@ def run_benchmark(categories, limit_per_cat, top_k, mode, cache_dir, out_file):
     print(f"\n{'=' * 60}\n")
 
     if out_file:
-        with open(out_file, "w") as f:
+        with open(out_file, "w", encoding="utf-8") as f:
             json.dump(results_log, f, indent=2)
         print(f"  Results saved to: {out_file}")
 

--- a/benchmarks/locomo_bench.py
+++ b/benchmarks/locomo_bench.py
@@ -636,7 +636,7 @@ def run_benchmark(
     llm_base_url="",
 ):
     """Run LoCoMo retrieval benchmark."""
-    with open(data_file) as f:
+    with open(data_file, encoding="utf-8") as f:
         data = json.load(f)
 
     if limit > 0:
@@ -661,7 +661,7 @@ def run_benchmark(
             Path(__file__).parent / "palace_cache_locomo.json"
         )
         if Path(_palace_cache_path).exists():
-            with open(_palace_cache_path) as f:
+            with open(_palace_cache_path, encoding="utf-8") as f:
                 palace_cache = json.load(f)
             print(f"  Palace cache: {len(palace_cache)} room assignments loaded")
 
@@ -675,7 +675,7 @@ def run_benchmark(
     print(f"  Top-k:       {top_k}")
     print(f"  Mode:        {mode}{rerank_label}")
     print(f"  Granularity: {granularity}")
-    print(f"{'─' * 60}\n")
+    print(f"{'-' * 60}\n")
 
     all_recall = []
     per_category = defaultdict(list)
@@ -703,14 +703,14 @@ def run_benchmark(
             )
             # Persist updated cache after each conversation
             if _palace_cache_path:
-                with open(_palace_cache_path, "w") as f:
+                with open(_palace_cache_path, "w", encoding="utf-8") as f:
                     json.dump(palace_cache, f, indent=2)
             rooms_summary = {}
             for sid, room in room_assignments.items():
                 rooms_summary[room] = rooms_summary.get(room, 0) + 1
             print(
                 f"  [{conv_idx + 1}/{len(data)}] {sample_id}: "
-                f"{len(sessions)} sessions → {len(rooms_summary)} rooms, {len(qa_pairs)} questions"
+                f"{len(sessions)} sessions -> {len(rooms_summary)} rooms, {len(qa_pairs)} questions"
             )
             print(f"    Rooms: {dict(sorted(rooms_summary.items(), key=lambda x: -x[1]))}")
         else:
@@ -977,7 +977,7 @@ def run_benchmark(
     print(f"\n{'=' * 60}\n")
 
     if out_file:
-        with open(out_file, "w") as f:
+        with open(out_file, "w", encoding="utf-8") as f:
             json.dump(results_log, f, indent=2)
         print(f"  Results saved to: {out_file}")
 

--- a/benchmarks/membench_bench.py
+++ b/benchmarks/membench_bench.py
@@ -204,7 +204,7 @@ def load_membench(data_dir: str, categories=None, topic="movie", limit=0):
         fpath = data_dir / fname
         if not fpath.exists():
             continue
-        with open(fpath) as f:
+        with open(fpath, encoding="utf-8") as f:
             raw = json.load(f)
 
         # Files have two formats:
@@ -321,7 +321,7 @@ def run_membench(
     print(f"  Items:       {len(items)}")
     print(f"  Top-k:       {top_k}")
     print(f"  Mode:        {mode}")
-    print(f"{'─' * 58}\n")
+    print(f"{'-' * 58}\n")
 
     results = []
     by_cat = defaultdict(lambda: {"hit_at_k": 0, "total": 0})
@@ -419,7 +419,7 @@ def run_membench(
     print(f"\n{'=' * 58}\n")
 
     if out_file:
-        with open(out_file, "w") as f:
+        with open(out_file, "w", encoding="utf-8") as f:
             json.dump(results, f, indent=2)
         print(f"  Results saved to: {out_file}")
 


### PR DESCRIPTION
## Summary

Follow-up to #1204 (LongMemEval Windows encoding) per @mschultheiss83's request. Applies the same narrow Windows correctness pattern to the three sibling benchmark runners that share the same shape:

- `benchmarks/locomo_bench.py`
- `benchmarks/membench_bench.py`
- `benchmarks/convomem_bench.py`

## What changed (per file)

- All local `open(path)` / `open(path, "w")` calls now pass `encoding="utf-8"` (was inheriting the platform default — `cp1252` on Windows, `GBK` on Chinese Windows). Mirrors #1204's pattern at `longmemeval_bench.py:2917 / :2927 / :2957 / :2998 / :3031`.
- Non-ASCII separator characters in `print(...)` chrome replaced with ASCII (`─` → `-`, `→` → `->`) so a default `cp1252` console doesn't raise `UnicodeEncodeError` mid-run. Comments/docstrings (which never hit stdout) are untouched.
- `urllib.request.urlopen(...)` calls intentionally left alone — they don't open local files, and the original #1204 audit didn't flag them.

Total diff: +16 / -16 across 3 files. No behavior change beyond Windows correctness.

## Audit provenance

The file selection isn't speculative — jphein already audited the codebase in [#1204's review thread](https://github.com/MemPalace/mempalace/pull/1204#issuecomment-2849049770) and flagged the exact `open(...)` lines in these three files. @mschultheiss83 asked for the follow-up at https://github.com/MemPalace/mempalace/pull/1204#issuecomment-2851275537. This PR is just the mechanical follow-through.

## Out of scope

- The pre-existing `C901` ruff finding on `locomo_bench.py:621` (`run_benchmark` complexity 36) is from upstream `develop` (verified by stash + re-lint on stock branch); not from this PR.
- Non-encoding-related Windows fixes (path separators, line-ending handling) — those would be a different audit.

## Test plan
- [ ] CI green on Linux / macOS / Windows
- [ ] Manual smoke (Linux): each of the three runners imports without error and the read/write paths exercised by `--cache-dir` arguments don't regress
- [ ] No new ruff lint errors introduced (verified locally — pre-existing C901 unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)