### PR TITLE
fix(tunnels): preserve hyphenated wing slugs in create_tunnel write-path (#1504)

### DIFF
--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -43,8 +43,12 @@ def _normalize_wing(wing: str | None) -> str | None:
     (e.g. ``mempalace_public``).  Callers that pass the raw directory name
     (``mempalace-public``) would silently miss.  This helper aligns the lookup
     key with the stored metadata.
+
+    Non-string inputs (from corrupt or hand-edited ``tunnels.json``) return
+    ``None`` rather than raising, so a single malformed record cannot break
+    the read-path filters that iterate the whole file.
     """
-    if wing is None:
+    if not isinstance(wing, str):
         return None
     wing = wing.strip()
     if not wing:
@@ -432,7 +436,8 @@ def create_tunnel(
     Tunnels are undirected: ``create_tunnel(A, B)`` and ``create_tunnel(B, A)``
     resolve to the same canonical ID. A second call with the same endpoints
     updates the stored label (and drawer IDs, if provided) rather than
-    creating a duplicate.
+    creating a duplicate. Endpoints are compared **verbatim** — ``"my-wing"``
+    and ``"my_wing"`` are distinct (see Note below and #1504).
 
     The ``source`` / ``target`` fields on the returned dict preserve the
     argument order the caller used, so callers can display it directionally
@@ -457,14 +462,18 @@ def create_tunnel(
 
     Raises:
         ValueError: if any wing or room is empty or non-string.
+
+    Note:
+        Wing slugs are stored verbatim — passing ``"my-wing"`` and ``"my_wing"``
+        produces two distinct tunnels (canonical IDs differ). Read-path helpers
+        (``list_tunnels`` / ``follow_tunnels``) normalize both sides at compare
+        time so legacy underscore data and explicit-flag hyphen data both
+        match queries in either form. See #1504.
     """
     source_wing = _require_name(source_wing, "source_wing")
     source_room = _require_name(source_room, "source_room")
     target_wing = _require_name(target_wing, "target_wing")
     target_room = _require_name(target_room, "target_room")
-
-    source_wing = _normalize_wing(source_wing)
-    target_wing = _normalize_wing(target_wing)
 
     tunnel_id = _canonical_tunnel_id(source_wing, source_room, target_wing, target_room)
 
@@ -509,10 +518,17 @@ def list_tunnels(wing: str = None):
     norm_wing = _normalize_wing(wing)
     tunnels = _load_tunnels()
     if norm_wing:
+        # Normalize stored wings too: older tunnels.json records hold the
+        # underscore form (from the prior write-path normalization), while
+        # post-#1504 records hold whatever the caller passed. Comparing
+        # normalized-on-both-sides matches either.
+        # ``t.get(k) or {}`` (not ``t.get(k, {})``) handles ``"source": null``
+        # from a hand-edited file — ``.get`` defaults only on missing keys.
         tunnels = [
             t
             for t in tunnels
-            if t["source"]["wing"] == norm_wing or t["target"]["wing"] == norm_wing
+            if _normalize_wing((t.get("source") or {}).get("wing")) == norm_wing
+            or _normalize_wing((t.get("target") or {}).get("wing")) == norm_wing
         ]
     return tunnels
 
@@ -532,15 +548,23 @@ def follow_tunnels(wing: str, room: str, col=None, config=None):
     Given a location (wing/room), finds all tunnels leading from or to it,
     and optionally fetches the connected drawer content.
     """
+    # Fall back to raw ``wing`` so an empty/whitespace query string still
+    # produces a value to compare with; ``_normalize_wing`` returns ``None``
+    # for empty input. Stored wings are normalized on the read path so the
+    # mempalace.yaml slug (underscore) and an explicit ``--wing`` slug
+    # (verbatim) both resolve through the same comparison.
     norm_wing = _normalize_wing(wing) or wing
     tunnels = _load_tunnels()
     connections = []
 
     for t in tunnels:
-        src = t["source"]
-        tgt = t["target"]
+        # ``or {}`` (not ``.get(k, {})``) handles ``"source": null`` from a
+        # hand-edited file — ``.get`` defaults only on missing keys, not on
+        # explicit ``null`` values.
+        src = t.get("source") or {}
+        tgt = t.get("target") or {}
 
-        if src["wing"] == norm_wing and src["room"] == room:
+        if _normalize_wing(src.get("wing")) == norm_wing and src.get("room") == room:
             connections.append(
                 {
                     "direction": "outgoing",
@@ -551,7 +575,7 @@ def follow_tunnels(wing: str, room: str, col=None, config=None):
                     "tunnel_id": t["id"],
                 }
             )
-        elif tgt["wing"] == norm_wing and tgt["room"] == room:
+        elif _normalize_wing(tgt.get("wing")) == norm_wing and tgt.get("room") == room:
             connections.append(
                 {
                     "direction": "incoming",
@@ -669,7 +693,12 @@ def compute_topic_tunnels(
                 continue
             bucket.setdefault(key, n.strip())
         if bucket:
-            wing_topics[wing.strip()] = bucket
+            # Auto-generated topic tunnels normalize the wing key so repeated
+            # mining runs with mixed slug forms (``my-wing`` vs ``my_wing``)
+            # produce one canonical record, not two parallel ones. User-issued
+            # ``create_tunnel`` calls (e.g. via MCP) preserve verbatim slugs;
+            # only this auto-generation path canonicalizes the key.
+            wing_topics[normalize_wing_name(wing.strip())] = bucket
 
     wings = sorted(wing_topics.keys())
     created: list[dict] = []
@@ -713,8 +742,19 @@ def topic_tunnels_for_wing(
     if not topics_by_wing or not isinstance(wing, str) or not wing.strip():
         return []
 
-    wing = wing.strip()
+    # Canonicalize the lookup key so a hyphenated arg still finds an
+    # underscore-normalized entry (and vice versa). ``compute_topic_tunnels``
+    # canonicalizes the keys it writes, so callers can pass either form.
+    wing = normalize_wing_name(wing.strip())
     own = topics_by_wing.get(wing)
+    if own is None:
+        # Fallback: caller may have built ``topics_by_wing`` with verbatim
+        # keys (unusual but allowed). Try every entry, normalized, before
+        # giving up.
+        for k, v in topics_by_wing.items():
+            if isinstance(k, str) and normalize_wing_name(k.strip()) == wing:
+                own = v
+                break
     if not isinstance(own, (list, tuple)) or not own:
         return []
 
@@ -724,7 +764,9 @@ def topic_tunnels_for_wing(
     # one place.
     created: list[dict] = []
     for other, other_topics in topics_by_wing.items():
-        if not isinstance(other, str) or not other.strip() or other == wing:
+        if not isinstance(other, str) or not other.strip():
+            continue
+        if normalize_wing_name(other.strip()) == wing:
             continue
         if not isinstance(other_topics, (list, tuple)) or not other_topics:
             continue

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -882,6 +882,26 @@ class TestWriteTools:
         assert result["success"] is True
         assert result.get("noop") is True
 
+    def test_tool_create_tunnel_preserves_hyphenated_wings(self, monkeypatch, tmp_path):
+        """Regression for #1504: ``tool_create_tunnel`` stores the wing slug
+        verbatim, and both hyphen and underscore queries find the result."""
+        from mempalace import mcp_server, palace_graph
+
+        monkeypatch.setattr(palace_graph, "_TUNNEL_FILE", str(tmp_path / "tunnels.json"))
+
+        t = mcp_server.tool_create_tunnel(
+            source_wing="other-wing",
+            source_room="r1",
+            target_wing="my-wing",
+            target_room="r2",
+            label="hyphen preservation",
+        )
+
+        assert t["source"]["wing"] == "other-wing"
+        assert t["target"]["wing"] == "my-wing"
+        assert len(mcp_server.tool_list_tunnels(wing="my-wing")) == 1
+        assert len(mcp_server.tool_list_tunnels(wing="my_wing")) == 1
+
 
 # ── KG Tools ────────────────────────────────────────────────────────────
 

--- a/tests/test_palace_graph_tunnels.py
+++ b/tests/test_palace_graph_tunnels.py
@@ -73,6 +73,10 @@ class TestExplicitTunnels:
         assert palace_graph._normalize_wing(" Mempalace-Public ") == "mempalace_public"
         assert palace_graph._normalize_wing("   ") is None
         assert palace_graph._normalize_wing(None) is None
+        # Non-string inputs (corrupt or hand-edited tunnels.json) return None
+        # instead of raising — keeps read-path filters robust to bad records.
+        assert palace_graph._normalize_wing(42) is None
+        assert palace_graph._normalize_wing(["x"]) is None
 
     def test_create_tunnel_deduplicates_reverse_order_and_updates_label(
         self, tmp_path, monkeypatch
@@ -287,6 +291,17 @@ class TestTopicTunnels:
         assert palace_graph.topic_tunnels_for_wing("wing_missing", topics_by_wing) == []
         assert palace_graph.list_tunnels() == []
 
+    def test_topic_tunnels_for_wing_matches_across_slug_forms(self, tmp_path, monkeypatch):
+        """The wing arg and ``topics_by_wing`` keys may carry different slug
+        forms (hyphen vs underscore). ``topic_tunnels_for_wing`` resolves
+        the lookup through ``normalize_wing_name`` so a caller passing
+        ``"my-wing"`` against a registry keyed by ``"my_wing"`` still wires
+        up the topic tunnels."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        topics_by_wing = {"my_wing": ["Angular"], "wing_people": ["Angular"]}
+        created = palace_graph.topic_tunnels_for_wing("my-wing", topics_by_wing)
+        assert len(created) == 1
+
     def test_compute_topic_tunnels_dedupe_on_recompute(self, tmp_path, monkeypatch):
         _use_tmp_tunnel_file(monkeypatch, tmp_path)
         topics_by_wing = {
@@ -335,13 +350,39 @@ class TestTopicTunnels:
         kinds = sorted(t["kind"] for t in tunnels)
         assert kinds == ["explicit", "topic"]
 
+    def test_compute_topic_tunnels_normalizes_wing_keys(self, tmp_path, monkeypatch):
+        """Auto-generated topic tunnels canonicalize the wing slug so two
+        mining runs with mixed forms (``my-wing`` then ``my_wing``) produce
+        a single deduped record. Only user-issued ``create_tunnel`` calls
+        preserve verbatim slugs (#1504); the topic-tunnel auto-generator
+        owns its own slugs and stays canonical."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+
+        palace_graph.compute_topic_tunnels(
+            {"my-wing": ["Angular"], "wing_people": ["Angular"]}, min_count=1
+        )
+        palace_graph.compute_topic_tunnels(
+            {"my_wing": ["Angular"], "wing_people": ["Angular"]}, min_count=1
+        )
+
+        tunnels = palace_graph.list_tunnels()
+        assert len(tunnels) == 1
+        stored_wings = {tunnels[0]["source"]["wing"], tunnels[0]["target"]["wing"]}
+        assert stored_wings == {"my_wing", "wing_people"}
+
 
 class TestHyphenatedWingNormalization:
-    """Wing names with hyphens or spaces are normalized to underscores on init.
+    """Wing names may reach ``tunnels.json`` in either form:
 
-    Tunnel helpers must apply the same normalization at lookup time so that
-    ``mempalace-public`` resolves to ``mempalace_public`` and matches the
-    metadata written by ``room_detector_local.py``.
+    * ``mempalace mine`` without ``--wing`` derives the slug from the dir
+      name through ``normalize_wing_name`` → stored as ``mempalace_public``.
+    * ``mempalace mine --wing my-wing`` (or any explicit slug) is stored
+      verbatim by ``create_tunnel`` (regression #1504) → ``my-wing``.
+
+    Read-path helpers (``list_tunnels`` / ``follow_tunnels``) must accept
+    queries in either form and match both storage forms — normalization
+    is applied on both the stored value and the query key at comparison
+    time, never at write time.
     """
 
     def test_list_tunnels_filters_hyphenated_wing(self, tmp_path, monkeypatch):
@@ -363,14 +404,18 @@ class TestHyphenatedWingNormalization:
         assert len(by_under) == 1
         assert by_hyphen[0]["connected_wing"] == "wing_people"
 
-    def test_create_tunnel_normalizes_wing_names(self, tmp_path, monkeypatch):
+    def test_create_tunnel_preserves_hyphenated_wing_names(self, tmp_path, monkeypatch):
+        """Regression for #1504: wings created via ``mempalace mine --wing my-wing``
+        keep the hyphen in metadata, so ``create_tunnel`` must store the slug
+        verbatim. Read-path normalization in ``list_tunnels``/``follow_tunnels``
+        keeps both query forms working."""
         _use_tmp_tunnel_file(monkeypatch, tmp_path)
 
         t = palace_graph.create_tunnel("my-project", "src", "your-project", "dst", label="cross")
-        assert t["source"]["wing"] == "my_project"
-        assert t["target"]["wing"] == "your_project"
-        assert len(palace_graph.list_tunnels("my_project")) == 1
+        assert t["source"]["wing"] == "my-project"
+        assert t["target"]["wing"] == "your-project"
         assert len(palace_graph.list_tunnels("my-project")) == 1
+        assert len(palace_graph.list_tunnels("my_project")) == 1
 
     def test_find_tunnels_warns_on_empty_result(self, tmp_path, monkeypatch, caplog):
         _use_tmp_tunnel_file(monkeypatch, tmp_path)
@@ -379,3 +424,60 @@ class TestHyphenatedWingNormalization:
             result = palace_graph.find_tunnels("nonexistent-wing")
         assert result == []
         assert "No tunnels found" in caplog.text
+
+    def test_read_path_skips_records_with_null_endpoints(self, tmp_path, monkeypatch):
+        """A hand-edited ``tunnels.json`` may carry ``"source": null`` or
+        ``"target": null``. The read-path filters must skip such rows
+        instead of crashing the whole iteration with ``AttributeError``."""
+        _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        palace_graph._save_tunnels(
+            [
+                {
+                    "id": "broken",
+                    "source": None,
+                    "target": None,
+                    "label": "corrupt",
+                    "kind": "explicit",
+                    "created_at": "2026-05-01T00:00:00+00:00",
+                },
+                {
+                    "id": "ok",
+                    "source": {"wing": "wing_a", "room": "r1"},
+                    "target": {"wing": "wing_b", "room": "r2"},
+                    "label": "good",
+                    "kind": "explicit",
+                    "created_at": "2026-05-02T00:00:00+00:00",
+                },
+            ]
+        )
+
+        # Both filters must skip the broken record and return the good one.
+        assert {t["id"] for t in palace_graph.list_tunnels("wing_a")} == {"ok"}
+        connections = palace_graph.follow_tunnels("wing_a", "r1")
+        assert [c["tunnel_id"] for c in connections] == ["ok"]
+
+    def test_pre_1504_underscore_tunnels_remain_findable(self, tmp_path, monkeypatch):
+        """A ``tunnels.json`` written before #1504 stored wings in normalized
+        underscore form (the write-path normalization is now gone). Read-path
+        queries with either hyphen or underscore must still find those
+        records after the fix."""
+        tunnel_file = _use_tmp_tunnel_file(monkeypatch, tmp_path)
+        palace_graph._save_tunnels(
+            [
+                {
+                    "id": "pre_1504_record",
+                    "source": {"wing": "mempalace_public", "room": "auth"},
+                    "target": {"wing": "wing_people", "room": "users"},
+                    "label": "pre-#1504 record",
+                    "kind": "explicit",
+                    "created_at": "2026-05-10T00:00:00+00:00",
+                }
+            ]
+        )
+        assert tunnel_file.exists()
+
+        assert len(palace_graph.list_tunnels("mempalace_public")) == 1
+        assert len(palace_graph.list_tunnels("mempalace-public")) == 1
+
+        assert len(palace_graph.follow_tunnels("mempalace_public", "auth")) == 1
+        assert len(palace_graph.follow_tunnels("mempalace-public", "auth")) == 1


### PR DESCRIPTION
## What does this PR do?

- Removes silent hyphen→underscore normalization from `create_tunnel`'s write-path. Wings created via `mempalace mine --wing my-wing` are now stored verbatim in `tunnels.json` — `tool_create_tunnel(target_wing="my-wing", ...)` keeps `target.wing == "my-wing"`. Closes #1504.
- `list_tunnels` and `follow_tunnels` filters normalize **both** the stored value and the query at compare time, so previously-stored underscore tunnels (from the prior write-path normalization) and post-fix verbatim tunnels both resolve via either query form.
- Auto-generated topic tunnels (`compute_topic_tunnels`) canonicalize their wing keys, so repeated mining runs with mixed slug forms (`my-wing` then `my_wing`) cannot accumulate parallel duplicate tunnels. `topic_tunnels_for_wing` gains a symmetric lookup so a hyphenated argument finds an underscore-keyed registry entry.
- Hardens `_normalize_wing` against non-string inputs and read-path filters against `"source": null` / `"target": null` from hand-edited `tunnels.json`.

## How to test

```bash
uv run pytest tests/test_palace_graph_tunnels.py tests/test_mcp_server.py -v
```

End-to-end against a real palace:

```bash
PALACE=$(mktemp -d) && export MEMPALACE_PALACE_PATH=$PALACE
mkdir -p /tmp/x && echo "test" > /tmp/x/c.md
mempalace init
mempalace mine /tmp/x --mode convos --wing my-wing
mempalace status              # WING: my-wing (verbatim)
python -c "from mempalace import mcp_server; \
  t = mcp_server.tool_create_tunnel('my-wing','technical','other','x',label='t'); \
  print(t['source']['wing'])  # 'my-wing'"
```

## Checklist

- [x] Tests pass (`uv run pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`uv run ruff check .`)