### PR TITLE
fix(miner): log skipped symlinks in mine paths (#1462)

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -296,6 +296,7 @@ def scan_convos(convo_dir: str) -> list:
             if filepath.suffix.lower() in CONVO_EXTENSIONS:
                 # Skip symlinks and oversized files
                 if filepath.is_symlink():
+                    print(f"  SKIP: {filepath.name} (symlink)")
                     continue
                 try:
                     if filepath.stat().st_size > MAX_FILE_SIZE:

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -284,7 +284,12 @@ def detect_convo_room(content: str) -> str:
 
 
 def scan_convos(convo_dir: str) -> list:
-    """Find all potential conversation files."""
+    """Find all potential conversation files.
+
+    Skips symlinks and oversized files. Each skipped symlink is logged to
+    ``sys.stderr`` with a ``  SKIP: <relative-path> (symlink)`` line so the
+    caller can tell why an apparent conversation directory yielded no files.
+    """
     convo_path = Path(convo_dir).expanduser().resolve()
     files = []
     for root, dirs, filenames in os.walk(convo_path):
@@ -296,7 +301,11 @@ def scan_convos(convo_dir: str) -> list:
             if filepath.suffix.lower() in CONVO_EXTENSIONS:
                 # Skip symlinks and oversized files
                 if filepath.is_symlink():
-                    print(f"  SKIP: {filepath.name} (symlink)")
+                    rel = filepath.relative_to(convo_path).as_posix()
+                    try:
+                        print(f"  SKIP: {rel} (symlink)", file=sys.stderr)
+                    except OSError:
+                        pass
                     continue
                 try:
                     if filepath.stat().st_size > MAX_FILE_SIZE:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1008,6 +1008,7 @@ def scan_project(
                     continue
             # Skip symlinks — prevents following links to /dev/urandom, etc.
             if filepath.is_symlink():
+                print(f"  SKIP: {filepath.name} (symlink)")
                 continue
             # Skip files exceeding size limit
             try:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -960,7 +960,12 @@ def scan_project(
     respect_gitignore: bool = True,
     include_ignored: list = None,
 ) -> list:
-    """Return list of all readable file paths."""
+    """Return list of all readable file paths under ``project_dir``.
+
+    Skips symlinks and oversized files. Each skipped symlink is logged to
+    ``sys.stderr`` with a ``  SKIP: <relative-path> (symlink)`` line so the
+    caller can tell why a directory looks empty after walking.
+    """
     project_path = Path(project_dir).expanduser().resolve()
     files = []
     active_matchers = []
@@ -1008,7 +1013,11 @@ def scan_project(
                     continue
             # Skip symlinks — prevents following links to /dev/urandom, etc.
             if filepath.is_symlink():
-                print(f"  SKIP: {filepath.name} (symlink)")
+                rel = filepath.relative_to(project_path).as_posix()
+                try:
+                    print(f"  SKIP: {rel} (symlink)", file=sys.stderr)
+                except OSError:
+                    pass
                 continue
             # Skip files exceeding size limit
             try:

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -115,6 +115,24 @@ class TestScanConvos:
         files = scan_convos(str(tmp_path))
         assert files == []
 
+    def test_scan_logs_skipped_symlinks(self, tmp_path, capsys):
+        real_target = tmp_path / "outside" / "real.txt"
+        real_target.parent.mkdir()
+        real_target.write_text("real content", encoding="utf-8")
+        link_root = tmp_path / "link_root"
+        link_root.mkdir()
+        (link_root / "link.txt").symlink_to(real_target)
+        (link_root / "regular.txt").write_text("regular content", encoding="utf-8")
+
+        files = scan_convos(str(link_root))
+
+        names = {f.name for f in files}
+        assert "link.txt" not in names
+        assert "regular.txt" in names
+        out = capsys.readouterr().out
+        assert out.count("SKIP:") == 1
+        assert "link.txt" in out
+
 
 class TestFileChunksLocked:
     def test_uses_bounded_upsert_batches(self, monkeypatch):

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -1,6 +1,9 @@
 """Unit tests for convo_miner pure functions (no chromadb needed)."""
 
 import contextlib
+import sys
+
+import pytest
 
 from mempalace.convo_miner import (
     _file_chunks_locked,
@@ -115,23 +118,74 @@ class TestScanConvos:
         files = scan_convos(str(tmp_path))
         assert files == []
 
-    def test_scan_logs_skipped_symlinks(self, tmp_path, capsys):
-        real_target = tmp_path / "outside" / "real.txt"
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="symlink creation requires elevated privileges on Windows",
+    )
+    def test_scan_convos_logs_skipped_symlinks(self, tmp_path, capsys):
+        real_target = tmp_path / "outside" / "real.jsonl"
         real_target.parent.mkdir()
-        real_target.write_text("real content", encoding="utf-8")
+        real_target.write_text('{"role":"user","content":"hi"}\n', encoding="utf-8")
         link_root = tmp_path / "link_root"
         link_root.mkdir()
-        (link_root / "link.txt").symlink_to(real_target)
-        (link_root / "regular.txt").write_text("regular content", encoding="utf-8")
+        (link_root / "link.jsonl").symlink_to(real_target)
+        (link_root / "regular.jsonl").write_text(
+            '{"role":"user","content":"hello"}\n', encoding="utf-8"
+        )
 
         files = scan_convos(str(link_root))
 
         names = {f.name for f in files}
-        assert "link.txt" not in names
-        assert "regular.txt" in names
-        out = capsys.readouterr().out
-        assert out.count("SKIP:") == 1
-        assert "link.txt" in out
+        assert "link.jsonl" not in names
+        assert "regular.jsonl" in names
+        err = capsys.readouterr().err
+        assert err.count("SKIP:") == 1
+        assert "  SKIP:" in err
+        assert "link.jsonl" in err
+        assert "(symlink)" in err
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="symlink creation requires elevated privileges on Windows",
+    )
+    def test_scan_convos_logs_dangling_symlink(self, tmp_path, capsys):
+        real_target = tmp_path / "outside" / "ghost.jsonl"
+        real_target.parent.mkdir()
+        real_target.touch()
+        link_root = tmp_path / "link_root"
+        link_root.mkdir()
+        (link_root / "dangling.jsonl").symlink_to(real_target)
+        real_target.unlink()  # target deleted, link dangles
+
+        files = scan_convos(str(link_root))
+
+        assert files == []
+        err = capsys.readouterr().err
+        assert err.count("SKIP:") == 1
+        assert "dangling.jsonl" in err
+        assert "(symlink)" in err
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="symlink creation requires elevated privileges on Windows",
+    )
+    def test_scan_convos_logs_nested_symlink_with_relative_path(self, tmp_path, capsys):
+        real_target = tmp_path / "outside" / "real.jsonl"
+        real_target.parent.mkdir()
+        real_target.write_text('{"x":1}\n', encoding="utf-8")
+        link_root = tmp_path / "link_root"
+        subdir = link_root / "deep" / "subdir"
+        subdir.mkdir(parents=True)
+        (subdir / "nested.jsonl").symlink_to(real_target)
+
+        files = scan_convos(str(link_root))
+
+        assert files == []
+        err = capsys.readouterr().err
+        # Forward slash even on Windows (as_posix) and full relative path,
+        # not just the leaf — proves relative_to(convo_path) over .name.
+        assert "deep/subdir/nested.jsonl" in err
+        assert "(symlink)" in err
 
 
 class TestFileChunksLocked:

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -253,6 +253,25 @@ def test_scan_project_skip_dirs_still_apply_without_override():
         shutil.rmtree(tmpdir)
 
 
+def test_scan_project_logs_skipped_symlinks(tmp_path, capsys):
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    real_target = tmp_path / "outside" / "real.md"
+    real_target.parent.mkdir()
+    real_target.write_text("real content\n" * 5, encoding="utf-8")
+    (project_root / "link.md").symlink_to(real_target)
+    (project_root / "regular.md").write_text("regular content\n" * 5, encoding="utf-8")
+
+    files = scan_project(str(project_root))
+
+    names = {f.name for f in files}
+    assert "link.md" not in names
+    assert "regular.md" in names
+    out = capsys.readouterr().out
+    assert out.count("SKIP:") == 1
+    assert "link.md" in out
+
+
 def test_entity_metadata_finds_cyrillic_names(monkeypatch):
     """Entity extraction must find non-Latin names when entity_languages includes the locale."""
     import mempalace.palace as palace_mod

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -1,10 +1,12 @@
 import os
 import shlex
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 
 import chromadb
+import pytest
 import yaml
 
 from mempalace.miner import detect_room, load_config, mine, scan_project, status
@@ -253,23 +255,72 @@ def test_scan_project_skip_dirs_still_apply_without_override():
         shutil.rmtree(tmpdir)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink creation requires elevated privileges on Windows",
+)
 def test_scan_project_logs_skipped_symlinks(tmp_path, capsys):
     project_root = tmp_path / "proj"
     project_root.mkdir()
     real_target = tmp_path / "outside" / "real.md"
