### PR TITLE
fix(mcp): canonicalize KG cache key via realpath + normcase (#1372)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -120,8 +120,21 @@ def _resolve_kg_path() -> str:
     return DEFAULT_KG_PATH
 
 
+def _canonicalize_kg_path(path: str) -> str:
+    """Canonicalize a KG cache key so aliases collapse onto one entry.
+
+    ``realpath`` resolves symlinks: two tenants pointing at the same
+    SQLite file via different layouts (``/srv/A`` and
+    ``/srv/link-to-A``) hit a single cached ``KnowledgeGraph`` rather
+    than opening duplicate connections. ``normcase`` normalizes Windows
+    drive-letter casing (``C:\\palace`` vs ``c:\\palace``) and
+    path-separator style; on POSIX it returns the input unchanged.
+    """
+    return os.path.normcase(os.path.realpath(path))
+
+
 def _get_kg() -> KnowledgeGraph:
-    path = os.path.abspath(_resolve_kg_path())
+    path = _canonicalize_kg_path(_resolve_kg_path())
     kg = _kg_by_path.get(path)
     if kg is not None:
         return kg
@@ -157,7 +170,7 @@ def _call_kg(op):
             return op(kg)
         except sqlite3.ProgrammingError:
             if attempt == 0:
-                path = os.path.abspath(_resolve_kg_path())
+                path = _canonicalize_kg_path(_resolve_kg_path())
                 with _kg_cache_lock:
                     if _kg_by_path.get(path) is kg:
                         _kg_by_path.pop(path, None)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -133,8 +133,22 @@ def _canonicalize_kg_path(path: str) -> str:
     return os.path.normcase(os.path.realpath(path))
 
 
-def _get_kg() -> KnowledgeGraph:
-    path = _canonicalize_kg_path(_resolve_kg_path())
+def _get_kg(canonical_path=None) -> KnowledgeGraph:
+    """Return the cached ``KnowledgeGraph`` for the resolved palace.
+
+    When ``canonical_path`` is ``None`` (default), the path is resolved
+    from module state and canonicalized. Callers like :func:`_call_kg`
+    that have already captured a canonical key before entering a retry
+    loop should pass it through here so the dict insertion uses the same
+    key the caller will later use for eviction. Recomputing the key
+    inside this function would let ``MEMPALACE_PALACE_PATH`` rotation,
+    a symlink remap, or a mount remap between the captured value and
+    this call drift the insert and evict keys apart, stranding a closed
+    handle under one key while the lookup probes another.
+    """
+    path = (
+        canonical_path if canonical_path is not None else _canonicalize_kg_path(_resolve_kg_path())
+    )
     kg = _kg_by_path.get(path)
     if kg is not None:
         return kg
@@ -164,17 +178,19 @@ def _call_kg(op):
     sustained race we won't win in this loop, and a hung loop is worse
     than a clear failure surface.
 
-    The eviction path is captured once before the retry loop rather than
-    re-canonicalized inside the ``except`` branch. Doing it there would
-    let ``realpath`` raise ``OSError`` on a transient FS hiccup (Windows
-    junction loss, mount remap) and mask the original
-    ``sqlite3.ProgrammingError``; it would also let canonicalization
-    drift between insert and evict, leaving the closed handle in the
-    cache under a key the lookup no longer matches.
+    The canonical path is captured once at the top and threaded through
+    every ``_get_kg`` call plus the eviction lookup. Doing canonicalize
+    only here means an ``OSError`` from ``realpath`` (transient Windows
+    junction loss, broken mount) surfaces cleanly before any handler
+    runs instead of masking a ``sqlite3.ProgrammingError`` mid-retry.
+    Passing the captured key through to ``_get_kg`` also locks the
+    insert key to the evict key even if FS or env state mutates between
+    attempts, preventing a closed handle from leaking under a stale
+    key the lookup no longer matches.
     """
     path = _canonicalize_kg_path(_resolve_kg_path())
     for attempt in range(2):
-        kg = _get_kg()
+        kg = _get_kg(path)
         try:
             return op(kg)
         except sqlite3.ProgrammingError:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -163,14 +163,22 @@ def _call_kg(op):
     KG. Beyond one retry give up: a second close means we're losing a
     sustained race we won't win in this loop, and a hung loop is worse
     than a clear failure surface.
+
+    The eviction path is captured once before the retry loop rather than
+    re-canonicalized inside the ``except`` branch. Doing it there would
+    let ``realpath`` raise ``OSError`` on a transient FS hiccup (Windows
+    junction loss, mount remap) and mask the original
+    ``sqlite3.ProgrammingError``; it would also let canonicalization
+    drift between insert and evict, leaving the closed handle in the
+    cache under a key the lookup no longer matches.
     """
+    path = _canonicalize_kg_path(_resolve_kg_path())
     for attempt in range(2):
         kg = _get_kg()
         try:
             return op(kg)
         except sqlite3.ProgrammingError:
             if attempt == 0:
-                path = _canonicalize_kg_path(_resolve_kg_path())
                 with _kg_cache_lock:
                     if _kg_by_path.get(path) is kg:
                         _kg_by_path.pop(path, None)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -77,7 +77,9 @@ def _patch_mcp_server(monkeypatch, config, kg):
     from mempalace import mcp_server
 
     monkeypatch.setattr(mcp_server, "_config", config)
-    monkeypatch.setattr(mcp_server, "_get_kg", lambda: kg)
+    # Accept varargs because production ``_get_kg`` now takes an optional
+    # canonical_path; ``_call_kg`` passes the captured key through.
+    monkeypatch.setattr(mcp_server, "_get_kg", lambda *a, **kw: kg)
 
 
 def _get_collection(palace_path, create=False):
@@ -1927,6 +1929,91 @@ class TestKGLazyCache:
         with pytest.raises(_sqlite3.ProgrammingError):
             mcp_server._call_kg(lambda kg: kg.query_entity("Alice"))
         assert calls["count"] == 2, "expected exactly one retry beyond the initial attempt"
+
+    def test_call_kg_passes_captured_path_through_resolve_drift(self, monkeypatch):
+        """``_call_kg`` must thread its captured canonical path through
+        ``_get_kg`` so insertion and eviction agree on the cache key even
+        when FS or env state would otherwise drift between attempts. The
+        end-to-end invariant: after the retry, the closed handle that was
+        cached under the captured path is gone (evicted) and the cache no
+        longer holds it under the stale key.
+        """
+        import sqlite3 as _sqlite3
+        from mempalace import mcp_server
+
+        class _ClosedKG:
+            def query_entity(self, entity, **kwargs):
+                raise _sqlite3.ProgrammingError("Cannot operate on a closed database")
+
+        class _FreshKG:
+            def query_entity(self, entity, **kwargs):
+                return [{"entity": entity}]
+
+        # _resolve_kg_path returns shifting values (env rotation between
+        # attempts). _canonicalize_kg_path is identity so paths flow
+        # through verbatim.
+        resolved_seq = iter(["/path/v1", "/path/v2", "/path/v3"])
+        monkeypatch.setattr(mcp_server, "_resolve_kg_path", lambda: next(resolved_seq))
+        monkeypatch.setattr(mcp_server, "_canonicalize_kg_path", lambda p: p)
+
+        closed = _ClosedKG()
+        cache = {"/path/v1": closed}
+        monkeypatch.setattr(mcp_server, "_kg_by_path", cache)
+
+        get_kg_args: list = []
+
+        def spy_get_kg(canonical_path=None):
+            get_kg_args.append(canonical_path)
+            return cache.get(canonical_path) if canonical_path in cache else _FreshKG()
+
+        monkeypatch.setattr(mcp_server, "_get_kg", spy_get_kg)
+
+        result = mcp_server._call_kg(lambda kg: kg.query_entity("Alice"))
+
+        assert result == [{"entity": "Alice"}]
+        # Both _get_kg calls received the captured path "/path/v1" rather
+        # than the drifted "/path/v2". Without pass-through, the second
+        # call would have used "/path/v2" and the closed handle at
+        # "/path/v1" would never have been evicted.
+        assert get_kg_args == ["/path/v1", "/path/v1"], (
+            f"expected both _get_kg calls to receive captured '/path/v1', "
+            f"got {get_kg_args} -- captured-path pass-through broken"
+        )
+        # Eviction landed under the captured key: the closed handle is
+        # gone from the cache. With drift the closed handle would still
+        # be at "/path/v1" because eviction would have probed "/path/v2".
+        assert "/path/v1" not in cache, (
+            f"closed handle leaked under captured key after retry; "
+            f"cache state: {[(k, type(v).__name__) for k, v in cache.items()]}"
+        )
+
+    def test_call_kg_oserror_at_top_propagates_unmasked(self, monkeypatch):
+        """``OSError`` from ``_canonicalize_kg_path`` at the top of
+        ``_call_kg`` (e.g. transient Windows realpath hiccup on a stale
+        junction) must propagate unchanged. The fix-rationale invariant:
+        capturing the canonical path before the retry loop means an FS
+        error surfaces cleanly to the dispatcher's exception envelope
+        instead of getting raised inside the ``except`` branch where it
+        would mask a ``sqlite3.ProgrammingError``.
+        """
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_resolve_kg_path", lambda: "/fake/path")
+        monkeypatch.setattr(
+            mcp_server,
+            "_canonicalize_kg_path",
+            lambda p: (_ for _ in ()).throw(OSError("simulated realpath failure")),
+        )
+
+        op_calls = {"n": 0}
+
+        def op(kg):
+            op_calls["n"] += 1
+            return None
+
+        with pytest.raises(OSError, match="simulated realpath failure"):
+            mcp_server._call_kg(op)
+        assert op_calls["n"] == 0, "op must not run if canonicalize fails at top"
 
     def test_canonicalize_kg_path_collapses_symlink_alias(self, tmp_path):
         """A symlink layer over the palace directory must collapse to one

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1867,7 +1867,7 @@ class TestKGLazyCache:
             def query_entity(self, entity, **kwargs):
                 return [{"entity": entity}]
 
-        cache = {os.path.abspath(path): _ClosedKG()}
+        cache = {mcp_server._canonicalize_kg_path(path): _ClosedKG()}
         monkeypatch.setattr(mcp_server, "_kg_by_path", cache)
 
         # Second _get_kg() call (after the cache eviction) constructs a new
@@ -1877,7 +1877,7 @@ class TestKGLazyCache:
         result = mcp_server._call_kg(lambda kg: kg.query_entity("Alice"))
         assert result == [{"entity": "Alice"}]
         # The closed instance must be evicted; the fresh one must be cached.
-        assert isinstance(cache[os.path.abspath(path)], _FreshKG)
+        assert isinstance(cache[mcp_server._canonicalize_kg_path(path)], _FreshKG)
 
     def test_call_kg_does_not_retry_on_other_errors(self, monkeypatch):
         """Non-ProgrammingError exceptions must propagate without retry —
@@ -1894,7 +1894,9 @@ class TestKGLazyCache:
                 calls["count"] += 1
                 raise ValueError("bad input")
 
-        monkeypatch.setattr(mcp_server, "_kg_by_path", {os.path.abspath(path): _FailingKG()})
+        monkeypatch.setattr(
+            mcp_server, "_kg_by_path", {mcp_server._canonicalize_kg_path(path): _FailingKG()}
+        )
         monkeypatch.setattr(mcp_server, "KnowledgeGraph", lambda **_: _FailingKG())
 
         with pytest.raises(ValueError, match="bad input"):
@@ -1925,6 +1927,85 @@ class TestKGLazyCache:
         with pytest.raises(_sqlite3.ProgrammingError):
             mcp_server._call_kg(lambda kg: kg.query_entity("Alice"))
         assert calls["count"] == 2, "expected exactly one retry beyond the initial attempt"
+
+    def test_canonicalize_kg_path_collapses_symlink_alias(self, tmp_path):
+        """A symlink layer over the palace directory must collapse to one
+        cache key — otherwise two tenants pointing at /srv/A and
+        /srv/link-to-A open duplicate sqlite3.Connections over the same
+        file."""
+        if sys.platform == "win32":
+            pytest.skip("symlink creation requires admin privileges on Windows runners")
+
+        from mempalace import mcp_server
+
+        target = tmp_path / "real"
+        target.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(target)
+
+        real_db = str(target / "knowledge_graph.sqlite3")
+        link_db = str(link / "knowledge_graph.sqlite3")
+
+        assert mcp_server._canonicalize_kg_path(real_db) == mcp_server._canonicalize_kg_path(
+            link_db
+        )
+
+    def test_canonicalize_kg_path_routes_through_normcase(self, monkeypatch):
+        """``_canonicalize_kg_path`` must apply ``os.path.normcase`` so the
+        cache key collapses Windows drive-letter casing
+        (``C:\\palace`` vs ``c:\\palace``). On POSIX runners normcase is a
+        no-op, so we monkeypatch it to verify the wiring rather than the
+        OS behaviour."""
+        from mempalace import mcp_server
+
+        seen: list = []
+
+        def fake_normcase(p: str) -> str:
+            seen.append(p)
+            return p.lower()
+
+        monkeypatch.setattr(os.path, "normcase", fake_normcase)
+
+        result = mcp_server._canonicalize_kg_path("/Some/Path/KG.sqlite3")
+
+        assert seen, "expected normcase to be invoked"
+        assert result == seen[-1].lower()
+
+    def test_get_kg_dedupes_symlink_alias_end_to_end(self, tmp_path, monkeypatch):
+        """End-to-end: two ``_get_kg()`` calls via different symlink layers
+        return the same cached instance and construct only one
+        ``KnowledgeGraph``."""
+        if sys.platform == "win32":
+            pytest.skip("symlink creation requires admin privileges on Windows runners")
+
+        from mempalace import mcp_server
+
+        target = tmp_path / "real"
+        target.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(target)
+
+        real_db = str(target / "knowledge_graph.sqlite3")
+        link_db = str(link / "knowledge_graph.sqlite3")
+
+        constructed: list = []
+
+        class _StubKG:
+            def __init__(self, db_path=None):
+                constructed.append(db_path)
+
+        monkeypatch.setattr(mcp_server, "_kg_by_path", {})
+        monkeypatch.setattr(mcp_server, "KnowledgeGraph", _StubKG)
+
+        paths = iter([real_db, link_db])
+        monkeypatch.setattr(mcp_server, "_resolve_kg_path", lambda: next(paths))
+
+        kg1 = mcp_server._get_kg()
+        kg2 = mcp_server._get_kg()
+
+        assert kg1 is kg2, "symlink alias must hit the cached KG, not construct a duplicate"
+        assert len(constructed) == 1, f"expected 1 KG construction, got {len(constructed)}"
+        assert len(mcp_server._kg_by_path) == 1
 
 
 # ── Param-shape diagnostics on tools/call dispatch (#1351) ──────────────

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1954,22 +1954,27 @@ class TestKGLazyCache:
         """``_canonicalize_kg_path`` must apply ``os.path.normcase`` so the
         cache key collapses Windows drive-letter casing
         (``C:\\palace`` vs ``c:\\palace``). On POSIX runners normcase is a
-        no-op, so we monkeypatch it to verify the wiring rather than the
-        OS behaviour."""
+        no-op, so we patch both ``realpath`` and ``normcase`` with sentinel
+        wrappers and assert the helper composes them as
+        ``normcase(realpath(p))`` -- swapping the order would leave Windows
+        symlinks under the original case, defeating the dedup.
+        """
         from mempalace import mcp_server
 
-        seen: list = []
+        def fake_realpath(p: str) -> str:
+            return f"<RP:{p}>"
 
         def fake_normcase(p: str) -> str:
-            seen.append(p)
-            return p.lower()
+            return f"<NC:{p}>"
 
+        monkeypatch.setattr(os.path, "realpath", fake_realpath)
         monkeypatch.setattr(os.path, "normcase", fake_normcase)
 
-        result = mcp_server._canonicalize_kg_path("/Some/Path/KG.sqlite3")
+        result = mcp_server._canonicalize_kg_path("/some/Path/KG.sqlite3")
 
-        assert seen, "expected normcase to be invoked"
-        assert result == seen[-1].lower()
+        assert (
+            result == "<NC:<RP:/some/Path/KG.sqlite3>>"
+        ), f"expected normcase(realpath(p)) composition, got {result!r}"
 
     def test_get_kg_dedupes_symlink_alias_end_to_end(self, tmp_path, monkeypatch):
         """End-to-end: two ``_get_kg()`` calls via different symlink layers


### PR DESCRIPTION
## What

`_get_kg()` and `_call_kg()` now key the per-path `KnowledgeGraph` cache through a
new `_canonicalize_kg_path(path)` helper that applies `os.path.realpath`
(resolves symlinks) followed by `os.path.normcase` (Windows drive-letter
casing + path-separator). On POSIX `normcase` is a no-op; the real change
is symlink resolution. On Windows both apply.

## Why

#1372 (`mcp: per-path KG cache should canonicalize via realpath, not abspath`):

> #1160 replaced the module-level `KnowledgeGraph` singleton with a lazy
> per-path cache keyed by `os.path.abspath(_resolve_kg_path())`.
> `os.path.abspath()` does not resolve symlinks or canonicalize Windows
> drive-letter casing. Two tenants pointing at `/srv/A` and
> `/srv/link-to-A` (or `C:\palace\foo` and `c:\palace\foo`) get separate
> `KnowledgeGraph` instances over the same SQLite file.

The PR scope-note for #1160 explicitly accepted this trade-off as v3.4
follow-up territory.

## How

```python
def _canonicalize_kg_path(path: str) -> str:
    return os.path.normcase(os.path.realpath(path))
```

Applied at both `_kg_by_path` access sites:

- `_get_kg(canonical_path=None)` -- insert + lookup. The optional arg
  lets a caller that has already captured a canonical key (see
  `_call_kg` below) pass it through, so the dict insert here uses the
  same key the caller will later evict under. With `canonical_path=None`
  the function resolves and canonicalizes from module state -- the
  default for direct callers.
- `_call_kg()` -- captures the canonical key once at the top of the
  function, before the retry loop, and threads it through every
  `_get_kg(path)` call plus the eviction lookup. Capturing at the top
  surfaces an `OSError` from `realpath` cleanly via the dispatcher's
  exception envelope rather than letting it raise inside the
  `except sqlite3.ProgrammingError` branch and mask the original close
  signal. Threading the captured key through `_get_kg` locks the
  insert/evict keys together even if env (`MEMPALACE_PALACE_PATH`
  rotation) or FS state (symlink remap, mount remap) mutates between
  attempts.

Drain logic in `tool_reconnect` iterates `_kg_by_path.values()`, so it is not
path-sensitive and stays unchanged.

## Tests

`TestKGLazyCache` gains:

- `test_canonicalize_kg_path_collapses_symlink_alias` -- creates a real
  symlinked tmp_path layout; asserts both `real/kg.sqlite3` and
  `link/kg.sqlite3` produce the same canonical key. Skipped on Windows
  because symlink creation requires admin.
- `test_canonicalize_kg_path_routes_through_normcase` -- patches both
  `os.path.realpath` and `os.path.normcase` with sentinel wrappers and
  asserts the helper composes them as `normcase(realpath(p))`. Swapping
  the order would leave Windows symlinks under the original case,
  defeating the dedup.
- `test_get_kg_dedupes_symlink_alias_end_to_end` -- two `_get_kg()` calls
  via different symlink layers; asserts identical instance + a single
  `KnowledgeGraph` construction.
- `test_call_kg_passes_captured_path_through_resolve_drift` -- patches
  `_resolve_kg_path` with a shifting iterator, pre-seeds the closed
  handle under the captured key, and asserts both `_get_kg` calls
  receive the captured path and the closed handle is evicted by retry.
  Without the pass-through, the second `_get_kg` would re-resolve to
  the drifted path and the closed handle would leak.
- `test_call_kg_oserror_at_top_propagates_unmasked` -- patches
  `_canonicalize_kg_path` to raise `OSError`; asserts it propagates
  unchanged. Pins the rationale that capturing-at-the-top means FS
  errors surface cleanly instead of masking a `ProgrammingError`
  mid-retry.

The existing `_call_kg` retry tests
(`test_call_kg_retries_after_concurrent_close`,
`test_call_kg_does_not_retry_on_other_errors`) now use
`_canonicalize_kg_path(path)` for cache setup so lookup keys match the
production code path on every platform -- under `os.path.abspath` they
would diverge from production keys on Windows.

Local: full suite `pytest tests/ --ignore=tests/benchmarks` -- 1556 pass +
1 skip + 3 pre-existing chromadb/httpx env failures on Python 3.14
linuxbrew (same on every branch, unrelated). `ruff check . && ruff format
--check .` clean. Symlink smoke test confirms `/tmp/symtest_link/...`
collapses to `/tmp/symtest_real/...`.

## Out of scope

- Default-path resolution when `--palace` is not passed -- separate
  concern.
- Path normalization elsewhere in the codebase (palace_path, WAL dir,
  etc.) -- separate concerns.

Closes #1372.
