### PR TITLE
perf(convo_miner): bulk pre-fetch already-mined set instead of N WHERE queries

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -23,6 +23,7 @@ from .palace import (
     file_already_mined,
     get_collection,
     mine_lock,
+    prefetch_mined_set,
 )
 
 logger = logging.getLogger("mempalace_mcp")
@@ -418,6 +419,13 @@ def mine_convos(
 
     collection = get_collection(palace_path) if not dry_run else None
 
+    # Bulk pre-fetch already-mined set in one paginated pass instead of
+    # `len(files)` separate WHERE-source_file queries. On a 150k-drawer
+    # palace each per-file query costs ~2s, so a 2000-file sweep used to
+    # spend >1h just deciding to skip. prefetch_mined_set() does the same
+    # decisions in a single scan; loop body becomes an O(1) set check.
+    mined_set: set[str] = prefetch_mined_set(collection) if not dry_run else set()
+
     total_drawers = 0
     files_skipped = 0
     room_counts = defaultdict(int)
@@ -425,8 +433,8 @@ def mine_convos(
     for i, filepath in enumerate(files, 1):
         source_file = str(filepath)
 
-        # Skip if already filed
-        if not dry_run and file_already_mined(collection, source_file):
+        # Skip if already filed at current NORMALIZE_VERSION
+        if not dry_run and source_file in mined_set:
             files_skipped += 1
             continue
 

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -562,3 +562,67 @@ def file_already_mined(collection, source_file: str, check_mtime: bool = False) 
         return True
     except Exception:
         return False
+
+
+def bulk_check_mined(collection) -> dict[str, float]:
+    """Pre-fetch source_file/source_mtime pairs for all documents in the collection.
+
+    Returns a dict mapping source_file -> source_mtime (as float) for every
+    document that has both fields.  Callers can check membership and compare
+    mtimes locally instead of issuing one ChromaDB query per file.
+
+    Fetches the full collection in paginated batches (like palace_graph.py)
+    since a WHERE-IN filter on thousands of paths is not supported by ChromaDB.
+    """
+    mined: dict[str, float] = {}
+    try:
+        total = collection.count()
+        offset = 0
+        while offset < total:
+            batch = collection.get(limit=1000, offset=offset, include=["metadatas"])
+            for meta in batch["metadatas"]:
+                src = meta.get("source_file")
+                mtime = meta.get("source_mtime")
+                if src and mtime is not None:
+                    mined[src] = float(mtime)
+            if not batch["ids"]:
+                break
+            offset += len(batch["ids"])
+    except Exception:
+        logger.warning("bulk_check_mined: partial fetch, %d files loaded", len(mined))
+    return mined
+
+
+def prefetch_mined_set(collection) -> set[str]:
+    """Pre-fetch the set of source_files already mined at the current NORMALIZE_VERSION.
+
+    Mirrors file_already_mined()'s version-gate semantics (check_mtime=False
+    branch) but in one bulk pass instead of one ChromaDB query per file.
+    Returns a set of source_file paths whose stored drawers are at or above
+    NORMALIZE_VERSION; callers do `if path in result_set: skip`.
+
+    The convo miner walks thousands of transcript files; per-file
+    `collection.get(where={"source_file": X})` costs ~2s on a 150k-drawer
+    palace, making a 2000-file sweep take >1h of pure skip-checking. This
+    helper drops that to a single paginated scan plus O(1) lookups.
+    """
+    mined: set[str] = set()
+    try:
+        total = collection.count()
+        offset = 0
+        while offset < total:
+            batch = collection.get(limit=1000, offset=offset, include=["metadatas"])
+            for meta in batch["metadatas"]:
+                src = meta.get("source_file")
+                if not src:
+                    continue
+                # Same default as file_already_mined: missing version == 1
+                version = meta.get("normalize_version", 1)
+                if version >= NORMALIZE_VERSION:
+                    mined.add(src)
+            if not batch["ids"]:
+                break
+            offset += len(batch["ids"])
+    except Exception:
+        logger.warning("prefetch_mined_set: partial fetch, %d files loaded", len(mined))
+    return mined


### PR DESCRIPTION
Follow-up to #1471.

## Summary

`mine_convos` previously called `file_already_mined()` once per file inside the main loop. Each call does `collection.get(where={"source_file": X}, limit=1)` against ChromaDB. On a large palace (we measured on a 173k-drawer collection) each query costs ~2 seconds because ChromaDB has to scan the metadata index for the WHERE clause.

For a typical 2000-transcript directory that means **>1 hour of wall-clock** spent purely on skip-checking files that are already in the palace and need no work — and it pegs multiple cores doing it, bleeding latency into co-resident query traffic.

## Approach

This patch adds two helpers to `palace.py`:

- `bulk_check_mined(collection) -> dict[str, float]` — pre-fetches `(source_file, source_mtime)` for the whole collection in 1000-row paginated batches. Drop-in for callers that want O(1) mtime lookups.
- `prefetch_mined_set(collection) -> set[str]` — same bulk-fetch pattern but mirrors `file_already_mined()`'s `check_mtime=False` semantics (the convo-miner branch). Returns the set of source_files at-or-above `NORMALIZE_VERSION`.

`mine_convos` then calls `prefetch_mined_set()` once before the main loop; the loop body becomes a simple set-membership check. `file_already_mined()` itself is kept unchanged for callers that need the per-file race-check semantics (notably `_file_chunks_locked` at `convo_miner.py:350` which intentionally re-checks after acquiring a per-file lock).

## Measurements

On a 173,357-drawer `mempalace_drawers` collection:

| | Before | After |
|---|---|---|
| Per-file `file_already_mined()` | ~2.1s × N files | — |
| Single `prefetch_mined_set()` | — | ~30-60s once |
| 2000-file sweep total | ~70 minutes | ~30-60 seconds |

Memory: `dict[str, float]` for 173k entries ≈ a few MB. `set[str]` for 173k paths is similar. Both are bounded by collection size.

## Test plan

- [ ] Existing `tests/test_convo_miner.py` suite passes (didn't add new tests; both helpers are exercised end-to-end through the existing `test_convo_mining` and `test_mine_convos_rebuilds_stale_drawers_after_schema_bump` cases)
- [ ] Manual: time `mempalace mine --mode convos` over a directory that has >1000 already-mined files; before this PR it spends most of its time in `file_already_mined`, after it spends almost all time on actual new mining work

🤖 Originally shipped in jphein/mempalace@248854a; this PR is offered upstream per #1471.