### PR TITLE
fix(miner): apply `--limit` AFTER the already-mined skip

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1167,6 +1167,17 @@ def _mine_impl(
             include_ignored=include_ignored,
         )
     if limit > 0:
+        # `--limit N` bounds NEW work, not WALK. Without this pre-filter,
+        # `--limit` truncates the file list before `process_file`'s
+        # `file_already_mined` skip, so a mine on a corpus where the first-N
+        # walk-order files are all already-mined produces 0 new drawers
+        # despite the budget being intact. See #1535.
+        if not dry_run:
+            mined_col = get_collection(palace_path)
+            files = [
+                f for f in files
+                if not file_already_mined(mined_col, str(f), check_mtime=True)
+            ]
         files = files[:limit]
 
     from .embedding import describe_device

--- a/tests/test_miner_limit_filter.py
+++ b/tests/test_miner_limit_filter.py
@@ -1,0 +1,165 @@
+"""Tests for `--limit` semantics — should bound NEW work, not WALK.
+
+Regression for #1535: before the fix, `--limit N` truncated the file list
+BEFORE `file_already_mined` was checked in `process_file`, so a mine on a
+corpus where the first-N walk-order files were all already-mined produced
+0 new drawers despite the budget being intact.
+
+These tests exercise:
+- A second mine with `--limit N` makes forward progress past the first
+  N files (would loop on first-N already-mined under the old behavior).
+- A full mine then `--limit N` re-mine produces 0 new drawers (everything
+  is already-mined; expected behavior either way) and doesn't crash.
+- `--limit` on a fresh empty palace processes up to N files normally.
+- `dry_run=True` with `--limit` doesn't try to query the palace
+  (palace may not exist yet in dry-run scenarios).
+"""
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import chromadb
+import yaml
+
+from mempalace.miner import mine
+from mempalace.palace import file_already_mined
+
+
+def _make_corpus(root: Path, n: int) -> None:
+    """Stand up a corpus of `n` small .md files plus a mempalace.yaml."""
+    for i in range(n):
+        path = root / f"doc_{i:03d}.md"
+        # Content varies per file so chunking + drawer creation is realistic.
+        path.write_text(
+            f"# Document {i}\n\n"
+            + ("This is a sample paragraph with enough text to chunk. " * 30),
+            encoding="utf-8",
+        )
+    with open(root / "mempalace.yaml", "w") as f:
+        yaml.dump(
+            {
+                "wing": "limit_test",
+                "rooms": [{"name": "general", "description": "All"}],
+            },
+            f,
+        )
+
+
+def _drawer_count(palace_path: Path) -> int:
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_collection("mempalace_drawers")
+    return col.count()
+
+
+def test_limit_skips_already_mined_makes_forward_progress():
+    """Two mines with `--limit 3` on a 6-file corpus should cover all 6.
+
+    Under the old behavior (truncate before skip), the second mine would
+    see the same first-3 files in walk order — all already-mined — and
+    produce 0 new drawers, never reaching files 4-6.
+    """
+    tmpdir = Path(tempfile.mkdtemp())
+    try:
+        corpus = tmpdir / "corpus"
+        corpus.mkdir()
+        _make_corpus(corpus, n=6)
+        palace = tmpdir / "palace"
+
+        # First mine: limit=3 → only 3 files mined.
+        mine(str(corpus), str(palace), limit=3)
+        after_first = _drawer_count(palace)
+        assert after_first > 0, "first mine should produce drawers"
+
+        # Second mine: limit=3 → should pick up the OTHER 3 files
+        # (already-mined files are skipped BEFORE the limit is applied,
+        # so the limit budget goes to new files).
+        mine(str(corpus), str(palace), limit=3)
+        after_second = _drawer_count(palace)
+        assert after_second > after_first, (
+            f"second mine made no progress: drawers {after_first} -> "
+            f"{after_second}. Under the old --limit semantics, the second "
+            f"mine would loop on the first-N already-mined files."
+        )
+
+        # All 6 files should now be marked as mined.
+        client = chromadb.PersistentClient(path=str(palace))
+        col = client.get_collection("mempalace_drawers")
+        for i in range(6):
+            path = corpus / f"doc_{i:03d}.md"
+            assert file_already_mined(col, str(path), check_mtime=True), (
+                f"file {path.name} should be mined after two --limit=3 runs"
+            )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_limit_when_corpus_fully_mined_is_safe_noop():
+    """A `--limit` mine against a fully-mined corpus should not crash and
+    should not produce new drawers (everything is already-mined)."""
+    tmpdir = Path(tempfile.mkdtemp())
+    try:
+        corpus = tmpdir / "corpus"
+        corpus.mkdir()
+        _make_corpus(corpus, n=3)
+        palace = tmpdir / "palace"
+
+        # Mine everything first.
+        mine(str(corpus), str(palace))
+        after_full = _drawer_count(palace)
+
+        # Re-mine with --limit 10. Pre-filter drops everything; the slice
+        # is empty; no new drawers; no crash.
+        mine(str(corpus), str(palace), limit=10)
+        after_relimit = _drawer_count(palace)
+
+        assert after_relimit == after_full, (
+            f"already-mined re-mine should be a no-op; saw {after_full} -> {after_relimit}"
+        )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_limit_on_fresh_palace_processes_up_to_n():
+    """`--limit N` on a fresh palace processes up to N files (the
+    pre-filter finds zero already-mined, so the slice gets the first N)."""
+    tmpdir = Path(tempfile.mkdtemp())
+    try:
+        corpus = tmpdir / "corpus"
+        corpus.mkdir()
+        _make_corpus(corpus, n=10)
+        palace = tmpdir / "palace"
+
+        mine(str(corpus), str(palace), limit=4)
+
+        client = chromadb.PersistentClient(path=str(palace))
+        col = client.get_collection("mempalace_drawers")
+        # Count distinct source_files in the palace.
+        rows = col.get(where={"wing": "limit_test"}, include=["metadatas"])
+        mined_files = {m["source_file"] for m in rows.get("metadatas", []) if m}
+        assert len(mined_files) <= 4, (
+            f"--limit 4 mined {len(mined_files)} distinct files; expected ≤ 4"
+        )
+        assert len(mined_files) > 0, "expected at least one file mined"
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_dry_run_with_limit_does_not_touch_palace():
+    """`dry_run=True` short-circuits the pre-filter (palace may not even
+    exist yet in a dry-run check). Should not crash on a missing palace."""
+    tmpdir = Path(tempfile.mkdtemp())
+    try:
+        corpus = tmpdir / "corpus"
+        corpus.mkdir()
+        _make_corpus(corpus, n=5)
+        palace = tmpdir / "palace_that_does_not_exist"
+
+        # Should not raise — dry_run skips palace I/O entirely.
+        mine(str(corpus), str(palace), limit=2, dry_run=True)
+
+        # Palace dir may or may not be created by other code paths, but
+        # in either case, the call must complete without error.
+        assert True  # reaching here is the assertion
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Fix for #1535. Pre-filter already-mined files BEFORE `--limit N` truncates the file list, so `--limit N` bounds NEW work, not WALK.

