### PR TITLE
feat(sources): OpenCode adapter on RFC 002 contract

### DIFF
--- a/mempalace/sources/context.py
+++ b/mempalace/sources/context.py
@@ -114,6 +114,16 @@ class PalaceContext:
         advancing past the item."""
         self._skip_requested = True
 
+    def is_skip_requested(self) -> bool:
+        """Return whether :meth:`skip_current_item` was called since the last
+        time core advanced past an item. Adapters check this between the
+        ``SourceItemMetadata`` yield and the cost of processing the item — if
+        core has signaled skip (because :meth:`is_current` returned True), the
+        adapter can bail out of expensive work (SQL queries, chunking, etc.)
+        rather than waiting for core to drop drawers downstream. Core resets
+        the flag on its own; adapters MUST NOT clear it."""
+        return self._skip_requested
+
     def emit(self, event: str, **details: Any) -> None:
         """Invoke each registered progress hook with ``(event, **details)``."""
         for hook in self.progress_hooks:

--- a/mempalace/sources/opencode.py
+++ b/mempalace/sources/opencode.py
@@ -20,7 +20,6 @@ branch.
 
 from __future__ import annotations
 
-import json
 import logging
 import sqlite3
 from datetime import datetime, timezone
@@ -307,8 +306,7 @@ class OpenCodeSourceAdapter(BaseSourceAdapter):
                     size_hint=None,
                     route_hint=self._route_hint_for(directory, ""),
                 )
-                if palace._skip_requested:
-                    palace._skip_requested = False
+                if palace.is_skip_requested():
                     continue
 
                 messages = _extract_session_messages(conn, sid)
@@ -334,6 +332,15 @@ class OpenCodeSourceAdapter(BaseSourceAdapter):
                 wing = self._wing_for(source, directory)
                 room = detect_convo_room(transcript)
                 created_iso = _utc_iso(time_created or 0)
+                # Pre-compute once per session so every chunk of the same
+                # session shares the same filed_at timestamp.
+                filed_at = (
+                    datetime.now(timezone.utc)
+                    .replace(microsecond=0)
+                    .isoformat()
+                    .replace("+00:00", "Z")
+                )
+                session_version = str(time_updated or time_created or 0)
                 for chunk in chunks:
                     content = chunk["content"]
                     chunk_index = int(chunk["chunk_index"])
@@ -341,10 +348,7 @@ class OpenCodeSourceAdapter(BaseSourceAdapter):
                         # Universal §5.1 fields
                         "source_file": src_file,
                         "chunk_index": chunk_index,
-                        "filed_at": datetime.now(timezone.utc)
-                        .replace(microsecond=0)
-                        .isoformat()
-                        .replace("+00:00", "Z"),
+                        "filed_at": filed_at,
                         "added_by": "opencode-adapter",
                         "wing": wing,
                         "room": room,
@@ -359,6 +363,9 @@ class OpenCodeSourceAdapter(BaseSourceAdapter):
                         "session_created_at": created_iso,
                         "message_count": len(messages),
                         "opencode_db_path": db_path,
+                        # Required by is_current() for incremental ingest;
+                        # mirrors the SourceItemMetadata.version yielded above.
+                        "opencode_session_version": session_version,
                     }
                     yield DrawerRecord(
                         content=content,

--- a/mempalace/sources/opencode.py
+++ b/mempalace/sources/opencode.py
@@ -88,9 +88,7 @@ def _resolve_db(local_path: Optional[str] = None) -> str:
     )
 
 
-def _build_source_bytes_per_session(
-    conn: sqlite3.Connection, session_id: str
-) -> str:
+def _build_source_bytes_per_session(conn: sqlite3.Connection, session_id: str) -> str:
     """Return the canonical ``source bytes`` for one OpenCode session.
 
     The bytes are role-prefixed ``part.data`` JSON values, one per line, in
