### PR TITLE
fix(audit): chunk content before embedding upsert (#1539)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ venv/
 # ChromaDB local data
 *.sqlite3-journal
 .envrc
+.review-logs

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -601,7 +601,7 @@ def mine_convos(
         if extract_mode == "general":
             from .general_extractor import extract_memories
 
-            chunks = extract_memories(content)
+            chunks = extract_memories(content, chunk_size=cfg_chunk_size)
             # Each chunk already has memory_type; use it as the room name
         else:
             chunks = chunk_exchanges(

--- a/mempalace/diary_ingest.py
+++ b/mempalace/diary_ingest.py
@@ -18,11 +18,13 @@ Usage:
 
 import hashlib
 import json
+import logging
 import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .config import MempalaceConfig
 from .miner import _extract_entities_for_metadata
 from .palace import (
     build_closet_lines,
@@ -32,6 +34,8 @@ from .palace import (
     purge_file_closets,
     upsert_closet_lines,
 )
+
+logger = logging.getLogger(__name__)
 
 DIARY_ENTRY_RE = re.compile(r"^## .+", re.MULTILINE)
 
@@ -61,10 +65,33 @@ def _split_entries(text):
 
 
 def _diary_drawer_id(wing: str, date_str: str) -> str:
-    """Stable, wing-scoped drawer ID. Two diaries (e.g. 'work' vs 'personal')
-    sharing the same date never collide."""
+    """Stable, wing-scoped legacy drawer ID (file-level).
+
+    Retained for backwards-compatible cleanup of palaces that ingested
+    diaries before #1539 — those palaces hold one ``drawer_diary_{...}``
+    per file. New drawers use ``_diary_drawer_id_entry`` so each ``##``
+    entry becomes its own drawer (with per-entry character chunking
+    when an entry exceeds ``chunk_size``).
+    """
     suffix = hashlib.sha256(f"{wing}|{date_str}".encode()).hexdigest()[:24]
     return f"drawer_diary_{suffix}"
+
+
+def _diary_drawer_id_entry(wing: str, date_str: str, entry_idx: int, entry_chunk_idx: int) -> str:
+    """Per-entry, per-chunk drawer ID introduced in #1539.
+
+    The ``v2_`` prefix distinguishes new IDs from the legacy file-level
+    scheme (one drawer per file). Legacy drawers from pre-#1539 palaces
+    are auto-purged on any ``ingest_diaries`` call that triggers a full
+    rebuild (``force=True`` or detected content change). The per-source
+    ``delete(where=...)`` step on full rebuild collects both legacy and
+    stale v2 drawers via the ``source_file`` metadata key, so the
+    schema migration runs as a side effect of normal use.
+    """
+    suffix = hashlib.sha256(
+        f"{wing}|{date_str}|{entry_idx}|{entry_chunk_idx}".encode()
+    ).hexdigest()[:24]
+    return f"drawer_diary_v2_{suffix}"
 
 
 def _diary_closet_id_base(wing: str, date_str: str) -> str:
@@ -106,6 +133,7 @@ def ingest_diaries(
 
     drawers_col = get_collection(palace_path)
     closets_col = get_closets_collection(palace_path)
+    chunk_size = MempalaceConfig().chunk_size
 
     days_updated = 0
     closets_created = 0
@@ -144,14 +172,17 @@ def ingest_diaries(
         content_changed = prev_hash is not None and curr_hash != prev_hash
 
         now_iso = datetime.now(timezone.utc).isoformat()
-        drawer_id = _diary_drawer_id(wing, date_str)
         entities = _extract_entities_for_metadata(text)
         source_file = str(diary_path)
 
         # Serialize per source — two terminals running ingest at once must
         # not interleave the upsert + closet-rebuild.
         with mine_lock(source_file):
-            drawer_meta = {
+            entries = _split_entries(text)
+            prev_entry_count = state.get(state_key, {}).get("entry_count", 0)
+            full_rebuild = force or content_changed
+
+            base_meta = {
                 "date": date_str,
                 "wing": wing,
                 "room": "daily",
@@ -160,24 +191,104 @@ def ingest_diaries(
                 "filed_at": now_iso,
             }
             if entities:
-                drawer_meta["entities"] = entities
-            drawers_col.upsert(
-                documents=[text],
-                ids=[drawer_id],
-                metadatas=[drawer_meta],
-            )
+                base_meta["entities"] = entities
 
-            entries = _split_entries(text)
-            prev_entry_count = state.get(state_key, {}).get("entry_count", 0)
-            full_rebuild = force or content_changed
+            # On full rebuild, purge ALL prior drawers for this source_file
+            # before writing fresh entries. This covers three cases in one
+            # step: (a) legacy pre-#1539 file-level drawers under the old
+            # ``drawer_diary_`` prefix, (b) v2 drawers from a prior pass
+            # where the file had MORE entries than the current run (entry
+            # deletion would otherwise leave trailing orphan drawers), and
+            # (c) in-place edits that shift content across entry boundaries.
+            if full_rebuild:
+                try:
+                    drawers_col.delete(where={"source_file": source_file})
+                except Exception as exc:
+                    # ChromaDB ``delete(where=...)`` against an empty collection
+                    # returns silently rather than raising, so this catch only
+                    # fires on real backend errors (locked DB, schema mismatch,
+                    # transient I/O). Log at debug to preserve diagnostics
+                    # without aborting the rebuild: the upsert below is the
+                    # load-bearing write, and if it also fails the state file
+                    # is left unchanged so the next pass retries cleanly.
+                    logger.debug(
+                        "legacy purge skipped for %s: %s",
+                        source_file,
+                        exc,
+                        exc_info=True,
+                    )
+
+            # Per-entry drawers, with character chunking inside any entry
+            # whose serialized text exceeds chunk_size. ``chunk_index`` is
+            # a global counter across the file so the searcher's
+            # ``_expand_with_neighbors`` (which queries by source_file +
+            # chunk_index) can stitch sibling chunks back together
+            # regardless of entry boundary. ``entry_index`` and
+            # ``entry_chunk_index`` are preserved for entry-grouping
+            # consumers.
+            #
+            # Accumulate all drawers for the file into one batched upsert
+            # so the embedding pass either commits every chunk or none.
+            # A mid-loop embedding failure would otherwise leave a
+            # half-written day's drawers behind, which the next
+            # incremental pass would skip (state file already updated)
+            # and the searcher would silently return partial results.
+            global_chunk_index = 0
+            batch_ids: list[str] = []
+            batch_docs: list[str] = []
+            batch_metas: list[dict] = []
+            for entry_idx, (header, body) in enumerate(entries):
+                entry_text = f"{header}\n{body}" if body else header
+                if len(entry_text) <= chunk_size:
+                    batch_ids.append(_diary_drawer_id_entry(wing, date_str, entry_idx, 0))
+                    batch_docs.append(entry_text)
+                    batch_metas.append(
+                        {
+                            **base_meta,
+                            "chunk_index": global_chunk_index,
+                            "entry_index": entry_idx,
+                            "entry_chunk_index": 0,
+                            "entry_header_preview": header[:120],
+                        }
+                    )
+                    global_chunk_index += 1
+                else:
+                    for entry_chunk_idx, start in enumerate(range(0, len(entry_text), chunk_size)):
+                        batch_ids.append(
+                            _diary_drawer_id_entry(wing, date_str, entry_idx, entry_chunk_idx)
+                        )
+                        batch_docs.append(entry_text[start : start + chunk_size])
+                        batch_metas.append(
+                            {
+                                **base_meta,
+                                "chunk_index": global_chunk_index,
+                                "entry_index": entry_idx,
+                                "entry_chunk_index": entry_chunk_idx,
+                                "entry_header_preview": header[:120],
+                            }
+                        )
+                        global_chunk_index += 1
+
+            if batch_ids:
+                drawers_col.upsert(
+                    ids=batch_ids,
+                    documents=batch_docs,
+                    metadatas=batch_metas,
+                )
+
             new_entries = entries if full_rebuild else entries[prev_entry_count:]
-
             if new_entries:
                 all_lines = []
-                for header, body in new_entries:
-                    entry_text = f"{header}\n{body}"
+                for offset, (header, body) in enumerate(new_entries):
+                    entry_idx = offset if full_rebuild else prev_entry_count + offset
+                    entry_text = f"{header}\n{body}" if body else header
+                    # Closet references the canonical (entry_chunk_idx=0)
+                    # drawer for the entry. Searcher._expand_with_neighbors
+                    # stitches sibling chunks back via the
+                    # (source_file, chunk_index) pair.
+                    entry_drawer_id = _diary_drawer_id_entry(wing, date_str, entry_idx, 0)
                     entry_lines = build_closet_lines(
-                        source_file, [drawer_id], entry_text, wing, "daily"
+                        source_file, [entry_drawer_id], entry_text, wing, "daily"
                     )
                     all_lines.extend(entry_lines)
 

--- a/mempalace/general_extractor.py
+++ b/mempalace/general_extractor.py
@@ -22,6 +22,8 @@ Usage:
 import re
 from typing import List, Dict, Tuple
 
+from .config import DEFAULT_CHUNK_SIZE
+
 
 # =============================================================================
 # MARKER SETS — One per memory type
@@ -360,13 +362,23 @@ def _score_markers(text: str, markers: List[str]) -> Tuple[float, List[str]]:
 # =============================================================================
 
 
-def extract_memories(text: str, min_confidence: float = 0.3) -> List[Dict]:
+def extract_memories(
+    text: str,
+    min_confidence: float = 0.3,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+) -> List[Dict]:
     """
     Extract memories from a text string.
 
     Args:
         text: The text to extract from (any format).
         min_confidence: Minimum confidence threshold (0.0-1.0).
+        chunk_size: Per-memory character cap. Segments exceeding this
+            size are sliced verbatim into multiple memories that share
+            the same ``memory_type``. Caller (typically ``mine_convos``)
+            should pass ``MempalaceConfig.chunk_size`` so config-driven
+            sizing reaches this path; the default matches the
+            module-level CHUNK_SIZE in ``convo_miner.py``.
 
     Returns:
         List of dicts: {"content": str, "memory_type": str, "chunk_index": int}
@@ -410,13 +422,30 @@ def extract_memories(text: str, min_confidence: float = 0.3) -> List[Dict]:
         if confidence < min_confidence:
             continue
 
-        memories.append(
-            {
-                "content": para.strip(),
-                "memory_type": max_type,
-                "chunk_index": len(memories),
-            }
-        )
+        content = para.strip()
+        # Slice oversized segments verbatim. ``memory_type`` is propagated
+        # to every slice — reclassifying sub-segments risks dropping data
+        # (marker may live in only one slice), and the verbatim-store
+        # mandate in CLAUDE.md forbids silent loss. Acceptable trade-off:
+        # the label is an approximation for sub-slices, not a fresh
+        # classification.
+        if len(content) <= chunk_size:
+            memories.append(
+                {
+                    "content": content,
+                    "memory_type": max_type,
+                    "chunk_index": len(memories),
+                }
+            )
+            continue
+        for i in range(0, len(content), chunk_size):
+            memories.append(
+                {
+                    "content": content[i : i + chunk_size],
+                    "memory_type": max_type,
+                    "chunk_index": len(memories),
+                }
+            )
 
     return memories
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1103,7 +1103,18 @@ def tool_follow_tunnels(wing: str, room: str):
 def tool_add_drawer(
     wing: str, room: str, content: str, source_file: str = None, added_by: str = "mcp"
 ):
-    """File verbatim content into a wing/room. Checks for duplicates first."""
+    """File verbatim content into a wing/room. Checks for duplicates first.
+
+    Content above ``chunk_size`` is split into bounded per-chunk drawers
+    via a single batched upsert. Each chunk carries ``parent_drawer_id``
+    linkage and ``chunk_index`` metadata so search can rejoin them. The
+    returned ``drawer_id`` is the LOGICAL group handle on the chunked
+    path; physical drawer ids are in ``chunk_ids`` (#1539). To delete
+    or fetch the underlying drawers, iterate ``chunk_ids`` or query by
+    ``parent_drawer_id`` — ``tool_get_drawer(drawer_id)`` and
+    ``tool_delete_drawer(drawer_id)`` report "not found" on the chunked
+    path because no row is stored under the logical group id.
+    """
     global _metadata_cache
     try:
         wing = sanitize_name(wing, "wing")
@@ -1132,38 +1143,93 @@ def tool_add_drawer(
         },
     )
 
-    # Idempotency: if the deterministic ID already exists, return success as a no-op.
+    chunk_size = _config.chunk_size
+    base_meta = {
+        "wing": wing,
+        "room": room,
+        "source_file": source_file or "",
+        "added_by": added_by,
+        "filed_at": datetime.now().isoformat(),
+    }
+
+    # Idempotency. Three cases to detect a prior committed write:
+    # (a) Single-doc path: drawer_id row exists (the only id used).
+    # (b) Chunked path: probe the LAST chunk id — its presence implies
+    #     every earlier chunk also landed, since the batched upsert
+    #     is all-or-nothing.
+    # (c) Legacy pre-#1539 single-row write of oversized content under
+    #     drawer_id: probe drawer_id alongside the last chunk id so a
+    #     re-call with identical oversized content does not duplicate
+    #     the legacy row by adding fresh chunks under different ids.
+    if len(content) <= chunk_size:
+        idempotency_probe_ids = [drawer_id]
+    else:
+        last_chunk_idx = (len(content) - 1) // chunk_size
+        idempotency_probe_ids = [drawer_id, f"{drawer_id}_chunk_{last_chunk_idx:06d}"]
     try:
-        existing = col.get(ids=[drawer_id], include=[])
+        existing = col.get(ids=idempotency_probe_ids, include=[])
         if existing.ids:
             return {"success": True, "reason": "already_exists", "drawer_id": drawer_id}
     except Exception:
-        logger.debug("Idempotency pre-check failed for %s", drawer_id, exc_info=True)
+        logger.debug("Idempotency pre-check failed for %s", idempotency_probe_ids, exc_info=True)
 
     try:
-        col.upsert(
-            ids=[drawer_id],
-            documents=[content],
-            metadatas=[
-                {
-                    "wing": wing,
-                    "room": room,
-                    "source_file": source_file or "",
-                    "chunk_index": 0,
-                    "added_by": added_by,
-                    "filed_at": datetime.now().isoformat(),
-                }
-            ],
-        )
-        inserted = col.get(ids=[drawer_id], include=[])
+        if len(content) <= chunk_size:
+            col.upsert(
+                ids=[drawer_id],
+                documents=[content],
+                metadatas=[{**base_meta, "chunk_index": 0}],
+            )
+            inserted = col.get(ids=[drawer_id], include=[])
+            if not inserted.ids:
+                raise RuntimeError(
+                    "Drawer write was acknowledged but the new ID is not readable. "
+                    "The palace index may be stale; run reconnect or repair."
+                )
+            _metadata_cache = None
+            logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")
+            return {
+                "success": True,
+                "drawer_id": drawer_id,
+                "wing": wing,
+                "room": room,
+                "chunks": 1,
+            }
+
+        # Oversized content: split into bounded per-chunk drawers so the
+        # embedding model never sees a document above ``chunk_size``.
+        # Single batched ``upsert`` so the embedding pass either commits
+        # every chunk or none — no half-written palace if the embedding
+        # model fails mid-loop (#1539).
+        chunk_ids: list[str] = []
+        chunk_docs: list[str] = []
+        chunk_metas: list[dict] = []
+        for i in range(0, len(content), chunk_size):
+            chunk_idx = i // chunk_size
+            chunk_ids.append(f"{drawer_id}_chunk_{chunk_idx:06d}")
+            chunk_docs.append(content[i : i + chunk_size])
+            chunk_metas.append(
+                {**base_meta, "chunk_index": chunk_idx, "parent_drawer_id": drawer_id}
+            )
+        col.upsert(ids=chunk_ids, documents=chunk_docs, metadatas=chunk_metas)
+        # Probe the LAST chunk id, not the first — its presence confirms
+        # the whole batch landed, not just the leading row.
+        inserted = col.get(ids=[chunk_ids[-1]], include=[])
         if not inserted.ids:
             raise RuntimeError(
                 "Drawer write was acknowledged but the new ID is not readable. "
                 "The palace index may be stale; run reconnect or repair."
             )
         _metadata_cache = None
-        logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")
-        return {"success": True, "drawer_id": drawer_id, "wing": wing, "room": room}
+        logger.info(f"Filed drawer: {drawer_id} → {wing}/{room} ({len(chunk_ids)} chunks)")
+        return {
+            "success": True,
+            "drawer_id": drawer_id,
+            "wing": wing,
+            "room": room,
+            "chunks": len(chunk_ids),
+            "chunk_ids": chunk_ids,
+        }
     except Exception as e:
         return {"success": False, "error": str(e)}
 
@@ -1579,29 +1645,76 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
         # semantic search quality. For now, store raw AAAK in metadata so it's
         # preserved, and keep the document as-is for embedding (even though
         # compressed AAAK degrades embedding quality).
-        col.add(
-            ids=[entry_id],
-            documents=[entry],
-            metadatas=[
+        base_metadata = {
+            "wing": wing,
+            "room": room,
+            "hall": "hall_diary",
+            "topic": topic,
+            "type": "diary_entry",
+            "agent": agent_name,
+            "filed_at": now.isoformat(),
+            "date": now.strftime("%Y-%m-%d"),
+        }
+        chunk_size = _config.chunk_size
+        if len(entry) <= chunk_size:
+            col.add(
+                ids=[entry_id],
+                documents=[entry],
+                metadatas=[{**base_metadata, "chunk_index": 0}],
+            )
+            logger.info(f"Diary entry: {entry_id} → {wing}/diary/{topic}")
+            return {
+                "success": True,
+                "entry_id": entry_id,
+                "agent": agent_name,
+                "topic": topic,
+                "timestamp": now.isoformat(),
+                "chunks": 1,
+            }
+
+        # Oversized entry: split into bounded per-chunk drawers so the
+        # embedding model never sees a document above ``chunk_size``.
+        # Every chunk carries ``parent_entry_id`` so search can rejoin
+        # them and ``chunk_index`` for ordered reconstruction (#1539).
+        # Note on ``entry_id`` in the return value: for the chunked
+        # path the returned ``entry_id`` is the LOGICAL group handle
+        # (no drawer is stored under that exact id). The physical
+        # drawer ids are in ``chunk_ids``. Callers wanting to fetch
+        # by id should iterate ``chunk_ids``; callers wanting to
+        # query by metadata can filter on ``parent_entry_id``.
+        # Use a single batched ``add`` so the embedding pass either
+        # commits all chunks or none — avoids a half-written palace
+        # if the embedding model fails mid-loop. ``col.add`` (not
+        # ``upsert``) is intentional here: ``entry_id`` is timestamp-
+        # based with microsecond precision, so every call generates a
+        # fresh id and a duplicate is by definition a same-microsecond
+        # clash that should surface as an error rather than silently
+        # overwrite the prior entry (cf. ``tool_add_drawer`` whose
+        # content-hash ids are deliberately idempotent and use upsert).
+        chunk_ids: list[str] = []
+        chunk_docs: list[str] = []
+        chunk_metas: list[dict] = []
+        for i in range(0, len(entry), chunk_size):
+            chunk_idx = i // chunk_size
+            chunk_ids.append(f"{entry_id}_chunk_{chunk_idx:06d}")
+            chunk_docs.append(entry[i : i + chunk_size])
+            chunk_metas.append(
                 {
-                    "wing": wing,
-                    "room": room,
-                    "hall": "hall_diary",
-                    "topic": topic,
-                    "type": "diary_entry",
-                    "agent": agent_name,
-                    "filed_at": now.isoformat(),
-                    "date": now.strftime("%Y-%m-%d"),
+                    **base_metadata,
+                    "chunk_index": chunk_idx,
+                    "parent_entry_id": entry_id,
                 }
-            ],
-        )
-        logger.info(f"Diary entry: {entry_id} → {wing}/diary/{topic}")
+            )
+        col.add(ids=chunk_ids, documents=chunk_docs, metadatas=chunk_metas)
+        logger.info(f"Diary entry: {entry_id} → {wing}/diary/{topic} ({len(chunk_ids)} chunks)")
         return {
             "success": True,
             "entry_id": entry_id,
             "agent": agent_name,
             "topic": topic,
             "timestamp": now.isoformat(),
+            "chunks": len(chunk_ids),
+            "chunk_ids": chunk_ids,
         }
     except Exception as e:
         return {"success": False, "error": str(e)}

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -31,6 +31,7 @@ import tempfile
 import threading
 import time
 
+import pytest
 import yaml
 
 from mempalace.miner import (
@@ -732,14 +733,17 @@ class TestDiaryIngest:
 
         palace_dir = tmp_path / "palace"
 
-        from mempalace.diary_ingest import _diary_drawer_id, ingest_diaries
+        from mempalace.diary_ingest import _diary_drawer_id_entry, ingest_diaries
 
         ingest_diaries(str(personal_dir), str(palace_dir), wing="personal", force=True)
         ingest_diaries(str(work_dir), str(palace_dir), wing="work", force=True)
 
         col = get_collection(str(palace_dir))
-        personal_id = _diary_drawer_id("personal", "2026-04-13")
-        work_id = _diary_drawer_id("work", "2026-04-13")
+        # Post-#1539: per-entry drawers. Each single-entry diary produces
+        # one drawer keyed by (wing, date, entry_idx=0, chunk_idx=0). The
+        # wing component still keeps work vs personal collisions apart.
+        personal_id = _diary_drawer_id_entry("personal", "2026-04-13", 0, 0)
+        work_id = _diary_drawer_id_entry("work", "2026-04-13", 0, 0)
         assert personal_id != work_id
 
         personal = col.get(ids=[personal_id])
@@ -748,6 +752,284 @@ class TestDiaryIngest:
         assert work["ids"] == [work_id]
         assert "Personal-only marker." in personal["documents"][0]
         assert "Work-only marker." in work["documents"][0]
+
+    # ── #1539: per-entry drawers, oversized-entry chunking ─────────
+
+    def test_diary_multiple_entries_one_drawer_each(self, tmp_path):
+        """Regression for #1539: each ``##`` entry must become its own
+        drawer rather than the whole file being one document. Pre-fix
+        behaviour: a single file-level drawer for any number of entries.
+        Post-fix: one drawer per entry."""
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n"
+            "## 10:00 — first\n\nfirst body content here, well above min size.\n\n"
+            "## 11:00 — second\n\nsecond body content with enough length here.\n\n"
+            "## 12:00 — third\n\nthird body content with sufficient text in it.\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import ingest_diaries
+
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        count = get_collection(str(palace_dir)).count()
+        assert count == 3, f"expected one drawer per ## entry (3 entries); got {count} drawers"
+
+    def test_large_diary_with_oversized_entry_chunks_within_entry(self, tmp_path):
+        """Regression for #1539: when a single ``##`` entry exceeds
+        chunk_size, the ingester must chunk that entry into bounded
+        drawers rather than uploading the whole entry as one oversized
+        document (which crashes the embedding model in production)."""
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        # Middle entry body is 1500 chars — above CHUNK_SIZE=800 but below
+        # the embedding model's hard token limit. This trips the size-cap
+        # assertion on develop without crashing the test infrastructure.
+        big_body = "X" * 1500
+        (diary_dir / "2026-04-13.md").write_text(
+            f"# 2026-04-13\n\n"
+            f"## 10:00 — first\n\nfirst body content here, well above min size.\n\n"
+            f"## 11:00 — big\n\n{big_body}\n\n"
+            f"## 12:00 — last\n\nlast body content with sufficient text in it.\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import ingest_diaries
+
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        col = get_collection(str(palace_dir))
+        drawers = col.get()
+        docs = drawers["documents"]
+
+        max_len = max(len(d) for d in docs)
+        assert max_len <= 800, (
+            f"no drawer document may exceed CHUNK_SIZE=800; got max_len={max_len}"
+        )
+        # 3 entries with the middle entry split into >= 2 chunks → >= 4 drawers
+        assert len(docs) >= 4, (
+            f"oversized middle entry must produce multiple drawers; got {len(docs)} total drawers"
+        )
+
+    def test_incremental_appends_new_entry_only(self, tmp_path):
+        """Regression for #1539: incremental ingest must add exactly the
+        delta when one new entry is appended (not re-rewrite all)."""
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        diary_file = diary_dir / "2026-04-13.md"
+        diary_file.write_text(
+            "# 2026-04-13\n\n"
+            "## 10:00 — first\n\nfirst body content, sufficiently long.\n\n"
+            "## 11:00 — second\n\nsecond body content with text in it.\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import ingest_diaries
+
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        initial = get_collection(str(palace_dir)).count()
+        assert initial == 2, f"baseline: 2 entries → 2 drawers; got {initial}"
+
+        diary_file.write_text(
+            diary_file.read_text()
+            + "\n## 12:00 — third\n\nthird body, newly added on second run.\n"
+        )
+        ingest_diaries(str(diary_dir), str(palace_dir))
+        final = get_collection(str(palace_dir)).count()
+        assert final == 3, f"after appending 1 entry: 3 drawers total; got {final}"
+
+    def test_entry_count_watermark_matches_drawer_count(self, tmp_path):
+        """Regression for #1539: persisted ``entry_count`` watermark
+        must equal the number of entries split from the file (and
+        therefore the number of drawers under the new schema)."""
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n"
+            "## 10:00 — a\n\nbody one with enough text to count.\n\n"
+            "## 11:00 — b\n\nbody two with enough text to count.\n\n"
+            "## 12:00 — c\n\nbody three with enough text to count.\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import _state_file_for, _split_entries, ingest_diaries
+
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+
+        state = json.loads(_state_file_for(str(palace_dir), diary_dir.resolve()).read_text())
+        key = "diary|2026-04-13.md"
+        assert state[key]["entry_count"] == 3, (
+            f"watermark must equal entry count; got {state[key]['entry_count']}"
+        )
+
+        text = (diary_dir / "2026-04-13.md").read_text()
+        assert len(_split_entries(text)) == state[key]["entry_count"]
+
+    def test_diary_chunk_index_is_global_across_entries(self, tmp_path):
+        """Regression for #1539 review: ``chunk_index`` must be a global
+        counter across the file (not per-entry) so the searcher's
+        ``_expand_with_neighbors`` (which queries by source_file +
+        chunk_index range) can stitch sibling chunks regardless of
+        entry boundary. Pre-fix the metadata key was ``entry_chunk_index``
+        and search neighbor expansion silently fell back to the matched
+        drawer alone for any diary hit."""
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        # 3 entries; middle is oversized (1500 chars > CHUNK_SIZE=800).
+        big_body = "X" * 1500
+        (diary_dir / "2026-04-13.md").write_text(
+            f"# 2026-04-13\n\n"
+            f"## 10:00 — a\n\nfirst body content with enough length here.\n\n"
+            f"## 11:00 — b\n\n{big_body}\n\n"
+            f"## 12:00 — c\n\nthird body content with enough length here.\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import ingest_diaries
+
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        col = get_collection(str(palace_dir))
+        all_drawers = col.get()
+
+        indices = sorted(m["chunk_index"] for m in all_drawers["metadatas"])
+        # Global counter: 0, 1, 2, ... contiguous across all entries.
+        assert indices == list(range(len(indices))), (
+            f"chunk_index must be contiguous 0..N-1 globally; got {indices}"
+        )
+        # All chunks have the same source_file (filter target for neighbor
+        # expansion). Verify the searcher-required pair (source_file +
+        # chunk_index) is consistent on every drawer.
+        sources = {m["source_file"] for m in all_drawers["metadatas"]}
+        assert len(sources) == 1, f"all drawers must share one source_file; got {sources}"
+
+    def test_diary_entry_deletion_purges_orphan_drawers(self, tmp_path):
+        """Regression for #1539 review: if a diary shrinks (entries
+        deleted), the full-rebuild step must purge prior-pass drawers
+        for that ``source_file`` before re-writing — otherwise trailing
+        drawers from the longer prior pass remain as orphans and
+        pollute search results forever."""
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        diary_file = diary_dir / "2026-04-13.md"
+        diary_file.write_text(
+            "# 2026-04-13\n\n"
+            "## 10:00 — first\n\nfirst body content with enough length here.\n\n"
+            "## 11:00 — second\n\nsecond body content with enough length here.\n\n"
+            "## 12:00 — third\n\nthird body content with enough length here.\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import ingest_diaries
+
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        col = get_collection(str(palace_dir))
+        assert col.count() == 3, f"baseline: 3 entries → 3 drawers; got {col.count()}"
+
+        # Shrink the file to 1 entry. Hash changes → content_changed=True
+        # → full_rebuild=True → purge step must remove the trailing 2 drawers.
+        diary_file.write_text(
+            "# 2026-04-13\n\n## 10:00 — first\n\nfirst body content with enough length here.\n"
+        )
+        ingest_diaries(str(diary_dir), str(palace_dir))
+        final = col.count()
+        assert final == 1, (
+            f"after shrinking 3 entries → 1 entry: exactly 1 drawer; "
+            f"got {final} (orphans from prior pass not purged)"
+        )
+
+    def test_diary_header_only_entry_produces_drawer(self, tmp_path):
+        """A ``##`` header with no body still produces a drawer carrying
+        the header text. Catches a regression where ``if body`` would
+        collapse the entry."""
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-04-13.md").write_text(
+            "# 2026-04-13\n\n"
+            "## 10:00 — note one with sufficient length to pass min size\n\n"
+            "## 11:00 — note two with sufficient length to pass min size\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        from mempalace.diary_ingest import ingest_diaries
+
+        ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+        col = get_collection(str(palace_dir))
+        assert col.count() == 2, (
+            f"expected 2 drawers (one per header-only entry); got {col.count()}"
+        )
+        docs = col.get()["documents"]
+        # Each drawer holds the header line itself.
+        joined = "\n".join(docs)
+        assert "note one" in joined
+        assert "note two" in joined
+
+    def test_diary_atomic_batched_upsert_on_failure(self, tmp_path, monkeypatch):
+        """A mid-pass embedding failure must leave the collection empty
+        rather than half-written. Without batched-atomic upsert, an
+        earlier per-loop upsert would partially commit and the state
+        file would skip the file on re-run, silently losing entries.
+
+        The fixture mixes normal entries with one oversized entry so
+        the failed batch exercises both the single-entry-per-drawer
+        branch and the per-entry character-chunk fallback."""
+        from mempalace import diary_ingest
+
+        diary_dir = tmp_path / "diaries"
+        diary_dir.mkdir()
+        (diary_dir / "2026-05-18.md").write_text(
+            "# 2026-05-18\n\n"
+            "## 10:00 — entry one with sufficient body to clear min size threshold\n"
+            "More body text for entry one with enough length.\n\n"
+            "## 11:00 — entry two with oversized body that forces per-entry chunking\n"
+            + "A"
+            * 3000
+            + "\n\n"
+            "## 12:00 — entry three with body added for adequate test fixture size\n"
+            "More body text for entry three to make it realistic.\n"
+        )
+        palace_dir = tmp_path / "palace"
+
+        class _RaisingCollection:
+            def __init__(self, real):
+                self._real = real
+                self.upsert_call_count = 0
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def upsert(self, **kwargs):
+                self.upsert_call_count += 1
+                raise RuntimeError("simulated embedding model failure")
+
+        real_get_collection = diary_ingest.get_collection
+        raising_holder = {}
+
+        def _wrap_get_collection(path):
+            real = real_get_collection(path)
+            wrapped = _RaisingCollection(real)
+            raising_holder["col"] = wrapped
+            return wrapped
+
+        monkeypatch.setattr(diary_ingest, "get_collection", _wrap_get_collection)
+
+        with pytest.raises(RuntimeError, match="simulated embedding model failure"):
+            diary_ingest.ingest_diaries(str(diary_dir), str(palace_dir), force=True)
+
+        # Exactly one batched upsert attempt — not three per-loop calls.
+        # Fixture has a single diary file, so one batch per file == one
+        # total. With a multi-file fixture this would be N batches.
+        assert raising_holder["col"].upsert_call_count == 1, (
+            "diary ingest must accumulate one batch per file; "
+            f"got {raising_holder['col'].upsert_call_count} upsert calls"
+        )
+
+        # Re-open the real collection (untouched by the failed write) and
+        # confirm nothing landed for this source file.
+        real_col = real_get_collection(str(palace_dir))
+        rows = real_col.get(where={"source_file": str(diary_dir / "2026-05-18.md")})
+        assert rows["ids"] == [], (
+            f"failed batched upsert must leave no partial drawers; got {rows['ids']}"
+        )
 
 
 # ── cross-wing tunnels ───────────────────────────────────────────────

--- a/tests/test_general_extractor.py
+++ b/tests/test_general_extractor.py
@@ -246,3 +246,67 @@ def test_positive_words():
 def test_negative_words():
     assert "bug" in NEGATIVE_WORDS
     assert "crash" in NEGATIVE_WORDS
+
+
+# ── extract_memories — oversized segment chunking (#1539) ──────────────
+
+
+def test_extract_memories_oversized_segment_slices_with_label_preserved():
+    """Regression for #1539: a segment longer than chunk_size must be
+    split into multiple memories with the same memory_type. Joined
+    slices must equal the original (verbatim store per CLAUDE.md)."""
+    decision_phrase = "We decided to migrate to PostgreSQL because performance matters. "
+    long_segment = decision_phrase * 50  # ~3,200 chars, well above default 800
+    memories = extract_memories(long_segment)
+    assert len(memories) > 1, (
+        f"oversized segment must split into multiple slices; got {len(memories)}"
+    )
+    assert all(len(m["content"]) <= 800 for m in memories), (
+        f"all slices must be <= chunk_size=800; got max={max(len(m['content']) for m in memories)}"
+    )
+    types = {m["memory_type"] for m in memories}
+    assert len(types) == 1, f"all slices must share one memory_type; got {types}"
+    assert "decision" in types
+    joined = "".join(m["content"] for m in memories)
+    assert joined == long_segment.strip(), (
+        "joined slices must equal original (after strip) verbatim"
+    )
+
+
+def test_extract_memories_oversized_segment_with_custom_chunk_size():
+    """Regression for #1539: caller-supplied chunk_size must govern the
+    paragraph slicer in extract_memories."""
+    decision_phrase = "We decided on Redis because we measured the latency profile. "
+    long_segment = decision_phrase * 40  # ~2,500 chars
+    memories = extract_memories(long_segment, chunk_size=400)
+    assert len(memories) > 1
+    assert all(len(m["content"]) <= 400 for m in memories), (
+        f"all slices must be <= 400; got max={max(len(m['content']) for m in memories)}"
+    )
+
+
+def test_extract_memories_normal_segment_unchanged():
+    """Regression catch: a segment under chunk_size must produce
+    exactly one memory (existing pre-#1539 behaviour for sub-cap)."""
+    text = (
+        "We decided to use React because it fits our team workflow and "
+        "the migration path from our existing stack is clear."
+    )
+    memories = extract_memories(text)
+    assert len(memories) == 1
+    assert memories[0]["content"] == text
+    assert memories[0]["memory_type"] == "decision"
+
+
+def test_extract_memories_chunk_index_contiguous_across_segments():
+    """Regression for #1539: chunk_index must be sequential 0,1,2,...
+    across mixed normal + oversized segments without gaps."""
+    decision_phrase = "We decided to choose Postgres because the index plan works. "
+    long_segment = decision_phrase * 30  # ~1,800 chars → multiple slices at 800
+    second_short = "I prefer always writing tests first because it shapes the API better."
+    text = long_segment + "\n\n" + second_short
+    memories = extract_memories(text)
+    indices = [m["chunk_index"] for m in memories]
+    assert indices == list(range(len(memories))), (
+        f"chunk_index must be 0..N-1 sequential; got {indices}"
+    )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1408,6 +1408,158 @@ class TestWriteTools:
 
         assert result == {"error": msg}
 
+    def test_add_drawer_normal_content_single_drawer(self, monkeypatch, config, palace_path, kg):
+        """Regression catch: content below CHUNK_SIZE produces exactly
+        one drawer with ``chunks == 1``. Pre-#1539 contract preserved."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(wing="w", room="r", content="Short content well under chunk_size.")
+        assert result["success"] is True
+        assert result["chunks"] == 1
+        assert "chunk_ids" not in result
+        _client2, col = _get_collection(palace_path)
+        del _client2
+        assert col.count() == 1
+        assert col.get()["ids"] == [result["drawer_id"]]
+
+    def test_add_drawer_oversized_content_chunked(self, monkeypatch, config, palace_path, kg):
+        """Regression for #1539: content far above chunk_size must be
+        sliced into bounded per-chunk drawers, each linked by a
+        ``parent_drawer_id`` metadata field. No stored document may
+        exceed the configured chunk_size."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        oversized = "X" * 10000
+        result = tool_add_drawer(wing="w", room="r", content=oversized)
+        assert result["success"] is True
+        assert result["chunks"] > 1
+        assert "chunk_ids" in result and len(result["chunk_ids"]) == result["chunks"]
+
+        _client2, col = _get_collection(palace_path)
+        del _client2
+        stored = col.get()
+        max_doc = max(len(d) for d in stored["documents"])
+        assert max_doc <= config.chunk_size, (
+            f"no stored document may exceed chunk_size={config.chunk_size}; got max={max_doc}"
+        )
+        # Chroma does not guarantee insertion order on a bare ``get()``;
+        # sort by ``chunk_index`` before joining so the verbatim check
+        # is deterministic.
+        ordered = sorted(
+            zip(stored["metadatas"], stored["documents"]),
+            key=lambda pair: pair[0]["chunk_index"],
+        )
+        assert "".join(doc for _meta, doc in ordered) == oversized
+        parent_ids = {m.get("parent_drawer_id") for m in stored["metadatas"]}
+        assert parent_ids == {result["drawer_id"]}, (
+            f"all chunks must share one parent_drawer_id; got {parent_ids}"
+        )
+
+    def test_add_drawer_oversized_idempotency_skips_duplicate_chunk_writes(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        """Re-calling with identical oversized content must not duplicate
+        any drawer. Idempotency on the chunked path probes the last
+        chunk id (its presence implies the whole batch committed) and
+        also the legacy logical drawer_id so a pre-#1539 single-row
+        write under the same logical id does not get co-resident chunk
+        siblings on the next call."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        oversized = "Y" * 5000
+        r1 = tool_add_drawer(wing="w", room="r", content=oversized)
+        assert r1["success"] is True and r1["chunks"] > 1
+        r2 = tool_add_drawer(wing="w", room="r", content=oversized)
+        assert r2["success"] is True
+        assert r2.get("reason") == "already_exists"
+
+        _client2, col = _get_collection(palace_path)
+        del _client2
+        assert col.count() == r1["chunks"]
+        # The probe must succeed against the last chunk id (atomicity
+        # signal), and no row must be stored under the logical id.
+        last_chunk = r1["chunk_ids"][-1]
+        assert col.get(ids=[last_chunk])["ids"] == [last_chunk]
+        assert col.get(ids=[r1["drawer_id"]])["ids"] == []
+
+    def test_add_drawer_chunk_metadata_carries_parent_link(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        """Every chunk produced from oversized content must carry both
+        ``chunk_index`` (0..N-1) and ``parent_drawer_id`` matching the
+        logical group handle returned to the caller."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(wing="w", room="r", content="Q" * 3500)
+        assert result["success"] is True and result["chunks"] > 1
+
+        _client2, col = _get_collection(palace_path)
+        del _client2
+        stored = col.get()
+        indices = sorted(m["chunk_index"] for m in stored["metadatas"])
+        assert indices == list(range(len(indices)))
+        for meta in stored["metadatas"]:
+            assert meta.get("parent_drawer_id") == result["drawer_id"]
+
+    def test_add_drawer_boundary_exact_chunk_size_stays_single(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        """The ``<= chunk_size`` predicate must include the boundary:
+        content of exactly chunk_size chars stays a single drawer, not
+        an off-by-one chunked write."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        boundary = "Z" * config.chunk_size
+        result = tool_add_drawer(wing="w", room="r", content=boundary)
+        assert result["success"] is True
+        assert result["chunks"] == 1
+        assert "chunk_ids" not in result
+
+    def test_add_drawer_chunked_logical_id_not_fetchable_directly(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        """Documented contract on the chunked path: ``tool_get_drawer``
+        and ``tool_delete_drawer`` against the returned logical
+        ``drawer_id`` report ``not found`` because no row is stored
+        under that id. Callers must iterate ``chunk_ids`` or query by
+        ``parent_drawer_id`` metadata."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer, tool_delete_drawer, tool_get_drawer
+
+        result = tool_add_drawer(wing="w", room="r", content="P" * 4000)
+        assert result["success"] is True and result["chunks"] > 1
+
+        # tool_get_drawer against logical id: not found.
+        got_logical = tool_get_drawer(result["drawer_id"])
+        assert "error" in got_logical and "not found" in got_logical["error"].lower()
+
+        # tool_get_drawer against the first chunk id: found, full content slice.
+        got_chunk = tool_get_drawer(result["chunk_ids"][0])
+        assert got_chunk["content"] == "P" * config.chunk_size
+        assert got_chunk["metadata"]["parent_drawer_id"] == result["drawer_id"]
+
+        # tool_delete_drawer against logical id: also not found.
+        deleted_logical = tool_delete_drawer(result["drawer_id"])
+        assert deleted_logical["success"] is False
+        assert "not found" in deleted_logical["error"].lower()
+
 
 # ── KG Tools ────────────────────────────────────────────────────────────
 
@@ -1937,6 +2089,81 @@ class TestDiaryTools:
         # default wing is derived from that lowercase form too.
         assert w1["agent"] == "claude"
         assert w2["agent"] == "claude"
+
+    # ── #1539: oversized-entry chunking ────────────────────────────
+
+    def test_diary_write_normal_entry_single_drawer(self, monkeypatch, config, palace_path, kg):
+        """Regression catch: a normal entry (< CHUNK_SIZE) must produce
+        exactly one drawer with ``chunks == 1`` in the result. Existing
+        pre-#1539 behaviour preserved for the common path."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_diary_write
+
+        r = tool_diary_write(
+            agent_name="TestAgent",
+            entry="A normal-length entry that fits comfortably under chunk_size.",
+            topic="general",
+        )
+        assert r["success"] is True
+        assert r["chunks"] == 1
+        _client2, col = _get_collection(palace_path)
+        del _client2
+        assert col.count() == 1
+
+    def test_diary_write_oversized_entry_chunked(self, monkeypatch, config, palace_path, kg):
+        """Regression for #1539: an entry far above CHUNK_SIZE must be
+        sliced into bounded per-chunk drawers, each linked by a
+        ``parent_entry_id`` metadata field. No single document stored
+        may exceed CHUNK_SIZE."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_diary_write
+
+        # 5000 chars: well above CHUNK_SIZE=800. Expected chunks: ceil(5000/800) = 7.
+        oversized = "Z" * 5000
+        r = tool_diary_write(agent_name="TestAgent", entry=oversized, topic="general")
+
+        assert r["success"] is True
+        assert r["chunks"] > 1, f"oversized entry must produce >1 chunks; got {r['chunks']}"
+        assert "chunk_ids" in r and len(r["chunk_ids"]) == r["chunks"]
+
+        _client2, col = _get_collection(palace_path)
+        del _client2
+        stored = col.get()
+        assert all(len(d) <= 800 for d in stored["documents"]), (
+            f"no stored document may exceed CHUNK_SIZE=800; "
+            f"got max={max(len(d) for d in stored['documents'])}"
+        )
+        joined = "".join(stored["documents"])
+        assert joined == oversized, "joined chunks must equal original entry verbatim"
+
+        parent_ids = {m.get("parent_entry_id") for m in stored["metadatas"]}
+        assert len(parent_ids) == 1 and None not in parent_ids, (
+            f"all chunks must share one parent_entry_id; got {parent_ids}"
+        )
+
+    def test_diary_write_chunk_index_metadata(self, monkeypatch, config, palace_path, kg):
+        """Regression for #1539: each oversized-entry chunk must carry a
+        ``chunk_index`` metadata field that runs 0, 1, 2, ... in order."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_diary_write
+
+        oversized = "Q" * 3500  # ~5 chunks at CHUNK_SIZE=800
+        r = tool_diary_write(agent_name="TestAgent", entry=oversized, topic="general")
+        assert r["success"] is True and r["chunks"] > 1
+
+        _client2, col = _get_collection(palace_path)
+        del _client2
+        stored = col.get()
+        indices = sorted(m["chunk_index"] for m in stored["metadatas"])
+        assert indices == list(range(len(indices))), (
+            f"chunk_index must be 0..N-1 contiguous; got {indices}"
+        )
 
 
 # ── Cache Invalidation (inode/mtime) ──────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Closes #1539. Fixes four sites that fed unbounded content to `collection.upsert(documents=[...])` or `collection.add(documents=[...])`. On the current `mempalace/develop` `95caf80` the upstream embedder accepts the oversized input and silently truncates it at its 256-token window, so the stored drawer's search vector represents only the first ~512 characters and the rest of the content becomes undiscoverable by semantic search. The same code path still hits `RuntimeError: Invalid buffer size` on multi-MB single-document inputs (the crash class #1534 fixed in `convo_miner._chunk_by_paragraph`); the four sites here were catalogued in #1539 during that audit.

**Site 1: `general_extractor.extract_memories`** (`mempalace/general_extractor.py:426-444`)

A 200,000-char single segment with classification markers used to become one oversized memory whose search vector represented only the first ~512 characters of the segment (and crashed embedding upsert outright on the pre-#1534 attention-buffer behavior). The fix adds a `chunk_size: int = DEFAULT_CHUNK_SIZE` parameter and a post-classification slicer that propagates `memory_type` to every slice. Reclassifying sub-slices would risk dropping data (markers may live in only one slice), so the label is approximated for sub-slices rather than re-derived. `convo_miner.py:552` (the only in-tree caller) now passes `chunk_size=cfg_chunk_size` so `MempalaceConfig.chunk_size` reaches this path.

**Site 2: `diary_ingest.ingest_diaries`** (`mempalace/diary_ingest.py:230-273`)

A multi-MB daily diary file used to upsert as ONE document. The fix introduces per-entry drawers via the existing `_split_entries(text)` call, with character-chunk fallback for any single entry larger than `chunk_size`. New `_diary_drawer_id_entry(wing, date_str, entry_idx, entry_chunk_idx)` helper carries the per-entry/per-chunk position.

`chunk_index` in drawer metadata is a global counter across the file so `searcher._expand_with_neighbors` (which queries by `source_file + chunk_index`) stitches sibling chunks back together regardless of entry boundary.

Upsert is batched atomic per file: one `drawers_col.upsert(ids=..., documents=..., metadatas=...)` call carries every entry/chunk for the file, so a mid-pass embedding failure either commits the day in full or leaves no partial drawers behind. The state file is updated only after the upsert returns, so a failed batch is retried on the next run rather than silently skipped.

Auto-purge on full rebuild deletes prior-pass drawers via `where={"source_file": ...}`, which also migrates pre-#1539 legacy `drawer_diary_` IDs as a side effect of normal use. No separate migration command needed; existing palaces auto-clean on the first `ingest_diaries` call that triggers a full rebuild (`force=True` or detected content change).

**Site 3: `mcp_server.tool_diary_write`** (`mempalace/mcp_server.py:1599-1710`)

The MCP tool accepted entries up to 100 KB (the `sanitize_content` cap) and filed them as one document. The fix splits oversized entries into bounded per-chunk drawers via a single batched `col.add(ids=..., documents=..., metadatas=...)` so the embedding pass is atomic (no half-written palace if the embedding model fails mid-loop). Each chunk carries `parent_entry_id` linkage and `chunk_index` metadata. Return shape is additive: `chunks` field is always present, `chunk_ids` is added on the chunked path. Single-chunk entries return `chunks=1` and an `entry_id` that matches the stored drawer id (preserves the pre-#1539 contract).

**Site 4: `mcp_server.tool_add_drawer`** (`mempalace/mcp_server.py:1103-1215`)

The MCP `mempalace_add_drawer` tool accepted `content` up to 100 KB through `sanitize_content` and filed it as one document, reproducing the Site 3 design defect on the more common `add_drawer` surface. The fix mirrors Site 3: content above `chunk_size` is split into bounded per-chunk drawers via a single batched `col.upsert(ids=..., documents=..., metadatas=...)`. Each chunk carries `parent_drawer_id` linkage and `chunk_index` metadata. Chunk ids use a 6-digit `{drawer_id}_chunk_NNNNNN` suffix so even a low-`chunk_size` config (down to single-digit) cannot lex-sort chunks out of order.

Idempotency on the chunked path probes both the last chunk id (its presence implies the whole batched upsert committed atomically) and the legacy logical `drawer_id` (so a pre-#1539 single-row write of oversized content under the same id is detected and skipped rather than getting co-resident chunk siblings on the next call).

Return shape is additive: `chunks` is always present; `chunk_ids` is added on the chunked path. Single-chunk content returns `chunks=1` and a `drawer_id` that matches the stored drawer id (preserves the pre-#1539 contract). `tool_get_drawer(drawer_id)` and `tool_delete_drawer(drawer_id)` against the logical handle return "not found" on the chunked path; callers must iterate `chunk_ids` or query by `parent_drawer_id` metadata. The docstring on `tool_add_drawer` documents this contract.

**Adjacent known issue, NOT closed by this PR**

#390 (open) reports that the default `CHUNK_SIZE = 800` exceeds the default embedding model's 256-token / ~512-char window, causing **silent truncation** in embeddings. That is a different failure mode than the crash this PR fixes: crash on multi-MB input vs. silent quality degradation on chunks above ~512 chars. The PR honours whatever `chunk_size` is configured (`MempalaceConfig.chunk_size`, via #1024), so users hitting the silent-truncation case today can drop `chunk_size` in their config. Default change and per-model binding (#442) are out of scope here.

**Out-of-scope sites surfaced during the audit (filed as follow-ups, not fixed here)**

- `mempalace/miner.py:add_drawer` legacy shim: no in-tree caller passes unbounded content; recommend a size-cap if a future external caller wires raw documents through.
- `mempalace/sources/context.py:upsert_drawer` interface (`PalaceContext`): RFC 002 adapter surface, no in-tree adapter currently constructs records of unbounded size; recommend a separate issue to enforce `len(record.content) <= chunk_size` at the boundary before the adapter surface stabilises.
- `mempalace/sweeper.py:parse_claude_jsonl` per-message `content`: a transcript message carrying a multi-MB `tool_result` block reaches `collection.upsert(documents=[...])` at line 251 unbounded. Separate code path (Stop hook only), file a dedicated follow-up issue.

Thanks to @davidglidden for the upstream #1534 report that surfaced the audit.

## How to test

Manual reproducers (all four exit 0 and emit `CHUNK_SIZE`-bounded drawers on this branch; on `mempalace/develop` `95caf80` the same calls also exit 0 but file the input as a single oversized drawer whose search vector represents only the first ~512 characters. Observe `chunks` field absent or equal to 1 on develop, versus multiple bounded chunks on this branch):

```bash
# Site 1: extract_memories
TMPDIR=$(mktemp -d)
uv run python -c "open('$TMPDIR/long.txt','w').write('We decided to migrate to PostgreSQL because performance matters. ' * 200)"
uv run python -m mempalace mine "$TMPDIR" --mode convos --extract general --wing repro-1539-extract

# Site 2: diary_ingest with multi-MB single entry
DIARY=$(mktemp -d)/2026-05-18.md
PALACE=$(mktemp -d)
uv run python -c "
content = '# 2026-05-18\n\n## 10:00\nshort entry one.\n\n## 11:00\n' + ('A' * 50000) + '\n\n## 12:00\nshort entry two.\n'
open('$DIARY','w').write(content)
"
uv run python -c "
from mempalace.diary_ingest import ingest_diaries
print(ingest_diaries('$(dirname $DIARY)', '$PALACE', wing='repro-1539-diary', force=True))
"

# Site 3: tool_diary_write via direct invocation
uv run python -c "
from mempalace.mcp_server import tool_diary_write
result = tool_diary_write(agent_name='audit', entry='Z' * 5000, wing='repro-1539-mcp')
assert result['success'] and result['chunks'] > 1
print(result)
"

# Site 4: tool_add_drawer via direct invocation
uv run python -c "
from mempalace.mcp_server import tool_add_drawer
result = tool_add_drawer(wing='repro-1539-add', room='paste', content='X' * 10000)
assert result['success'] and result.get('chunks', 1) > 1
print(result)
"
```

Unit suite (21 new tests across the four sites, including atomicity coverage for Site 2 and contract coverage for Site 4):

```bash
uv run pytest tests/test_general_extractor.py tests/test_closets.py::TestDiaryIngest tests/test_mcp_server.py::TestWriteTools tests/test_mcp_server.py::TestDiaryTools -v
```

Coverage added:
- `extract_memories` oversized-segment slicing with `memory_type` propagation + custom `chunk_size` plumbing
- `diary_ingest` per-entry drawer count, oversized-entry character chunking, file-shrink orphan purge, header-only entry, global `chunk_index` contiguity, incremental append idempotence, batched-upsert atomicity on embedding failure
- `tool_diary_write` normal vs. chunked return shape, `chunk_index` metadata, `parent_entry_id` linkage, joined verbatim equality
- `tool_add_drawer` normal vs. chunked return shape, `chunk_index` + `parent_drawer_id` metadata, idempotency on re-call with identical oversized content (last-chunk + legacy `drawer_id` probe), boundary at `len == chunk_size`, documented contract that `tool_get_drawer` / `tool_delete_drawer` against the logical `drawer_id` report "not found" on the chunked path

## Checklist
- [x] Tests pass (`uv run pytest tests/ -v --ignore=tests/benchmarks`)
- [x] No hardcoded paths
- [x] Linter passes (`uvx --from 'ruff==0.15.9' ruff check . && uvx --from 'ruff==0.15.9' ruff format --check .` per CI ruff pin)

