### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1198,7 +1198,7 @@ def main():
     p_init.add_argument(
         "--llm-provider",
         default="ollama",
-        choices=["ollama", "openai-compat", "anthropic"],
+        choices=["ollama", "openai-compat", "anthropic", "litellm"],
         help="LLM provider (default: ollama). Pass --no-llm to disable LLM-assisted refinement entirely.",
     )
     p_init.add_argument(

--- a/mempalace/llm_client.py
+++ b/mempalace/llm_client.py
@@ -431,6 +431,88 @@ class AnthropicProvider(LLMProvider):
         return LLMResponse(text=text, model=self.model, provider=self.name, raw=data)
 
 
+# ==================== LITELLM ====================
+
+
+class LiteLLMProvider(LLMProvider):
+    """Routes to 100+ LLM providers via the litellm SDK.
+
+    Uses the litellm model string format (e.g. ``anthropic/claude-sonnet-4-5``,
+    ``openai/gpt-4o``, ``bedrock/anthropic.claude-v2``, ``vertex_ai/gemini-pro``).
+    Provider-specific API keys are read from environment variables automatically
+    (e.g. ``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``).
+
+    See https://docs.litellm.ai/docs/providers for supported providers.
+    """
+
+    name = "litellm"
+
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        timeout: int = 120,
+        **_: object,
+    ):
+        super().__init__(
+            model=model,
+            endpoint=endpoint,
+            api_key=api_key,
+            timeout=timeout,
+        )
+
+    def check_available(self) -> tuple[bool, str]:
+        try:
+            import litellm  # noqa: F401
+        except ImportError:
+            return False, "litellm not installed. Install with: pip install litellm"
+        return True, "ok"
+
+    def classify(
+        self,
+        system: str,
+        user: str,
+        json_mode: bool = True,
+        think: Optional[bool] = None,  # noqa: ARG002
+    ) -> LLMResponse:
+        import litellm
+
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+
+        kwargs: dict = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": 0.1,
+            "stream": False,
+        }
+        if json_mode:
+            kwargs["response_format"] = {"type": "json_object"}
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+
+        try:
+            response = litellm.completion(**kwargs)
+        except Exception as e:
+            raise LLMError(f"LiteLLM error (model={self.model}): {e}") from e
+
+        try:
+            text = response.choices[0].message.content
+        except (AttributeError, IndexError, TypeError) as e:
+            raise LLMError(f"Unexpected response shape: {e}") from e
+        if not text:
+            raise LLMError(f"Empty response from LiteLLM (model={self.model})")
+        return LLMResponse(
+            text=text,
+            model=response.model or self.model,
+            provider=self.name,
+            raw=response.model_dump(mode="json"),
+        )
+
+
 # ==================== FACTORY ====================
 
 
@@ -438,6 +520,7 @@ PROVIDERS: dict[str, type[LLMProvider]] = {
     "ollama": OllamaProvider,
     "openai-compat": OpenAICompatProvider,
     "anthropic": AnthropicProvider,
+    "litellm": LiteLLMProvider,
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ chroma = "mempalace.backends.chroma:ChromaBackend"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]
+litellm = ["litellm>=1.55.0,<1.85"]
 spellcheck = ["autocorrect>=2.0"]
 # Hardware acceleration for the ONNX embedding model. Install exactly one:
 #   pip install mempalace[gpu]       — NVIDIA CUDA


### PR DESCRIPTION

## What does this PR do?

Adds LiteLLM as a fourth LLM provider, giving users BYOK access to 100+ cloud providers (Anthropic, OpenAI, Google, Bedrock, Vertex AI, Cohere, Mistral, etc.) through a single provider class.

`LiteLLMProvider` follows the same `LLMProvider` pattern as Ollama, OpenAI-compat, and Anthropic. It routes to the correct provider based on the model string (e.g. `anthropic/claude-sonnet-4-5`, `openai/gpt-4o`, `bedrock/anthropic.claude-v2`). Provider-specific API keys are read from env vars automatically by LiteLLM.

Respects MemPalace's local-first principle: LiteLLM is an optional extra (`pip install mempalace[litellm]`), never a default, only runs when user explicitly selects `--llm-provider litellm`.

**Changes:**
- `mempalace/llm_client.py` - new `LiteLLMProvider` class, registered in `PROVIDERS` dict
- `mempalace/cli.py` - added `litellm` to `--llm-provider` choices
- `pyproject.toml` - added `litellm>=1.55.0,<1.85` as optional dependency

## How to test

```bash
pip install -e ".[litellm]"
```
# Via Python
```python
from mempalace.llm_client import get_provider
provider = get_provider("litellm", "anthropic/claude-sonnet-4-5")
result = provider.classify(
    system='You are a JSON classifier. Return {"category": "greeting"}',
    user="Hello world",
    json_mode=True,
)
print(result.text)   # {"category": "greeting"}
print(result.model)  # claude-sonnet-4-5-20250929
```
# Via CLI
```bash
export ANTHROPIC_API_KEY="sk-..."
mempalace init --llm-provider litellm --llm-model anthropic/claude-sonnet-4-5
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
