### PR TITLE
fix(entity_registry): clean up .tmp sidecar on write or rename failure (#1373)

### DIFF
--- a/mempalace/entity_registry.py
+++ b/mempalace/entity_registry.py
@@ -327,15 +327,26 @@ class EntityRegistry:
         # instead of a half-written file or an empty file from the truncate.
         payload = json.dumps(self._data, indent=2)
         tmp_path = self._path.with_name(self._path.name + ".tmp")
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            f.write(payload)
-            f.flush()
-            os.fsync(f.fileno())
         try:
-            tmp_path.chmod(0o600)
-        except (OSError, NotImplementedError):
-            pass
-        os.replace(tmp_path, self._path)
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                f.write(payload)
+                f.flush()
+                os.fsync(f.fileno())
+            try:
+                tmp_path.chmod(0o600)
+            except (OSError, NotImplementedError):
+                pass
+            os.replace(tmp_path, self._path)
+        except BaseException:
+            # Disk full, perms flip, broken FUSE mount, IO error, KeyboardInterrupt
+            # mid-write — unlink the .tmp sidecar so it does not litter the palace
+            # directory or confuse diagnostics. The previous registry is intact
+            # because os.replace is atomic on POSIX/NTFS.
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
         # On ext4 (and similar) the rename's durability across power loss
         # requires an additional fsync on the parent directory. Without it,
         # the kernel can ack the rename and a crash reverts to the state

--- a/tests/test_entity_registry.py
+++ b/tests/test_entity_registry.py
@@ -115,6 +115,52 @@ def test_save_preserves_previous_on_serialization_failure(tmp_path, monkeypatch)
     # Restore os.replace before reading so the assertion can rely on it.
     monkeypatch.setattr(_os, "replace", real_replace)
     assert target.read_text(encoding="utf-8") == original
+    # The .tmp sidecar must also be cleaned up — otherwise it litters the
+    # palace directory and a future diagnostic cannot distinguish stale
+    # debris from an in-flight write.
+    leftover = list(tmp_path.glob("entity_registry.json.tmp*"))
+    assert leftover == [], f"atomic write leaked tmp on rename failure: {leftover}"
+
+
+def test_save_cleans_tmp_on_write_failure(tmp_path, monkeypatch):
+    # Failure BEFORE the rename (disk full, FUSE break, IO error during
+    # write/fsync) must also clean up the .tmp sidecar. The existing
+    # rename-failure test only covers the post-write path; this exercises
+    # the gap between write and rename.
+    registry = EntityRegistry.load(config_dir=tmp_path)
+    registry.seed(
+        mode="personal",
+        people=[{"name": "Alice", "relationship": "friend", "context": "personal"}],
+        projects=[],
+    )
+    registry.save()
+    target = tmp_path / "entity_registry.json"
+    original = target.read_text(encoding="utf-8")
+
+    # Force os.fsync to raise — simulates IO error after the bytes are in
+    # the kernel page cache but before they hit the platter.
+    import os as _os
+
+    real_fsync = _os.fsync
+
+    def boom(fd):
+        raise OSError("simulated fsync failure")
+
+    monkeypatch.setattr(_os, "fsync", boom)
+    with pytest.raises(OSError):
+        registry.seed(
+            mode="personal",
+            people=[{"name": "Bob", "relationship": "friend", "context": "personal"}],
+            projects=[],
+        )
+        registry.save()
+    monkeypatch.setattr(_os, "fsync", real_fsync)
+
+    # Previous registry intact (rename never happened — atomic guarantee).
+    assert target.read_text(encoding="utf-8") == original
+    # And the .tmp sidecar is gone, not litter on disk.
+    leftover = list(tmp_path.glob("entity_registry.json.tmp*"))
+    assert leftover == [], f"atomic write leaked tmp on fsync failure: {leftover}"
 
 
 # ── seed ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What and Why

#1215 made `EntityRegistry.save()` atomic via temp-file + fsync + `os.replace`. Crash-mid-write durability is correct — the previous registry stays intact on any failure. But the `.tmp` sidecar was left on disk if `f.write()` / `f.flush()` / `os.fsync()` / `os.replace()` raised. Subsequent saves overwrite the same temp filename so this does not grow unboundedly, but it litters the palace directory and obscures diagnostics: a user inspecting `entity_registry.json.tmp` after a crash cannot tell whether it is the in-flight write of an ongoing process or stale debris from a prior failure.

@igorls flagged this in #1373.

## Root Cause

`mempalace/entity_registry.py:328-338` — the write + chmod + `os.replace` block ran without an outer `try/except`. The `with open(...) as f:` block closes the fd on exit but does not unlink the file. If `f.write()`, `f.flush()`, or `os.fsync()` raised (disk full, perms flip, broken FUSE mount, IO error), the temp file stayed. If `os.replace()` raised, same outcome.

## Reproduction

```python
import os, pytest
from mempalace.entity_registry import EntityRegistry

registry = EntityRegistry.load(config_dir=tmp_path)
registry.seed(mode='personal', people=[{'name': 'Alice', 'relationship': 'friend', 'context': 'personal'}], projects=[])
registry.save()

# Force os.fsync to raise — simulates IO error after bytes are in page cache
real_fsync = os.fsync
os.fsync = lambda fd: (_ for _ in ()).throw(OSError('IO error'))
try:
    registry.seed(mode='personal', people=[{'name': 'Bob', ...}], projects=[])
    registry.save()
except OSError:
    pass
os.fsync = real_fsync

# Before this PR:
list(tmp_path.glob('entity_registry.json.tmp*'))  # ['entity_registry.json.tmp']  ← litter

# After this PR:
list(tmp_path.glob('entity_registry.json.tmp*'))  # []
```

## Change Summary

- `mempalace/entity_registry.py:328-348` — wrap the write + chmod + `os.replace` block in `try/except BaseException`. On failure, `tmp_path.unlink(missing_ok=True)` and re-raise. The dir-fsync stays outside the `try` because it only runs on the successful-rename path.
- Cleanup uses `BaseException` so `KeyboardInterrupt` mid-write also leaves a clean directory; the inner `unlink` itself is wrapped against an `OSError` race so cleanup cannot mask the original exception.
- `tests/test_entity_registry.py` — augment `test_save_preserves_previous_on_serialization_failure` with an additional `assert leftover == []` after the forced `os.replace` failure.
- `tests/test_entity_registry.py` — new `test_save_cleans_tmp_on_write_failure` that forces `os.fsync` to raise (the gap between write and rename that the existing test does not cover) and asserts both the durability invariant (previous registry intact) and the cleanup invariant (no `.tmp` sidecar left).

## Test Plan

- [x] All 32 `test_entity_registry.py` tests pass.
- [x] Full suite: 1549 passed (1548 → 1549, my new test); 76 pre-existing failures on macOS ARM64 are the chromadb_rust_bindings segfault tracked in #1355 and are identical on pristine `develop`.
- [x] `ruff check .` passes on both modified files.
- [x] `ruff format --check .` passes.
- [x] Manually verified: forcing `os.fsync` and `os.replace` to raise leaves no `.tmp` litter; previous registry content unchanged.

Closes #1373.