### PR TITLE
fix(convo_miner): validate explicit min_chunk_size instead of raw config reach

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -332,7 +332,9 @@ class MempalaceConfig:
                 if not value:
                     return None
             value = int(value)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
+            # OverflowError: JSON ``1e1000`` parses to float('inf'), and
+            # ``int(inf)`` raises it — still just garbage config, not a crash.
             return None
         if minimum is not None and value < minimum:
             return None
@@ -403,8 +405,10 @@ class MempalaceConfig:
         Returns the coerced int when ``config.json`` defines a usable
         ``min_chunk_size`` (``>= 0`` and ``<= chunk_size``); ``None`` when
         the key is absent/null or the value is unusable. ``convo_miner``
-        relies on the ``None`` sentinel to keep its stricter 30-char floor
-        for untuned users while still honoring an explicit override —
+        relies on the ``None`` sentinel to keep its lower 30-char floor
+        (more permissive than the 50-char project default, so short
+        exchanges are not dropped) for untuned users while still honoring
+        an explicit override —
         replacing the raw, unvalidated ``_file_config`` reach that crashed
         convo ingest on a bad key (#1024 review).
         """

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -313,6 +313,31 @@ class MempalaceConfig:
         """Mapping of hall names to keyword lists."""
         return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
 
+    @staticmethod
+    def _try_coerce_int(value, minimum=None):
+        """Coerce a raw config value to int, or ``None`` if it cannot be a
+        valid setting.
+
+        bool, empty/garbage string, non-numeric, and below-``minimum``
+        values all return ``None``. Shared by ``_coerce_config_int``
+        (which substitutes a documented default) and
+        ``min_chunk_size_explicit`` (which must distinguish "unusable"
+        from "explicitly set" without crashing the convo path).
+        """
+        if isinstance(value, bool):
+            return None
+        try:
+            if isinstance(value, str):
+                value = value.strip()
+                if not value:
+                    return None
+            value = int(value)
+        except (TypeError, ValueError):
+            return None
+        if minimum is not None and value < minimum:
+            return None
+        return value
+
     def _coerce_config_int(self, key: str, default: int, minimum=None) -> int:
         """Read an int config value, falling back to ``default`` on bad input.
 
@@ -321,20 +346,8 @@ class MempalaceConfig:
         should crash mining or hang ``chunk_text()`` — fall back silently
         to the documented default rather than letting a typo break ingest.
         """
-        value = self._file_config.get(key, default)
-        if isinstance(value, bool):
-            return default
-        try:
-            if isinstance(value, str):
-                value = value.strip()
-                if not value:
-                    return default
-            value = int(value)
-        except (TypeError, ValueError):
-            return default
-        if minimum is not None and value < minimum:
-            return default
-        return value
+        coerced = self._try_coerce_int(self._file_config.get(key, default), minimum)
+        return default if coerced is None else coerced
 
     def _validated_chunk_config(self):
         """Return ``(chunk_size, chunk_overlap, min_chunk_size)`` post-validation.
@@ -382,6 +395,26 @@ class MempalaceConfig:
     def min_chunk_size(self) -> int:
         """Minimum chunk size — skip smaller chunks (validated, ``<= chunk_size``)."""
         return self._validated_chunk_config()[2]
+
+    @property
+    def min_chunk_size_explicit(self):
+        """Validated ``min_chunk_size`` iff the user explicitly set it.
+
+        Returns the coerced int when ``config.json`` defines a usable
+        ``min_chunk_size`` (``>= 0`` and ``<= chunk_size``); ``None`` when
+        the key is absent/null or the value is unusable. ``convo_miner``
+        relies on the ``None`` sentinel to keep its stricter 30-char floor
+        for untuned users while still honoring an explicit override —
+        replacing the raw, unvalidated ``_file_config`` reach that crashed
+        convo ingest on a bad key (#1024 review).
+        """
+        raw = self._file_config.get("min_chunk_size")
+        if raw is None:
+            return None
+        coerced = self._try_coerce_int(raw, minimum=0)
+        if coerced is None or coerced > self.chunk_size:
+            return None
+        return coerced
 
     @property
     def entity_languages(self):

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -430,9 +430,10 @@ def mine_convos(
     Chunking parameters (chunk_size, min_chunk_size) are read from
     MempalaceConfig so `config.json` governs both this path and the
     project-file miner in `miner.py`. `min_chunk_size` preserves
-    convo_miner's stricter default (30) when not explicitly set in
-    config.json, so a user who never touches chunking keeps the
-    existing behavior.
+    convo_miner's lower default (30 — more permissive than the 50-char
+    project default, so short conversation exchanges are not dropped)
+    when not explicitly set in config.json, so a user who never touches
+    chunking keeps the existing behavior.
     """
     from .config import MempalaceConfig
 
@@ -440,8 +441,10 @@ def mine_convos(
     cfg_chunk_size = palace_config.chunk_size
     # Only override convo_miner's MIN_CHUNK_SIZE when the user has set
     # min_chunk_size explicitly. min_chunk_size_explicit returns the
-    # validated value or None — None keeps convo's stricter 30-char
-    # floor. Using the validated accessor (not raw _file_config) means a
+    # validated value or None — None keeps convo's lower 30-char floor
+    # (more permissive than the 50-char project default, so short
+    # exchanges aren't dropped). Using the validated accessor (not raw
+    # _file_config) means a
     # garbage/negative/bool config value can't TypeError the length gate
     # below or ValueError out of chunk_exchanges and abort convo ingest.
     explicit_min = palace_config.min_chunk_size_explicit

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -439,10 +439,13 @@ def mine_convos(
     palace_config = MempalaceConfig()
     cfg_chunk_size = palace_config.chunk_size
     # Only override convo_miner's MIN_CHUNK_SIZE when the user has set
-    # min_chunk_size explicitly — default MempalaceConfig returns miner.py's
-    # 50, which would drop legitimate short conversation exchanges.
-    raw_min = palace_config._file_config.get("min_chunk_size")
-    cfg_min_chunk_size = raw_min if raw_min is not None else MIN_CHUNK_SIZE
+    # min_chunk_size explicitly. min_chunk_size_explicit returns the
+    # validated value or None — None keeps convo's stricter 30-char
+    # floor. Using the validated accessor (not raw _file_config) means a
+    # garbage/negative/bool config value can't TypeError the length gate
+    # below or ValueError out of chunk_exchanges and abort convo ingest.
+    explicit_min = palace_config.min_chunk_size_explicit
+    cfg_min_chunk_size = explicit_min if explicit_min is not None else MIN_CHUNK_SIZE
 
     convo_path = Path(convo_dir).expanduser().resolve()
     if not wing:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -508,6 +508,17 @@ def test_convo_min_chunk_fallback_is_always_safe_int(tmp_path):
     assert (explicit if explicit is not None else MIN_CHUNK_SIZE) == 15
 
 
+def test_min_chunk_size_explicit_handles_json_infinity(tmp_path):
+    """JSON ``Infinity`` round-trips to float('inf'); ``int(inf)`` raises
+    OverflowError. That is still garbage config, not a crash — must fall
+    back to None (untuned), same as any other unusable value."""
+    cfg = _write_config(tmp_path, min_chunk_size=float("inf"))
+    assert cfg.min_chunk_size_explicit is None
+    # chunk_size path coerces the same value → documented default, no crash.
+    cfg2 = _write_config(tmp_path, chunk_size=float("inf"))
+    assert cfg2.chunk_size == 800
+
+
 def test_chunk_text_rejects_non_positive_chunk_size():
     """Direct callers (tests, library users) that pass ``chunk_size <= 0``
     must hit a clear ValueError, not loop forever."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -443,6 +443,71 @@ def test_chunk_config_min_chunk_size_above_size_repaired(tmp_path):
     assert cfg2.min_chunk_size == 20  # default (50) > chunk_size, clamp
 
 
+# ── min_chunk_size_explicit (convo-path validated accessor) ────────────
+# Backs the #1024-review fix: convo_miner must distinguish "user tuned
+# min_chunk_size" from "untuned" WITHOUT reaching into raw _file_config.
+# Untuned/unusable → None (convo keeps its 30 floor). Usable → validated
+# int. A bad key must never reach the convo length-gate / chunk_exchanges
+# as a non-int and crash ingest.
+
+
+def test_min_chunk_size_explicit_none_when_unset(tmp_path):
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.min_chunk_size_explicit is None
+
+
+def test_min_chunk_size_explicit_none_when_json_null(tmp_path):
+    """Explicit JSON ``null`` is treated as untuned (preserves the prior
+    ``_file_config.get(...) is None`` sentinel semantics)."""
+    cfg = _write_config(tmp_path, min_chunk_size=None)
+    assert cfg.min_chunk_size_explicit is None
+
+
+def test_min_chunk_size_explicit_returns_validated_value(tmp_path):
+    cfg = _write_config(tmp_path, min_chunk_size=80)
+    assert cfg.min_chunk_size_explicit == 80
+
+
+def test_min_chunk_size_explicit_coerces_numeric_string(tmp_path):
+    cfg = _write_config(tmp_path, min_chunk_size="42")
+    assert cfg.min_chunk_size_explicit == 42
+
+
+@pytest.mark.parametrize("bad", ["abc", -5, True, "", "  "])
+def test_min_chunk_size_explicit_none_on_unusable_value(tmp_path, bad):
+    """Garbage / negative / bool / blank → None, NOT a crash and NOT the
+    miner.py default. convo_miner then falls back to its own 30 floor.
+    This is the exact class of value that used to TypeError the convo
+    length-gate or ValueError out of chunk_exchanges."""
+    cfg = _write_config(tmp_path, min_chunk_size=bad)
+    assert cfg.min_chunk_size_explicit is None
+
+
+def test_min_chunk_size_explicit_none_when_above_chunk_size(tmp_path):
+    """min_chunk_size > chunk_size would zero out ingest — treat as
+    unusable so convo falls back to its floor instead."""
+    cfg = _write_config(tmp_path, chunk_size=100, min_chunk_size=500)
+    assert cfg.min_chunk_size_explicit is None
+
+
+def test_convo_min_chunk_fallback_is_always_safe_int(tmp_path):
+    """Regression for #1024 review: the convo_miner fallback expression
+    must yield a usable int for ANY config — never a str/bool/negative
+    that would crash the length gate or chunk_exchanges."""
+    from mempalace.convo_miner import MIN_CHUNK_SIZE
+
+    for bad in ("not-a-number", -10, True, {}, []):
+        cfg = _write_config(tmp_path, min_chunk_size=bad)
+        explicit = cfg.min_chunk_size_explicit
+        effective = explicit if explicit is not None else MIN_CHUNK_SIZE
+        assert isinstance(effective, int) and not isinstance(effective, bool)
+        assert effective == MIN_CHUNK_SIZE  # untuned floor, no crash
+
+    cfg = _write_config(tmp_path, min_chunk_size=15)
+    explicit = cfg.min_chunk_size_explicit
+    assert (explicit if explicit is not None else MIN_CHUNK_SIZE) == 15
+
+
 def test_chunk_text_rejects_non_positive_chunk_size():
     """Direct callers (tests, library users) that pass ``chunk_size <= 0``
     must hit a clear ValueError, not loop forever."""


### PR DESCRIPTION
## Why

Follow-up to #1024. That PR routed `min_chunk_size` for the project-file miner through the repairing `MempalaceConfig` validation, but the conversation path still read the raw, unvalidated `_file_config["min_chunk_size"]`.

This meant a malformed `config.json` value behaved inconsistently across the two mining paths for the same key:

| `config.json` value | `miner.py` path | convo path (before this fix) |
| --- | --- | --- |
| `"min_chunk_size": -5` | repaired to default | `chunk_exchanges` raises `ValueError`, convo mine aborts |
| `"min_chunk_size": "abc"` | repaired to default | length gate `len(...) < "abc"` raises `TypeError`, aborts |
| `"min_chunk_size": true` | repaired to default | passes as `True`, silent threshold-of-1 |

This broke #1024's own stated guarantee ("a single bad `config.json` key doesn't take ingest down") for the convo path, and relied on reaching into another module's private `_file_config`.

## What

- Extract `MempalaceConfig._try_coerce_int` — shared by `_coerce_config_int` (substitutes the documented default) and the new accessor. `_coerce_config_int` behavior is unchanged.
- Add public `MempalaceConfig.min_chunk_size_explicit`: returns the validated int when the user explicitly set a usable `min_chunk_size` (`>= 0` and `<= chunk_size`), else `None` (key absent/null/unusable).
- `convo_miner.mine_convos()` uses the `None` sentinel to keep its stricter 30-char floor for untuned users while honoring a valid override — no raw `_file_config` reach.

## Backwards compatibility

- Untuned users: unchanged (convo floor stays 30, project miner stays 50).
- Valid explicit `min_chunk_size`: unchanged, honored on both paths.
- Only change: a malformed value on the convo path now falls back to the convo floor instead of crashing the run — matching the `miner.py` path's repair semantics.

## Tests

- New `min_chunk_size_explicit` accessor tests (unset, JSON null, valid, numeric string, garbage/negative/bool/blank, above-chunk-size) and a convo-fallback regression test asserting a safe int for any config.
- `tests/test_config.py tests/test_convo_miner_unit.py tests/test_miner.py tests/test_convo_miner.py` — 151 passed.
- `ruff check` / `ruff format --check` clean (ruff 0.4.x, CI pin).

## Test plan

- [x] `uv run pytest tests/test_config.py tests/test_convo_miner_unit.py tests/test_miner.py tests/test_convo_miner.py`
- [x] ruff check + format check on changed files