### PR TITLE
feat(mcp): add since time-window filter + added_by/filed_at in list_drawers response

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1115,8 +1115,27 @@ def tool_get_drawer(drawer_id: str):
         return {"error": str(e)}
 
 
-def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offset: int = 0):
-    """List drawers with pagination. Optional wing/room filter."""
+def tool_list_drawers(
+    wing: str = None,
+    room: str = None,
+    limit: int = 20,
+    offset: int = 0,
+    since: str = None,
+):
+    """List drawers with pagination. Optional wing/room filter and time-window.
+
+    `since` is an ISO-8601 datetime string (e.g. "2026-05-11T00:00:00"). When
+    provided, only drawers with ``filed_at >= since`` are returned. ChromaDB
+    `$gte` only accepts numeric operands, so the filter is applied client-side
+    via lexicographic comparison on the stored ISO string. `offset` is ignored
+    when `since` is set — anomaly-detection / time-window queries want
+    newest-in-window, not arbitrary pagination.
+
+    Response shape also includes per-drawer ``added_by`` and ``filed_at``
+    fields, which are needed for provenance / anomaly-detection consumers
+    (e.g. guarding against spoofed agent identities by checking who filed
+    recent drawers in a given wing/room).
+    """
     limit = max(1, min(limit, _MAX_RESULTS))
     offset = max(0, offset)
     try:
@@ -1139,27 +1158,44 @@ def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offse
         elif len(conditions) > 1:
             where = {"$and": conditions}
 
-        kwargs = {"include": ["documents", "metadatas"], "limit": limit, "offset": offset}
-        if where:
-            kwargs["where"] = where
-        result = col.get(**kwargs)
-
-        # Compute total matching drawers for pagination.
-        if where:
-            total_result = col.get(where=where, include=[])
-            total = len(total_result["ids"])
+        if since:
+            kwargs = {"include": ["documents", "metadatas"]}
+            if where:
+                kwargs["where"] = where
+            result = col.get(**kwargs)
+            matched = []
+            for i, did in enumerate(result["ids"]):
+                meta = result["metadatas"][i] or {}
+                if meta.get("filed_at", "") < since:
+                    continue
+                doc = result["documents"][i]
+                matched.append((did, meta, doc))
+            total = len(matched)
+            sliced = matched[:limit]
         else:
-            total = col.count()
+            kwargs = {"include": ["documents", "metadatas"], "limit": limit, "offset": offset}
+            if where:
+                kwargs["where"] = where
+            result = col.get(**kwargs)
+            sliced = [
+                (result["ids"][i], result["metadatas"][i] or {}, result["documents"][i])
+                for i in range(len(result["ids"]))
+            ]
+            if where:
+                total_result = col.get(where=where, include=[])
+                total = len(total_result["ids"])
+            else:
+                total = col.count()
 
         drawers = []
-        for i, did in enumerate(result["ids"]):
-            meta = result["metadatas"][i]
-            doc = result["documents"][i]
+        for did, meta, doc in sliced:
             drawers.append(
                 {
                     "drawer_id": did,
                     "wing": meta.get("wing", ""),
                     "room": meta.get("room", ""),
+                    "added_by": meta.get("added_by", ""),
+                    "filed_at": meta.get("filed_at", ""),
                     "content_preview": doc[:200] + "..." if len(doc) > 200 else doc,
                 }
             )
@@ -1167,7 +1203,7 @@ def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offse
             "drawers": drawers,
             "total": total,
             "count": len(drawers),
-            "offset": offset,
+            "offset": offset if not since else 0,
             "limit": limit,
         }
     except Exception as e:
@@ -2015,7 +2051,7 @@ TOOLS = {
         "handler": tool_get_drawer,
     },
     "mempalace_list_drawers": {
-        "description": "List drawers with pagination. Optional wing/room filter. Returns IDs, wings, rooms, content previews, and total matching count for pagination.",
+        "description": "List drawers with pagination, optional wing/room filter, and optional time-window via `since`. Returns drawer_id, wing, room, added_by, filed_at, content_preview, and total matching count.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -2029,8 +2065,12 @@ TOOLS = {
                 },
                 "offset": {
                     "type": "integer",
-                    "description": "Offset for pagination (default 0)",
+                    "description": "Offset for pagination (default 0). Ignored when `since` is set.",
                     "minimum": 0,
+                },
+                "since": {
+                    "type": "string",
+                    "description": "ISO-8601 datetime — only return drawers with filed_at >= since. Lexicographic comparison on the stored ISO string; works for same-timezone time-window queries.",
                 },
             },
         },

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -787,6 +787,67 @@ class TestWriteTools:
         result = tool_list_drawers(offset=-5)
         assert result["offset"] == 0
 