-    real_target.parent.mkdir()
-    real_target.write_text("real content\n" * 5, encoding="utf-8")
+    write_file(real_target, "real content\n" * 5)
     (project_root / "link.md").symlink_to(real_target)
-    (project_root / "regular.md").write_text("regular content\n" * 5, encoding="utf-8")
+    write_file(project_root / "regular.md", "regular content\n" * 5)
 
-    files = scan_project(str(project_root))
+    files = scanned_files(project_root, respect_gitignore=False)
 
-    names = {f.name for f in files}
-    assert "link.md" not in names
-    assert "regular.md" in names
-    out = capsys.readouterr().out
-    assert out.count("SKIP:") == 1
-    assert "link.md" in out
+    assert "link.md" not in files
+    assert "regular.md" in files
+    err = capsys.readouterr().err
+    assert err.count("SKIP:") == 1
+    assert "  SKIP:" in err
+    assert "link.md" in err
+    assert "(symlink)" in err
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink creation requires elevated privileges on Windows",
+)
+def test_scan_project_logs_dangling_symlink(tmp_path, capsys):
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    real_target = tmp_path / "outside" / "ghost.md"
+    real_target.parent.mkdir()
+    real_target.touch()
+    (project_root / "dangling.md").symlink_to(real_target)
+    real_target.unlink()  # target deleted, link dangles
+
+    files = scanned_files(project_root, respect_gitignore=False)
+
+    assert files == []
+    err = capsys.readouterr().err
+    assert err.count("SKIP:") == 1
+    assert "dangling.md" in err
+    assert "(symlink)" in err
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink creation requires elevated privileges on Windows",
+)
+def test_scan_project_logs_nested_symlink_with_relative_path(tmp_path, capsys):
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    real_target = tmp_path / "outside" / "real.md"
+    write_file(real_target, "real content\n" * 5)
+    deep = project_root / "deep" / "subdir"
+    deep.mkdir(parents=True)
+    (deep / "nested.md").symlink_to(real_target)
+
+    files = scanned_files(project_root, respect_gitignore=False)
+
+    assert files == []
+    err = capsys.readouterr().err
+    # Forward slash even on Windows (as_posix) and full relative path,
+    # not just the leaf — proves relative_to(project_path) over .name.
+    assert "deep/subdir/nested.md" in err
+    assert "(symlink)" in err
 
 
 def test_entity_metadata_finds_cyrillic_names(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Closes #1462.

When `mempalace mine` walks a target directory (`--mode convos` or `--mode projects`) and finds a `.jsonl` or readable file that is a symlink, the file is dropped from the scan. Pre-fix this dropped silently: a caller staging a temp directory of symlinks pointing at a single Claude Code transcript saw `Files: 0, Drawers filed: 0` with no diagnostic and no way to tell why the directory looked empty.

This PR keeps the existing skip-symlinks behavior (so the miner does not follow links into arbitrary paths) and adds a `  SKIP:` log line per skipped symlink, including the path relative to the scan root and a `(symlink)` reason marker. The line is written to `sys.stderr` (matching the warning channel already used in `miner.py` for the "No mempalace.yaml found" notice and topic-tunnel warnings), with `.as_posix()` for stable forward-slash rendering on every platform.

Both miners contain the identical silent-skip pattern, so both are fixed:

- `mempalace/convo_miner.py` `scan_convos()` for `--mode convos`
- `mempalace/miner.py` `scan_project()` for `--mode projects`

The `print` is wrapped in `try/except OSError`, mirroring the guard already in place around the `filepath.stat()` call a few lines below, so a broken pipe or closed stderr does not abort the scan mid-walk. The `relative_to(...)` call is computed outside the `try` since its invariant is guaranteed by `os.walk` (the file is always a descendant of the resolved scan root). Docstrings on both functions document the stderr side effect.

## How to test

End-to-end repro (matches the issue body): create `/tmp/mine-test`, add a symlink inside it pointing at a real `.jsonl` Claude Code transcript, then run `mempalace mine /tmp/mine-test --mode convos --wing test`. Pre-fix prints `Files: 0` to stdout with no SKIP log anywhere. With this PR, stderr carries `  SKIP: linked.jsonl (symlink)` while stdout stays unchanged, so the caller can see the directory is non-empty but skipped because of symlinks.

Six new unit tests across the two miners, gated on Linux/macOS via `@pytest.mark.skipif(sys.platform == "win32", ...)` since `Path.symlink_to` requires elevated privileges on Windows:

- `tests/test_convo_miner_unit.py::TestScanConvos::test_scan_convos_logs_skipped_symlinks`
- `tests/test_convo_miner_unit.py::TestScanConvos::test_scan_convos_logs_dangling_symlink`
- `tests/test_convo_miner_unit.py::TestScanConvos::test_scan_convos_logs_nested_symlink_with_relative_path`
- `tests/test_miner.py::test_scan_project_logs_skipped_symlinks`
- `tests/test_miner.py::test_scan_project_logs_dangling_symlink`
- `tests/test_miner.py::test_scan_project_logs_nested_symlink_with_relative_path`

Run them:

```
uv run pytest tests/test_convo_miner_unit.py::TestScanConvos tests/test_miner.py -k scan_project -v
```

Full suite stays green:

```
uv run pytest tests/ -q --ignore=tests/benchmarks
```

## Checklist

- [x] Tests added covering the regression
- [x] No CHANGELOG.md change (maintainer-managed)
- [x] No emoji or AI attribution in source or commits