**Before this PR.** `_mine_impl` (`mempalace/miner.py:1169-1170`) truncates the scanned file list before `process_file`'s `file_already_mined` check (`miner.py:810`). So on a corpus where the first-N walk-order files are all already-mined (very common when running under a wall-clock budget — launchd / cron / systemd retries that mine incrementally), the limit budget gets consumed by the metadata short-circuit and no new drawers are filed. The mine completes "successfully" with `Drawers filed: 0`.

**After this PR.** `--limit N` skips files that are already mined when computing the limit slice, so it bounds NEW work. Matches the natural mental model for budget-bounded mines.

## Test plan

Four new tests in `tests/test_miner_limit_filter.py`:

- [x] `test_limit_skips_already_mined_makes_forward_progress` — two `--limit 3` mines on a 6-file corpus → all 6 mined. **This is the regression case**; would fail under the old behavior because the second mine would see the same first-3 already-mined files.
- [x] `test_limit_when_corpus_fully_mined_is_safe_noop` — re-mine fully-mined corpus with `--limit` → no new drawers, no crash.
- [x] `test_limit_on_fresh_palace_processes_up_to_n` — `--limit N` on a fresh palace processes ≤ N distinct files.
- [x] `test_dry_run_with_limit_does_not_touch_palace` — `dry_run=True` short-circuits the pre-filter (palace may not exist yet).

All four pass locally against the patched `_mine_impl`.

## Trade-offs

- Adds **O(N) chroma metadata lookups** before the file loop. For a 2k-file scan on a ~250k-drawer palace: ~10–40s upfront (depends on Chroma index size). Worth batching with `$in` queries if the per-file cost becomes a bottleneck at larger scale — happy to take that suggestion in review.
- **Behavior change:** `--limit N` no longer means "stop after the first N input files (some may be skipped as already-mined)". It now means "do up to N units of NEW work". This is arguably the more useful semantics for the budget-bounded use case, but does change behavior for any tooling that depended on the old "first-N-in-walk-order" interpretation. Happy to instead add a `--new-only` flag and keep `--limit` semantics unchanged if you'd prefer the back-compat path — let me know.

## Context

We hit this in production on a 2,067-file `repo_docs` wing under a 5400s per-wing budget — mines were timing out at ~1871/2067, then with `--limit` added as a workaround the trap would have caught us on subsequent fires. The full thread is in issue #1535. We're shipping a local vendor patch in our wrapper repo for now; if this lands upstream the patch becomes a no-op and we drop it.

## Marking as Draft

Opened as draft pending your design preference (`--limit` semantics change vs. new `--new-only` flag). Will mark ready-for-review once direction is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)