+    def test_list_drawers_includes_added_by_and_filed_at(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        result = tool_list_drawers(limit=4)
+        assert result["count"] == 4
+        for d in result["drawers"]:
+            assert "added_by" in d
+            assert "filed_at" in d
+            assert d["added_by"] == "miner"
+            assert d["filed_at"].startswith("2026-01-")
+
+    def test_list_drawers_since_filters_by_filed_at(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # Seed has filed_at: 2026-01-01, 2026-01-02, 2026-01-03, 2026-01-04
+        # since="2026-01-03T00:00:00" should yield the 3rd and 4th drawers
+        result = tool_list_drawers(since="2026-01-03T00:00:00")
+        assert result["count"] == 2
+        assert result["total"] == 2
+        filed_dates = sorted(d["filed_at"] for d in result["drawers"])
+        assert filed_dates == ["2026-01-03T00:00:00", "2026-01-04T00:00:00"]
+
+    def test_list_drawers_since_yields_zero_when_window_in_future(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        result = tool_list_drawers(since="2099-01-01T00:00:00")
+        assert result["count"] == 0
+        assert result["total"] == 0
+        assert result["drawers"] == []
+
+    def test_list_drawers_since_ignores_offset(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # offset=99 with since= should still return matches; offset reported as 0
+        result = tool_list_drawers(since="2026-01-01T00:00:00", offset=99)
+        assert result["count"] == 4
+        assert result["offset"] == 0
+
+    def test_list_drawers_since_combines_with_wing_filter(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # 3 drawers in wing=project; only 2 of them have filed_at >= 2026-01-02
+        result = tool_list_drawers(wing="project", since="2026-01-02T00:00:00")
+        assert result["count"] == 2
+        assert all(d["wing"] == "project" for d in result["drawers"])
+
     def test_update_drawer_content(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_update_drawer, tool_get_drawer


### PR DESCRIPTION
## Summary

Two additive extensions to `mempalace_list_drawers`:

1. **`since` kwarg** (ISO-8601 datetime). When set, returns only drawers with `filed_at >= since`. ChromaDB `$gte` only accepts numeric operands, so the filter runs client-side via lexicographic compare on the stored ISO string. `offset` is ignored in this mode (time-window queries want newest-in-window, not pagination) and the response reports `offset=0`.

2. **`added_by` and `filed_at` per drawer** in the response. These metadata fields are already stored by `tool_add_drawer`; this just surfaces them in the list output so consumers don't have to follow up with per-drawer `get_drawer` calls.

## Motivation

Driving use case: an HTTP bridge that delegates work to a remote agent files drawers tagged `added_by=<remote-agent-name>`. A periodic cron polls `list_drawers(wing, room, since=now-5min)` to detect identity spoofing by checking the `added_by` distribution over a recent window. With only `limit/offset` this required paginating until you crossed the time boundary or fetching everything in the wing/room.

Generally useful for any anomaly / provenance / freshness consumer.

## Backward compatibility

Fully backward compatible:
- `since=None` (default) preserves pre-existing behavior — same query path, same response, just two extra keys per drawer.
- The two new per-drawer fields are additive; existing consumers ignore them.

## Tests

5 new tests in `tests/test_mcp_server.py`:
- `test_list_drawers_includes_added_by_and_filed_at`
- `test_list_drawers_since_filters_by_filed_at`
- `test_list_drawers_since_yields_zero_when_window_in_future`
- `test_list_drawers_since_ignores_offset`
- `test_list_drawers_since_combines_with_wing_filter`

Full `test_mcp_server.py` suite passes (113/113) locally on Python 3.12.13.

## Design notes

- Client-side filter when `since` is set: ChromaDB `$gte` rejects string operands ("Expected operand value to be an int or a float for operator \$gte"). Lexicographic compare on ISO-8601 strings is correct as long as producer + consumer share a timezone (the use case is anomaly detection on a single machine over short windows, so this is fine in practice). Switching to a numeric `filed_at_epoch` would be a schema migration — separate PR if desired.
- Offset is ignored when `since` is set rather than honored, since the natural semantics of "drawers since X" is "the set of matching drawers", not "page N of that set".

🤖 Generated with [Claude Code](https://claude.com/claude-code)