### PR TITLE
fix: drop leaked PYTHONPATH on package init (#1423)

### DIFF
--- a/mempalace/__init__.py
+++ b/mempalace/__init__.py
@@ -9,13 +9,18 @@ def _strip_leaked_pythonpath() -> None:
     # Venvs inherit PYTHONPATH; on multi-Python systems it can cause
     # transitive imports to load compiled extensions (pydantic_core,
     # chromadb_rust_bindings) from the wrong ABI. Drop the env var
-    # and remove the sys.path entries the interpreter populated from
-    # it before the consumer imports anything that ships compiled code.
+    # and remove sys.path entries the interpreter populated from it.
+    # Comparison normalizes case + separators so Windows paths and
+    # trailing-separator quirks do not slip through string equality.
     leaked = os.environ.pop("PYTHONPATH", None)
     if not leaked:
         return
-    leaked_entries = {p for p in leaked.split(os.pathsep) if p}
-    sys.path[:] = [p for p in sys.path if p not in leaked_entries]
+
+    def _norm(path: str) -> str:
+        return os.path.normcase(os.path.normpath(path))
+
+    leaked_entries = {_norm(p.strip()) for p in leaked.split(os.pathsep) if p.strip()}
+    sys.path[:] = [p for p in sys.path if _norm(p) not in leaked_entries]
 
 
 _strip_leaked_pythonpath()

--- a/mempalace/__init__.py
+++ b/mempalace/__init__.py
@@ -5,16 +5,24 @@ import os
 import sys
 
 
-def _strip_leaked_pythonpath() -> None:
+def _strip_leaked_pythonpath_from_sys_path() -> None:
     # Venvs inherit PYTHONPATH; on multi-Python systems it can cause
     # transitive imports to load compiled extensions (pydantic_core,
-    # chromadb_rust_bindings) from the wrong ABI. Drop the env var
-    # and remove sys.path entries the interpreter populated from it.
-    # Comparison normalizes case + separators so Windows paths and
-    # trailing-separator quirks do not slip through string equality.
-    # The empty-string CWD marker on sys.path is preserved regardless,
-    # so PYTHONPATH=. does not collapse the implicit current directory.
-    leaked = os.environ.pop("PYTHONPATH", None)
+    # chromadb_rust_bindings) from the wrong ABI. Remove sys.path entries
+    # the interpreter populated from PYTHONPATH so this process imports
+    # only the venv's own packages. Comparison normalizes case + separators
+    # so Windows paths and trailing-separator quirks do not slip through
+    # string equality. The empty-string CWD marker on sys.path is preserved
+    # regardless, so PYTHONPATH=. does not collapse the implicit current
+    # directory.
+    #
+    # os.environ is intentionally NOT modified here. CLI entry points
+    # (mempalace.cli:main, mempalace.mcp_server:main) drop PYTHONPATH from
+    # the env themselves so any subprocess they spawn starts clean. Host
+    # applications that embed mempalace as a library (e.g. import
+    # mempalace.searcher) keep their PYTHONPATH intact for their own
+    # unrelated subprocesses.
+    leaked = os.environ.get("PYTHONPATH", None)
     if not leaked:
         return
 
@@ -25,7 +33,7 @@ def _strip_leaked_pythonpath() -> None:
     sys.path[:] = [p for p in sys.path if not p or _norm(p) not in leaked_entries]
 
 
-_strip_leaked_pythonpath()
+_strip_leaked_pythonpath_from_sys_path()
 
 from .version import __version__  # noqa: E402
 

--- a/mempalace/__init__.py
+++ b/mempalace/__init__.py
@@ -12,6 +12,8 @@ def _strip_leaked_pythonpath() -> None:
     # and remove sys.path entries the interpreter populated from it.
     # Comparison normalizes case + separators so Windows paths and
     # trailing-separator quirks do not slip through string equality.
+    # The empty-string CWD marker on sys.path is preserved regardless,
+    # so PYTHONPATH=. does not collapse the implicit current directory.
     leaked = os.environ.pop("PYTHONPATH", None)
     if not leaked:
         return
@@ -19,8 +21,8 @@ def _strip_leaked_pythonpath() -> None:
     def _norm(path: str) -> str:
         return os.path.normcase(os.path.normpath(path))
 
-    leaked_entries = {_norm(p.strip()) for p in leaked.split(os.pathsep) if p.strip()}
-    sys.path[:] = [p for p in sys.path if _norm(p) not in leaked_entries]
+    leaked_entries = {_norm(p) for p in leaked.split(os.pathsep) if p}
+    sys.path[:] = [p for p in sys.path if not p or _norm(p) not in leaked_entries]
 
 
 _strip_leaked_pythonpath()

--- a/mempalace/__init__.py
+++ b/mempalace/__init__.py
@@ -1,6 +1,16 @@
 """MemPalace — Give your AI a memory. No API key required."""
 
 import logging
+import os
+
+
+def _strip_leaked_pythonpath() -> None:
+    # Venvs inherit PYTHONPATH; on multi-Python systems it can load
+    # compiled extensions with the wrong ABI and crash on import.
+    os.environ.pop("PYTHONPATH", None)
+
+
+_strip_leaked_pythonpath()
 
 from .version import __version__  # noqa: E402
 

--- a/mempalace/__init__.py
+++ b/mempalace/__init__.py
@@ -2,12 +2,20 @@
 
 import logging
 import os
+import sys
 
 
 def _strip_leaked_pythonpath() -> None:
-    # Venvs inherit PYTHONPATH; on multi-Python systems it can load
-    # compiled extensions with the wrong ABI and crash on import.
-    os.environ.pop("PYTHONPATH", None)
+    # Venvs inherit PYTHONPATH; on multi-Python systems it can cause
+    # transitive imports to load compiled extensions (pydantic_core,
+    # chromadb_rust_bindings) from the wrong ABI. Drop the env var
+    # and remove the sys.path entries the interpreter populated from
+    # it before the consumer imports anything that ships compiled code.
+    leaked = os.environ.pop("PYTHONPATH", None)
+    if not leaked:
+        return
+    leaked_entries = {p for p in leaked.split(os.pathsep) if p}
+    sys.path[:] = [p for p in sys.path if p not in leaked_entries]
 
 
 _strip_leaked_pythonpath()

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1129,6 +1129,12 @@ def _reconfigure_stdio_utf8_on_windows():
 
 
 def main():
+    # Drop leaked PYTHONPATH so any subprocess the CLI spawns (mine workers,
+    # repair tooling) starts with a clean env. The sys.path filter in
+    # mempalace/__init__.py already protects this process from the same
+    # ABI mismatch; here we extend the protection to children.
+    os.environ.pop("PYTHONPATH", None)
+
     _reconfigure_stdio_utf8_on_windows()
 
     version_label = f"MemPalace {__version__}"

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1129,6 +1129,15 @@ def _reconfigure_stdio_utf8_on_windows():
 
 
 def main():
+    """CLI entry point for the ``mempalace`` console script.
+
+    Side effect: pops ``PYTHONPATH`` from ``os.environ`` (see #1423) so
+    any subprocess this CLI spawns inherits a clean env. Host applications
+    that call ``main()`` programmatically should be aware that the parent
+    process loses ``PYTHONPATH`` as well. Library imports
+    (``import mempalace.searcher`` from a host app) do NOT trigger this
+    side effect; only the CLI/MCP entry points pop the env var.
+    """
     # Drop leaked PYTHONPATH so any subprocess the CLI spawns (mine workers,
     # repair tooling) starts with a clean env. The sys.path filter in
     # mempalace/__init__.py already protects this process from the same

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2294,6 +2294,11 @@ def _restore_stdout():
 
 
 def main():
+    # Drop leaked PYTHONPATH so any subprocess this server spawns starts
+    # with a clean env. The sys.path filter in mempalace/__init__.py
+    # already protects this process from the same ABI mismatch; here we
+    # extend the protection to children.
+    os.environ.pop("PYTHONPATH", None)
     _restore_stdout()
     # Force UTF-8 on stdio. MCP JSON-RPC is UTF-8, but Python on Windows
     # defaults stdin/stdout to the system codepage (e.g. cp1251), which

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2294,6 +2294,15 @@ def _restore_stdout():
 
 
 def main():
+    """MCP server entry point for the ``mempalace-mcp`` console script.
+
+    Side effect: pops ``PYTHONPATH`` from ``os.environ`` (see #1423) so
+    any subprocess this server spawns inherits a clean env. Host
+    applications that call ``main()`` programmatically should be aware
+    that the parent process loses ``PYTHONPATH`` as well. Library imports
+    (``import mempalace.searcher`` from a host app) do NOT trigger this
+    side effect; only the CLI/MCP entry points pop the env var.
+    """
     # Drop leaked PYTHONPATH so any subprocess this server spawns starts
     # with a clean env. The sys.path filter in mempalace/__init__.py
     # already protects this process from the same ABI mismatch; here we

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
 """Tests for mempalace.cli — the main CLI dispatcher."""
 
 import argparse
+import os
 import shlex
 import sqlite3
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -22,6 +24,56 @@ from mempalace.cli import (
     cmd_wakeup,
     main,
 )
+
+
+# ── CLI entry point: PYTHONPATH stripping ────────────────────────────────
+
+
+_LEAK_PREFIX = "/__mempalace_cli_leak_sentinel__"
+
+
+def test_cli_main_strips_leaked_pythonpath_from_env():
+    """mempalace.cli:main must drop PYTHONPATH from the process env so
+    any subprocess the CLI spawns starts clean. Mirrors the
+    sys.path-filter test in test_init.py but for the env half of the
+    split fix. See #1423.
+
+    Asserts ENV_MID between import and main() to prove that main() is
+    the strip site, not the package import. If a regression moves the
+    env pop back into __init__.py, ENV_MID would change and this test
+    would fail."""
+    expected_env = f"{_LEAK_PREFIX}/a{os.pathsep}{_LEAK_PREFIX}/b"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = expected_env
+    # Run main() with --version so it exits cleanly without entering any
+    # subcommand. argparse raises SystemExit on --version; the wrapper
+    # catches it and prints the post-main PYTHONPATH so the assertion
+    # is observable.
+    code = (
+        "import os, sys\n"
+        "from mempalace.cli import main\n"
+        "print('ENV_MID:', repr(os.environ.get('PYTHONPATH')))\n"
+        "sys.argv = ['mempalace', '--version']\n"
+        "try:\n"
+        "    main()\n"
+        "except SystemExit:\n"
+        "    pass\n"
+        "print('ENV_AFTER:', repr(os.environ.get('PYTHONPATH')))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    diag = f"rc={result.returncode}; stdout={result.stdout!r}; stderr={result.stderr!r}"
+    assert result.returncode == 0, f"subprocess failed: {diag}"
+    assert (
+        f"ENV_MID: {expected_env!r}" in result.stdout
+    ), f"package import unexpectedly stripped env (regression in __init__.py): {diag}"
+    assert "ENV_AFTER: None" in result.stdout, f"CLI did not strip PYTHONPATH: {diag}"
 
 
 # ── cmd_status ─────────────────────────────────────────────────────────

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,26 +38,35 @@ def test_cli_main_strips_leaked_pythonpath_from_env():
     sys.path-filter test in test_init.py but for the env half of the
     split fix. See #1423.
 
-    Asserts ENV_MID between import and main() to prove that main() is
-    the strip site, not the package import. If a regression moves the
-    env pop back into __init__.py, ENV_MID would change and this test
-    would fail."""
+    Three assertions cover the full split contract:
+    - ENV_MID (after import, before main) is preserved verbatim:
+      regression detector for someone moving the env pop back into
+      __init__.py.
+    - SENTINEL_IN_PATH is False at import time: package-level sys.path
+      filter half of the split actually ran.
+    - ENV_AFTER (after main) is None: CLI entry-point env strip ran.
+
+    SystemExit is caught with a narrowed exit-code check so a future
+    argparse change that exits with a non-zero code (e.g. usage error)
+    surfaces as a test failure instead of being swallowed."""
     expected_env = f"{_LEAK_PREFIX}/a{os.pathsep}{_LEAK_PREFIX}/b"
     env = os.environ.copy()
     env["PYTHONPATH"] = expected_env
     # Run main() with --version so it exits cleanly without entering any
-    # subcommand. argparse raises SystemExit on --version; the wrapper
-    # catches it and prints the post-main PYTHONPATH so the assertion
-    # is observable.
+    # subcommand. argparse raises SystemExit(0) on --version; the wrapper
+    # asserts the exit code is clean and prints the post-main PYTHONPATH
+    # so the assertion is observable.
     code = (
         "import os, sys\n"
         "from mempalace.cli import main\n"
+        f"prefix = {_LEAK_PREFIX!r}\n"
         "print('ENV_MID:', repr(os.environ.get('PYTHONPATH')))\n"
+        "print('SENTINEL_IN_PATH:', any(prefix in (p or '') for p in sys.path))\n"
         "sys.argv = ['mempalace', '--version']\n"
         "try:\n"
         "    main()\n"
-        "except SystemExit:\n"
-        "    pass\n"
+        "except SystemExit as exc:\n"
+        "    assert exc.code in (0, None), f'unexpected exit code: {exc.code!r}'\n"
         "print('ENV_AFTER:', repr(os.environ.get('PYTHONPATH')))\n"
     )
     result = subprocess.run(
@@ -73,6 +82,9 @@ def test_cli_main_strips_leaked_pythonpath_from_env():
     assert (
         f"ENV_MID: {expected_env!r}" in result.stdout
     ), f"package import unexpectedly stripped env (regression in __init__.py): {diag}"
+    assert (
+        "SENTINEL_IN_PATH: False" in result.stdout
+    ), f"package import did not filter sys.path (regression in __init__.py): {diag}"
     assert "ENV_AFTER: None" in result.stdout, f"CLI did not strip PYTHONPATH: {diag}"
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,12 +23,18 @@ _LEAK_PREFIX = "/__mempalace_leak_test_sentinel__"
     ],
     ids=["single", "multi", "trailing-sep", "leading-pathsep", "dot", "empty", "unset"],
 )
-def test_init_strips_leaked_pythonpath(pythonpath):
-    """Package init must clear PYTHONPATH (env) AND remove all of its
-    sentinel-prefixed entries from sys.path. Asserts on the sentinel
-    substring directly so the test does not couple to the production
-    normalization logic. The dot/empty/unset cases additionally
-    exercise the early-return / collision paths without crashing."""
+def test_init_filters_sys_path_from_leaked_pythonpath(pythonpath):
+    """Package init must remove sentinel-prefixed entries from sys.path
+    so transitive imports do not pull compiled extensions from the
+    leaked PYTHONPATH. os.environ['PYTHONPATH'] is left intact so host
+    applications embedding mempalace as a library keep their env for
+    their own subprocesses; the env strip lives in the CLI/MCP entry
+    points (see test_cli.py / test_mcp_server.py).
+
+    Asserts on the sentinel substring directly so the test does not
+    couple to the production normalization logic. The dot/empty/unset
+    cases additionally exercise the early-return / collision paths
+    without crashing."""
     env = os.environ.copy()
     if pythonpath is None:
         env.pop("PYTHONPATH", None)
@@ -37,8 +43,12 @@ def test_init_strips_leaked_pythonpath(pythonpath):
     code = (
         "import mempalace, os, sys; "
         f"prefix = {_LEAK_PREFIX!r}; "
+        "mempalace_parent = os.path.dirname(os.path.dirname(mempalace.__file__)); "
         "print('ENV:', repr(os.environ.get('PYTHONPATH'))); "
-        "print('SENTINEL_IN_PATH:', any(prefix in (p or '') for p in sys.path))"
+        "print('SENTINEL_IN_PATH:', any(prefix in (p or '') for p in sys.path)); "
+        "print('MEMPALACE_PARENT_PRESENT:', any("
+        "os.path.normcase(os.path.normpath(p)) == os.path.normcase(os.path.normpath(mempalace_parent)) "
+        "for p in sys.path if p))"
     )
     result = subprocess.run(
         [sys.executable, "-c", code],
@@ -53,8 +63,17 @@ def test_init_strips_leaked_pythonpath(pythonpath):
     )
     assert result.returncode == 0, f"subprocess failed: {diag}"
     out = result.stdout
-    assert "ENV: None" in out, f"PYTHONPATH not cleared: {diag}"
+    # Env must be preserved verbatim: embedded callers may need it.
+    expected_env = repr(pythonpath) if pythonpath is not None else repr(None)
+    assert (
+        f"ENV: {expected_env}" in out
+    ), f"PYTHONPATH should be preserved by package import: {diag}"
     assert "SENTINEL_IN_PATH: False" in out, f"sentinel-prefix leak: {diag}"
+    # Filter must not over-strip: the mempalace package itself must remain
+    # importable, so its parent directory must survive on sys.path.
+    assert (
+        "MEMPALACE_PARENT_PRESENT: True" in out
+    ), f"filter over-stripped sys.path (mempalace parent gone): {diag}"
 
 
 def test_init_preserves_cwd_marker_when_pythonpath_collides():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,18 +7,25 @@ import sys
 import pytest
 
 
+_LEAK_PREFIX = "/__mempalace_leak_test_sentinel__"
+
+
 @pytest.mark.parametrize(
     "pythonpath",
     [
-        "/tmp/some/leaked/path",
-        f"/tmp/leak-a{os.pathsep}/tmp/leak-b",
+        f"{_LEAK_PREFIX}/single",
+        f"{_LEAK_PREFIX}/a{os.pathsep}{_LEAK_PREFIX}/b",
+        f"{_LEAK_PREFIX}/with-trailing{os.sep}",
+        f"{os.pathsep}{_LEAK_PREFIX}/leading-sep",
+        "",
         None,
     ],
+    ids=["single", "multi", "trailing-sep", "leading-pathsep", "empty", "unset"],
 )
 def test_init_strips_leaked_pythonpath(pythonpath):
-    """Package init must clear PYTHONPATH (env) AND remove its entries
-    from sys.path so compiled-extension imports cannot resolve from a
-    leaked location."""
+    """Package init must clear PYTHONPATH (env) AND remove all of its
+    leaked entries from sys.path, normalizing case and trailing
+    separators so Windows and POSIX behave alike."""
     env = os.environ.copy()
     if pythonpath is None:
         env.pop("PYTHONPATH", None)
@@ -28,8 +35,11 @@ def test_init_strips_leaked_pythonpath(pythonpath):
         "import mempalace, os, sys; "
         f"leaked = {pythonpath!r}; "
         "print('ENV:', repr(os.environ.get('PYTHONPATH'))); "
-        "entries = leaked.split(os.pathsep) if leaked else []; "
-        "leaked_in_path = any(e in sys.path for e in entries); "
+        "tokens = leaked.split(os.pathsep) if leaked else []; "
+        "entries = [t.strip() for t in tokens if t.strip()]; "
+        "norm = lambda p: os.path.normcase(os.path.normpath(p)); "
+        "leaked_norm = {norm(e) for e in entries}; "
+        "leaked_in_path = any(norm(p) in leaked_norm for p in sys.path); "
         "print('SYSPATH_LEAK:', leaked_in_path)"
     )
     result = subprocess.run(
@@ -37,10 +47,13 @@ def test_init_strips_leaked_pythonpath(pythonpath):
         env=env,
         capture_output=True,
         text=True,
-        check=True,
+        check=False,
     )
