### PR TITLE
feat(docs): wire Google Analytics into the published docs site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           DOCS_BASE: ${{ steps.pages.outputs.base_path }}
           DOCS_EDIT_BRANCH: ${{ github.ref_name }}
+          MEMPALACE_DOCS_GA_ID: ${{ vars.MEMPALACE_DOCS_GA_ID }}
         run: bun run docs:build
 
       - uses: actions/upload-pages-artifact@v5

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -30,8 +30,8 @@ export default withMermaid(
       ['meta', { property: 'og:description', content: '96.6% LongMemEval recall. Zero API calls. Local, free, open source.' }],
       ['meta', { property: 'og:image', content: `${docsBase}mempalace_logo.png` }],
       ...(gaId ? [
-        ['script', { async: '', src: `https://www.googletagmanager.com/gtag/js?id=${gaId}` }],
-        ['script', {}, `window.dataLayer = window.dataLayer || [];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js', new Date());\ngtag('config', '${gaId}');`],
+        ['script', { async: '', src: `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(gaId)}` }],
+        ['script', {}, `window.dataLayer = window.dataLayer || [];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js', new Date());\ngtag('config', ${JSON.stringify(gaId)});`],
       ] as const : []),
     ],
 


### PR DESCRIPTION
## Summary
- Pass `MEMPALACE_DOCS_GA_ID` (set as a repo Variable) from the deploy workflow into the VitePress build, so the published site at mempalaceofficial.com actually emits the gtag tags. Today the conditional in `config.mts` exists but the env var was never injected, so GA shipped as dead code.
- Harden the gtag snippet: `encodeURIComponent` on the script URL and `JSON.stringify` for the inline `gtag('config', ...)` call, so a malformed value can't break the page.

The privacy/local-first guarantees in CLAUDE.md apply to the Python product, not the marketing/docs site, so analytics on the public site is in scope.

## Test plan
- [x] Confirm the `MEMPALACE_DOCS_GA_ID` repo Variable is set in **Settings → Secrets and variables → Actions → Variables**.
- [ ] Merge to `develop` and let the `Deploy Docs` workflow run.
- [ ] View source on https://mempalaceofficial.com — expect two new `<script>` tags pointing at `googletagmanager.com/gtag/js?id=G-...` and the inline `gtag('config', ...)`.
- [ ] Confirm a hit shows up in the GA4 Realtime view.
- [ ] Sanity check: if the Variable is ever unset, the build still succeeds and emits no GA tags (existing behavior, preserved).