@@ -114,9 +112,7 @@ def _build_source_bytes_per_session(
     return "\n".join(f"{role or ''}\t{part}" for role, part in rows)
 
 
-def _extract_session_messages(
-    conn: sqlite3.Connection, session_id: str
-) -> List[Tuple[str, str]]:
+def _extract_session_messages(conn: sqlite3.Connection, session_id: str) -> List[Tuple[str, str]]:
     """Walk ``part.data`` for one session and return merged ``(role, text)`` pairs.
 
     Applies the OpenCode-specific transformations in declaration order using
@@ -436,9 +432,7 @@ class OpenCodeSourceAdapter(BaseSourceAdapter):
         """
         tables = {
             r[0]
-            for r in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
         }
         required = {"session", "message", "part"}
         missing = required - tables
@@ -469,9 +463,7 @@ class OpenCodeSourceAdapter(BaseSourceAdapter):
                 return normalize_wing_name(base)
         return "opencode_general"
 
-    def _route_hint_for(
-        self, source: SourceRef, directory: Optional[str]
-    ) -> Optional[RouteHint]:
+    def _route_hint_for(self, source: SourceRef, directory: Optional[str]) -> Optional[RouteHint]:
         # Same wing precedence as _wing_for (RFC 002 §2.5) so the
         # SourceItemMetadata route_hint matches the DrawerRecord wing
         # when the caller passed options={"wing": ...} — otherwise core

--- a/mempalace/sources/opencode.py
+++ b/mempalace/sources/opencode.py
@@ -32,7 +32,6 @@ from . import transforms as _transforms
 from .base import (
     AdapterClosedError,
     AdapterSchema,
-    AuthRequiredError,  # noqa: F401  (re-exported error type used in docstrings)
     BaseSourceAdapter,
     DrawerRecord,
     FieldSpec,
@@ -304,7 +303,7 @@ class OpenCodeSourceAdapter(BaseSourceAdapter):
                     source_file=src_file,
                     version=str(time_updated or time_created or 0),
                     size_hint=None,
-                    route_hint=self._route_hint_for(directory, ""),
+                    route_hint=self._route_hint_for(source, directory),
                 )
                 if palace.is_skip_requested():
                     continue
@@ -471,13 +470,13 @@ class OpenCodeSourceAdapter(BaseSourceAdapter):
         return "opencode_general"
 
     def _route_hint_for(
-        self, directory: Optional[str], content: str
+        self, source: SourceRef, directory: Optional[str]
     ) -> Optional[RouteHint]:
-        wing = (
-            normalize_wing_name(Path(directory).name)
-            if directory and Path(directory).name
-            else "opencode_general"
-        )
+        # Same wing precedence as _wing_for (RFC 002 §2.5) so the
+        # SourceItemMetadata route_hint matches the DrawerRecord wing
+        # when the caller passed options={"wing": ...} — otherwise core
+        # could make wrong skip/routing decisions on the gap.
+        wing = self._wing_for(source, directory)
         # Room is content-dependent so we leave it None at the lazy-fetch stage;
         # the eager DrawerRecord emit fills it in per chunk.
         return RouteHint(wing=wing, room=None, hall=None)

--- a/mempalace/sources/opencode.py
+++ b/mempalace/sources/opencode.py
@@ -1,0 +1,482 @@
+"""OpenCode source adapter (RFC 002).
+
+Ingests OpenCode AI-coding-CLI session transcripts out of OpenCode's local
+SQLite store (default ``~/.local/share/opencode/opencode.db``) into the
+palace as :class:`DrawerRecord` instances.
+
+Each OpenCode session becomes one ``source_file`` of the shape
+``opencode://<absolute-db-path>#session=<sid>``. The drawers under that
+``source_file`` are exchange-pair chunks of the session transcript,
+formatted to match the existing ``convo_miner`` shape so downstream
+ranking, search, and closet-building behave identically.
+
+Reverse-engineering credit: the SQLite schema, ``json_extract`` paths,
+tool-echo / file-injection skip filters, and same-role merge originated in
+@JakobSachs's PR #23 (``feat: add OpenCode SQLite session database
+support``). This adapter rebuilds those same primitives on the RFC 002
+contract so it can ship as a registered adapter rather than a normalize.py
+branch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, List, Optional, Tuple
+
+from ..convo_miner import chunk_exchanges, detect_convo_room
+from ..config import normalize_wing_name
+from . import transforms as _transforms
+from .base import (
+    AdapterClosedError,
+    AdapterSchema,
+    AuthRequiredError,  # noqa: F401  (re-exported error type used in docstrings)
+    BaseSourceAdapter,
+    DrawerRecord,
+    FieldSpec,
+    RouteHint,
+    SourceItemMetadata,
+    SourceNotFoundError,
+    SourceRef,
+    SourceSummary,
+)
+from .context import PalaceContext
+
+logger = logging.getLogger(__name__)
+
+
+# Default lookup order for the OpenCode SQLite store. Verified 2026-05-12 on
+# opencode-ai 1.14.39 (Linux XDG path); the ``~/.opencode`` legacy location
+# is kept for older macOS installs (see PR #23 thread).
+_DEFAULT_DB_PATHS: Tuple[str, ...] = (
+    "~/.local/share/opencode/opencode.db",
+    "~/.opencode/opencode.db",
+)
+
+
+# Hall-detection helper: defer to convo_miner's cached lookup so an adapter
+# instance never re-reads the palace config per drawer. Imported lazily because
+# convo_miner module-load imports chromadb on some paths.
+def _detect_hall(content: str) -> str:
+    from ..convo_miner import _detect_hall_cached
+
+    return _detect_hall_cached(content)
+
+
+def _resolve_db(local_path: Optional[str] = None) -> str:
+    """Resolve a concrete SQLite path for the OpenCode store.
+
+    Order:
+        1. ``local_path`` if it points at an existing file (caller chose).
+        2. Each entry of :data:`_DEFAULT_DB_PATHS` in declaration order.
+
+    Raises :class:`SourceNotFoundError` if no candidate resolves.
+    """
+    candidates: List[str] = []
+    if local_path:
+        candidates.append(local_path)
+    candidates.extend(_DEFAULT_DB_PATHS)
+    for raw in candidates:
+        p = Path(raw).expanduser()
+        if p.is_file():
+            return str(p.resolve())
+    raise SourceNotFoundError(
+        f"No OpenCode SQLite database found (searched {candidates}). "
+        f"Pass SourceRef(local_path=<path>) or place the file at one of the "
+        f"default paths."
+    )
+
+
+def _build_source_bytes_per_session(
+    conn: sqlite3.Connection, session_id: str
+) -> str:
+    """Return the canonical ``source bytes`` for one OpenCode session.
+
+    The bytes are role-prefixed ``part.data`` JSON values, one per line, in
+    ``(message.time_created, part.time_created)`` order. This is the shape
+    the declared OpenCode transformations (``opencode_extract_text_parts``
+    onward) consume; the conformance suite uses the same shape so the
+    declared-transformation round-trip is exact.
+    """
+    rows = conn.execute(
+        """
+        SELECT
+            json_extract(m.data, '$.role')  AS role,
+            p.data                           AS part_data
+        FROM message m
+        JOIN part p ON p.message_id = m.id
+        WHERE m.session_id = ?
+        ORDER BY m.time_created, p.time_created
+        """,
+        (session_id,),
+    ).fetchall()
+    return "\n".join(f"{role or ''}\t{part}" for role, part in rows)
+
+
+def _extract_session_messages(
+    conn: sqlite3.Connection, session_id: str
+) -> List[Tuple[str, str]]:
+    """Walk ``part.data`` for one session and return merged ``(role, text)`` pairs.
+
+    Applies the OpenCode-specific transformations in declaration order using
+    the reference implementations in :mod:`mempalace.sources.transforms`.
+    Returns the resulting list of ``(role, body)`` tuples ready for the
+    exchange-format emit step.
+    """
+    raw = _build_source_bytes_per_session(conn, session_id)
+    if not raw:
+        return []
+    pipeline = [
+        _transforms.opencode_extract_text_parts,
+        _transforms.opencode_skip_tool_echo,
+        _transforms.opencode_skip_file_injection,
+        _transforms.opencode_role_coerce,
+        _transforms.opencode_same_role_merge,
+    ]
+    text = raw
+    for step in pipeline:
+        text = step(text)
+    # Final state is ``role\tbody`` lines; split back into tuples.
+    pairs: List[Tuple[str, str]] = []
+    for line in text.split("\n"):
+        role, sep, body = line.partition("\t")
+        if not sep:
+            continue
+        pairs.append((role, body))
+    return pairs
+
+
+def _session_transcript(messages: List[Tuple[str, str]]) -> str:
+    """Render merged ``(role, text)`` pairs as exchange-pair markdown.
+
+    Uses the declared ``opencode_format_exchange`` transformation; emits
+    ``> user-text`` blocks alternating with assistant blocks.
+    """
+    role_lines = "\n".join(f"{r}\t{b}" for r, b in messages)
+    formatted = _transforms.opencode_format_exchange(role_lines)
+    formatted = _transforms.newline_normalize(formatted)
+    return _transforms.whitespace_trim(formatted)
+
+
+def _utc_iso(ms: int) -> str:
+    """Convert OpenCode millisecond-epoch to ISO-8601 UTC string."""
+    return (
+        datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def session_source_file(db_path: str, session_id: str) -> str:
+    """Construct the stable per-session ``source_file`` identifier.
+
+    Shape: ``opencode://<absolute-db-path>#session=<sid>``. Stable across
+    re-ingests, used as the ChromaDB ``where={"source_file": ...}`` key and
+    by ``is_current`` to look up existing drawers.
+    """
+    return f"opencode://{db_path}#session={session_id}"
+
+
+class OpenCodeSourceAdapter(BaseSourceAdapter):
+    """Mine OpenCode AI-coding-CLI sessions into the palace (RFC 002 §1)."""
+
+    name = "opencode"
+    adapter_version = "0.1.0"
+    capabilities = frozenset(
+        {
+            "supports_incremental",
+            "supports_structured_metadata",
+            "requires_local_tool",  # SQLite is python-stdlib but the .db is opencode's
+            "adapter_owns_routing",
+        }
+    )
+    supported_modes = frozenset({"chunked_content"})
+    declared_transformations = frozenset(
+        {
+            "opencode_extract_text_parts",
+            "opencode_skip_tool_echo",
+            "opencode_skip_file_injection",
+            "opencode_role_coerce",
+            "opencode_same_role_merge",
+            "opencode_format_exchange",
+            "newline_normalize",
+            "whitespace_trim",
+        }
+    )
+    default_privacy_class = "pii_potential"
+
+    # Order of declared transformations as applied by the adapter. The
+    # conformance suite walks this list in order, so it MUST mirror the
+    # actual pipeline in ``_extract_session_messages`` + ``_session_transcript``.
+    DECLARED_TRANSFORMATION_ORDER: Tuple[str, ...] = (
+        "opencode_extract_text_parts",
+        "opencode_skip_tool_echo",
+        "opencode_skip_file_injection",
+        "opencode_role_coerce",
+        "opencode_same_role_merge",
+        "opencode_format_exchange",
+        "newline_normalize",
+        "whitespace_trim",
+    )
+
+    def __init__(self) -> None:
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def describe_schema(self) -> AdapterSchema:
+        return AdapterSchema(
+            version="1.0",
+            fields={
+                "session_id": FieldSpec(
+                    type="string",
+                    required=True,
+                    description="OpenCode session id (e.g. ses_a1b2c3...)",
+                    indexed=True,
+                ),
+                "session_title": FieldSpec(
+                    type="string",
+                    required=False,
+                    description="Session title as recorded by OpenCode",
+                ),
+                "project_dir": FieldSpec(
+                    type="string",
+                    required=True,
+                    description="Absolute filesystem path where the session was started",
+                    indexed=True,
+                ),
+                "session_created_at": FieldSpec(
+                    type="string",
+                    required=True,
+                    description="ISO-8601 UTC of session creation (from time_created ms)",
+                ),
+                "message_count": FieldSpec(
+                    type="int",
+                    required=True,
+                    description="Number of merged (role, text) exchange parts in the session",
+                ),
+                "extract_mode": FieldSpec(
+                    type="string",
+                    required=True,
+                    description="Always 'exchange' for the OpenCode adapter in v0.1",
+                ),
+                "opencode_db_path": FieldSpec(
+                    type="string",
+                    required=True,
+                    description="Absolute path of the OpenCode SQLite database the drawer was extracted from",
+                ),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Ingest
+    # ------------------------------------------------------------------
+
+    def ingest(
+        self,
+        *,
+        source: SourceRef,
+        palace: PalaceContext,
+    ) -> Iterator[object]:
+        if self._closed:
+            raise AdapterClosedError("OpenCodeSourceAdapter is closed")
+        db_path = _resolve_db(source.local_path)
+        conn = sqlite3.connect(db_path)
+        try:
+            self._verify_schema(conn, db_path)
+            sessions = conn.execute(
+                """
+                SELECT id, title, directory, time_created, time_updated
+                FROM session
+                ORDER BY time_created
+                """
+            ).fetchall()
+            for sid, title, directory, time_created, time_updated in sessions:
+                src_file = session_source_file(db_path, sid)
+                # Yield the lazy-fetch metadata so core can short-circuit when
+                # the session has not changed since the previous ingest.
+                yield SourceItemMetadata(
+                    source_file=src_file,
+                    version=str(time_updated or time_created or 0),
+                    size_hint=None,
+                    route_hint=self._route_hint_for(directory, ""),
+                )
+                if palace._skip_requested:
+                    palace._skip_requested = False
+                    continue
+
+                messages = _extract_session_messages(conn, sid)
+                if len(messages) < 2:
+                    # Skip cancelled / single-turn sessions — matches PR #23
+                    # behavior and convo_miner's general "skip too-small files"
+                    # heuristic.
+                    logger.debug(
+                        "opencode adapter: skipping session %s (%d messages)",
+                        sid,
+                        len(messages),
+                    )
+                    continue
+
+                transcript = _session_transcript(messages)
+                if not transcript:
+                    continue
+
+                chunks = chunk_exchanges(transcript)
+                if not chunks:
+                    continue
+
+                wing = self._wing_for(source, directory)
+                room = detect_convo_room(transcript)
+                created_iso = _utc_iso(time_created or 0)
+                for chunk in chunks:
+                    content = chunk["content"]
+                    chunk_index = int(chunk["chunk_index"])
+                    metadata = {
+                        # Universal §5.1 fields
+                        "source_file": src_file,
+                        "chunk_index": chunk_index,
+                        "filed_at": datetime.now(timezone.utc)
+                        .replace(microsecond=0)
+                        .isoformat()
+                        .replace("+00:00", "Z"),
+                        "added_by": "opencode-adapter",
+                        "wing": wing,
+                        "room": room,
+                        "hall": _detect_hall(content),
+                        "ingest_mode": "chunked_content",
+                        "extract_mode": "exchange",
+                        "privacy_class": self.default_privacy_class,
+                        # Adapter-declared fields (§5.2)
+                        "session_id": sid,
+                        "session_title": title or "",
+                        "project_dir": directory or "",
+                        "session_created_at": created_iso,
+                        "message_count": len(messages),
+                        "opencode_db_path": db_path,
+                    }
+                    yield DrawerRecord(
+                        content=content,
+                        source_file=src_file,
+                        chunk_index=chunk_index,
+                        metadata=metadata,
+                        route_hint=RouteHint(wing=wing, room=room, hall=metadata["hall"]),
+                    )
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Incremental ingest
+    # ------------------------------------------------------------------
+
+    def is_current(
+        self,
+        *,
+        item: SourceItemMetadata,
+        existing_metadata: Optional[dict],
+    ) -> bool:
+        if not existing_metadata:
+            return False
+        # Existing palace drawers expose either ``session_created_at`` (ISO)
+        # or an older opaque metadata blob. The cheapest stable comparison is
+        # the raw ``time_updated`` ms-epoch we encoded into ``version`` — but
+        # the palace stores ISO. Honor both: if a ``opencode_session_version``
+        # field is present (future-proof), use it; otherwise fall back to the
+        # ISO-vs-ISO comparison against ``session_created_at``.
+        stored_version = existing_metadata.get("opencode_session_version")
+        if stored_version is not None:
+            return str(stored_version) == item.version
+        # Fall back to "we have drawers for this source_file" → assume current.
+        # Safer than a default of "always re-extract" because OpenCode session
+        # rows are append-only: an existing drawer for a session_id means we
+        # already mined the messages that existed at last extraction.
+        return True
+
+    def source_summary(self, *, source: SourceRef) -> SourceSummary:
+        try:
+            db_path = _resolve_db(source.local_path)
+        except SourceNotFoundError:
+            return SourceSummary(description="OpenCode database not found", item_count=0)
+        conn = sqlite3.connect(db_path)
+        try:
+            self._verify_schema(conn, db_path)
+            (count,) = conn.execute("SELECT COUNT(*) FROM session").fetchone()
+        finally:
+            conn.close()
+        return SourceSummary(
+            description=f"OpenCode database at {db_path}",
+            item_count=int(count),
+        )
+
+    def close(self) -> None:
+        self._closed = True
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _verify_schema(conn: sqlite3.Connection, db_path: str) -> None:
+        """Confirm the SQLite has the tables the adapter relies on.
+
+        ``json_extract`` is a SQLite JSON1 feature — usually built into
+        modern Python/SQLite shipments but we sanity-check it once so we
+        raise a clear error instead of an opaque OperationalError mid-fetch.
+        """
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        required = {"session", "message", "part"}
+        missing = required - tables
+        if missing:
+            raise SourceNotFoundError(
+                f"OpenCode database at {db_path} is missing tables: {sorted(missing)}"
+            )
+        try:
+            conn.execute("SELECT json_extract('{}', '$')").fetchone()
+        except sqlite3.OperationalError as e:
+            raise SourceNotFoundError(
+                f"SQLite at {db_path} lacks JSON1 (json_extract) — upgrade SQLite/Python: {e}"
+            ) from e
+
+    def _wing_for(self, source: SourceRef, directory: Optional[str]) -> str:
+        """Resolve the wing for a session, RFC 002 §2.5 precedence:
+
+        1. Explicit ``options["wing"]`` from the SourceRef
+        2. Project directory basename (the session's ``directory`` column)
+        3. Adapter fallback: ``"opencode_general"``
+        """
+        explicit = (source.options or {}).get("wing")
+        if explicit:
+            return normalize_wing_name(str(explicit))
+        if directory and directory != "/":
+            base = Path(directory).name
+            if base:
+                return normalize_wing_name(base)
+        return "opencode_general"
+
+    def _route_hint_for(
+        self, directory: Optional[str], content: str
+    ) -> Optional[RouteHint]:
+        wing = (
+            normalize_wing_name(Path(directory).name)
+            if directory and Path(directory).name
+            else "opencode_general"
+        )
+        # Room is content-dependent so we leave it None at the lazy-fetch stage;
+        # the eager DrawerRecord emit fills it in per chunk.
+        return RouteHint(wing=wing, room=None, hall=None)
+
+
+__all__ = [
+    "OpenCodeSourceAdapter",
+    "session_source_file",
+]

--- a/mempalace/sources/transforms.py
+++ b/mempalace/sources/transforms.py
@@ -154,6 +154,147 @@ def speaker_role_assignment(text: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Adapter-namespaced reference implementations
+# ---------------------------------------------------------------------------
+#
+# Per RFC 002 §7.3, custom (non-reserved) transformations declared by an
+# adapter MUST expose a reference implementation under
+# ``mempalace.sources.transforms.<adapter_name>_<transform_name>`` so the
+# conformance suite can locate and apply them by attribute lookup. The
+# implementations below are the OpenCode adapter's; future adapters add
+# their own under their own ``<name>_`` prefix.
+#
+# The OpenCode adapter's canonical source bytes for one session are the
+# newline-joined JSON-encoded ``part.data`` rows in
+# ``(message.time_created, part.time_created)`` order, each row prefixed with
+# its message's ``role`` field as ``"<role>\t<part_json>"``. That format is
+# what ``canonical_source_bytes`` returns to the conformance suite, and is
+# what the chain of transformations below collapses into the drawer content.
+
+import json as _json
+
+
+def opencode_extract_text_parts(text: str) -> str:
+    """Pluck ``data.text`` from each JSON-blob line where ``data.type == "text"``.
+
+    Input lines are ``"<role>\\t<part_json>"``. The output preserves the
+    ``<role>\\t`` prefix on each kept line so downstream merge and format
+    transformations can still see roles. Tool-input, tool-output, and
+    whitespace-only ``text`` parts are dropped — same skip the live
+    extraction path applies.
+    """
+    out: list[str] = []
+    for line in text.split("\n"):
+        if not line:
+            continue
+        # Split role from JSON; first \t is the separator.
+        role, _, part_json = line.partition("\t")
+        if not part_json:
+            continue
+        try:
+            obj = _json.loads(part_json)
+        except (ValueError, TypeError):
+            continue
+        if obj.get("type") != "text":
+            continue
+        body = obj.get("text") or ""
+        if not body.strip():
+            continue
+        out.append(f"{role}\t{body}")
+    return "\n".join(out)
+
+
+_TOOL_ECHO_NEEDLE = " tool with the following input"
+
+
+def opencode_skip_tool_echo(text: str) -> str:
+    """Drop user-turn echoes of tool invocations (``Called the X tool ...``).
+
+    Operates on the role-prefixed line stream produced by
+    :func:`opencode_extract_text_parts`. A line whose body (everything after
+    the first tab) opens with ``Called the …  tool with the following input``
+    is dropped wholesale.
+    """
+    kept: list[str] = []
+    for line in text.split("\n"):
+        _, _, body = line.partition("\t")
+        body_lstripped = body.lstrip()
+        if body_lstripped.startswith("Called the ") and _TOOL_ECHO_NEEDLE in body_lstripped:
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def opencode_skip_file_injection(text: str) -> str:
+    """Drop ``<path>…</path>`` file-context injections wrapped around context."""
+    kept: list[str] = []
+    for line in text.split("\n"):
+        _, _, body = line.partition("\t")
+        body_lstripped = body.lstrip()
+        if body_lstripped.startswith("<path>") and "<type>file</type>" in body_lstripped:
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def opencode_role_coerce(text: str) -> str:
+    """Coerce non-``user`` roles to ``assistant``.
+
+    OpenCode emits a small handful of role values (``user``, ``assistant``,
+    occasionally ``system`` or ``tool``). For transcript-shaped storage the
+    adapter only distinguishes ``user`` from everything-else.
+    """
+    out: list[str] = []
+    for line in text.split("\n"):
+        role, sep, body = line.partition("\t")
+        if not sep:
+            out.append(line)
+            continue
+        coerced = "user" if role == "user" else "assistant"
+        out.append(f"{coerced}\t{body}")
+    return "\n".join(out)
+
+
+def opencode_same_role_merge(text: str) -> str:
+    """Merge consecutive same-role lines into a single line with ``\\n\\n`` joiner."""
+    out: list[tuple[str, str]] = []
+    for line in text.split("\n"):
+        role, sep, body = line.partition("\t")
+        if not sep:
+            continue
+        if out and out[-1][0] == role:
+            prev_role, prev_body = out[-1]
+            out[-1] = (prev_role, prev_body + "\n\n" + body)
+        else:
+            out.append((role, body))
+    return "\n".join(f"{r}\t{b}" for r, b in out)
+
+
+def opencode_format_exchange(text: str) -> str:
+    """Reformat role-prefixed lines as ``convo_miner`` exchange-pair markdown.
+
+    ``user`` lines become ``> <body>``; ``assistant`` lines become the body
+    on its own paragraph. Pairs are separated by blank lines. The output of
+    this is what ``mempalace.convo_miner.chunk_exchanges`` recognises as an
+    exchange transcript.
+    """
+    blocks: list[str] = []
+    for line in text.split("\n"):
+        role, sep, body = line.partition("\t")
+        if not sep:
+            continue
+        body = body.strip()
+        if not body:
+            continue
+        if role == "user":
+            quoted = "\n".join(f"> {ln}" for ln in body.split("\n"))
+            blocks.append(quoted)
+        else:
+            blocks.append(body)
+    return "\n\n".join(blocks)
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 

--- a/mempalace/sources/transforms.py
+++ b/mempalace/sources/transforms.py
@@ -23,6 +23,8 @@ conformance suite can locate and apply them.
 
 from __future__ import annotations
 
+import json as _json
+
 import re
 from typing import Protocol, Union
 
@@ -170,8 +172,6 @@ def speaker_role_assignment(text: str) -> str:
 # its message's ``role`` field as ``"<role>\t<part_json>"``. That format is
 # what ``canonical_source_bytes`` returns to the conformance suite, and is
 # what the chain of transformations below collapses into the drawer content.
-
-import json as _json
 
 
 def opencode_extract_text_parts(text: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,12 @@ mempalace-mcp = "mempalace.mcp_server:main"
 [project.entry-points."mempalace.backends"]
 chroma = "mempalace.backends.chroma:ChromaBackend"
 
-# RFC 002 source-adapter entry-point group. Core publishes no first-party
-# adapters under this group yet; ``miner.py`` and ``convo_miner.py`` migrate
-# onto ``BaseSourceAdapter`` in a follow-up PR. Third-party adapter packages
-# (``mempalace-source-cursor``, ``mempalace-source-git``, …) register here.
+# RFC 002 source-adapter entry-point group. First-party adapters land here as
+# they migrate onto ``BaseSourceAdapter``; third-party adapter packages
+# (``mempalace-source-cursor``, ``mempalace-source-git``, …) also register
+# under this group.
 [project.entry-points."mempalace.sources"]
+opencode = "mempalace.sources.opencode:OpenCodeSourceAdapter"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff==0.15.9", "psutil>=5.9"]

--- a/tests/fixtures/opencode/sample_session_2026_05_12/README.md
+++ b/tests/fixtures/opencode/sample_session_2026_05_12/README.md
@@ -1,0 +1,77 @@
+# OpenCode sample sessions — fixture builder
+
+This directory does **not** ship a recorded OpenCode `.db` file. The actual
+SQLite schema (verified 2026-05-12 against `opencode-ai 1.14.39` at
+`~/.local/share/opencode/opencode.db` on JP's Ubuntu desktop) is replicated
+verbatim by the builder script `build_fixture.py`, which produces an
+in-memory or on-disk SQLite database populated with synthetic-but-realistic
+session data the adapter and its tests consume.
+
+## Why builder, not recorded fixture
+
+1. OpenCode `.db` files contain the raw text content of every user/assistant
+   turn including any pasted file paths, tokens, or secrets — committing a
+   real recording would leak data even after redaction passes.
+2. The schema is small (3 tables we touch — `session`, `message`, `part`).
+   Constructing a fixture in Python is shorter than a serialized binary.
+3. Schema fidelity is the property that matters for adapter testing; content
+   fidelity matters for `convo_miner`-style integration testing, which is
+   covered by chunking tests on the synthesized transcripts.
+
+## Schema captured (verbatim from JP's live DB on 2026-05-12)
+
+```
+CREATE TABLE `session` (
+    `id` text PRIMARY KEY,
+    `project_id` text NOT NULL,
+    `parent_id` text,
+    `slug` text NOT NULL,
+    `directory` text NOT NULL,
+    `title` text NOT NULL,
+    `version` text NOT NULL,
+    `share_url` text,
+    `summary_additions` integer,
+    `summary_deletions` integer,
+    `summary_files` integer,
+    `summary_diffs` text,
+    `revert` text,
+    `permission` text,
+    `time_created` integer NOT NULL,
+    `time_updated` integer NOT NULL,
+    `time_compacting` integer,
+    `time_archived` integer,
+    `workspace_id` text,
+    `path` text,
+    `agent` text,
+    `model` text
+);
+
+CREATE TABLE `message` (
+    `id` text PRIMARY KEY,
+    `session_id` text NOT NULL,
+    `time_created` integer NOT NULL,
+    `time_updated` integer NOT NULL,
+    `data` text NOT NULL
+);
+
+CREATE TABLE `part` (
+    `id` text PRIMARY KEY,
+    `message_id` text NOT NULL,
+    `session_id` text NOT NULL,
+    `time_created` integer NOT NULL,
+    `time_updated` integer NOT NULL,
+    `data` text NOT NULL
+);
+
+CREATE INDEX `message_session_time_created_id_idx` ON `message` (`session_id`,`time_created`,`id`);
+CREATE INDEX `part_message_id_id_idx` ON `part` (`message_id`,`id`);
+CREATE INDEX `part_session_idx` ON `part` (`session_id`);
+CREATE INDEX `session_project_idx` ON `session` (`project_id`);
+```
+
+`message.data` is JSON containing `{"role": "user|assistant", ...}`.
+`part.data` is JSON containing `{"type": "text|tool-input|tool-output|...", "text": "..."}`.
+
+OpenCode-PR-#23 reverse-engineered the same schema; `session.directory` is
+the path the session was started in, used by this adapter to route the
+session's drawers to a wing.

--- a/tests/fixtures/opencode/sample_session_2026_05_12/build_fixture.py
+++ b/tests/fixtures/opencode/sample_session_2026_05_12/build_fixture.py
@@ -1,0 +1,327 @@
+"""Build a synthetic OpenCode SQLite fixture matching the live schema.
+
+Live schema captured 2026-05-12 from opencode-ai 1.14.39 at
+``~/.local/share/opencode/opencode.db``; see README.md in this directory.
+
+The builder is a *fixture factory* — tests call ``build_fixture(path,
+sessions=...)`` to populate any SQLite path with a known shape. No
+recorded `.db` files ship in this directory because the content of a
+real OpenCode session is unsanitizably user-private.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+# Verbatim DDL from JP's live opencode.db on 2026-05-12.
+# We only include the columns the adapter actually reads + their indexes;
+# additional columns that OpenCode populates (slug, version, agent, model,
+# workspace_id) are kept here so a fixture mirrors the real on-disk shape
+# instead of a stripped-down minimum.
+DDL = [
+    """
+    CREATE TABLE `session` (
+        `id` text PRIMARY KEY,
+        `project_id` text NOT NULL,
+        `parent_id` text,
+        `slug` text NOT NULL,
+        `directory` text NOT NULL,
+        `title` text NOT NULL,
+        `version` text NOT NULL,
+        `share_url` text,
+        `summary_additions` integer,
+        `summary_deletions` integer,
+        `summary_files` integer,
+        `summary_diffs` text,
+        `revert` text,
+        `permission` text,
+        `time_created` integer NOT NULL,
+        `time_updated` integer NOT NULL,
+        `time_compacting` integer,
+        `time_archived` integer,
+        `workspace_id` text,
+        `path` text,
+        `agent` text,
+        `model` text
+    );
+    """,
+    """
+    CREATE TABLE `message` (
+        `id` text PRIMARY KEY,
+        `session_id` text NOT NULL,
+        `time_created` integer NOT NULL,
+        `time_updated` integer NOT NULL,
+        `data` text NOT NULL
+    );
+    """,
+    """
+    CREATE TABLE `part` (
+        `id` text PRIMARY KEY,
+        `message_id` text NOT NULL,
+        `session_id` text NOT NULL,
+        `time_created` integer NOT NULL,
+        `time_updated` integer NOT NULL,
+        `data` text NOT NULL
+    );
+    """,
+    "CREATE INDEX `message_session_time_created_id_idx` ON `message` (`session_id`,`time_created`,`id`);",
+    "CREATE INDEX `part_message_id_id_idx` ON `part` (`message_id`,`id`);",
+    "CREATE INDEX `part_session_idx` ON `part` (`session_id`);",
+    "CREATE INDEX `session_project_idx` ON `session` (`project_id`);",
+]
+
+
+@dataclass
+class SyntheticPart:
+    """One part of a message — usually one ``type=text`` part per turn."""
+
+    type: str = "text"
+    text: str = ""
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class SyntheticMessage:
+    role: str  # "user" or "assistant"
+    parts: List[SyntheticPart] = field(default_factory=list)
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class SyntheticSession:
+    session_id: str
+    project_id: str
+    directory: str
+    title: str
+    messages: List[SyntheticMessage] = field(default_factory=list)
+    time_created_ms: int = 1_715_000_000_000
+    slug: Optional[str] = None
+    version: str = "0.1.0"
+    agent: Optional[str] = None
+    model: Optional[str] = None
+    workspace_id: Optional[str] = None
+
+
+def build_fixture(
+    path: str,
+    *,
+    sessions: Iterable[SyntheticSession],
+) -> str:
+    """Create a SQLite file at ``path`` populated with the given sessions.
+
+    Returns the path back so callers can chain into ``SourceRef``.
+    """
+    p = Path(path)
+    if p.exists():
+        p.unlink()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(p))
+    try:
+        for ddl in DDL:
+            conn.execute(ddl)
+        for sess in sessions:
+            conn.execute(
+                """
+                INSERT INTO session (
+                    id, project_id, parent_id, slug, directory, title,
+                    version, share_url, summary_additions, summary_deletions,
+                    summary_files, summary_diffs, revert, permission,
+                    time_created, time_updated, time_compacting, time_archived,
+                    workspace_id, path, agent, model
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    sess.session_id,
+                    sess.project_id,
+                    None,
+                    sess.slug or sess.session_id,
+                    sess.directory,
+                    sess.title,
+                    sess.version,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    sess.time_created_ms,
+                    sess.time_created_ms,
+                    None,
+                    None,
+                    sess.workspace_id,
+                    sess.directory,
+                    sess.agent,
+                    sess.model,
+                ),
+            )
+            for msg_idx, msg in enumerate(sess.messages):
+                msg_id = f"msg_{sess.session_id}_{msg_idx}"
+                msg_time = sess.time_created_ms + msg_idx * 1000
+                msg_data = {"role": msg.role, **msg.extra}
+                conn.execute(
+                    """INSERT INTO message (id, session_id, time_created,
+                                            time_updated, data)
+                       VALUES (?,?,?,?,?)""",
+                    (msg_id, sess.session_id, msg_time, msg_time, json.dumps(msg_data)),
+                )
+                for part_idx, part in enumerate(msg.parts):
+                    part_id = f"part_{sess.session_id}_{msg_idx}_{part_idx}"
+                    part_data = {"type": part.type, "text": part.text, **part.extra}
+                    conn.execute(
+                        """INSERT INTO part (id, message_id, session_id,
+                                             time_created, time_updated, data)
+                           VALUES (?,?,?,?,?,?)""",
+                        (
+                            part_id,
+                            msg_id,
+                            sess.session_id,
+                            msg_time + part_idx,
+                            msg_time + part_idx,
+                            json.dumps(part_data),
+                        ),
+                    )
+        conn.commit()
+    finally:
+        conn.close()
+    return str(p)
+
+
+# Canonical fixture used by the adapter unit + conformance tests.
+# Three sessions across two project directories, with a mix of:
+#   * normal user/assistant text exchanges
+#   * tool-input parts (skipped on extraction)
+#   * tool-output parts (skipped on extraction)
+#   * empty-text parts (skipped on extraction)
+#   * a session with too few real turns (skipped at the session level)
+CANONICAL_SESSIONS: List[SyntheticSession] = [
+    SyntheticSession(
+        session_id="ses_aaa111",
+        project_id="proj_frontend",
+        directory="/home/jp/Projects/frontend",
+        title="Refactor TanStack Query wrapper",
+        agent="opencode",
+        model="anthropic/claude-sonnet-4-6",
+        messages=[
+            SyntheticMessage(
+                role="user",
+                parts=[
+                    SyntheticPart(
+                        text="Can you refactor the fetch wrapper to use TanStack Query mutations?"
+                    )
+                ],
+            ),
+            SyntheticMessage(
+                role="assistant",
+                parts=[
+                    SyntheticPart(
+                        text="Sure. The mutation hook would look like this:\n\nuseMutation({ mutationFn: postUser })\n\nThis gives you onSuccess/onError callbacks."
+                    ),
+                    # Tool-input part should be SKIPPED on extraction.
+                    SyntheticPart(
+                        type="tool-input",
+                        text="",
+                        extra={"name": "edit", "input": {"path": "src/api.ts"}},
+                    ),
+                    # Tool-output part should be SKIPPED on extraction.
+                    SyntheticPart(
+                        type="tool-output",
+                        text="",
+                        extra={"name": "edit", "output": "file edited"},
+                    ),
+                ],
+            ),
+            SyntheticMessage(
+                role="user",
+                parts=[
+                    SyntheticPart(text="And how do I invalidate the query cache after?")
+                ],
+            ),
+            SyntheticMessage(
+                role="assistant",
+                parts=[
+                    SyntheticPart(
+                        text="Call queryClient.invalidateQueries({ queryKey: ['users'] }) inside onSuccess."
+                    )
+                ],
+            ),
+        ],
+    ),
+    SyntheticSession(
+        session_id="ses_bbb222",
+        project_id="proj_frontend",
+        directory="/home/jp/Projects/frontend",
+        title="Add session login route",
+        time_created_ms=1_715_001_000_000,
+        agent="opencode",
+        model="anthropic/claude-sonnet-4-6",
+        messages=[
+            SyntheticMessage(
+                role="user",
+                parts=[SyntheticPart(text="Add a /login route with JWT auth.")],
+            ),
+            SyntheticMessage(
+                role="assistant",
+                parts=[
+                    SyntheticPart(
+                        text="Add the route handler in routes/login.ts and verify the token against the JWT secret on each request."
+                    )
+                ],
+            ),
+        ],
+    ),
+    SyntheticSession(
+        session_id="ses_ccc333",
+        project_id="proj_backend",
+        directory="/home/jp/Projects/backend",
+        title="Alembic migration question",
+        time_created_ms=1_715_002_000_000,
+        agent="opencode",
+        model="anthropic/claude-sonnet-4-6",
+        messages=[
+            SyntheticMessage(
+                role="user",
+                parts=[
+                    SyntheticPart(
+                        text="How do I downgrade an Alembic migration safely in production?"
+                    )
+                ],
+            ),
+            SyntheticMessage(
+                role="assistant",
+                parts=[
+                    SyntheticPart(
+                        text="Run alembic downgrade -1 against a staging copy first; verify schema, then run the same command against production inside a transaction."
+                    )
+                ],
+            ),
+        ],
+    ),
+    # Sessions with <2 real text parts should be SKIPPED entirely.
+    SyntheticSession(
+        session_id="ses_ddd444",
+        project_id="proj_backend",
+        directory="/home/jp/Projects/backend",
+        title="Cancelled session",
+        time_created_ms=1_715_003_000_000,
+        messages=[
+            SyntheticMessage(
+                role="user",
+                parts=[SyntheticPart(text="wait nvm")],
+            ),
+        ],
+    ),
+]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual fixture generation
+    import sys
+
+    target = sys.argv[1] if len(sys.argv) > 1 else "/tmp/opencode_fixture.db"
+    build_fixture(target, sessions=CANONICAL_SESSIONS)
+    print(f"wrote fixture to {target}")

--- a/tests/fixtures/opencode/sample_session_2026_05_12/build_fixture.py
+++ b/tests/fixtures/opencode/sample_session_2026_05_12/build_fixture.py
@@ -238,9 +238,7 @@ CANONICAL_SESSIONS: List[SyntheticSession] = [
             ),
             SyntheticMessage(
                 role="user",
-                parts=[
-                    SyntheticPart(text="And how do I invalidate the query cache after?")
-                ],
+                parts=[SyntheticPart(text="And how do I invalidate the query cache after?")],
             ),
             SyntheticMessage(
                 role="assistant",

--- a/tests/test_corpus_origin_integration.py
+++ b/tests/test_corpus_origin_integration.py
@@ -1352,6 +1352,7 @@ def test_no_internal_coordination_jargon_in_source_or_tests():
         "mempalace/knowledge_graph.py",
         "mempalace/i18n/",
         "tests/test_sources.py",
+        "tests/test_sources_opencode.py",
         "tests/test_i18n_lang_case.py",
     )
     # Allowlist for self-reference: this test file mentions the leak

--- a/tests/test_sources_opencode.py
+++ b/tests/test_sources_opencode.py
@@ -177,7 +177,9 @@ def test_ingest_raises_source_not_found_for_missing_db(adapter, palace_ctx, tmp_
         list(adapter.ingest(source=ref, palace=palace_ctx))
 
 
-def test_ingest_raises_source_not_found_for_db_without_expected_tables(adapter, palace_ctx, tmp_path):
+def test_ingest_raises_source_not_found_for_db_without_expected_tables(
+    adapter, palace_ctx, tmp_path
+):
     path = tmp_path / "bad.db"
     conn = sqlite3.connect(str(path))
     conn.execute("CREATE TABLE other (id INTEGER)")
@@ -209,9 +211,7 @@ def test_source_summary_counts_sessions(adapter, canonical_db):
 
 
 def test_source_summary_for_missing_db(adapter, tmp_path):
-    summary = adapter.source_summary(
-        source=SourceRef(local_path=str(tmp_path / "absent.db"))
-    )
+    summary = adapter.source_summary(source=SourceRef(local_path=str(tmp_path / "absent.db")))
     assert summary.item_count == 0
     assert "not found" in summary.description.lower()
 
@@ -240,9 +240,9 @@ def test_ingest_skips_cancelled_session_with_too_few_turns(adapter, palace_ctx, 
     results = list(adapter.ingest(source=SourceRef(local_path=canonical_db), palace=palace_ctx))
     drawers = [r for r in results if isinstance(r, DrawerRecord)]
     src_files = {d.source_file for d in drawers}
-    assert all("ses_ddd444" not in sf for sf in src_files), (
-        "single-message cancelled session must be skipped"
-    )
+    assert all(
+        "ses_ddd444" not in sf for sf in src_files
+    ), "single-message cancelled session must be skipped"
 
 
 def test_drawer_metadata_carries_universal_and_schema_fields(adapter, palace_ctx, canonical_db):
@@ -264,17 +264,17 @@ def test_drawer_metadata_carries_universal_and_schema_fields(adapter, palace_ctx
     }
     for drawer in drawers:
         meta = drawer.metadata
-        assert universal_keys.issubset(meta.keys()), (
-            f"missing universal keys: {universal_keys - meta.keys()}"
-        )
-        assert schema_keys.issubset(meta.keys()), (
-            f"missing schema keys: {schema_keys - meta.keys()}"
-        )
+        assert universal_keys.issubset(
+            meta.keys()
+        ), f"missing universal keys: {universal_keys - meta.keys()}"
+        assert schema_keys.issubset(
+            meta.keys()
+        ), f"missing schema keys: {schema_keys - meta.keys()}"
         # Flat-scalar invariant — chroma constraint.
         for k, v in meta.items():
-            assert isinstance(v, (str, int, float, bool)), (
-                f"metadata[{k}]={v!r} of type {type(v).__name__} is not flat-scalar"
-            )
+            assert isinstance(
+                v, (str, int, float, bool)
+            ), f"metadata[{k}]={v!r} of type {type(v).__name__} is not flat-scalar"
 
 
 def test_drawer_route_hint_carries_wing(adapter, palace_ctx, canonical_db):
@@ -328,15 +328,10 @@ def test_is_current_uses_version_when_present(adapter):
     item = SourceItemMetadata(source_file="opencode:///x#session=ses_a", version="123")
     assert adapter.is_current(item=item, existing_metadata=None) is False
     assert (
-        adapter.is_current(
-            item=item, existing_metadata={"opencode_session_version": "123"}
-        )
-        is True
+        adapter.is_current(item=item, existing_metadata={"opencode_session_version": "123"}) is True
     )
     assert (
-        adapter.is_current(
-            item=item, existing_metadata={"opencode_session_version": "999"}
-        )
+        adapter.is_current(item=item, existing_metadata={"opencode_session_version": "999"})
         is False
     )
 
@@ -347,9 +342,7 @@ def test_is_current_falls_back_to_presence_when_version_missing(adapter):
     # any other-metadata-present scenario should return True (we assume we
     # already mined this session) — this is safer than always re-extracting.
     assert (
-        adapter.is_current(
-            item=item, existing_metadata={"session_id": "ses_a", "wing": "x"}
-        )
+        adapter.is_current(item=item, existing_metadata={"session_id": "ses_a", "wing": "x"})
         is True
     )
 
@@ -366,8 +359,7 @@ def test_tool_input_and_tool_output_parts_are_skipped(adapter, palace_ctx, canon
     drawers = [
         r
         for r in results
-        if isinstance(r, DrawerRecord)
-        and r.source_file.endswith("#session=ses_aaa111")
+        if isinstance(r, DrawerRecord) and r.source_file.endswith("#session=ses_aaa111")
     ]
     joined = "\n".join(d.content for d in drawers)
     # Sentinels we wrote into tool-input/tool-output parts in the fixture
@@ -378,7 +370,9 @@ def test_tool_input_and_tool_output_parts_are_skipped(adapter, palace_ctx, canon
 def test_tool_echo_lines_are_stripped():
     """A user turn echoing a tool invocation should be dropped before the
     transcript is chunked."""
-    raw = "user\t" + json.dumps({"type": "text", "text": "Called the read tool with the following input"})
+    raw = "user\t" + json.dumps(
+        {"type": "text", "text": "Called the read tool with the following input"}
+    )
     raw += "\nuser\t" + json.dumps({"type": "text", "text": "Actually, what's the answer?"})
     out = src_transforms.opencode_extract_text_parts(raw)
     out = src_transforms.opencode_skip_tool_echo(out)

--- a/tests/test_sources_opencode.py
+++ b/tests/test_sources_opencode.py
@@ -240,9 +240,9 @@ def test_ingest_skips_cancelled_session_with_too_few_turns(adapter, palace_ctx, 
     results = list(adapter.ingest(source=SourceRef(local_path=canonical_db), palace=palace_ctx))
     drawers = [r for r in results if isinstance(r, DrawerRecord)]
     src_files = {d.source_file for d in drawers}
-    assert all(
-        "ses_ddd444" not in sf for sf in src_files
-    ), "single-message cancelled session must be skipped"
+    assert all("ses_ddd444" not in sf for sf in src_files), (
+        "single-message cancelled session must be skipped"
+    )
 
 
 def test_drawer_metadata_carries_universal_and_schema_fields(adapter, palace_ctx, canonical_db):
@@ -264,17 +264,17 @@ def test_drawer_metadata_carries_universal_and_schema_fields(adapter, palace_ctx
     }
     for drawer in drawers:
         meta = drawer.metadata
-        assert universal_keys.issubset(
-            meta.keys()
-        ), f"missing universal keys: {universal_keys - meta.keys()}"
-        assert schema_keys.issubset(
-            meta.keys()
-        ), f"missing schema keys: {schema_keys - meta.keys()}"
+        assert universal_keys.issubset(meta.keys()), (
+            f"missing universal keys: {universal_keys - meta.keys()}"
+        )
+        assert schema_keys.issubset(meta.keys()), (
+            f"missing schema keys: {schema_keys - meta.keys()}"
+        )
         # Flat-scalar invariant — chroma constraint.
         for k, v in meta.items():
-            assert isinstance(
-                v, (str, int, float, bool)
-            ), f"metadata[{k}]={v!r} of type {type(v).__name__} is not flat-scalar"
+            assert isinstance(v, (str, int, float, bool)), (
+                f"metadata[{k}]={v!r} of type {type(v).__name__} is not flat-scalar"
+            )
 
 
 def test_drawer_route_hint_carries_wing(adapter, palace_ctx, canonical_db):

--- a/tests/test_sources_opencode.py
+++ b/tests/test_sources_opencode.py
@@ -1,0 +1,563 @@
+"""Tests for the OpenCode source adapter (RFC 002).
+
+Covers:
+    * Adapter class identity (capabilities, modes, declared transformations).
+    * Conformance against the RFC 002 spec — declared-transformation
+      round-trip, schema-conformance, stable source_file shape.
+    * Unit tests for the SQLite walk, tool-echo/file-injection skip,
+      same-role merge, role coerce, transcript formatting, and the chunked
+      exchange emit through ``convo_miner.chunk_exchanges``.
+    * Edge cases: empty session, single-message session, sessions with
+      mixed text + tool parts, multi-session DB across projects.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from mempalace.sources import transforms as src_transforms
+from mempalace.sources.base import (
+    AdapterClosedError,
+    AdapterSchema,
+    DrawerRecord,
+    FieldSpec,
+    SourceItemMetadata,
+    SourceNotFoundError,
+    SourceRef,
+)
+from mempalace.sources.context import PalaceContext
+from mempalace.sources.opencode import (
+    OpenCodeSourceAdapter,
+    _build_source_bytes_per_session,
+    session_source_file,
+)
+
+# Fixture builder lives next to the fixture data on purpose so it is
+# discoverable by anyone investigating the .db format.
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "opencode" / "sample_session_2026_05_12"
+import sys
+
+sys.path.insert(0, str(FIXTURE_DIR))
+import build_fixture  # noqa: E402  (path-injected fixture builder)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def canonical_db(tmp_path):
+    """Build a SQLite fixture from the canonical synthetic sessions."""
+    path = tmp_path / "opencode.db"
+    build_fixture.build_fixture(str(path), sessions=build_fixture.CANONICAL_SESSIONS)
+    return str(path)
+
+
+@pytest.fixture
+def adapter():
+    return OpenCodeSourceAdapter()
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.upserts = []
+
+    def add(self, **kwargs):
+        pass
+
+    def upsert(self, **kwargs):
+        self.upserts.append(kwargs)
+
+    def query(self, **kwargs):
+        return {}
+
+    def get(self, **kwargs):
+        return {}
+
+    def delete(self, **kwargs):
+        pass
+
+    def count(self):
+        return 0
+
+
+class _FakeKG:
+    def add_triple(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture
+def palace_ctx():
+    return PalaceContext(
+        drawer_collection=_FakeCollection(),
+        knowledge_graph=_FakeKG(),
+        palace_path="/tmp/palace",
+        adapter_name="opencode",
+        adapter_version="0.1.0",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Class identity
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_identity():
+    assert OpenCodeSourceAdapter.name == "opencode"
+    assert OpenCodeSourceAdapter.spec_version == "1.0"
+    assert OpenCodeSourceAdapter.adapter_version == "0.1.0"
+    assert "chunked_content" in OpenCodeSourceAdapter.supported_modes
+    assert "supports_incremental" in OpenCodeSourceAdapter.capabilities
+    assert "adapter_owns_routing" in OpenCodeSourceAdapter.capabilities
+    assert OpenCodeSourceAdapter.default_privacy_class == "pii_potential"
+
+
+def test_declared_transformations_have_reference_impls():
+    """Every declared transformation MUST resolve to an attribute on
+    mempalace.sources.transforms (RFC 002 §7.3)."""
+    for name in OpenCodeSourceAdapter.declared_transformations:
+        impl = getattr(src_transforms, name, None)
+        assert callable(impl), f"declared transformation {name!r} has no callable reference impl"
+
+
+def test_describe_schema_returns_adapter_schema(adapter):
+    schema = adapter.describe_schema()
+    assert isinstance(schema, AdapterSchema)
+    assert schema.version == "1.0"
+    required = {k for k, v in schema.fields.items() if v.required}
+    assert {
+        "session_id",
+        "project_dir",
+        "session_created_at",
+        "message_count",
+        "extract_mode",
+        "opencode_db_path",
+    }.issubset(required)
+    assert isinstance(schema.fields["session_id"], FieldSpec)
+    assert schema.fields["session_id"].indexed is True
+    assert schema.fields["project_dir"].indexed is True
+
+
+# ---------------------------------------------------------------------------
+# Source-file identity
+# ---------------------------------------------------------------------------
+
+
+def test_session_source_file_shape_is_stable():
+    s1 = session_source_file("/tmp/x.db", "ses_abc")
+    s2 = session_source_file("/tmp/x.db", "ses_abc")
+    s3 = session_source_file("/tmp/x.db", "ses_def")
+    assert s1 == s2
+    assert s1 != s3
+    assert s1 == "opencode:///tmp/x.db#session=ses_abc"
+
+
+# ---------------------------------------------------------------------------
+# DB resolution / errors
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_raises_source_not_found_for_missing_db(adapter, palace_ctx, tmp_path):
+    missing = tmp_path / "nope.db"
+    ref = SourceRef(local_path=str(missing))
+    with pytest.raises(SourceNotFoundError):
+        list(adapter.ingest(source=ref, palace=palace_ctx))
+
+
+def test_ingest_raises_source_not_found_for_db_without_expected_tables(adapter, palace_ctx, tmp_path):
+    path = tmp_path / "bad.db"
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE other (id INTEGER)")
+    conn.commit()
+    conn.close()
+    ref = SourceRef(local_path=str(path))
+    with pytest.raises(SourceNotFoundError):
+        list(adapter.ingest(source=ref, palace=palace_ctx))
+
+
+def test_close_then_ingest_raises_adapter_closed(adapter, palace_ctx, canonical_db):
+    adapter.close()
+    ref = SourceRef(local_path=canonical_db)
+    with pytest.raises(AdapterClosedError):
+        list(adapter.ingest(source=ref, palace=palace_ctx))
+
+
+# ---------------------------------------------------------------------------
+# Source-summary
+# ---------------------------------------------------------------------------
+
+
+def test_source_summary_counts_sessions(adapter, canonical_db):
+    summary = adapter.source_summary(source=SourceRef(local_path=canonical_db))
+    # 4 sessions in the canonical fixture; the <2-message one is still counted
+    # at the summary stage (it's a session, just skipped on ingest).
+    assert summary.item_count == 4
+    assert "OpenCode database at" in summary.description
+
+
+def test_source_summary_for_missing_db(adapter, tmp_path):
+    summary = adapter.source_summary(
+        source=SourceRef(local_path=str(tmp_path / "absent.db"))
+    )
+    assert summary.item_count == 0
+    assert "not found" in summary.description.lower()
+
+
+# ---------------------------------------------------------------------------
+# Ingest shape
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_yields_metadata_then_drawers_per_session(adapter, palace_ctx, canonical_db):
+    results = list(adapter.ingest(source=SourceRef(local_path=canonical_db), palace=palace_ctx))
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    # 4 sessions in the fixture, each gets a SourceItemMetadata
+    assert len(metas) == 4
+    # 3 sessions have >=2 real text exchanges; the 4th (ses_ddd444) is skipped
+    src_files = {d.source_file for d in drawers}
+    assert len(src_files) == 3
+    # Source files all carry the opencode:// prefix
+    for sf in src_files:
+        assert sf.startswith("opencode://")
+        assert "#session=" in sf
+
+
+def test_ingest_skips_cancelled_session_with_too_few_turns(adapter, palace_ctx, canonical_db):
+    results = list(adapter.ingest(source=SourceRef(local_path=canonical_db), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    src_files = {d.source_file for d in drawers}
+    assert all("ses_ddd444" not in sf for sf in src_files), (
+        "single-message cancelled session must be skipped"
+    )
+
+
+def test_drawer_metadata_carries_universal_and_schema_fields(adapter, palace_ctx, canonical_db):
+    results = list(adapter.ingest(source=SourceRef(local_path=canonical_db), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert drawers, "expected at least one drawer"
+    schema_keys = set(adapter.describe_schema().fields.keys())
+    universal_keys = {
+        "source_file",
+        "chunk_index",
+        "filed_at",
+        "added_by",
+        "wing",
+        "room",
+        "hall",
+        "ingest_mode",
+        "extract_mode",
+        "privacy_class",
+    }
+    for drawer in drawers:
+        meta = drawer.metadata
+        assert universal_keys.issubset(meta.keys()), (
+            f"missing universal keys: {universal_keys - meta.keys()}"
+        )
+        assert schema_keys.issubset(meta.keys()), (
+            f"missing schema keys: {schema_keys - meta.keys()}"
+        )
+        # Flat-scalar invariant — chroma constraint.
+        for k, v in meta.items():
+            assert isinstance(v, (str, int, float, bool)), (
+                f"metadata[{k}]={v!r} of type {type(v).__name__} is not flat-scalar"
+            )
+
+
+def test_drawer_route_hint_carries_wing(adapter, palace_ctx, canonical_db):
+    results = list(adapter.ingest(source=SourceRef(local_path=canonical_db), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    for d in drawers:
+        assert d.route_hint is not None
+        assert d.route_hint.wing  # never empty
+        # OpenCode adapter populates room from convo_miner.detect_convo_room.
+        assert d.route_hint.room
+
+
+def test_wing_routing_groups_by_session_directory(adapter, palace_ctx, canonical_db):
+    """Two frontend sessions and one backend session should produce two wings."""
+    results = list(adapter.ingest(source=SourceRef(local_path=canonical_db), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    wings = {d.metadata["wing"] for d in drawers}
+    assert "frontend" in wings
+    assert "backend" in wings
+
+
+def test_explicit_wing_option_wins_over_directory(adapter, palace_ctx, canonical_db):
+    ref = SourceRef(local_path=canonical_db, options={"wing": "Custom Wing"})
+    results = list(adapter.ingest(source=ref, palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    wings = {d.metadata["wing"] for d in drawers}
+    assert wings == {"custom_wing"}  # normalize_wing_name lower+underscored
+
+
+# ---------------------------------------------------------------------------
+# Skip / incremental behavior
+# ---------------------------------------------------------------------------
+
+
+def test_skip_current_item_short_circuits_drawer_emit(adapter, palace_ctx, canonical_db):
+    """When core calls palace.skip_current_item() after a metadata item, the
+    adapter MUST stop emitting drawers for that item and move on."""
+    ref = SourceRef(local_path=canonical_db)
+    gen = adapter.ingest(source=ref, palace=palace_ctx)
+    drawers_seen = 0
+    for result in gen:
+        if isinstance(result, SourceItemMetadata):
+            palace_ctx.skip_current_item()
+        elif isinstance(result, DrawerRecord):
+            drawers_seen += 1
+    # Every session was skipped after metadata, so zero drawers should emerge.
+    assert drawers_seen == 0
+
+
+def test_is_current_uses_version_when_present(adapter):
+    item = SourceItemMetadata(source_file="opencode:///x#session=ses_a", version="123")
+    assert adapter.is_current(item=item, existing_metadata=None) is False
+    assert (
+        adapter.is_current(
+            item=item, existing_metadata={"opencode_session_version": "123"}
+        )
+        is True
+    )
+    assert (
+        adapter.is_current(
+            item=item, existing_metadata={"opencode_session_version": "999"}
+        )
+        is False
+    )
+
+
+def test_is_current_falls_back_to_presence_when_version_missing(adapter):
+    """Older drawers may not carry opencode_session_version; presence implies current."""
+    item = SourceItemMetadata(source_file="opencode:///x#session=ses_a", version="123")
+    # any other-metadata-present scenario should return True (we assume we
+    # already mined this session) — this is safer than always re-extracting.
+    assert (
+        adapter.is_current(
+            item=item, existing_metadata={"session_id": "ses_a", "wing": "x"}
+        )
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool/file part skipping
+# ---------------------------------------------------------------------------
+
+
+def test_tool_input_and_tool_output_parts_are_skipped(adapter, palace_ctx, canonical_db):
+    """ses_aaa111 has tool-input + tool-output parts; their content must not
+    appear in any drawer."""
+    results = list(adapter.ingest(source=SourceRef(local_path=canonical_db), palace=palace_ctx))
+    drawers = [
+        r
+        for r in results
+        if isinstance(r, DrawerRecord)
+        and r.source_file.endswith("#session=ses_aaa111")
+    ]
+    joined = "\n".join(d.content for d in drawers)
+    # Sentinels we wrote into tool-input/tool-output parts in the fixture
+    assert "src/api.ts" not in joined
+    assert "file edited" not in joined
+
+
+def test_tool_echo_lines_are_stripped():
+    """A user turn echoing a tool invocation should be dropped before the
+    transcript is chunked."""
+    raw = "user\t" + json.dumps({"type": "text", "text": "Called the read tool with the following input"})
+    raw += "\nuser\t" + json.dumps({"type": "text", "text": "Actually, what's the answer?"})
+    out = src_transforms.opencode_extract_text_parts(raw)
+    out = src_transforms.opencode_skip_tool_echo(out)
+    assert "Called the read tool" not in out
+    assert "Actually, what's the answer?" in out
+
+
+def test_file_injection_lines_are_stripped():
+    raw = "user\t" + json.dumps({"type": "text", "text": "<path>foo.py</path><type>file</type>"})
+    raw += "\nuser\t" + json.dumps({"type": "text", "text": "Real question follows."})
+    out = src_transforms.opencode_extract_text_parts(raw)
+    out = src_transforms.opencode_skip_file_injection(out)
+    assert "<path>foo.py</path>" not in out
+    assert "Real question follows." in out
+
+
+# ---------------------------------------------------------------------------
+# Build-source-bytes / declared-transformation round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_build_source_bytes_returns_role_tab_part_lines(canonical_db):
+    conn = sqlite3.connect(canonical_db)
+    try:
+        raw = _build_source_bytes_per_session(conn, "ses_aaa111")
+    finally:
+        conn.close()
+    lines = raw.split("\n")
+    # Every line is "<role>\t<json>"
+    for line in lines:
+        role, sep, body = line.partition("\t")
+        assert sep == "\t"
+        assert role in {"user", "assistant", ""}
+        obj = json.loads(body)
+        assert "type" in obj
+
+
+def test_declared_transformation_round_trip_reproduces_drawer_content(
+    adapter, palace_ctx, canonical_db
+):
+    """RFC 002 §7.3: applying the declared transformations to canonical source
+    bytes, in the adapter's declared order, MUST reproduce the chunk content
+    (modulo chunk_exchanges' chunking step which is applied on top)."""
+    results = list(adapter.ingest(source=SourceRef(local_path=canonical_db), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    # Group drawers by source_file, then verify the transcript reproduces from
+    # canonical source bytes via the declared pipeline.
+    by_src: dict[str, list[DrawerRecord]] = {}
+    for d in drawers:
+        by_src.setdefault(d.source_file, []).append(d)
+
+    conn = sqlite3.connect(canonical_db)
+    try:
+        for src_file, ds in by_src.items():
+            # Extract session_id from source_file shape opencode://<path>#session=<sid>
+            sid = src_file.split("#session=", 1)[1]
+            raw = _build_source_bytes_per_session(conn, sid)
+            transformed = raw
+            for name in adapter.DECLARED_TRANSFORMATION_ORDER:
+                fn = getattr(src_transforms, name)
+                transformed = fn(transformed)
+            # `transformed` is the pre-chunking transcript; chunk_exchanges then
+            # produces the same per-drawer content list. We import locally so
+            # the test mirrors what the adapter does.
+            from mempalace.convo_miner import chunk_exchanges
+
+            expected_chunks = chunk_exchanges(transformed)
+            assert len(expected_chunks) == len(ds), (
+                f"chunk count mismatch for {src_file}: "
+                f"{len(expected_chunks)} expected, {len(ds)} produced"
+            )
+            ds_sorted = sorted(ds, key=lambda d: d.chunk_index)
+            for c, d in zip(expected_chunks, ds_sorted):
+                assert c["content"] == d.content
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Empty / edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_db_yields_nothing(adapter, palace_ctx, tmp_path):
+    """A schema-valid but empty OpenCode DB ingests cleanly with zero records."""
+    path = tmp_path / "empty.db"
+    build_fixture.build_fixture(str(path), sessions=[])
+    results = list(adapter.ingest(source=SourceRef(local_path=str(path)), palace=palace_ctx))
+    assert results == []
+
+
+def test_session_with_only_user_turn_is_skipped(adapter, palace_ctx, tmp_path):
+    """A single-turn session (just one user message) cannot form an exchange
+    pair, so the adapter skips it and emits no drawer (only the metadata)."""
+    only_user = build_fixture.SyntheticSession(
+        session_id="ses_only_user",
+        project_id="p",
+        directory="/tmp/p",
+        title="Only user",
+        messages=[
+            build_fixture.SyntheticMessage(
+                role="user", parts=[build_fixture.SyntheticPart(text="hi")]
+            )
+        ],
+    )
+    path = tmp_path / "only_user.db"
+    build_fixture.build_fixture(str(path), sessions=[only_user])
+    results = list(adapter.ingest(source=SourceRef(local_path=str(path)), palace=palace_ctx))
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert len(metas) == 1
+    assert drawers == []
+
+
+def test_unicode_content_preserved_end_to_end(adapter, palace_ctx, tmp_path):
+    """Unicode (BMP and non-BMP) in user/assistant text MUST survive to
+    drawer.content unchanged."""
+    # Use larger Unicode bodies so chunk_exchanges' MIN_CHUNK_SIZE (30 chars)
+    # doesn't elide the only exchange in the session.
+    sess = build_fixture.SyntheticSession(
+        session_id="ses_uni",
+        project_id="p",
+        directory="/tmp/p",
+        title="Unicode session",
+        messages=[
+            build_fixture.SyntheticMessage(
+                role="user",
+                parts=[
+                    build_fixture.SyntheticPart(
+                        text=(
+                            "日本語テスト 🎯 кириллица — how do I handle UTF-8 in "
+                            "the database column when storing user names with emoji?"
+                        )
+                    )
+                ],
+            ),
+            build_fixture.SyntheticMessage(
+                role="assistant",
+                parts=[
+                    build_fixture.SyntheticPart(
+                        text=(
+                            "हिन्दी और عربى — emoji 🚀 ok. Use utf8mb4 in MySQL, "
+                            "TEXT in Postgres (already 4-byte UTF-8), and make sure "
+                            "your connection charset is utf8mb4 too."
+                        )
+                    )
+                ],
+            ),
+        ],
+    )
+    path = tmp_path / "uni.db"
+    build_fixture.build_fixture(str(path), sessions=[sess])
+    results = list(adapter.ingest(source=SourceRef(local_path=str(path)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert drawers
+    combined = "\n".join(d.content for d in drawers)
+    for needle in ("日本語テスト", "🎯", "кириллица", "हिन्दी", "عربى", "🚀"):
+        assert needle in combined, f"unicode {needle!r} did not survive transcript"
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+def test_registry_can_resolve_opencode_when_registered_explicitly():
+    """Even without entry-point discovery (pip install -e .) the registry
+    SHOULD admit explicit registration."""
+    from mempalace.sources.registry import (
+        available_adapters,
+        get_adapter,
+        register,
+        unregister,
+    )
+
+    register("opencode", OpenCodeSourceAdapter)
+    try:
+        assert "opencode" in available_adapters()
+        inst = get_adapter("opencode")
+        assert isinstance(inst, OpenCodeSourceAdapter)
+    finally:
+        unregister("opencode")
+
+
+def test_capability_byte_preserving_is_NOT_advertised():
+    """Sanity check: the OpenCode adapter is declared-lossy (transforms
+    declared but non-empty), so it MUST NOT advertise byte_preserving."""
+    assert "byte_preserving" not in OpenCodeSourceAdapter.capabilities
+    assert len(OpenCodeSourceAdapter.declared_transformations) > 0

--- a/tests/test_sources_opencode.py
+++ b/tests/test_sources_opencode.py
@@ -13,9 +13,10 @@ Covers:
 
 from __future__ import annotations
 
+import importlib.util
 import json
-import os
 import sqlite3
+import sys
 from pathlib import Path
 
 import pytest
@@ -38,12 +39,18 @@ from mempalace.sources.opencode import (
 )
 
 # Fixture builder lives next to the fixture data on purpose so it is
-# discoverable by anyone investigating the .db format.
+# discoverable by anyone investigating the .db format. Loaded via
+# importlib so we don't mutate sys.path at module scope (which would
+# also trip ruff E402 on the import-not-at-top check).
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "opencode" / "sample_session_2026_05_12"
-import sys
-
-sys.path.insert(0, str(FIXTURE_DIR))
-import build_fixture  # noqa: E402  (path-injected fixture builder)
+_fixture_spec = importlib.util.spec_from_file_location(
+    "build_fixture", FIXTURE_DIR / "build_fixture.py"
+)
+build_fixture = importlib.util.module_from_spec(_fixture_spec)
+# Register in sys.modules so dataclass / typing introspection inside
+# build_fixture can resolve back to the module via cls.__module__.
+sys.modules["build_fixture"] = build_fixture
+_fixture_spec.loader.exec_module(build_fixture)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `OpenCodeSourceAdapter` — an RFC 002 `BaseSourceAdapter` that ingests OpenCode AI-coding-CLI session transcripts from OpenCode's local SQLite store (`~/.local/share/opencode/opencode.db`) into the palace, formatted to match `convo_miner`'s exchange-pair drawer shape.

## What's included

- `mempalace/sources/opencode.py` — 482-line adapter:
  - Yields `SourceItemMetadata` then `DrawerRecord`s per session
  - One `source_file` per session shaped as `opencode://<absolute-db-path>#session=<sid>`
  - Chunks via `convo_miner.chunk_exchanges` exchange-pair shape
  - Declares 8 transformations (6 opencode-namespaced + 2 reserved); every name resolves to a reference implementation on `mempalace.sources.transforms` per RFC 002 §7.3
  - Schema fields: `session_id`, `session_title`, `project_dir`, `session_created_at`, `message_count`, `extract_mode`, `opencode_db_path`
  - `supports_incremental` + `adapter_owns_routing`; `default_privacy_class = "pii_potential"`
  - Routes wing from `session.directory` basename (or explicit `options["wing"]`); room from `detect_convo_room`; hall from `_detect_hall_cached`
- `mempalace/sources/transforms.py` — +141 lines adding the 6 opencode-namespaced reference transformations
- `pyproject.toml` — entry-point registration under `[project.entry-points."mempalace.sources"]` as `opencode = "mempalace.sources.opencode:OpenCodeSourceAdapter"`
- `tests/test_sources_opencode.py` — 28 tests covering identity, capabilities, schema, ingest, route hints, transforms round-trip (RFC 002 §7.3 byte-equivalence), edge cases
- `tests/fixtures/opencode/sample_session_2026_05_12/build_fixture.py` — SQLite-schema-verbatim fixture builder (mirrors opencode-ai 1.14.39's schema captured live from `~/.local/share/opencode/opencode.db`); no recorded `.db` ships because real-session content is unsanitizable

## Coordination

This work originated from the OpenCode SQLite spadework in @JakobSachs's #23 (DB-schema reverse engineering, session/message/part traversal, tool-input/tool-output stripping primitives) — rebuilt on the RFC 002 contract so OpenCode support can ship as a registered adapter rather than a `normalize.py` branch. Coordination thread at #23, comment posted offering three paths forward; pushing this PR as the working code per @JakobSachs's choice of how to land (see #23#issuecomment-4436116396). Co-authored credit on the commit.

Complementary to #297 (Milofax) which adds the **consumer-side** JS plugin (`examples/opencode_auto_plugin.js`) that auto-initializes MemPalace in OpenCode sessions. Together: this adapter ingests OpenCode sessions into the palace; #297's plugin queries the palace from OpenCode at runtime. Different layers, no overlap.

Built on top of #1014 (RFC 002 scaffolding by @igorls).

## Test plan

- [x] 28/28 OpenCode adapter tests pass in 1.53s
- [x] Full suite 1876 passed / 7 skipped / 106 deselected — zero regressions (+22 net vs pre-adapter baseline)
- [x] Adapter conformance via RFC 002 §7.3 declared-transformation round-trip (drawer content reproducible from transformations)
- [ ] Real-OpenCode-session smoke (deferred — fixture is schema-verbatim from a real install but doesn't ship recorded content; configuring an OpenCode provider for a billable real-session capture is non-blocking)

## Notes

- The 7 fork-only-on-jphein/main files (CLAUDE.md, README.md, FORK_CHANGELOG.md, docs/fork-changes.yaml, .claude-plugin/*, docs/internal/*, docs/research/*) are intentionally NOT in this diff — branch was rebuilt off `upstream/develop` carrying only commit `9030f06` so no fork-specific narrative leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)