### PR TITLE
fix: VACUUM + FTS5 rebuild after repair to reclaim SQLite space

### DIFF
--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -35,6 +35,7 @@ import shutil
 import sqlite3
 import time
 from collections import defaultdict
+from contextlib import closing
 from datetime import datetime
 import re
 from typing import Callable, Iterator, Optional
@@ -680,6 +681,40 @@ class _DefaultProgress:
         return f" (elapsed {_format_eta(elapsed)}, rate {rate:.1f}/s, ETA {_format_eta(eta)})"
 
 
+def _vacuum_and_rebuild_fts5(palace_path: str, progress=print) -> None:
+    """VACUUM the palace SQLite file and rebuild the FTS5 index if present.
+
+    Repeated ``repair --yes`` runs delete and recreate the drawers collection,
+    leaving freed SQLite pages unreclaimable without an explicit VACUUM.  The
+    FTS5 virtual table (``embedding_fulltext_search``) can also become
+    internally inconsistent after multiple collection deletes; the rebuild
+    command fixes it atomically without touching any row data.
+
+    Failures are non-fatal: a warning is printed and the caller continues.
+    The repair itself succeeded at this point — VACUUM/FTS5 are best-effort
+    cleanup, not correctness requirements.
+    """
+    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.exists(sqlite_path):
+        return
+    try:
+        with closing(sqlite3.connect(sqlite_path, isolation_level=None)) as conn:
+            tables = {
+                r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            }
+            if "embedding_fulltext_search" in tables:
+                conn.execute(
+                    "INSERT INTO embedding_fulltext_search"
+                    "(embedding_fulltext_search) VALUES('rebuild')"
+                )
+                conn.commit()
+                progress("  FTS5 index rebuilt.")
+            conn.execute("VACUUM")
+            progress("  SQLite VACUUM complete.")
+    except Exception as exc:
+        progress(f"  Warning: post-repair cleanup failed (non-fatal): {exc}")
+
+
 def rebuild_index(
     palace_path=None,
     confirm_truncation_ok: bool = False,
@@ -812,6 +847,9 @@ def rebuild_index(
         else:
             print("  Live collection was not replaced; leaving the original palace untouched.")
         raise
+
+    _close_chroma_handles(palace_path, backend=backend)
+    _vacuum_and_rebuild_fts5(palace_path, progress=progress)
 
     print(f"\n  Repair complete. {filed} drawers rebuilt.")
     print("  HNSW index is now clean with cosine distance metric.")

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1855,3 +1855,92 @@ def test_rebuild_from_sqlite_honors_configured_drawer_collection_name(tmp_path, 
         )
     except Exception:
         pass  # Expected: collection wasn't created.
+
+
+# ── _vacuum_and_rebuild_fts5 ──────────────────────────────────────────
+
+
+def test_vacuum_and_rebuild_fts5_vacuums_and_rebuilds(tmp_path):
+    """VACUUM runs and FTS5 index is rebuilt when the table is present."""
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    with closing(sqlite3.connect(str(sqlite_path))) as conn:
+        conn.execute(
+            "CREATE VIRTUAL TABLE embedding_fulltext_search"
+            " USING fts5(string_value, tokenize='unicode61')"
+        )
+        conn.execute("INSERT INTO embedding_fulltext_search(string_value) VALUES('hello world')")
+        conn.commit()
+
+    repair._vacuum_and_rebuild_fts5(str(tmp_path))
+
+    with closing(sqlite3.connect(str(sqlite_path))) as conn:
+        result = conn.execute("PRAGMA integrity_check").fetchall()
+    assert result == [("ok",)]
+
+
+def test_vacuum_and_rebuild_fts5_no_fts5_table(tmp_path):
+    """VACUUM runs without error when embedding_fulltext_search is absent."""
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    with closing(sqlite3.connect(str(sqlite_path))) as conn:
+        conn.execute("CREATE TABLE dummy (id INTEGER PRIMARY KEY)")
+        conn.commit()
+
+    # Must not raise even without the FTS5 table.
+    repair._vacuum_and_rebuild_fts5(str(tmp_path))
+
+    with closing(sqlite3.connect(str(sqlite_path))) as conn:
+        result = conn.execute("PRAGMA integrity_check").fetchall()
+    assert result == [("ok",)]
+
+
+def test_vacuum_and_rebuild_fts5_missing_sqlite(tmp_path):
+    """Silently skips when chroma.sqlite3 does not exist."""
+    repair._vacuum_and_rebuild_fts5(str(tmp_path))  # no file — must not raise
+
+
+@patch("mempalace.repair.shutil")
+@patch("mempalace.repair.ChromaBackend")
+def test_rebuild_index_calls_vacuum(mock_backend_cls, mock_shutil, tmp_path):
+    """rebuild_index closes chroma handles then calls _vacuum_and_rebuild_fts5.
+
+    ChromaDB's PersistentClient holds an open connection to chroma.sqlite3;
+    VACUUM requires an exclusive lock so _close_chroma_handles must be called
+    before _vacuum_and_rebuild_fts5.
+    """
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    with closing(sqlite3.connect(str(sqlite_path))) as conn:
+        conn.execute("CREATE TABLE dummy(id INTEGER PRIMARY KEY)")
+        conn.commit()
+
+    mock_col = MagicMock()
+    mock_col.count.return_value = 1
+    mock_col.get.return_value = {
+        "ids": ["id1"],
+        "documents": ["doc1"],
+        "metadatas": [{"wing": "a"}],
+    }
+    mock_new_col = MagicMock()
+    mock_new_col.count.return_value = 1
+    mock_temp_col = MagicMock()
+    mock_temp_col.count.return_value = 1
+    mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
+    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+
+    call_order = []
+    with (
+        patch.object(
+            repair, "_close_chroma_handles", side_effect=lambda *a, **kw: call_order.append("close")
+        ) as mock_close,
+        patch.object(
+            repair,
+            "_vacuum_and_rebuild_fts5",
+            side_effect=lambda *a, **kw: call_order.append("vacuum"),
+        ) as mock_vacuum,
+    ):
+        repair.rebuild_index(palace_path=str(tmp_path))
+        mock_close.assert_called_once()
+        mock_vacuum.assert_called_once()
+        assert call_order == ["close", "vacuum"], "backend must be closed before VACUUM"
+        args, kwargs = mock_vacuum.call_args
+        assert args[0] == str(tmp_path)
+        assert "progress" in kwargs


### PR DESCRIPTION
**What does this PR do?**
  Adds a VACUUM + FTS5 index rebuild step at the end of `repair --yes`.

  Repeated `repair --yes` runs delete and recreate the drawers collection, but SQLite never reclaims freed pages without an explicit VACUUM. On a 10,000-drawer palace this
  causes ~100 MB of bloat per repair run with no way to recover it from the CLI.

  The FTS5 virtual table (`embedding_fulltext_search`) can also become internally inconsistent after multiple collection deletes — `PRAGMA quick_check` reports `malformed
  inverted index`. The rebuild command fixes it atomically without touching row data.

  Both operations are non-fatal: if either fails, a warning is printed and the repair result is preserved.

  Closes #1516
  Closes #1517

  **How to test**
  Run `mempalace repair --yes` twice against the same palace and verify `chroma.sqlite3` does not grow on the second run. Or run the new unit tests:

  uv run pytest tests/test_repair.py -v -k "vacuum or fts5"

  **Checklist**
  - [x] Tests pass (`python -m pytest tests/ -v`)
  - [x] No hardcoded paths
  - [x] Linter passes (`ruff check .`)