### PR TITLE
Fix UTF-8 lock holder writes on Windows

### DIFF
--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -387,7 +387,10 @@ def _read_lock_holder(lock_file) -> str:
     """Read the prior holder's identity from the lock-file body, best-effort."""
     try:
         lock_file.seek(_LOCK_SENTINEL_BYTES)
-        content = lock_file.read().strip()
+        content = lock_file.read()
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+        content = content.strip()
     except OSError:
         return "another writer (identity not recorded)"
     if not content:
@@ -404,11 +407,12 @@ def _write_lock_holder(lock_file) -> None:
     """
     try:
         ident = f"{os.getpid()} {' '.join(sys.argv[:3])}".strip()
+        ident_bytes = ident.encode("utf-8")
         lock_file.seek(_LOCK_SENTINEL_BYTES)
-        lock_file.truncate(_LOCK_SENTINEL_BYTES + len(ident.encode("utf-8")))
-        lock_file.write(ident)
+        lock_file.truncate(_LOCK_SENTINEL_BYTES + len(ident_bytes))
+        lock_file.write(ident_bytes)
         lock_file.flush()
-    except OSError:
+    except (OSError, UnicodeError):
         pass
 
 
@@ -470,7 +474,7 @@ def mine_palace_lock(palace_path: str):
             os.close(fd)
         except FileExistsError:
             pass
-    lf = open(lock_path, "r+")
+    lf = open(lock_path, "r+b")
     acquired = False
     try:
         # Lock byte 0 explicitly. msvcrt.locking is byte-position dependent;

--- a/tests/test_palace_locks.py
+++ b/tests/test_palace_locks.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 import multiprocessing
 import os
 import time
+import sys
 
 import pytest
 
 from mempalace.palace import (
+    _write_lock_holder,
     MineAlreadyRunning,
     mine_global_lock,
     mine_palace_lock,
@@ -197,9 +199,9 @@ def test_reentrant_same_thread_passes_through(tmp_path, monkeypatch):
         child = ctx.Process(target=_try_acquire_expect_busy, args=(palace, result_q))
         try:
             child.start()
-            assert (
-                result_q.get(timeout=10) == "busy"
-            ), "outer lock should still be held by parent after inner re-entrant exit"
+            assert result_q.get(timeout=10) == "busy", (
+                "outer lock should still be held by parent after inner re-entrant exit"
+            )
             child.join(timeout=5)
             assert child.exitcode == 0
         finally:
@@ -265,12 +267,54 @@ def test_lock_failure_message_names_holder(tmp_path, monkeypatch):
                 pytest.fail("second acquire of same palace should have raised")
 
         msg = str(excinfo.value)
-        assert (
-            f"PID {holder_pid}" in msg
-        ), f"lock-failure message must name the holder PID; got: {msg!r}"
+        assert f"PID {holder_pid}" in msg, (
+            f"lock-failure message must name the holder PID; got: {msg!r}"
+        )
     finally:
         open(release, "w").close()
         holder.join(timeout=5)
+
+
+def test_write_lock_holder_writes_utf8_bytes_for_non_ascii_argv(tmp_path, monkeypatch):
+    """Regression #1435: lock-holder identity must be written as UTF-8 bytes.
+
+    The holder byte count and the on-disk bytes must agree even when argv
+    contains characters that are not representable in a Windows ANSI codepage.
+    """
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["mempalace", "mine", "café/北"],
+    )
+
+    lock_path = tmp_path / "holder.lock"
+    lock_path.write_bytes(b"\0stale-holder-identity-that-must-be-truncated")
+
+    with lock_path.open("r+b") as lock_file:
+        _write_lock_holder(lock_file)
+
+    ident = f"{os.getpid()} {' '.join(sys.argv[:3])}".strip()
+    assert lock_path.read_bytes() == b"\0" + ident.encode("utf-8")
+
+
+def test_write_lock_holder_is_best_effort_on_unicode_error(monkeypatch):
+    """Regression #1435: holder-write failures must not block lock acquisition."""
+
+    class UnicodeFailingLock:
+        def seek(self, _offset):
+            pass
+
+        def truncate(self, _size):
+            pass
+
+        def write(self, _data):
+            raise UnicodeEncodeError("cp1252", "北", 0, 1, "not representable")
+
+        def flush(self):
+            pass
+
+    monkeypatch.setattr(sys, "argv", ["mempalace", "mine", "北"])
+    _write_lock_holder(UnicodeFailingLock())
 
 
 def test_lock_holder_identity_persists_across_release(tmp_path, monkeypatch):

--- a/tests/test_palace_locks.py
+++ b/tests/test_palace_locks.py
@@ -199,9 +199,9 @@ def test_reentrant_same_thread_passes_through(tmp_path, monkeypatch):
         child = ctx.Process(target=_try_acquire_expect_busy, args=(palace, result_q))
         try:
             child.start()
-            assert result_q.get(timeout=10) == "busy", (
-                "outer lock should still be held by parent after inner re-entrant exit"
-            )
+            assert (
+                result_q.get(timeout=10) == "busy"
+            ), "outer lock should still be held by parent after inner re-entrant exit"
             child.join(timeout=5)
             assert child.exitcode == 0
         finally:
@@ -267,9 +267,9 @@ def test_lock_failure_message_names_holder(tmp_path, monkeypatch):
                 pytest.fail("second acquire of same palace should have raised")
 
         msg = str(excinfo.value)
-        assert f"PID {holder_pid}" in msg, (
-            f"lock-failure message must name the holder PID; got: {msg!r}"
-        )
+        assert (
+            f"PID {holder_pid}" in msg
+        ), f"lock-failure message must name the holder PID; got: {msg!r}"
     finally:
         open(release, "w").close()
         holder.join(timeout=5)


### PR DESCRIPTION
## What does this PR do?

Fixes #1435.

This updates the palace mine lock-holder identity to be written as explicit UTF-8 bytes instead of text-mode output using the platform default encoding.

## What changed

- Opens the per-palace lock file in binary read/write mode (`r+b`)
- Decodes holder identity as UTF-8 when reading diagnostics
- Writes holder identity as UTF-8 bytes when recording the current process
- Keeps holder recording best-effort by catching `UnicodeError` as well as `OSError`
- Adds regression coverage for non-ASCII argv values and best-effort Unicode failures

## Why

Previously `_write_lock_holder()` calculated the truncate size using `ident.encode("utf-8")`, but then wrote `ident` through a text-mode file. On Windows non-UTF-8 locales, this could make the truncate byte count disagree with the actual bytes written, or raise `UnicodeEncodeError`.

The holder string is diagnostic-only, so a failure to record it should never prevent the lock from being acquired.


## How to test

```bash
python -m pytest tests/test_palace_locks.py
python -m pytest tests/test_palace_locks.py -k "lock_holder or utf8 or unicode"
python -m ruff check mempalace/palace.py tests/test_palace_locks.py
python -m pytest tests/ -v
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
