### PR TITLE
fix(test): remove duplicate pytest import breaking lint on develop

### DIFF
--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -5,8 +5,6 @@ import sys
 
 import pytest
 
-import pytest
-
 from mempalace.convo_miner import (
     _file_chunks_locked,
     chunk_exchanges,


### PR DESCRIPTION
## Why

`lint` is currently red on `develop` (and therefore on every branch cut from it, including #1519). The #1024 merge added `import pytest` to `tests/test_convo_miner_unit.py` while a `pytest` import already existed from another independently-merged change. The two imports don't textually conflict, so git auto-merged cleanly and #1024's own pre-merge CI was green — the duplicate only exists *after* the merge.

CI ruff (0.4.x pin) flags it:

```
tests/test_convo_miner_unit.py:8:8: F811 [*] Redefinition of unused `pytest` from line 6
Found 1 error.
```

## What

Remove the duplicate `import pytest`. One import retained.

## Validation

- `ruff check .` (ruff 0.4.x, matching the CI pin) — all checks passed
- `uv run pytest tests/test_convo_miner_unit.py` — 23 passed

## Notes

Unblocks `develop`. Open PR #1519 will go green once it picks up this fix (rebase or merge-after).