### PR TITLE
fix(mcp): structured -32602 for unknown parameter name (#1512)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2242,6 +2242,26 @@ def handle_request(request):
         except (ValueError, TypeError):
             accepts_var_keyword = False
         if not accepts_var_keyword:
+            # An unknown kwarg here is almost always a wrong parameter *name*
+            # (e.g. text= instead of content=). Silently dropping it makes the
+            # cause surface only indirectly as a later "Missing required 'X'",
+            # so name it explicitly — symmetric with the missing-required path
+            # below. wait_for_previous is an internal transport kwarg in no
+            # tool schema; it is popped before dispatch further down, so it
+            # must not be reported as unknown here.
+            unknown = [k for k in tool_args if k not in schema_props and k != "wait_for_previous"]
+            if unknown:
+                quoted = ", ".join(f"'{k}'" for k in unknown)
+                word = "parameter" if len(unknown) == 1 else "parameters"
+                logger.debug("Tool %s: unknown %s %s", tool_name, word, quoted)
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {
+                        "code": -32602,
+                        "message": f"Unknown {word} {quoted} for tool {tool_name}",
+                    },
+                }
             tool_args = {k: v for k, v in tool_args.items() if k in schema_props}
         # Coerce argument types based on input_schema.
         # MCP JSON transport may deliver integers as floats or strings;

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2066,3 +2066,105 @@ class TestParamShapeDiagnostics:
         assert resp["error"]["message"] == "Internal tool error"
         assert "'foo'" not in resp["error"]["message"]
         assert "some_helper" not in resp["error"]["message"]
+
+
+class TestUnknownParamName:
+    """A kwarg not in the tool schema (wrong parameter *name*, e.g. text=
+    instead of content=) should surface as JSON-RPC -32602 naming the
+    offending kwarg, instead of being silently dropped and resurfacing
+    indirectly as a later "Missing required 'X'". Symmetric with the
+    missing-required path in TestParamShapeDiagnostics. The internal
+    wait_for_previous transport kwarg must never be flagged, and
+    **kwargs pass-through handlers must keep accepting unknown kwargs.
+    """
+
+    def test_unknown_param_returns_32602_naming_the_wrong_kwarg(self):
+        from mempalace.mcp_server import handle_request
+
+        resp = handle_request(
+            {
+                "method": "tools/call",
+                "id": 7,
+                "params": {
+                    "name": "mempalace_add_drawer",
+                    "arguments": {"wing": "w", "room": "r", "text": "hello"},
+                },
+            }
+        )
+        assert resp["error"]["code"] == -32602
+        message = resp["error"]["message"]
+        assert "'text'" in message
+        assert "Unknown parameter" in message
+        assert "mempalace_add_drawer" in message
+        # Names the actual wrong kwarg, not the indirect missing-required symptom.
+        assert "Missing required" not in message
+
+    def test_two_unknown_params_list_both_names(self):
+        from mempalace.mcp_server import handle_request
+
+        resp = handle_request(
+            {
+                "method": "tools/call",
+                "id": 8,
+                "params": {
+                    "name": "mempalace_add_drawer",
+                    "arguments": {"wing": "w", "room": "r", "text": "a", "bogus": "b"},
+                },
+            }
+        )
+        assert resp["error"]["code"] == -32602
+        message = resp["error"]["message"]
+        assert "parameters" in message
+        assert "'text'" in message
+        assert "'bogus'" in message
+
+    def test_wait_for_previous_not_flagged_as_unknown(self, monkeypatch):
+        """wait_for_previous is an internal transport kwarg in no tool schema;
+        it is popped before dispatch and must not trip the unknown-param check
+        for a normal (non-**kwargs) handler.
+        """
+        from mempalace import mcp_server
+
+        def stub(agent_name, entry, topic="general"):
+            return {"ok": True, "agent": agent_name}
+
+        monkeypatch.setitem(mcp_server.TOOLS["mempalace_diary_write"], "handler", stub)
+
+        resp = mcp_server.handle_request(
+            {
+                "method": "tools/call",
+                "id": 9,
+                "params": {
+                    "name": "mempalace_diary_write",
+                    "arguments": {
+                        "agent_name": "x",
+                        "entry": "y",
+                        "wait_for_previous": True,
+                    },
+                },
+            }
+        )
+        assert "error" not in resp
+        assert "result" in resp
+
+    def test_kwargs_passthrough_handler_keeps_accepting_unknown(self, monkeypatch):
+        """Handlers that explicitly accept **kwargs (per #684) bypass the
+        schema filter entirely, so an unknown kwarg must still pass through
+        rather than being rejected as -32602.
+        """
+        from mempalace import mcp_server
+
+        def passthrough(**kwargs):
+            return {"ok": True, "got": sorted(kwargs)}
+
+        monkeypatch.setitem(mcp_server.TOOLS["mempalace_status"], "handler", passthrough)
+
+        resp = mcp_server.handle_request(
+            {
+                "method": "tools/call",
+                "id": 10,
+                "params": {"name": "mempalace_status", "arguments": {"bogus": 1}},
+            }
+        )
+        assert "error" not in resp
+        assert "result" in resp


### PR DESCRIPTION
Second half of #1351, complementary to #1500. #1500 made the *missing-required* case structured; this does the same for the *wrong-name* case. Issue opened first (#1512) per CONTRIBUTING.

Closes #1512.

## What

A kwarg not in the tool's `input_schema.properties` (e.g. `mempalace_add_drawer(text=...)` instead of `content=...`) was silently dropped by the schema-filter, so the cause surfaced only indirectly as a later `Missing required 'content'` (post-#1500). The filter now emits `-32602 Unknown parameter 'text' for tool mempalace_add_drawer` — single point, all tools, symmetric with #1500's message shape, `-32602` code and `logger.debug` precedent.

- Gated by the existing `if not accepts_var_keyword:` so `**kwargs` pass-through handlers (#684) keep accepting unknown kwargs.
- `wait_for_previous` (internal transport kwarg, popped after the filter) is explicitly excluded so it isn't falsely flagged — the subtlety @mvalentsev confirmed in #1351.

## Behavior change

Previously-silently-dropped unknown kwargs now return `-32602` for non-`**kwargs` handlers. This is the deliberate strictness increase discussed and endorsed in #1351 (agents otherwise retry the same wrong-shape call); `**kwargs` pass-through handlers are unaffected.

## Tests

`TestUnknownParamName` (4):

- Two are **red→green**: on unmodified `develop` they fail with the indirect `Missing required parameter 'content' ...` (the #1500 symptom), and pass once the wrong name is named.
- Two are **regression guards** (pass before and after): `wait_for_previous` not flagged for a normal handler; `**kwargs` pass-through still accepts unknown.

No API key / network needed.

## Verification

```
ruff check .                                       # pass  (CI-pinned ruff 0.4.x)
ruff format --check .                               # clean
uv run pytest tests/ --ignore=tests/benchmarks     # 1764 passed, 1 skipped
```

Sequenced after #1500 per my note in #1351 (both touch the dispatch region); rebased on current `develop` (contains #1500).
