### PR TITLE
fix(hooks): replace mapfile with sed for bash 3.2 compat (#1440)

### DIFF
--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -66,20 +66,59 @@ fi
 INPUT=$(cat)
 
 # Parse session_id and transcript_path in one call. Sanitize both, then
-# read sanitized values from one-per-line stdout into shell variables —
-# avoids ``eval`` on generated code (#1231 review). Same contract as
-# mempal_save_hook.sh.
-mapfile -t _mempal_parsed < <(echo "$INPUT" | "$MEMPAL_PYTHON_BIN" -c "
+# read sanitized values from one-per-line stdout into shell variables
+# (avoids ``eval`` on generated code, #1231 review). Uses ``sed -n 'Np'``
+# rather than the bash 4-only ``mapfile`` so the script also runs on
+# macOS /bin/bash 3.2.57 (Apple GPLv3 freeze, 2006), where ``mapfile``
+# silently caused every parsed value to fall back to its default (#1440).
+#
+# The leading ``__MEMPAL_PARSE_OK__`` sentinel lets the defense-in-depth
+# guard below distinguish "Python parsed cleanly" from "Python crashed
+# and printed nothing". Same parsing contract as mempal_save_hook.sh.
+# Python stderr is captured to last_python_err.log so the guard below can
+# distinguish "bad user input" from "broken interpreter / future regression
+# in this inline script". Same diagnostic contract as mempal_save_hook.sh.
+_mempal_parsed=$(echo "$INPUT" | "$MEMPAL_PYTHON_BIN" -c "
 import sys, json, re
 data = json.load(sys.stdin)
-sid = data.get('session_id', 'unknown')
+sid = data.get('session_id', '')
 tp = data.get('transcript_path', '')
 safe = lambda s: re.sub(r'[^a-zA-Z0-9_/.\-~]', '', str(s))
+print('__MEMPAL_PARSE_OK__')
 print(safe(sid))
 print(safe(tp))
-" 2>/dev/null)
-SESSION_ID="${_mempal_parsed[0]:-unknown}"
-TRANSCRIPT_PATH="${_mempal_parsed[1]:-}"
+" 2>"$STATE_DIR/last_python_err.log")
+# Drop the empty file on success; chmod 600 on failure to mirror
+# last_input.log's privacy contract.
+if [ -s "$STATE_DIR/last_python_err.log" ]; then
+    chmod 600 "$STATE_DIR/last_python_err.log" 2>/dev/null
+else
+    rm -f "$STATE_DIR/last_python_err.log"
+fi
+_MEMPAL_PARSE_MARKER=$(printf '%s\n' "$_mempal_parsed" | sed -n '1p')
+SESSION_ID=$(printf '%s\n' "$_mempal_parsed" | sed -n '2p')
+TRANSCRIPT_PATH=$(printf '%s\n' "$_mempal_parsed" | sed -n '3p')
+SESSION_ID="${SESSION_ID:-unknown}"
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-}"
+
+# Defense-in-depth: if INPUT was non-empty but Python never reached the
+# print() calls (sentinel missing), parsing silently failed. Surface the
+# raw payload so the next debugger does not lose a day to hook.log lines
+# that say "Session unknown". Bounded to 4 KB and overwritten on each
+# failure (not appended) to keep ~/.mempalace/hook_state/ from growing
+# unbounded under a repeating misconfiguration. chmod 600 so the dump,
+# which mirrors the Claude Code PreCompact payload (includes
+# transcript_path revealing the user's home + project layout), is not
+# world-readable.
+if [ -n "$INPUT" ] && [ "$_MEMPAL_PARSE_MARKER" != "__MEMPAL_PARSE_OK__" ]; then
+    echo "[$(date '+%H:%M:%S')] WARN: input parse failed (sentinel missing); see $STATE_DIR/last_input.log and $STATE_DIR/last_python_err.log" >> "$STATE_DIR/hook.log"
+    # ``head -c 4096`` is a byte cap, locale-independent; ``${INPUT:0:4096}``
+    # would count characters under UTF-8 and slip a multibyte payload past
+    # the bound. ``set -o pipefail`` is not enabled in this script so the
+    # natural SIGPIPE-on-printf from ``head`` closing stdin is absorbed.
+    printf '%s' "$INPUT" | head -c 4096 > "$STATE_DIR/last_input.log"
+    chmod 600 "$STATE_DIR/last_input.log" 2>/dev/null
+fi
 
 # Expand ~ in path
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -8,8 +8,12 @@
 # context about what was discussed. This hook forces one final save of
 # EVERYTHING before that happens.
 #
-# Unlike the save hook (which triggers every N exchanges), this ALWAYS
-# blocks — because compaction is always worth saving before.
+# Unlike the save hook (which gates on a message-count threshold and on
+# MEMPAL_VERBOSE), this runs the mine synchronously on every PreCompact
+# event — compaction is always worth saving before. The hook itself
+# returns ``{}`` so it does not emit a ``decision: block`` to Claude
+# Code; the "always run" semantics live in the mine call, not in the
+# Stop-hook block protocol.
 #
 # === INSTALL ===
 # Add to .claude/settings.local.json:
@@ -35,10 +39,15 @@
 # === HOW IT WORKS ===
 #
 # Claude Code sends JSON on stdin with:
-#   session_id — unique session identifier
+#   session_id      — unique session identifier
+#   transcript_path — path to the JSONL transcript file
 #
-# We always return decision: "block" with a reason telling the AI
-# to save everything. After the AI saves, compaction proceeds normally.
+# The hook runs the transcript mine synchronously (the foreground
+# ``mempalace mine`` call below blocks until it returns), then prints
+# ``{}`` to stdout so Claude Code proceeds with the compaction. We do
+# not emit a ``decision: block`` to the hook protocol — the
+# "always save before compaction" guarantee is provided by the
+# synchronous mine, not by the Stop-hook block contract.
 #
 # === MEMPALACE CLI ===
 # The hook ALWAYS mines the active conversation transcript synchronously
@@ -78,7 +87,16 @@ INPUT=$(cat)
 # Python stderr is captured to last_python_err.log so the guard below can
 # distinguish "bad user input" from "broken interpreter / future regression
 # in this inline script". Same diagnostic contract as mempal_save_hook.sh.
-_mempal_parsed=$(echo "$INPUT" | "$MEMPAL_PYTHON_BIN" -c "
+#
+# ``umask 077`` inside the command-substitution subshell makes the
+# ``2>$STATE_DIR/last_python_err.log`` redirect create the file at mode
+# 0600 atomically, closing the TOCTOU window between creation at
+# umask-default and the ``chmod 600`` below. ``printf '%s'`` replaces
+# ``echo`` so payloads beginning with ``-n``/``-e``/``-E`` or containing
+# backslashes are not mangled by echo flag parsing.
+_mempal_parsed=$(
+    umask 077
+    printf '%s' "$INPUT" | "$MEMPAL_PYTHON_BIN" -c "
 import sys, json, re
 data = json.load(sys.stdin)
 sid = data.get('session_id', '')
@@ -87,7 +105,8 @@ safe = lambda s: re.sub(r'[^a-zA-Z0-9_/.\-~]', '', str(s))
 print('__MEMPAL_PARSE_OK__')
 print(safe(sid))
 print(safe(tp))
-" 2>"$STATE_DIR/last_python_err.log")
+" 2>"$STATE_DIR/last_python_err.log"
+)
 # Drop the empty file on success; chmod 600 on failure to mirror
 # last_input.log's privacy contract.
 if [ -s "$STATE_DIR/last_python_err.log" ]; then
@@ -116,7 +135,9 @@ if [ -n "$INPUT" ] && [ "$_MEMPAL_PARSE_MARKER" != "__MEMPAL_PARSE_OK__" ]; then
     # would count characters under UTF-8 and slip a multibyte payload past
     # the bound. ``set -o pipefail`` is not enabled in this script so the
     # natural SIGPIPE-on-printf from ``head`` closing stdin is absorbed.
-    printf '%s' "$INPUT" | head -c 4096 > "$STATE_DIR/last_input.log"
+    # ``umask 077`` in the subshell creates last_input.log at mode 0600
+    # atomically — the ``chmod 600`` below stays as belt-and-suspenders.
+    ( umask 077 && printf '%s' "$INPUT" | head -c 4096 > "$STATE_DIR/last_input.log" )
     chmod 600 "$STATE_DIR/last_input.log" 2>/dev/null
 fi
 

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -83,27 +83,81 @@ fi
 INPUT=$(cat)
 
 # Parse all fields in a single Python call (3x faster than separate invocations)
-# without invoking ``eval`` on generated code: Python prints one sanitized
-# value per line, the shell reads them via ``mapfile`` and does plain
-# variable assignment — same data, smaller blast radius if the sanitizer
-# is ever bypassed (#1231 review).
-mapfile -t _mempal_parsed < <(echo "$INPUT" | "$MEMPAL_PYTHON_BIN" -c "
+# without invoking ``eval`` on generated code: Python prints a parse-success
+# sentinel followed by one sanitized value per line, the shell reads each
+# line via ``sed -n 'Np'`` and does plain variable assignment. Same data,
+# smaller blast radius if the sanitizer is ever bypassed (#1231 review).
+#
+# Why ``sed -n 'Np'`` and not ``mapfile`` / ``readarray``: macOS ships
+# GNU bash 3.2.57 (frozen at Apple's GPLv3 cutoff in 2006), and both
+# array-read builtins only landed in bash 4.0 (2009). On a stock macOS
+# the previous ``mapfile`` form errored, every value fell back to its
+# default, and the hook silently produced zero saves (#1440).
+#
+# The leading ``__MEMPAL_PARSE_OK__`` sentinel lets the defense-in-depth
+# guard below distinguish "Python parsed cleanly, user set session_id to
+# the literal string 'unknown'" or "session_id was non-ASCII and got
+# sanitized to empty" from the actual failure mode ("Python crashed,
+# nothing was printed"). Without the sentinel the guard false-fires
+# every Stop hook for users on i18n harnesses or unusual harness configs.
+# Python stderr is captured to last_python_err.log so the guard below can
+# distinguish "bad user input" (JSONDecodeError) from "broken interpreter
+# / future regression in this inline script" (ImportError, SyntaxError,
+# ModuleNotFoundError). Without the stderr capture, last_input.log shows
+# a valid payload while the actual root cause stays hidden.
+_mempal_parsed=$(echo "$INPUT" | "$MEMPAL_PYTHON_BIN" -c "
 import sys, json, re
 data = json.load(sys.stdin)
-sid = data.get('session_id', 'unknown')
+sid = data.get('session_id', '')
 sha_raw = data.get('stop_hook_active', False)
 tp = data.get('transcript_path', '')
-# Shell-safe output — only allow alphanumeric, underscore, hyphen, slash, dot, tilde
+# Shell-safe output: only allow alphanumeric, underscore, hyphen, slash, dot, tilde
 safe = lambda s: re.sub(r'[^a-zA-Z0-9_/.\-~]', '', str(s))
 # Coerce stop_hook_active to strict boolean string
 sha = 'True' if sha_raw is True or str(sha_raw).lower() in ('true', '1', 'yes') else 'False'
+print('__MEMPAL_PARSE_OK__')
 print(safe(sid))
 print(sha)
 print(safe(tp))
-" 2>/dev/null)
-SESSION_ID="${_mempal_parsed[0]:-unknown}"
-STOP_HOOK_ACTIVE="${_mempal_parsed[1]:-False}"
-TRANSCRIPT_PATH="${_mempal_parsed[2]:-}"
+" 2>"$STATE_DIR/last_python_err.log")
+# The 2> redirect creates the file even when stderr is empty (success).
+# Remove the empty file so the state directory stays clean on the happy
+# path; on failure, lock the file's permissions to 600 to mirror
+# last_input.log's privacy contract (the traceback can reveal absolute
+# paths inside the user's home).
+if [ -s "$STATE_DIR/last_python_err.log" ]; then
+    chmod 600 "$STATE_DIR/last_python_err.log" 2>/dev/null
+else
+    rm -f "$STATE_DIR/last_python_err.log"
+fi
+_MEMPAL_PARSE_MARKER=$(printf '%s\n' "$_mempal_parsed" | sed -n '1p')
+SESSION_ID=$(printf '%s\n' "$_mempal_parsed" | sed -n '2p')
+STOP_HOOK_ACTIVE=$(printf '%s\n' "$_mempal_parsed" | sed -n '3p')
+TRANSCRIPT_PATH=$(printf '%s\n' "$_mempal_parsed" | sed -n '4p')
+SESSION_ID="${SESSION_ID:-unknown}"
+STOP_HOOK_ACTIVE="${STOP_HOOK_ACTIVE:-False}"
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-}"
+
+# Defense-in-depth: if INPUT was non-empty but Python never reached the
+# print() calls (sentinel missing), parsing silently failed. Surface the
+# raw payload so the next debugger does not lose a day to hook.log lines
+# that say "Session unknown". Bounded to 4 KB and overwritten on each
+# failure (not appended) to keep ~/.mempalace/hook_state/ from growing
+# unbounded under a repeating misconfiguration. chmod 600 so the dump,
+# which mirrors the Claude Code Stop payload (includes transcript_path
+# revealing the user's home + project layout), is not world-readable.
+if [ -n "$INPUT" ] && [ "$_MEMPAL_PARSE_MARKER" != "__MEMPAL_PARSE_OK__" ]; then
+    echo "[$(date '+%H:%M:%S')] WARN: input parse failed (sentinel missing); see $STATE_DIR/last_input.log and $STATE_DIR/last_python_err.log" >> "$STATE_DIR/hook.log"
+    # ``head -c 4096`` caps at exactly 4096 BYTES regardless of locale.
+    # Bash's ``${INPUT:0:4096}`` would count characters under a UTF-8
+    # locale, letting a CJK/emoji payload silently exceed the cap by up
+    # to 4x. ``set -o pipefail`` is not enabled in this script, so the
+    # natural ``head``-closes-stdin / SIGPIPE-on-printf interaction is
+    # silently absorbed by bash (the canonical way to read N bytes from
+    # a string in shell).
+    printf '%s' "$INPUT" | head -c 4096 > "$STATE_DIR/last_input.log"
+    chmod 600 "$STATE_DIR/last_input.log" 2>/dev/null
+fi
 
 # Expand ~ in path
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -105,7 +105,25 @@ INPUT=$(cat)
 # / future regression in this inline script" (ImportError, SyntaxError,
 # ModuleNotFoundError). Without the stderr capture, last_input.log shows
 # a valid payload while the actual root cause stays hidden.
-_mempal_parsed=$(echo "$INPUT" | "$MEMPAL_PYTHON_BIN" -c "
+#
+# Two extra hardenings inside the command-substitution subshell:
+#
+#   * ``umask 077`` so the ``2>$STATE_DIR/last_python_err.log`` redirect
+#     creates the file at mode 0600 atomically. Without it, the file
+#     appeared briefly at the parent process's umask (often 0644) before
+#     the explicit ``chmod 600`` below closed it — a small TOCTOU window
+#     where another local user on a shared box could read the traceback,
+#     which can echo back the user's home + project layout.
+#
+#   * ``printf '%s'`` in place of ``echo``. ``echo`` is unreliable for
+#     arbitrary payloads: it interprets ``-n``/``-e``/``-E`` as flags,
+#     handles backslashes inconsistently across builtin vs /bin/echo,
+#     and depends on the ``xpg_echo`` shopt on bash. JSON typically
+#     starts with ``{`` so the failure mode is latent, but flipping to
+#     ``printf '%s'`` removes the class of bug entirely.
+_mempal_parsed=$(
+    umask 077
+    printf '%s' "$INPUT" | "$MEMPAL_PYTHON_BIN" -c "
 import sys, json, re
 data = json.load(sys.stdin)
 sid = data.get('session_id', '')
@@ -119,7 +137,8 @@ print('__MEMPAL_PARSE_OK__')
 print(safe(sid))
 print(sha)
 print(safe(tp))
-" 2>"$STATE_DIR/last_python_err.log")
+" 2>"$STATE_DIR/last_python_err.log"
+)
 # The 2> redirect creates the file even when stderr is empty (success).
 # Remove the empty file so the state directory stays clean on the happy
 # path; on failure, lock the file's permissions to 600 to mirror
@@ -154,8 +173,11 @@ if [ -n "$INPUT" ] && [ "$_MEMPAL_PARSE_MARKER" != "__MEMPAL_PARSE_OK__" ]; then
     # to 4x. ``set -o pipefail`` is not enabled in this script, so the
     # natural ``head``-closes-stdin / SIGPIPE-on-printf interaction is
     # silently absorbed by bash (the canonical way to read N bytes from
-    # a string in shell).
-    printf '%s' "$INPUT" | head -c 4096 > "$STATE_DIR/last_input.log"
+    # a string in shell). The ``umask 077`` subshell creates
+    # last_input.log at mode 0600 atomically — the ``chmod 600`` below
+    # stays as a belt-and-suspenders guard if a future edit drops the
+    # umask line.
+    ( umask 077 && printf '%s' "$INPUT" | head -c 4096 > "$STATE_DIR/last_input.log" )
     chmod 600 "$STATE_DIR/last_input.log" 2>/dev/null
 fi
 

--- a/tests/test_hooks_bash_compat.py
+++ b/tests/test_hooks_bash_compat.py
@@ -57,9 +57,18 @@ def _run_hook(
     """Run a hook with a controlled environment and assert its exit code.
 
     Returns ``(stdout, stderr)``. On unexpected exit the assertion message
-    surfaces the captured stderr so CI failures are not silent (the hook
-    writes nothing useful to stdout on error, all diagnostics go to
-    stderr or hook.log).
+    surfaces the captured stderr so CI failures are not silent. The hook's
+    primary diagnostic stream is ``$STATE_DIR/hook.log`` plus the two
+    sidecar dumps ``last_input.log`` / ``last_python_err.log``; the
+    subprocess's stderr is typically empty on the documented exit paths
+    and is captured here only to surface unexpected interpreter failures
+    (e.g., a bash syntax error on a future edit).
+
+    Forces ``umask 0o022`` in the child so the hook's own ``umask 077``
+    inside the parse subshell is provably the sole reason the diagnostic
+    files end up at mode 0600 — without this, a permissive ambient umask
+    on the CI runner would mask a regression that drops the in-hook
+    ``umask`` line.
     """
     env = {
         "HOME": str(home),
@@ -74,6 +83,7 @@ def _run_hook(
         text=True,
         env=env,
         timeout=30,
+        preexec_fn=lambda: os.umask(0o022),
     )
     assert p.returncode == expected_rc, (
         f"{hook.name} exited {p.returncode} (expected {expected_rc}); "

--- a/tests/test_hooks_bash_compat.py
+++ b/tests/test_hooks_bash_compat.py
@@ -11,7 +11,7 @@ These tests cover:
 2. Behavioral parse contract (session_id reaches the log, not 'unknown').
 3. The fail-loud guard: fires only when the parser sentinel is missing,
    never on a legitimately empty/unicode/literal-'unknown' session_id.
-4. The guard's disk discipline (bounded dump, overwrite-not-append).
+4. The guard's disk discipline (bounded dump, overwrite-not-append, 0600).
 """
 
 from __future__ import annotations
@@ -28,6 +28,15 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SAVE_HOOK = REPO_ROOT / "hooks" / "mempal_save_hook.sh"
 PRECOMPACT_HOOK = REPO_ROOT / "hooks" / "mempal_precompact_hook.sh"
 
+# Re-used by every parametrize decorator that runs the same test against
+# both hooks. ``ids=`` keeps pytest output readable (`...[save_hook]`
+# rather than the default `hook0`/`hook1`).
+_BOTH_HOOKS = pytest.mark.parametrize(
+    "hook",
+    [SAVE_HOOK, PRECOMPACT_HOOK],
+    ids=["save_hook", "precompact_hook"],
+)
+
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="bash hook scripts are POSIX-only")
 
 
@@ -37,11 +46,27 @@ def _hook_src_no_comments(hook: Path) -> str:
     )
 
 
-def _run_hook(hook: Path, stdin: str, home: Path) -> tuple[int, str]:
+def _run_hook(
+    hook: Path,
+    stdin: str,
+    home: Path,
+    *,
+    expected_rc: int = 0,
+    extra_env: dict | None = None,
+) -> tuple[str, str]:
+    """Run a hook with a controlled environment and assert its exit code.
+
+    Returns ``(stdout, stderr)``. On unexpected exit the assertion message
+    surfaces the captured stderr so CI failures are not silent (the hook
+    writes nothing useful to stdout on error, all diagnostics go to
+    stderr or hook.log).
+    """
     env = {
         "HOME": str(home),
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
     }
+    if extra_env:
+        env.update(extra_env)
     p = subprocess.run(
         ["bash", str(hook)],
         input=stdin,
@@ -50,31 +75,41 @@ def _run_hook(hook: Path, stdin: str, home: Path) -> tuple[int, str]:
         env=env,
         timeout=30,
     )
-    return p.returncode, p.stdout
+    assert p.returncode == expected_rc, (
+        f"{hook.name} exited {p.returncode} (expected {expected_rc}); "
+        f"stderr={p.stderr!r}; stdout={p.stdout!r}"
+    )
+    return p.stdout, p.stderr
 
 
 class TestNoBash4OnlyBuiltins:
-    """Source-level regression: mapfile/readarray unavailable on macOS bash 3.2."""
+    """Source-level regression: bash 4.0 array-read builtins are unavailable on macOS bash 3.2."""
 
-    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    @_BOTH_HOOKS
     def test_no_mapfile(self, hook):
         code = _hook_src_no_comments(hook)
-        assert "mapfile" not in code, (
-            f"{hook.name} uses mapfile, unavailable on macOS /bin/bash 3.2 (#1440)"
-        )
-        assert "readarray" not in code, (
-            f"{hook.name} uses readarray, unavailable on macOS /bin/bash 3.2 (#1440)"
-        )
+        assert (
+            "mapfile" not in code
+        ), f"{hook.name} uses mapfile, unavailable on macOS /bin/bash 3.2 (#1440)"
+        assert (
+            "readarray" not in code
+        ), f"{hook.name} uses readarray, unavailable on macOS /bin/bash 3.2 (#1440)"
 
-    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    @_BOTH_HOOKS
     def test_sed_extraction_present(self, hook):
-        src = hook.read_text()
+        # Strip ``#`` line comments before counting so the assertion fails
+        # if all live ``sed -n 'Np'`` calls are deleted but the explanatory
+        # comments above the parse block (which mention ``sed -n 'Np'``
+        # several times in prose) are left behind — otherwise the test
+        # would false-pass on a regression that swapped the extraction
+        # method back to ``mapfile`` while keeping the old commentary.
+        src = _hook_src_no_comments(hook)
         # Each hook reads at least two values via ``sed -n 'Np'`` (sentinel + session_id).
-        assert src.count("sed -n '") >= 2, (
-            f"{hook.name} must use sed -n 'Np' for POSIX-portable line extraction"
-        )
+        assert (
+            src.count("sed -n '") >= 2
+        ), f"{hook.name} must use sed -n 'Np' for POSIX-portable line extraction"
 
-    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    @_BOTH_HOOKS
     def test_bash_syntax_clean(self, hook):
         p = subprocess.run(
             ["bash", "-n", str(hook)],
@@ -88,14 +123,13 @@ class TestSessionIdExtraction:
     """Hook must parse session_id from valid JSON, not fall back to 'unknown'."""
 
     def test_save_hook_extracts_session_id(self, tmp_path):
-        rc, out = _run_hook(
+        out, _ = _run_hook(
             SAVE_HOOK,
             json.dumps(
                 {"session_id": "abc12345", "stop_hook_active": False, "transcript_path": ""}
             ),
             tmp_path,
         )
-        assert rc == 0
         # Stdout must be valid JSON; Claude Code parses it. A regression that
         # leaks debug output here would silently break the harness contract.
         assert json.loads(out) == {}, f"hook stdout must be valid JSON, got: {out!r}"
@@ -106,24 +140,25 @@ class TestSessionIdExtraction:
         assert "WARN: input parse failed" not in log
         state_dir = tmp_path / ".mempalace" / "hook_state"
         assert not (state_dir / "last_input.log").exists()
-        assert not (state_dir / "last_python_err.log").exists(), (
-            "successful parse must leave no last_python_err.log behind"
-        )
+        assert not (
+            state_dir / "last_python_err.log"
+        ).exists(), "successful parse must leave no last_python_err.log behind"
 
     def test_precompact_hook_extracts_session_id(self, tmp_path):
-        rc, out = _run_hook(
+        out, _ = _run_hook(
             PRECOMPACT_HOOK,
             json.dumps({"session_id": "abc12345", "transcript_path": ""}),
             tmp_path,
         )
-        assert rc == 0
         assert json.loads(out) == {}, f"hook stdout must be valid JSON, got: {out!r}"
         log = (tmp_path / ".mempalace" / "hook_state" / "hook.log").read_text()
         assert "PRE-COMPACT triggered for session abc12345" in log
         assert "WARN: input parse failed" not in log
         state_dir = tmp_path / ".mempalace" / "hook_state"
         assert not (state_dir / "last_input.log").exists()
-        assert not (state_dir / "last_python_err.log").exists()
+        assert not (
+            state_dir / "last_python_err.log"
+        ).exists(), "successful parse must leave no last_python_err.log behind"
 
 
 class TestFailLoudGuard:
@@ -132,80 +167,92 @@ class TestFailLoudGuard:
     user-private. The guard must NOT fire on legitimately empty inputs
     or on sanitizer-stripped session_ids (#1440)."""
 
-    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    @_BOTH_HOOKS
     def test_malformed_input_logs_warning_and_dumps_input(self, hook, tmp_path):
-        rc, _ = _run_hook(hook, "not-json garbage", tmp_path)
-        assert rc == 0
+        _run_hook(hook, "not-json garbage", tmp_path)
         state_dir = tmp_path / ".mempalace" / "hook_state"
         log = (state_dir / "hook.log").read_text()
         last_input = (state_dir / "last_input.log").read_text()
         assert "WARN: input parse failed (sentinel missing)" in log
         assert "not-json garbage" in last_input
 
-    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    @_BOTH_HOOKS
     def test_empty_stdin_does_not_dump_or_warn(self, hook, tmp_path):
         """Empty stdin is a legitimate state (e.g. a hook re-fire on Stop
         with no message body). The guard's ``[ -n "$INPUT" ]`` short-circuit
         must hold so nothing is written to last_input.log."""
-        rc, _ = _run_hook(hook, "", tmp_path)
-        assert rc == 0
+        _run_hook(hook, "", tmp_path)
         state_dir = tmp_path / ".mempalace" / "hook_state"
         assert not (state_dir / "last_input.log").exists()
         log_path = state_dir / "hook.log"
         if log_path.exists():
             assert "WARN: input parse failed" not in log_path.read_text()
 
-    def test_unicode_session_id_does_not_trip_guard(self, tmp_path):
+    @_BOTH_HOOKS
+    def test_unicode_session_id_does_not_trip_guard(self, hook, tmp_path):
         """A session_id with non-ASCII characters (Cyrillic, CJK, emoji)
         is stripped by the sanitizer to '', defaults to 'unknown'. The
-        sentinel still printed, so the guard must skip and NOT spam disk."""
-        rc, _ = _run_hook(
-            SAVE_HOOK,
+        sentinel still printed, so the guard must skip and NOT spam disk.
+        Parametrized over both hooks: each has its own inline Python
+        parser and its own sanitizer regex, so a copy-paste regression
+        in only one would otherwise be invisible. The precompact parser
+        ignores the ``stop_hook_active`` key, so the same payload works
+        for both."""
+        _run_hook(
+            hook,
             json.dumps({"session_id": "сессия", "stop_hook_active": False, "transcript_path": ""}),
             tmp_path,
         )
-        assert rc == 0
         state_dir = tmp_path / ".mempalace" / "hook_state"
-        assert not (state_dir / "last_input.log").exists(), (
-            "unicode-only session_id sanitized to empty must NOT trip the guard"
-        )
+        assert not (
+            state_dir / "last_input.log"
+        ).exists(), "unicode-only session_id sanitized to empty must NOT trip the guard"
 
-    def test_literal_unknown_session_id_does_not_trip_guard(self, tmp_path):
+    @_BOTH_HOOKS
+    def test_literal_unknown_session_id_does_not_trip_guard(self, hook, tmp_path):
         """A user who literally passes session_id='unknown' is parsing
         cleanly; the sentinel-based guard must distinguish that from a
-        crash and skip the dump."""
-        rc, _ = _run_hook(
-            SAVE_HOOK,
+        crash and skip the dump. Parametrized over both hooks for the
+        same reason as the unicode test: the sentinel logic is duplicated
+        between the two parsers."""
+        _run_hook(
+            hook,
             json.dumps({"session_id": "unknown", "stop_hook_active": False, "transcript_path": ""}),
             tmp_path,
         )
-        assert rc == 0
         state_dir = tmp_path / ".mempalace" / "hook_state"
-        assert not (state_dir / "last_input.log").exists(), (
-            "literal session_id='unknown' must NOT trip the guard"
-        )
+        assert not (
+            state_dir / "last_input.log"
+        ).exists(), "literal session_id='unknown' must NOT trip the guard"
 
-    def test_dump_is_bounded_and_overwritten(self, tmp_path):
+    @_BOTH_HOOKS
+    def test_dump_is_bounded_and_overwritten(self, hook, tmp_path):
         """The dump caps at exactly 4096 bytes and overwrites on each
         failure so a repeating misconfiguration cannot grow the file
-        unbounded."""
+        unbounded. Both payloads here are intentionally not-valid-JSON so
+        the guard fires on each call — the overwrite contract is what
+        is being tested, not the validation logic. Parametrized over
+        both hooks because each hook has its own ``head -c 4096 > ...``
+        line — a future edit that flips one to ``>>`` would not be caught
+        by a save-only test."""
         # 4097 bytes: one over the cap, proves the cutoff fires at exactly
         # 4096 (a regression that silently shrinks the cap to e.g. 1024
         # would slip past a looser ``<= 4096`` check).
         big_payload = "x" * 4097
-        rc, _ = _run_hook(SAVE_HOOK, big_payload, tmp_path)
-        assert rc == 0
+        _run_hook(hook, big_payload, tmp_path)
         last_input = tmp_path / ".mempalace" / "hook_state" / "last_input.log"
-        assert last_input.stat().st_size == 4096, (
-            f"cap must be exactly 4096 bytes; got {last_input.stat().st_size}"
-        )
-        # Second failure with a smaller payload overwrites the first; the
-        # file shrinks instead of accumulating.
-        rc, _ = _run_hook(SAVE_HOOK, "tiny", tmp_path)
-        assert rc == 0
+        assert (
+            last_input.stat().st_size == 4096
+        ), f"cap must be exactly 4096 bytes; got {last_input.stat().st_size}"
+        # Second failure with a smaller payload (also not valid JSON, so the
+        # guard fires) overwrites the first; the file shrinks instead of
+        # accumulating.
+        _run_hook(hook, "tiny", tmp_path)
+        assert last_input.exists(), "second guard fire must produce a file, not skip the write"
         assert last_input.read_text() == "tiny", "dump must overwrite on each failure, not append"
 
-    def test_dump_cap_holds_under_utf8_locale(self, tmp_path):
+    @_BOTH_HOOKS
+    def test_dump_cap_holds_under_utf8_locale(self, hook, tmp_path):
         """Under a UTF-8 locale, a multibyte payload of 2000 CJK chars =
         6000 bytes would slip a character-counted substring (`${var:0:N}`)
         past the 4096-byte cap. The hook uses ``head -c`` precisely so
@@ -215,23 +262,14 @@ class TestFailLoudGuard:
         # bash falls back to the byte-based C locale gracefully;
         # ``en_US.UTF-8`` would silently degrade to no-op on minimal CI
         # images (Alpine, distroless) where that locale is not generated.
-        env = {
-            "HOME": str(tmp_path),
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-            "LANG": "C.UTF-8",
-            "LC_ALL": "C.UTF-8",
-        }
         # 2000 copies of U+4E2D (3 bytes each in UTF-8) = 6000 bytes.
         big_payload = "中" * 2000
-        p = subprocess.run(
-            ["bash", str(SAVE_HOOK)],
-            input=big_payload,
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=30,
+        _run_hook(
+            hook,
+            big_payload,
+            tmp_path,
+            extra_env={"LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"},
         )
-        assert p.returncode == 0
         last_input = tmp_path / ".mempalace" / "hook_state" / "last_input.log"
         size = last_input.stat().st_size
         assert size == 4096, (
@@ -239,40 +277,38 @@ class TestFailLoudGuard:
             "regression to ${var:0:N} would let multibyte input bypass the bound"
         )
 
-    def test_dump_is_not_world_readable(self, tmp_path):
-        """The dump mirrors the raw Stop payload (transcript_path reveals
+    @_BOTH_HOOKS
+    def test_dump_is_not_world_readable(self, hook, tmp_path):
+        """The dump mirrors the raw hook payload (transcript_path reveals
         the user's home + project layout). Permissions must be 600 so
         other users on a shared box cannot read it."""
-        rc, _ = _run_hook(SAVE_HOOK, "not-json garbage", tmp_path)
-        assert rc == 0
+        _run_hook(hook, "not-json garbage", tmp_path)
         last_input = tmp_path / ".mempalace" / "hook_state" / "last_input.log"
         mode = stat.S_IMODE(last_input.stat().st_mode)
         assert mode == 0o600, f"last_input.log mode should be 0600, got {oct(mode)}"
 
-    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    @_BOTH_HOOKS
     def test_python_stderr_captured_on_parse_failure(self, hook, tmp_path):
         """When the inline Python parser crashes (malformed JSON, missing
         interpreter, future regression), its stderr must land in
         last_python_err.log so a debugger can distinguish 'bad user
         input' from 'broken interpreter or broken inline script'."""
-        rc, _ = _run_hook(hook, "not-json garbage", tmp_path)
-        assert rc == 0
+        _run_hook(hook, "not-json garbage", tmp_path)
         err_log = tmp_path / ".mempalace" / "hook_state" / "last_python_err.log"
         assert err_log.exists(), "Python stderr must be captured on parse failure"
         contents = err_log.read_text()
         # Python's json.load raises JSONDecodeError with a recognizable
         # traceback. Don't pin the exact message (it varies by Python
         # version) but assert at least one canonical marker is present.
-        assert "Traceback" in contents or "json" in contents.lower(), (
-            f"expected Python traceback or json error, got: {contents!r}"
-        )
+        assert (
+            "Traceback" in contents or "json" in contents.lower()
+        ), f"expected Python traceback or json error, got: {contents!r}"
 
-    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    @_BOTH_HOOKS
     def test_python_stderr_log_is_not_world_readable_on_failure(self, hook, tmp_path):
         """The stderr capture mirrors the privacy expectation of
         last_input.log: on a populated failure write it must be 0600."""
-        rc, _ = _run_hook(hook, "not-json garbage", tmp_path)
-        assert rc == 0
+        _run_hook(hook, "not-json garbage", tmp_path)
         err_log = tmp_path / ".mempalace" / "hook_state" / "last_python_err.log"
         mode = stat.S_IMODE(err_log.stat().st_mode)
         assert mode == 0o600, f"last_python_err.log mode should be 0600 on failure, got {oct(mode)}"

--- a/tests/test_hooks_bash_compat.py
+++ b/tests/test_hooks_bash_compat.py
@@ -1,0 +1,278 @@
+"""Regression tests for the bash 3.2 compatibility fix (#1440).
+
+The legacy hooks/*.sh scripts run on the user's system. On stock macOS
+that is GNU bash 3.2.57 (Apple GPLv3 freeze, 2006). Using bash 4.0-only
+builtins like ``mapfile`` silently breaks parsing: every JSON field
+falls back to its default, the hook logs ``Session unknown: 0 exchanges``,
+and zero drawers are saved.
+
+These tests cover:
+1. Source-level shape (mapfile/readarray absent, sed-based extraction).
+2. Behavioral parse contract (session_id reaches the log, not 'unknown').
+3. The fail-loud guard: fires only when the parser sentinel is missing,
+   never on a legitimately empty/unicode/literal-'unknown' session_id.
+4. The guard's disk discipline (bounded dump, overwrite-not-append).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAVE_HOOK = REPO_ROOT / "hooks" / "mempal_save_hook.sh"
+PRECOMPACT_HOOK = REPO_ROOT / "hooks" / "mempal_precompact_hook.sh"
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="bash hook scripts are POSIX-only")
+
+
+def _hook_src_no_comments(hook: Path) -> str:
+    return "\n".join(
+        line for line in hook.read_text().splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _run_hook(hook: Path, stdin: str, home: Path) -> tuple[int, str]:
+    env = {
+        "HOME": str(home),
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+    }
+    p = subprocess.run(
+        ["bash", str(hook)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    return p.returncode, p.stdout
+
+
+class TestNoBash4OnlyBuiltins:
+    """Source-level regression: mapfile/readarray unavailable on macOS bash 3.2."""
+
+    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    def test_no_mapfile(self, hook):
+        code = _hook_src_no_comments(hook)
+        assert "mapfile" not in code, (
+            f"{hook.name} uses mapfile, unavailable on macOS /bin/bash 3.2 (#1440)"
+        )
+        assert "readarray" not in code, (
+            f"{hook.name} uses readarray, unavailable on macOS /bin/bash 3.2 (#1440)"
+        )
+
+    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    def test_sed_extraction_present(self, hook):
+        src = hook.read_text()
+        # Each hook reads at least two values via ``sed -n 'Np'`` (sentinel + session_id).
+        assert src.count("sed -n '") >= 2, (
+            f"{hook.name} must use sed -n 'Np' for POSIX-portable line extraction"
+        )
+
+    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    def test_bash_syntax_clean(self, hook):
+        p = subprocess.run(
+            ["bash", "-n", str(hook)],
+            capture_output=True,
+            text=True,
+        )
+        assert p.returncode == 0, f"{hook.name} syntax error: {p.stderr}"
+
+
+class TestSessionIdExtraction:
+    """Hook must parse session_id from valid JSON, not fall back to 'unknown'."""
+
+    def test_save_hook_extracts_session_id(self, tmp_path):
+        rc, out = _run_hook(
+            SAVE_HOOK,
+            json.dumps(
+                {"session_id": "abc12345", "stop_hook_active": False, "transcript_path": ""}
+            ),
+            tmp_path,
+        )
+        assert rc == 0
+        # Stdout must be valid JSON; Claude Code parses it. A regression that
+        # leaks debug output here would silently break the harness contract.
+        assert json.loads(out) == {}, f"hook stdout must be valid JSON, got: {out!r}"
+        log = (tmp_path / ".mempalace" / "hook_state" / "hook.log").read_text()
+        assert "Session abc12345:" in log, f"got fallback 'unknown'; log was: {log!r}"
+        # Negative cross-check: the sentinel-distinguishes-success-from-failure
+        # contract has no value if the guard fires on the happy path too.
+        assert "WARN: input parse failed" not in log
+        state_dir = tmp_path / ".mempalace" / "hook_state"
+        assert not (state_dir / "last_input.log").exists()
+        assert not (state_dir / "last_python_err.log").exists(), (
+            "successful parse must leave no last_python_err.log behind"
+        )
+
+    def test_precompact_hook_extracts_session_id(self, tmp_path):
+        rc, out = _run_hook(
+            PRECOMPACT_HOOK,
+            json.dumps({"session_id": "abc12345", "transcript_path": ""}),
+            tmp_path,
+        )
+        assert rc == 0
+        assert json.loads(out) == {}, f"hook stdout must be valid JSON, got: {out!r}"
+        log = (tmp_path / ".mempalace" / "hook_state" / "hook.log").read_text()
+        assert "PRE-COMPACT triggered for session abc12345" in log
+        assert "WARN: input parse failed" not in log
+        state_dir = tmp_path / ".mempalace" / "hook_state"
+        assert not (state_dir / "last_input.log").exists()
+        assert not (state_dir / "last_python_err.log").exists()
+
+
+class TestFailLoudGuard:
+    """Non-parseable stdin must dump the input and warn in hook.log so
+    future silent failures are loud, and the dump must stay bounded and
+    user-private. The guard must NOT fire on legitimately empty inputs
+    or on sanitizer-stripped session_ids (#1440)."""
+
+    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    def test_malformed_input_logs_warning_and_dumps_input(self, hook, tmp_path):
+        rc, _ = _run_hook(hook, "not-json garbage", tmp_path)
+        assert rc == 0
+        state_dir = tmp_path / ".mempalace" / "hook_state"
+        log = (state_dir / "hook.log").read_text()
+        last_input = (state_dir / "last_input.log").read_text()
+        assert "WARN: input parse failed (sentinel missing)" in log
+        assert "not-json garbage" in last_input
+
+    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    def test_empty_stdin_does_not_dump_or_warn(self, hook, tmp_path):
+        """Empty stdin is a legitimate state (e.g. a hook re-fire on Stop
+        with no message body). The guard's ``[ -n "$INPUT" ]`` short-circuit
+        must hold so nothing is written to last_input.log."""
+        rc, _ = _run_hook(hook, "", tmp_path)
+        assert rc == 0
+        state_dir = tmp_path / ".mempalace" / "hook_state"
+        assert not (state_dir / "last_input.log").exists()
+        log_path = state_dir / "hook.log"
+        if log_path.exists():
+            assert "WARN: input parse failed" not in log_path.read_text()
+
+    def test_unicode_session_id_does_not_trip_guard(self, tmp_path):
+        """A session_id with non-ASCII characters (Cyrillic, CJK, emoji)
+        is stripped by the sanitizer to '', defaults to 'unknown'. The
+        sentinel still printed, so the guard must skip and NOT spam disk."""
+        rc, _ = _run_hook(
+            SAVE_HOOK,
+            json.dumps({"session_id": "сессия", "stop_hook_active": False, "transcript_path": ""}),
+            tmp_path,
+        )
+        assert rc == 0
+        state_dir = tmp_path / ".mempalace" / "hook_state"
+        assert not (state_dir / "last_input.log").exists(), (
+            "unicode-only session_id sanitized to empty must NOT trip the guard"
+        )
+
+    def test_literal_unknown_session_id_does_not_trip_guard(self, tmp_path):
+        """A user who literally passes session_id='unknown' is parsing
+        cleanly; the sentinel-based guard must distinguish that from a
+        crash and skip the dump."""
+        rc, _ = _run_hook(
+            SAVE_HOOK,
+            json.dumps({"session_id": "unknown", "stop_hook_active": False, "transcript_path": ""}),
+            tmp_path,
+        )
+        assert rc == 0
+        state_dir = tmp_path / ".mempalace" / "hook_state"
+        assert not (state_dir / "last_input.log").exists(), (
+            "literal session_id='unknown' must NOT trip the guard"
+        )
+
+    def test_dump_is_bounded_and_overwritten(self, tmp_path):
+        """The dump caps at exactly 4096 bytes and overwrites on each
+        failure so a repeating misconfiguration cannot grow the file
+        unbounded."""
+        # 4097 bytes: one over the cap, proves the cutoff fires at exactly
+        # 4096 (a regression that silently shrinks the cap to e.g. 1024
+        # would slip past a looser ``<= 4096`` check).
+        big_payload = "x" * 4097
+        rc, _ = _run_hook(SAVE_HOOK, big_payload, tmp_path)
+        assert rc == 0
+        last_input = tmp_path / ".mempalace" / "hook_state" / "last_input.log"
+        assert last_input.stat().st_size == 4096, (
+            f"cap must be exactly 4096 bytes; got {last_input.stat().st_size}"
+        )
+        # Second failure with a smaller payload overwrites the first; the
+        # file shrinks instead of accumulating.
+        rc, _ = _run_hook(SAVE_HOOK, "tiny", tmp_path)
+        assert rc == 0
+        assert last_input.read_text() == "tiny", "dump must overwrite on each failure, not append"
+
+    def test_dump_cap_holds_under_utf8_locale(self, tmp_path):
+        """Under a UTF-8 locale, a multibyte payload of 2000 CJK chars =
+        6000 bytes would slip a character-counted substring (`${var:0:N}`)
+        past the 4096-byte cap. The hook uses ``head -c`` precisely so
+        the bound stays byte-based regardless of locale."""
+        # ``C.UTF-8`` is available on every mainstream Linux distribution
+        # (Debian/Ubuntu, Fedora, RHEL 8+, Alpine via musl) and macOS
+        # bash falls back to the byte-based C locale gracefully;
+        # ``en_US.UTF-8`` would silently degrade to no-op on minimal CI
+        # images (Alpine, distroless) where that locale is not generated.
+        env = {
+            "HOME": str(tmp_path),
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+        }
+        # 2000 copies of U+4E2D (3 bytes each in UTF-8) = 6000 bytes.
+        big_payload = "中" * 2000
+        p = subprocess.run(
+            ["bash", str(SAVE_HOOK)],
+            input=big_payload,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        assert p.returncode == 0
+        last_input = tmp_path / ".mempalace" / "hook_state" / "last_input.log"
+        size = last_input.stat().st_size
+        assert size == 4096, (
+            f"UTF-8 payload must still cap at 4096 bytes (got {size}); "
+            "regression to ${var:0:N} would let multibyte input bypass the bound"
+        )
+
+    def test_dump_is_not_world_readable(self, tmp_path):
+        """The dump mirrors the raw Stop payload (transcript_path reveals
+        the user's home + project layout). Permissions must be 600 so
+        other users on a shared box cannot read it."""
+        rc, _ = _run_hook(SAVE_HOOK, "not-json garbage", tmp_path)
+        assert rc == 0
+        last_input = tmp_path / ".mempalace" / "hook_state" / "last_input.log"
+        mode = stat.S_IMODE(last_input.stat().st_mode)
+        assert mode == 0o600, f"last_input.log mode should be 0600, got {oct(mode)}"
+
+    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    def test_python_stderr_captured_on_parse_failure(self, hook, tmp_path):
+        """When the inline Python parser crashes (malformed JSON, missing
+        interpreter, future regression), its stderr must land in
+        last_python_err.log so a debugger can distinguish 'bad user
+        input' from 'broken interpreter or broken inline script'."""
+        rc, _ = _run_hook(hook, "not-json garbage", tmp_path)
+        assert rc == 0
+        err_log = tmp_path / ".mempalace" / "hook_state" / "last_python_err.log"
+        assert err_log.exists(), "Python stderr must be captured on parse failure"
+        contents = err_log.read_text()
+        # Python's json.load raises JSONDecodeError with a recognizable
+        # traceback. Don't pin the exact message (it varies by Python
+        # version) but assert at least one canonical marker is present.
+        assert "Traceback" in contents or "json" in contents.lower(), (
+            f"expected Python traceback or json error, got: {contents!r}"
+        )
+
+    @pytest.mark.parametrize("hook", [SAVE_HOOK, PRECOMPACT_HOOK])
+    def test_python_stderr_log_is_not_world_readable_on_failure(self, hook, tmp_path):
+        """The stderr capture mirrors the privacy expectation of
+        last_input.log: on a populated failure write it must be 0600."""
+        rc, _ = _run_hook(hook, "not-json garbage", tmp_path)
+        assert rc == 0
+        err_log = tmp_path / ".mempalace" / "hook_state" / "last_python_err.log"
+        mode = stat.S_IMODE(err_log.stat().st_mode)
+        assert mode == 0o600, f"last_python_err.log mode should be 0600 on failure, got {oct(mode)}"


### PR DESCRIPTION
## What this PR does

The legacy `hooks/mempal_save_hook.sh` and `hooks/mempal_precompact_hook.sh` use `mapfile -t` (introduced in #1231) to read sanitized values from the inline Python JSON parser. On stock macOS `/bin/bash` is GNU 3.2.57 (Apple GPLv3 freeze) and `mapfile` only landed in bash 4.0 (2009), so the hook silently fails: every parsed value falls back to its default, the log writes `Session unknown: 0 exchanges`, and the hook returns `{}` + exit 0. Users see hooks "firing" with zero drawers added (#1440).

This PR replaces the array read with `sed -n 'Np'` line extraction, keeping the same one-value-per-line contract from the #1231 security hardening but staying within POSIX so `/bin/bash` 3.2 runs the scripts unmodified.

It also adds a defense-in-depth fail-loud guard. Python now prints a leading `__MEMPAL_PARSE_OK__` sentinel; if the sentinel is missing after parsing, the hook writes a `WARN` line to `hook.log` and dumps the first 4096 bytes of the raw input to `last_input.log` plus the Python traceback to `last_python_err.log`, both at mode 0600. This means the next time parsing silently fails for any reason (sanitizer regex too tight, broken interpreter, future inline-script regression), a maintainer has the raw payload and the Python error instead of a day of "Session unknown" log lines.

## How to test

- New tests: `tests/test_hooks_bash_compat.py` (26 cases, mirrored across both hooks where applicable) cover (a) `mapfile`/`readarray` absent in both scripts, (b) `sed -n` extraction shape present, (c) hook produces the expected log line under controlled stdin, (d) fail-loud guard fires on malformed JSON but not on empty stdin / unicode-stripped / literal `"unknown"` session_id, (e) the dump caps at exactly 4096 bytes including under a UTF-8 locale with a multibyte payload, (f) `last_input.log` and `last_python_err.log` are mode 0600 on failure and absent on success, (g) hook stdout stays valid JSON.
- Full suite: `uv run pytest tests/ -v --ignore=tests/benchmarks` stays green.
- Manual: `echo '{"session_id":"abc","stop_hook_active":false,"transcript_path":""}' | bash hooks/mempal_save_hook.sh` and inspect `~/.mempalace/hook_state/hook.log` for `Session abc:`.

## Checklist

- [x] Tests added covering the regression
- [x] No CHANGELOG.md change (maintainer-managed)
- [x] No emoji / AI attribution in source or commits