### PR TITLE
Fix: Reject zero-byte HNSW link lists during quarantine (#1457)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -70,8 +70,34 @@ def _hnsw_link_to_data_ratio(seg_dir: str) -> Optional[float]:
     return link_size / data_size
 
 
+def _hnsw_link_lists_is_usable_for_payload(seg_dir: str) -> bool:
+    """Return False when a non-trivial HNSW payload lacks usable link lists.
+
+    A missing or empty link_lists.bin is acceptable only for a fresh/empty
+    segment. Once data_level0.bin has real payload, a zero-byte link_lists.bin
+    is not a harmless async-flush shape: ChromaDB can later hand the broken
+    graph to hnswlib and crash in native code.
+    """
+    data_path = os.path.join(seg_dir, "data_level0.bin")
+    link_path = os.path.join(seg_dir, "link_lists.bin")
+
+    try:
+        if not os.path.isfile(data_path):
+            return True
+
+        data_size = os.path.getsize(data_path)
+        if data_size <= _HNSW_MISSING_METADATA_DATA_FLOOR:
+            return True
+
+        return os.path.isfile(link_path) and os.path.getsize(link_path) > 0
+    except OSError:
+        return False
+
+
 def _hnsw_payload_appears_sane(seg_dir: str) -> bool:
     """Return False when HNSW payload files are structurally implausible."""
+    if not _hnsw_link_lists_is_usable_for_payload(seg_dir):
+        return False
 
     ratio = _hnsw_link_to_data_ratio(seg_dir)
     return ratio is None or ratio <= _HNSW_LINK_TO_DATA_MAX_RATIO

--- a/tests/test_hnsw_payload_health.py
+++ b/tests/test_hnsw_payload_health.py
@@ -111,3 +111,50 @@ def test_quarantine_leaves_reasonable_payload_in_place(tmp_path):
 
     assert moved == []
     assert seg_dir.exists()
+
+
+def test_segment_health_rejects_zero_byte_link_lists_with_payload(tmp_path):
+    """Regression #1457: real HNSW payload with empty link_lists.bin is corrupt."""
+    seg_dir = tmp_path / "11111111-2222-3333-4444-555555555555"
+
+    _write_segment(
+        seg_dir,
+        data_size=2_000,
+        link_size=0,
+        write_metadata=True,
+    )
+
+    assert not _segment_appears_healthy(str(seg_dir))
+
+
+def test_quarantine_catches_zero_byte_link_lists_when_stale(tmp_path):
+    """Regression #1457: stale segments with empty link_lists.bin are quarantined."""
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    db_path = palace / "chroma.sqlite3"
+    db_path.write_text("sqlite placeholder")
+
+    seg_dir = palace / "11111111-2222-3333-4444-555555555555"
+    _write_segment(
+        seg_dir,
+        data_size=2_000,
+        link_size=0,
+        write_metadata=True,
+    )
+
+    hnsw_time = 1_700_000_000
+    sqlite_time = hnsw_time + 1_000
+    os.utime(seg_dir / "data_level0.bin", (hnsw_time, hnsw_time))
+    os.utime(db_path, (sqlite_time, sqlite_time))
+
+    moved = quarantine_stale_hnsw(str(palace), stale_seconds=300)
+
+    assert len(moved) == 1
+    assert not seg_dir.exists()
+
+    moved_path = Path(moved[0])
+    assert moved_path.exists()
+    assert moved_path.name.startswith(
+        "11111111-2222-3333-4444-555555555555.drift-"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes #1457.

This tightens the HNSW segment integrity gate so a stale segment with non-trivial `data_level0.bin` payload and a missing or zero-byte `link_lists.bin` is treated as corrupt instead of healthy.

## Why

`quarantine_stale_hnsw()` already checks for some unsafe HNSW shapes before ChromaDB opens the native segment reader. However, a segment can still have:

- non-empty `data_level0.bin`
- valid-looking `index_metadata.pickle`
- zero-byte `link_lists.bin`

That shape is not a safe async-flush state. It means the graph links are missing even though vector payload exists, and letting ChromaDB/hnswlib open it can crash the process later.

## What changed

- Added a payload sanity check for non-trivial HNSW payloads with unusable `link_lists.bin`
- Kept fresh/empty segments allowed so normal ChromaDB async flush behavior is not over-quarantined
- Added regression tests for:
  - `_segment_appears_healthy()` rejecting zero-byte `link_lists.bin`
  - `quarantine_stale_hnsw()` moving a stale corrupt segment aside


## How to test

```bash
python -m pytest tests/test_hnsw_payload_health.py -q
python -m pytest tests/test_hnsw_payload_health.py -k "zero_byte or payload"
python -m ruff check mempalace/backends/chroma.py tests/test_hnsw_payload_health.py
python -m pytest tests/ -v

```
## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
