### PR TITLE
style: ruff format test_hnsw_payload_health.py (#1461 follow-up)

### DIFF
--- a/tests/test_hnsw_payload_health.py
+++ b/tests/test_hnsw_payload_health.py
@@ -155,6 +155,4 @@ def test_quarantine_catches_zero_byte_link_lists_when_stale(tmp_path):
 
     moved_path = Path(moved[0])
     assert moved_path.exists()
-    assert moved_path.name.startswith(
-        "11111111-2222-3333-4444-555555555555.drift-"
-    )
+    assert moved_path.name.startswith("11111111-2222-3333-4444-555555555555.drift-")


### PR DESCRIPTION
Collapses the multi-line `assert startswith()` added in #1461 into a single line as required by `ruff format --check`. The format CI was failing after the merge.

No logic change — pure style fix.

Closes the ruff format regression introduced in #1461.