+    diag = (
+        f"input={pythonpath!r}; rc={result.returncode}; "
+        f"stdout={result.stdout!r}; stderr={result.stderr!r}"
+    )
+    assert result.returncode == 0, f"subprocess failed: {diag}"
     out = result.stdout
-    assert "ENV: None" in out, f"PYTHONPATH not cleared (input={pythonpath!r}): {out!r}"
-    assert (
-        "SYSPATH_LEAK: False" in out
-    ), f"sys.path retains leaked entry (input={pythonpath!r}): {out!r}"
+    assert "ENV: None" in out, f"PYTHONPATH not cleared: {diag}"
+    assert "SYSPATH_LEAK: False" in out, f"sys.path retains leaked entry: {diag}"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,15 +17,18 @@ _LEAK_PREFIX = "/__mempalace_leak_test_sentinel__"
         f"{_LEAK_PREFIX}/a{os.pathsep}{_LEAK_PREFIX}/b",
         f"{_LEAK_PREFIX}/with-trailing{os.sep}",
         f"{os.pathsep}{_LEAK_PREFIX}/leading-sep",
+        ".",
         "",
         None,
     ],
-    ids=["single", "multi", "trailing-sep", "leading-pathsep", "empty", "unset"],
+    ids=["single", "multi", "trailing-sep", "leading-pathsep", "dot", "empty", "unset"],
 )
 def test_init_strips_leaked_pythonpath(pythonpath):
     """Package init must clear PYTHONPATH (env) AND remove all of its
-    leaked entries from sys.path, normalizing case and trailing
-    separators so Windows and POSIX behave alike."""
+    sentinel-prefixed entries from sys.path. Asserts on the sentinel
+    substring directly so the test does not couple to the production
+    normalization logic. The dot/empty/unset cases additionally
+    exercise the early-return / collision paths without crashing."""
     env = os.environ.copy()
     if pythonpath is None:
         env.pop("PYTHONPATH", None)
@@ -33,14 +36,9 @@ def test_init_strips_leaked_pythonpath(pythonpath):
         env["PYTHONPATH"] = pythonpath
     code = (
         "import mempalace, os, sys; "
-        f"leaked = {pythonpath!r}; "
+        f"prefix = {_LEAK_PREFIX!r}; "
         "print('ENV:', repr(os.environ.get('PYTHONPATH'))); "
-        "tokens = leaked.split(os.pathsep) if leaked else []; "
-        "entries = [t.strip() for t in tokens if t.strip()]; "
-        "norm = lambda p: os.path.normcase(os.path.normpath(p)); "
-        "leaked_norm = {norm(e) for e in entries}; "
-        "leaked_in_path = any(norm(p) in leaked_norm for p in sys.path); "
-        "print('SYSPATH_LEAK:', leaked_in_path)"
+        "print('SENTINEL_IN_PATH:', any(prefix in (p or '') for p in sys.path))"
     )
     result = subprocess.run(
         [sys.executable, "-c", code],
@@ -56,4 +54,28 @@ def test_init_strips_leaked_pythonpath(pythonpath):
     assert result.returncode == 0, f"subprocess failed: {diag}"
     out = result.stdout
     assert "ENV: None" in out, f"PYTHONPATH not cleared: {diag}"
-    assert "SYSPATH_LEAK: False" in out, f"sys.path retains leaked entry: {diag}"
+    assert "SENTINEL_IN_PATH: False" in out, f"sentinel-prefix leak: {diag}"
+
+
+def test_init_preserves_cwd_marker_when_pythonpath_collides():
+    """PYTHONPATH='.' normalizes to the same value as the empty-string
+    CWD marker on sys.path. The strip must remove '.' from sys.path
+    without collapsing the implicit current-directory entry."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "."
+    code = (
+        "import mempalace, sys; "
+        "print('CWD_IN_PATH:', '' in sys.path); "
+        "print('DOT_IN_PATH:', '.' in sys.path)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    diag = f"rc={result.returncode}; stdout={result.stdout!r}; " f"stderr={result.stderr!r}"
+    assert result.returncode == 0, f"subprocess failed: {diag}"
+    assert "CWD_IN_PATH: True" in result.stdout, f"cwd marker dropped: {diag}"
+    assert "DOT_IN_PATH: False" in result.stdout, f"dot leak survived: {diag}"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,38 @@
+"""__init__-level guards that must take effect before transitive imports."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "pythonpath",
+    [
+        "/tmp/some/leaked/path",
+        None,
+    ],
+)
+def test_init_strips_leaked_pythonpath(pythonpath):
+    """Package init must drop PYTHONPATH before compiled extensions load,
+    regardless of whether it was set in the parent environment."""
+    env = os.environ.copy()
+    if pythonpath is None:
+        env.pop("PYTHONPATH", None)
+    else:
+        env["PYTHONPATH"] = pythonpath
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import mempalace, os; print(repr(os.environ.get('PYTHONPATH')))",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert (
+        result.stdout.strip() == "None"
+    ), f"PYTHONPATH not stripped (input was {pythonpath!r}): {result.stdout!r}"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,28 +11,36 @@ import pytest
     "pythonpath",
     [
         "/tmp/some/leaked/path",
+        f"/tmp/leak-a{os.pathsep}/tmp/leak-b",
         None,
     ],
 )
 def test_init_strips_leaked_pythonpath(pythonpath):
-    """Package init must drop PYTHONPATH before compiled extensions load,
-    regardless of whether it was set in the parent environment."""
+    """Package init must clear PYTHONPATH (env) AND remove its entries
+    from sys.path so compiled-extension imports cannot resolve from a
+    leaked location."""
     env = os.environ.copy()
     if pythonpath is None:
         env.pop("PYTHONPATH", None)
     else:
         env["PYTHONPATH"] = pythonpath
+    code = (
+        "import mempalace, os, sys; "
+        f"leaked = {pythonpath!r}; "
+        "print('ENV:', repr(os.environ.get('PYTHONPATH'))); "
+        "entries = leaked.split(os.pathsep) if leaked else []; "
+        "leaked_in_path = any(e in sys.path for e in entries); "
+        "print('SYSPATH_LEAK:', leaked_in_path)"
+    )
     result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            "import mempalace, os; print(repr(os.environ.get('PYTHONPATH')))",
-        ],
+        [sys.executable, "-c", code],
         env=env,
         capture_output=True,
         text=True,
         check=True,
     )
+    out = result.stdout
+    assert "ENV: None" in out, f"PYTHONPATH not cleared (input={pythonpath!r}): {out!r}"
     assert (
-        result.stdout.strip() == "None"
-    ), f"PYTHONPATH not stripped (input was {pythonpath!r}): {result.stdout!r}"
+        "SYSPATH_LEAK: False" in out
+    ), f"sys.path retains leaked entry (input={pythonpath!r}): {out!r}"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,10 +9,57 @@ via monkeypatch to avoid touching real data.
 from datetime import datetime
 import json
 import os
+import subprocess
 import sys
 from unittest.mock import MagicMock
 
 import pytest
+
+
+# ── MCP entry point: PYTHONPATH stripping ────────────────────────────────
+
+
+_MCP_LEAK_PREFIX = "/__mempalace_mcp_leak_sentinel__"
+
+
+def test_mcp_main_strips_leaked_pythonpath_from_env():
+    """mempalace.mcp_server:main must drop PYTHONPATH from the process env
+    so any subprocess this server spawns starts clean. Mirrors the
+    sys.path-filter test in test_init.py but for the env half of the
+    split fix. See #1423.
+
+    Asserts ENV_MID between import and main() to prove main() is the
+    strip site (not __init__.py). The main loop reads JSON-RPC lines
+    from stdin until EOF; closing stdin makes readline() return '' and
+    exits the loop cleanly, which lets us observe the post-main env
+    state."""
+    expected_env = f"{_MCP_LEAK_PREFIX}/a{os.pathsep}{_MCP_LEAK_PREFIX}/b"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = expected_env
+    code = (
+        "import os, sys\n"
+        "from mempalace.mcp_server import main\n"
+        # mcp_server redirects stdout at import time for clean JSON-RPC;
+        # write the probe to stderr so the subprocess can observe it.
+        "sys.stderr.write('ENV_MID: ' + repr(os.environ.get('PYTHONPATH')) + '\\n')\n"
+        "main()\n"
+        "sys.stderr.write('ENV_AFTER: ' + repr(os.environ.get('PYTHONPATH')) + '\\n')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        input="",  # empty stdin → readline() returns '' → loop breaks
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    diag = f"rc={result.returncode}; stdout={result.stdout!r}; stderr={result.stderr!r}"
+    assert result.returncode == 0, f"subprocess failed: {diag}"
+    assert (
+        f"ENV_MID: {expected_env!r}" in result.stderr
+    ), f"package import unexpectedly stripped env (regression in __init__.py): {diag}"
+    assert "ENV_AFTER: None" in result.stderr, f"MCP server did not strip PYTHONPATH: {diag}"
 
 
 def _patch_mcp_server(monkeypatch, config, kg):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -28,20 +28,27 @@ def test_mcp_main_strips_leaked_pythonpath_from_env():
     sys.path-filter test in test_init.py but for the env half of the
     split fix. See #1423.
 
-    Asserts ENV_MID between import and main() to prove main() is the
-    strip site (not __init__.py). The main loop reads JSON-RPC lines
-    from stdin until EOF; closing stdin makes readline() return '' and
-    exits the loop cleanly, which lets us observe the post-main env
-    state."""
+    Three assertions cover the full split contract:
+    - ENV_MID (after import, before main) is preserved verbatim:
+      regression detector for someone moving the env pop back into
+      __init__.py.
+    - SENTINEL_IN_PATH is False at import time: package-level sys.path
+      filter half of the split actually ran.
+    - ENV_AFTER (after main) is None: MCP entry-point env strip ran.
+
+    The main loop reads JSON-RPC lines from stdin until EOF; closing
+    stdin makes readline() return '' and exits the loop cleanly, which
+    lets us observe the post-main env state. Probes go to stderr because
+    mcp_server redirects stdout at import time for clean JSON-RPC."""
     expected_env = f"{_MCP_LEAK_PREFIX}/a{os.pathsep}{_MCP_LEAK_PREFIX}/b"
     env = os.environ.copy()
     env["PYTHONPATH"] = expected_env
     code = (
         "import os, sys\n"
         "from mempalace.mcp_server import main\n"
-        # mcp_server redirects stdout at import time for clean JSON-RPC;
-        # write the probe to stderr so the subprocess can observe it.
+        f"prefix = {_MCP_LEAK_PREFIX!r}\n"
         "sys.stderr.write('ENV_MID: ' + repr(os.environ.get('PYTHONPATH')) + '\\n')\n"
+        "sys.stderr.write('SENTINEL_IN_PATH: ' + repr(any(prefix in (p or '') for p in sys.path)) + '\\n')\n"
         "main()\n"
         "sys.stderr.write('ENV_AFTER: ' + repr(os.environ.get('PYTHONPATH')) + '\\n')\n"
     )
@@ -59,6 +66,9 @@ def test_mcp_main_strips_leaked_pythonpath_from_env():
     assert (
         f"ENV_MID: {expected_env!r}" in result.stderr
     ), f"package import unexpectedly stripped env (regression in __init__.py): {diag}"
+    assert (
+        "SENTINEL_IN_PATH: False" in result.stderr
+    ), f"package import did not filter sys.path (regression in __init__.py): {diag}"
     assert "ENV_AFTER: None" in result.stderr, f"MCP server did not strip PYTHONPATH: {diag}"
 
 


### PR DESCRIPTION
## What does this PR do?

Protects MemPalace against a leaked `PYTHONPATH` that points at another
Python's `site-packages`. This was the failure mode in #1423: a venv
running Python 3.11 inheriting `PYTHONPATH` from a Python 3.9 install
crashes on the first MemPalace command with `ModuleNotFoundError: No
module named 'pydantic_core._pydantic_core'` because the interpreter
preloaded the wrong-ABI compiled extension from the leaked path.

The fix is split between package init and the CLI/MCP entry points so
that embedded library callers are not affected.

**`mempalace/__init__.py`** filters `sys.path` only:
`_strip_leaked_pythonpath_from_sys_path()` reads `PYTHONPATH` via
`os.environ.get` (does NOT pop it), and removes from `sys.path` any
entry that matches a path listed in `PYTHONPATH`. Comparison goes
through `os.path.normcase` + `os.path.normpath` so case differences
(Windows) and trailing-separator variants do not slip through string
equality. The empty-string CWD marker on `sys.path` is preserved
unconditionally, so `PYTHONPATH=.` does not collapse the implicit
current directory.

**`mempalace/cli.py:main`** and **`mempalace/mcp_server.py:main`** each
call `os.environ.pop("PYTHONPATH", None)` as their first line, so any
subprocess these console scripts spawn (mine workers, repair tooling)
starts with a clean env. The pop runs before stdio reconfigure / stdout
restore in both entry points so the ordering is symmetric.

## Placement rationale

`sys.path` filter stays in `mempalace/__init__.py`: it runs at package
import and fixes the ABI mismatch crash for the current process
without touching `os.environ`. Host applications that import mempalace
as a library (for example `import mempalace.searcher`) keep their
`PYTHONPATH` intact for their own unrelated subprocesses.

`os.environ.pop("PYTHONPATH")` lives at the CLI/MCP entry points so the
strip affects only processes the user explicitly invoked (root of
trust) and the subprocesses those entry points spawn themselves.

## How to test

Import-time should preserve env and clean sys.path:

```bash
PYTHONPATH=/tmp/some/leaked/path uv run python -c "import mempalace, os, sys; print('ENV:', os.environ.get('PYTHONPATH')); print('IN_PATH:', '/tmp/some/leaked/path' in sys.path)"
# -> ENV: /tmp/some/leaked/path
# -> IN_PATH: False
```

CLI entry point should strip env:

```bash
PYTHONPATH=/tmp/some/leaked/path uv run python <<'PY'
import os, sys
from mempalace.cli import main
sys.argv = ['mempalace', '--version']
try:
    main()
except SystemExit:
    pass
print('ENV_AFTER:', os.environ.get('PYTHONPATH'))
PY
# -> MemPalace 3.3.5
# -> ENV_AFTER: None
```

CWD-collision edge case:

```bash
PYTHONPATH=. uv run python -c "import mempalace, sys; print('CWD:', '' in sys.path); print('DOT:', '.' in sys.path)"
# -> CWD: True
# -> DOT: False
```

Test coverage in `tests/test_init.py`, `tests/test_cli.py`,
`tests/test_mcp_server.py`. The init tests assert env is preserved AND
sentinel-prefixed `sys.path` entries are removed AND the mempalace
parent directory survives (no over-strip). The CLI/MCP tests assert
ENV_MID between import and main is preserved (proving main is the strip
site, not the import), SENTINEL_IN_PATH is False at import (proving the
sys.path filter ran), and ENV_AFTER is None.

Full suite + ruff:

```
uv run pytest tests/ -v --ignore=tests/benchmarks
uv run ruff check . && uv run ruff format --check .
```

## Checklist

- [x] Tests pass locally (`uv run pytest tests/ -v --ignore=tests/benchmarks`): 1735 passed
- [x] No hardcoded paths
- [x] Linter passes (`uv run ruff check . && uv run ruff format --check .`)
