### PR TITLE
ci(lint): pin ruff to 0.15.9 (CI + dev) and reformat tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: 'pip'
-      - run: pip install "ruff>=0.4.0,<0.5"
+      # Keep this pin identical to the `ruff==` pin in pyproject.toml
+      # ([project.optional-dependencies].dev and [dependency-groups].dev)
+      # so CI and `pip install -e ".[dev]"` format/lint identically.
+      - run: pip install "ruff==0.15.9"
       - run: ruff check .
       - run: ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,10 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Keep in lock-step with the ruff version pinned in .github/workflows/ci.yml
-    # (>=0.4.0,<0.5). Using a newer rev here produces a different formatter
-    # output than CI and breaks `ruff format --check` in the lint job.
-    rev: v0.4.10
+    # Keep this rev in lock-step with the exact ruff pin in pyproject.toml
+    # ([project.optional-dependencies].dev / [dependency-groups].dev) and
+    # .github/workflows/ci.yml. A different ruff here produces different
+    # formatter output than CI and breaks `ruff format --check` in lint.
+    rev: v0.15.9
     hooks:
       - id: ruff
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ chroma = "mempalace.backends.chroma:ChromaBackend"
 [project.entry-points."mempalace.sources"]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]
+dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff==0.15.9", "psutil>=5.9"]
 spellcheck = ["autocorrect>=2.0"]
 # Hardware acceleration for the ONNX embedding model. Install exactly one:
 #   pip install mempalace[gpu]       — NVIDIA CUDA
@@ -63,7 +63,7 @@ dml = ["onnxruntime-directml>=1.16"]
 coreml = ["onnxruntime>=1.16"]
 
 [dependency-groups]
-dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]
+dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff==0.15.9", "psutil>=5.9"]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -823,9 +823,9 @@ def test_make_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeyp
     ChromaBackend.make_client(palace_path)
     ChromaBackend.make_client(palace_path)
 
-    assert calls == [
-        palace_path
-    ], "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
+    assert calls == [palace_path], (
+        "quarantine_stale_hnsw should fire once per palace per process, not on every reconnect"
+    )
 
 
 def test_make_client_gates_invalid_metadata_on_first_call(tmp_path, monkeypatch):
@@ -941,9 +941,9 @@ def test_client_quarantines_only_on_first_call_per_palace(tmp_path, monkeypatch)
     finally:
         backend.close()
 
-    assert (
-        calls == [palace_path]
-    ), "quarantine_stale_hnsw should fire once per palace per process from _client(), not on every call"
+    assert calls == [palace_path], (
+        "quarantine_stale_hnsw should fire once per palace per process from _client(), not on every call"
+    )
 
 
 # ── _pin_hnsw_threads (per-process retrofit, separate from this PR's gate) ──

--- a/tests/test_chroma_collection_lock.py
+++ b/tests/test_chroma_collection_lock.py
@@ -317,9 +317,9 @@ def test_read_path_does_not_acquire_lock(tmp_path, monkeypatch):
             if method is None:
                 continue
             src = inspect.getsource(method)
-            assert (
-                "_write_lock" not in src
-            ), f"{read_attr} must NOT acquire the write lock (read path)"
+            assert "_write_lock" not in src, (
+                f"{read_attr} must NOT acquire the write lock (read path)"
+            )
     finally:
         open(release, "w").close()
         holder.join(timeout=5)

--- a/tests/test_claude_plugin_hook_config.py
+++ b/tests/test_claude_plugin_hook_config.py
@@ -51,23 +51,23 @@ def test_plugin_hook_timeout_within_bounds(hook_config: dict, event: str) -> Non
     )
     for entry in entries:
         sub_hooks = entry.get("hooks")
-        assert (
-            isinstance(sub_hooks, list) and sub_hooks
-        ), f"{event} entry missing non-empty 'hooks' array"
-        assert (
-            len(sub_hooks) == 1
-        ), f"{event} entry expected exactly one hook command, found {len(sub_hooks)}"
+        assert isinstance(sub_hooks, list) and sub_hooks, (
+            f"{event} entry missing non-empty 'hooks' array"
+        )
+        assert len(sub_hooks) == 1, (
+            f"{event} entry expected exactly one hook command, found {len(sub_hooks)}"
+        )
         for hook in sub_hooks:
-            assert (
-                hook.get("type") == "command"
-            ), f"unexpected hook type for {event}: {hook.get('type')!r}"
+            assert hook.get("type") == "command", (
+                f"unexpected hook type for {event}: {hook.get('type')!r}"
+            )
             assert "timeout" in hook, f"{event} hook missing 'timeout' key"
             timeout = hook["timeout"]
             # bool subclasses int, so reject it explicitly: True == 1 must fail.
             is_real_int = isinstance(timeout, int) and not isinstance(timeout, bool)
-            assert (
-                is_real_int and floor <= timeout <= ceiling
-            ), f"{event} hook timeout must be an int in [{floor}, {ceiling}]s; got {timeout!r}"
+            assert is_real_int and floor <= timeout <= ceiling, (
+                f"{event} hook timeout must be an int in [{floor}, {ceiling}]s; got {timeout!r}"
+            )
 
 
 def test_no_unbounded_events_in_plugin_config(hook_config: dict) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,12 +79,12 @@ def test_cli_main_strips_leaked_pythonpath_from_env():
     )
     diag = f"rc={result.returncode}; stdout={result.stdout!r}; stderr={result.stderr!r}"
     assert result.returncode == 0, f"subprocess failed: {diag}"
-    assert (
-        f"ENV_MID: {expected_env!r}" in result.stdout
-    ), f"package import unexpectedly stripped env (regression in __init__.py): {diag}"
-    assert (
-        "SENTINEL_IN_PATH: False" in result.stdout
-    ), f"package import did not filter sys.path (regression in __init__.py): {diag}"
+    assert f"ENV_MID: {expected_env!r}" in result.stdout, (
+        f"package import unexpectedly stripped env (regression in __init__.py): {diag}"
+    )
+    assert "SENTINEL_IN_PATH: False" in result.stdout, (
+        f"package import did not filter sys.path (regression in __init__.py): {diag}"
+    )
     assert "ENV_AFTER: None" in result.stdout, f"CLI did not strip PYTHONPATH: {diag}"
 
 

--- a/tests/test_closet_llm.py
+++ b/tests/test_closet_llm.py
@@ -312,9 +312,9 @@ class TestRegenerateClosets:
         survivors = closets.get(where={"source_file": source}, include=["documents", "metadatas"])
         assert survivors["ids"], "LLM closets should have been written"
         joined = "\n".join(survivors["documents"])
-        assert (
-            "STALE_REGEX_TOPIC" not in joined
-        ), "pre-existing regex closet was not purged before LLM write"
+        assert "STALE_REGEX_TOPIC" not in joined, (
+            "pre-existing regex closet was not purged before LLM write"
+        )
         assert "jwt auth" in joined
         for meta in survivors["metadatas"]:
             assert meta.get("generated_by", "").startswith("llm:")
@@ -399,9 +399,9 @@ class TestRegenerateClosets:
         # Three paginated calls: (limit=5000, offset=0), (5000, 5000), (5000, 10000).
         assert len(get_calls) == 3, f"expected 3 batched fetches, got {len(get_calls)}"
         for call in get_calls:
-            assert (
-                call["limit"] == 5000
-            ), f"batch must be 5000 — got {call['limit']} (would risk SQLITE_MAX_VARIABLE_NUMBER)"
+            assert call["limit"] == 5000, (
+                f"batch must be 5000 — got {call['limit']} (would risk SQLITE_MAX_VARIABLE_NUMBER)"
+            )
             # include must still request both documents and metadatas
             assert "documents" in call["include"]
             assert "metadatas" in call["include"]

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -140,9 +140,9 @@ class TestMineLock:
         # Sort by entry time and verify the second entry is after the first exit.
         intervals.sort(key=lambda iv: iv[1])
         (_, enter_a, exit_a), (_, enter_b, exit_b) = intervals
-        assert (
-            enter_a < exit_a <= enter_b < exit_b
-        ), f"critical sections overlapped — lock failed to serialize: {intervals}"
+        assert enter_a < exit_a <= enter_b < exit_b, (
+            f"critical sections overlapped — lock failed to serialize: {intervals}"
+        )
 
 
 # ── build_closet_lines ─────────────────────────────────────────────────
@@ -315,15 +315,15 @@ class TestMinerClosetRebuild:
         second_docs = "\n".join(second_pass["documents"]).lower()
         assert "only topic now" in second_docs
         for i in range(15):
-            assert (
-                f"topic {i}\n" not in second_docs
-            ), f"stale 'Topic {i}' from first mine survived the rebuild"
+            assert f"topic {i}\n" not in second_docs, (
+                f"stale 'Topic {i}' from first mine survived the rebuild"
+            )
         # Numbered closets that existed only in the larger first run must be gone.
         leftover = first_ids - set(second_pass["ids"])
         for stale_id in leftover:
-            assert not col.get(ids=[stale_id])[
-                "ids"
-            ], f"orphan closet {stale_id} from larger first run survived purge"
+            assert not col.get(ids=[stale_id])["ids"], (
+                f"orphan closet {stale_id} from larger first run survived purge"
+            )
 
 
 # ── _extract_drawer_ids_from_closet ───────────────────────────────────
@@ -702,9 +702,9 @@ class TestDiaryIngest:
 
         # No state file inside the user's diary dir.
         for entry in diary_dir.iterdir():
-            assert (
-                "diary_ingest" not in entry.name
-            ), f"state file leaked into user diary dir: {entry}"
+            assert "diary_ingest" not in entry.name, (
+                f"state file leaked into user diary dir: {entry}"
+            )
 
         # State file does exist under ~/.mempalace/state/.
         state_path = _state_file_for(str(palace_dir), diary_dir.resolve())
@@ -905,7 +905,7 @@ class TestTunnels:
         assert not errors, f"worker raised: {errors}"
         tunnels = list_tunnels()
         assert len(tunnels) == 5, (
-            f"expected 5 concurrent tunnels, got {len(tunnels)} — " "write race dropped some"
+            f"expected 5 concurrent tunnels, got {len(tunnels)} — write race dropped some"
         )
 
     def test_created_at_is_timezone_aware(self):

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -172,9 +172,9 @@ def test_mine_convos_rebuilds_stale_drawers_after_schema_bump(capsys):
         # Second mine — version gate should trigger rebuild
         mine_convos(tmpdir, palace_path, wing="test")
         out = capsys.readouterr().out
-        assert (
-            "Files skipped (already filed): 0" in out
-        ), "stale drawers should force a rebuild, not a skip"
+        assert "Files skipped (already filed): 0" in out, (
+            "stale drawers should force a rebuild, not a skip"
+        )
 
         client = chromadb.PersistentClient(path=palace_path)
         col = client.get_collection("mempalace_drawers")

--- a/tests/test_corpus_origin.py
+++ b/tests/test_corpus_origin.py
@@ -112,17 +112,17 @@ class TestHeuristic:
             "anthropic's haiku model is cheap enough to run on every drawer",
         ]
         result = detect_origin_heuristic(samples)
-        assert (
-            result.likely_ai_dialogue is True
-        ), f"lowercase brand terms missed; evidence: {result.evidence}"
+        assert result.likely_ai_dialogue is True, (
+            f"lowercase brand terms missed; evidence: {result.evidence}"
+        )
         # Evidence must show MULTIPLE distinct case-insensitive brand matches.
         # 'chatgpt' lowercase only matches under case-insensitive search
         # (the brand list has 'ChatGPT' proper-cased only).
         evidence_str = " ".join(result.evidence).lower()
         matched = sum(t in evidence_str for t in ("chatgpt", "anthropic", "haiku", "gemini-pro"))
-        assert (
-            matched >= 2
-        ), f"case-insensitive brand matches did not fire — only got: {result.evidence}"
+        assert matched >= 2, (
+            f"case-insensitive brand matches did not fire — only got: {result.evidence}"
+        )
 
     def test_zodiac_corpus_not_flagged_as_ai(self):
         """An astrology forum post with high 'Gemini' density but ZERO
@@ -138,9 +138,9 @@ class TestHeuristic:
             "The Gemini twins in Greek mythology are Castor and Pollux.",
         ]
         result = detect_origin_heuristic(samples)
-        assert (
-            result.likely_ai_dialogue is False
-        ), f"zodiac corpus wrongly flagged AI; evidence: {result.evidence}"
+        assert result.likely_ai_dialogue is False, (
+            f"zodiac corpus wrongly flagged AI; evidence: {result.evidence}"
+        )
 
     def test_french_novel_with_claude_name_not_flagged(self):
         """A French novel where 'Claude' is a character name (Claude is a
@@ -155,9 +155,9 @@ class TestHeuristic:
             "Les amis de Claude s'étaient réunis chez lui pour fêter ses soixante ans.",
         ]
         result = detect_origin_heuristic(samples)
-        assert (
-            result.likely_ai_dialogue is False
-        ), f"French novel wrongly flagged AI; evidence: {result.evidence}"
+        assert result.likely_ai_dialogue is False, (
+            f"French novel wrongly flagged AI; evidence: {result.evidence}"
+        )
 
     def test_poetry_corpus_with_haiku_sonnet_not_flagged(self):
         """A poetry corpus with high 'haiku', 'sonnet', 'opus' density
@@ -172,9 +172,9 @@ class TestHeuristic:
             "Her first opus, published at twenty, was a song cycle for soprano.",
         ]
         result = detect_origin_heuristic(samples)
-        assert (
-            result.likely_ai_dialogue is False
-        ), f"poetry corpus wrongly flagged AI; evidence: {result.evidence}"
+        assert result.likely_ai_dialogue is False, (
+            f"poetry corpus wrongly flagged AI; evidence: {result.evidence}"
+        )
 
     def test_word_boundary_brand_matching(self):
         """Brand-term matching must use word boundaries. Embedded matches
@@ -208,9 +208,9 @@ class TestHeuristic:
             )
 
         # And classification should be not-AI (no real AI signals present).
-        assert (
-            result.likely_ai_dialogue is False
-        ), f"corpus has no real AI signals; evidence: {result.evidence}"
+        assert result.likely_ai_dialogue is False, (
+            f"corpus has no real AI signals; evidence: {result.evidence}"
+        )
 
     def test_ambiguous_brand_with_unambiguous_signal_flagged(self):
         """When an ambiguous brand term ('Gemini') co-occurs with an
@@ -224,9 +224,9 @@ class TestHeuristic:
             "MCP server config: Gemini as primary, OpenAI as fallback.",
         ]
         result = detect_origin_heuristic(samples)
-        assert (
-            result.likely_ai_dialogue is True
-        ), f"ambiguous+unambiguous co-occurrence missed; evidence: {result.evidence}"
+        assert result.likely_ai_dialogue is True, (
+            f"ambiguous+unambiguous co-occurrence missed; evidence: {result.evidence}"
+        )
 
 
 # ── Tier 2: LLM-assisted (mocked) ─────────────────────────────────────────

--- a/tests/test_corpus_origin_integration.py
+++ b/tests/test_corpus_origin_integration.py
@@ -178,7 +178,7 @@ def test_corpus_origin_reclassifies_personas(
     # All three personas land in the new bucket.
     expected_personas = {"Echo", "Sparrow", "Cipher"}
     assert expected_personas <= persona_names_in_bucket, (
-        f"Expected all three personas in agent_personas, got: " f"{persona_names_in_bucket}"
+        f"Expected all three personas in agent_personas, got: {persona_names_in_bucket}"
     )
 
     # And NONE of them remain in the people bucket.
@@ -293,8 +293,7 @@ def test_init_pass_zero_writes_origin_json_to_palace(ai_dialogue_corpus: Path, t
     assert isinstance(data["result"].get("likely_ai_dialogue"), bool)
     # Fixture is heavy AI-dialogue — heuristic should classify as such.
     assert data["result"]["likely_ai_dialogue"] is True, (
-        "Heuristic should classify the AI-dialogue fixture as AI-dialogue. "
-        f"Got: {data['result']}"
+        f"Heuristic should classify the AI-dialogue fixture as AI-dialogue. Got: {data['result']}"
     )
 
 
@@ -744,9 +743,9 @@ def test_init_graceful_fallback_when_provider_unavailable(
     out = capsys.readouterr().out
     # The fallback message should mention how to silence (--no-llm) so the
     # user knows what flipped.
-    assert (
-        "no-llm" in out.lower() or "--no-llm" in out
-    ), f"Graceful fallback message must point at --no-llm. Got: {out!r}"
+    assert "no-llm" in out.lower() or "--no-llm" in out, (
+        f"Graceful fallback message must point at --no-llm. Got: {out!r}"
+    )
 
 
 def test_init_graceful_fallback_on_provider_construction_error(
@@ -1308,9 +1307,9 @@ def test_integration_llm_refine_corpus_origin_preamble_does_not_break_topic_labe
         "TOPIC label instructions disappeared from SYSTEM_PROMPT — "
         "corpus-origin preamble appears to have replaced rather than appended"
     )
-    assert (
-        "CORPUS CONTEXT" in captured["system"]
-    ), "corpus-origin corpus context preamble missing from prompt"
+    assert "CORPUS CONTEXT" in captured["system"], (
+        "corpus-origin corpus context preamble missing from prompt"
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -1546,12 +1545,12 @@ def test_merge_tier_fields_heuristic_no_no_personas_leak():
 
     assert wrapped is not None
     res = wrapped["result"]
-    assert (
-        res["likely_ai_dialogue"] is False
-    ), f"Both tiers said NOT AI-dialogue; merged result must be False. Got: {res}"
-    assert (
-        res["agent_persona_names"] == []
-    ), f"No personas should leak when both tiers report none. Got: {res}"
+    assert res["likely_ai_dialogue"] is False, (
+        f"Both tiers said NOT AI-dialogue; merged result must be False. Got: {res}"
+    )
+    assert res["agent_persona_names"] == [], (
+        f"No personas should leak when both tiers report none. Got: {res}"
+    )
     # Heuristic owns confidence. Mocked LLM returned 0.95; heuristic's
     # narrative-branch confidence is 0.9. Verifying we kept 0.9 catches
     # any future regression that lets LLM confidence override heuristic.
@@ -1609,24 +1608,23 @@ def test_merge_tier_fields_heuristic_yes_llm_yes_combines_evidence():
     # LLM produced its own; the merged result should include both signal
     # trails for audit purposes.
     evidence_text = " ".join(res["evidence"])
-    assert (
-        "LLM-extracted" in evidence_text
-    ), f"LLM evidence string missing from merged result. Got: {res['evidence']}"
+    assert "LLM-extracted" in evidence_text, (
+        f"LLM evidence string missing from merged result. Got: {res['evidence']}"
+    )
     # Heuristic always produces at least one evidence line for AI-dialogue
     # input (brand-term match), so the combined list has more than just LLM's.
     assert len(res["evidence"]) >= 2, (
-        f"Combined evidence should include both heuristic + LLM lines. " f"Got: {res['evidence']}"
+        f"Combined evidence should include both heuristic + LLM lines. Got: {res['evidence']}"
     )
     # Each entry must carry its tier prefix so on-disk origin.json is
     # auditable — readers can tell which tier produced which signal line.
     tier1_lines = [e for e in res["evidence"] if e.startswith("Tier-1 heuristic: ")]
     tier2_lines = [e for e in res["evidence"] if e.startswith("Tier-2 LLM: ")]
     assert tier1_lines, (
-        f"Expected at least one 'Tier-1 heuristic: ' prefixed evidence line. "
-        f"Got: {res['evidence']}"
+        f"Expected at least one 'Tier-1 heuristic: ' prefixed evidence line. Got: {res['evidence']}"
     )
     assert tier2_lines, (
-        f"Expected at least one 'Tier-2 LLM: ' prefixed evidence line. " f"Got: {res['evidence']}"
+        f"Expected at least one 'Tier-2 LLM: ' prefixed evidence line. Got: {res['evidence']}"
     )
     # Every entry should be tier-prefixed (no untagged passthrough).
     untagged = [
@@ -1759,11 +1757,11 @@ def test_init_prints_privacy_warning_when_provider_is_external(
 
     out = capsys.readouterr().out
     assert "EXTERNAL API" in out, (
-        f"Privacy warning must mention 'EXTERNAL API' when provider is external. " f"Got: {out!r}"
+        f"Privacy warning must mention 'EXTERNAL API' when provider is external. Got: {out!r}"
     )
-    assert (
-        "--no-llm" in out
-    ), f"Privacy warning must point users at --no-llm to opt out. Got: {out!r}"
+    assert "--no-llm" in out, (
+        f"Privacy warning must point users at --no-llm to opt out. Got: {out!r}"
+    )
     # The warning should also tell users MemPalace isn't responsible
     # for downstream provider behavior.
     assert (
@@ -1804,7 +1802,7 @@ def test_init_no_privacy_warning_when_provider_is_local(
 
     out = capsys.readouterr().out
     assert "EXTERNAL API" not in out, (
-        f"Privacy warning fired for a LOCAL provider — should not have. " f"Got: {out!r}"
+        f"Privacy warning fired for a LOCAL provider — should not have. Got: {out!r}"
     )
 
 
@@ -1827,9 +1825,9 @@ def test_init_no_privacy_warning_with_no_llm_flag(ai_dialogue_corpus: Path, tmp_
 
     mock_get.assert_not_called(), "--no-llm must short-circuit before provider acquisition"
     out = capsys.readouterr().out
-    assert (
-        "EXTERNAL API" not in out
-    ), f"Privacy warning fired on --no-llm path — should not have. Got: {out!r}"
+    assert "EXTERNAL API" not in out, (
+        f"Privacy warning fired on --no-llm path — should not have. Got: {out!r}"
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -1988,9 +1986,9 @@ def test_init_accept_external_llm_flag_bypasses_consent_prompt(
         "--accept-external-llm must bypass the consent prompt for "
         "non-interactive / CI use. input() was called anyway."
     )
-    assert (
-        fake_provider.classify.called
-    ), "With --accept-external-llm, init must proceed with the LLM."
+    assert fake_provider.classify.called, (
+        "With --accept-external-llm, init must proceed with the LLM."
+    )
 
 
 def test_init_no_consent_prompt_when_endpoint_is_local(

--- a/tests/test_hooks_bash_compat.py
+++ b/tests/test_hooks_bash_compat.py
@@ -98,12 +98,12 @@ class TestNoBash4OnlyBuiltins:
     @_BOTH_HOOKS
     def test_no_mapfile(self, hook):
         code = _hook_src_no_comments(hook)
-        assert (
-            "mapfile" not in code
-        ), f"{hook.name} uses mapfile, unavailable on macOS /bin/bash 3.2 (#1440)"
-        assert (
-            "readarray" not in code
-        ), f"{hook.name} uses readarray, unavailable on macOS /bin/bash 3.2 (#1440)"
+        assert "mapfile" not in code, (
+            f"{hook.name} uses mapfile, unavailable on macOS /bin/bash 3.2 (#1440)"
+        )
+        assert "readarray" not in code, (
+            f"{hook.name} uses readarray, unavailable on macOS /bin/bash 3.2 (#1440)"
+        )
 
     @_BOTH_HOOKS
     def test_sed_extraction_present(self, hook):
@@ -115,9 +115,9 @@ class TestNoBash4OnlyBuiltins:
         # method back to ``mapfile`` while keeping the old commentary.
         src = _hook_src_no_comments(hook)
         # Each hook reads at least two values via ``sed -n 'Np'`` (sentinel + session_id).
-        assert (
-            src.count("sed -n '") >= 2
-        ), f"{hook.name} must use sed -n 'Np' for POSIX-portable line extraction"
+        assert src.count("sed -n '") >= 2, (
+            f"{hook.name} must use sed -n 'Np' for POSIX-portable line extraction"
+        )
 
     @_BOTH_HOOKS
     def test_bash_syntax_clean(self, hook):
@@ -150,9 +150,9 @@ class TestSessionIdExtraction:
         assert "WARN: input parse failed" not in log
         state_dir = tmp_path / ".mempalace" / "hook_state"
         assert not (state_dir / "last_input.log").exists()
-        assert not (
-            state_dir / "last_python_err.log"
-        ).exists(), "successful parse must leave no last_python_err.log behind"
+        assert not (state_dir / "last_python_err.log").exists(), (
+            "successful parse must leave no last_python_err.log behind"
+        )
 
     def test_precompact_hook_extracts_session_id(self, tmp_path):
         out, _ = _run_hook(
@@ -166,9 +166,9 @@ class TestSessionIdExtraction:
         assert "WARN: input parse failed" not in log
         state_dir = tmp_path / ".mempalace" / "hook_state"
         assert not (state_dir / "last_input.log").exists()
-        assert not (
-            state_dir / "last_python_err.log"
-        ).exists(), "successful parse must leave no last_python_err.log behind"
+        assert not (state_dir / "last_python_err.log").exists(), (
+            "successful parse must leave no last_python_err.log behind"
+        )
 
 
 class TestFailLoudGuard:
@@ -214,9 +214,9 @@ class TestFailLoudGuard:
             tmp_path,
         )
         state_dir = tmp_path / ".mempalace" / "hook_state"
-        assert not (
-            state_dir / "last_input.log"
-        ).exists(), "unicode-only session_id sanitized to empty must NOT trip the guard"
+        assert not (state_dir / "last_input.log").exists(), (
+            "unicode-only session_id sanitized to empty must NOT trip the guard"
+        )
 
     @_BOTH_HOOKS
     def test_literal_unknown_session_id_does_not_trip_guard(self, hook, tmp_path):
@@ -231,9 +231,9 @@ class TestFailLoudGuard:
             tmp_path,
         )
         state_dir = tmp_path / ".mempalace" / "hook_state"
-        assert not (
-            state_dir / "last_input.log"
-        ).exists(), "literal session_id='unknown' must NOT trip the guard"
+        assert not (state_dir / "last_input.log").exists(), (
+            "literal session_id='unknown' must NOT trip the guard"
+        )
 
     @_BOTH_HOOKS
     def test_dump_is_bounded_and_overwritten(self, hook, tmp_path):
@@ -251,9 +251,9 @@ class TestFailLoudGuard:
         big_payload = "x" * 4097
         _run_hook(hook, big_payload, tmp_path)
         last_input = tmp_path / ".mempalace" / "hook_state" / "last_input.log"
-        assert (
-            last_input.stat().st_size == 4096
-        ), f"cap must be exactly 4096 bytes; got {last_input.stat().st_size}"
+        assert last_input.stat().st_size == 4096, (
+            f"cap must be exactly 4096 bytes; got {last_input.stat().st_size}"
+        )
         # Second failure with a smaller payload (also not valid JSON, so the
         # guard fires) overwrites the first; the file shrinks instead of
         # accumulating.
@@ -310,9 +310,9 @@ class TestFailLoudGuard:
         # Python's json.load raises JSONDecodeError with a recognizable
         # traceback. Don't pin the exact message (it varies by Python
         # version) but assert at least one canonical marker is present.
-        assert (
-            "Traceback" in contents or "json" in contents.lower()
-        ), f"expected Python traceback or json error, got: {contents!r}"
+        assert "Traceback" in contents or "json" in contents.lower(), (
+            f"expected Python traceback or json error, got: {contents!r}"
+        )
 
     @_BOTH_HOOKS
     def test_python_stderr_log_is_not_world_readable_on_failure(self, hook, tmp_path):

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -850,9 +850,9 @@ def test_spawn_mine_releases_slot_on_oserror(tmp_path):
             with patch("mempalace.hooks_cli.subprocess.Popen", side_effect=OSError("spawn fail")):
                 with pytest.raises(OSError):
                     _spawn_mine(cmd)
-                assert (
-                    not pid_file.exists()
-                ), "slot must be released so the next hook fire isn't permanently blocked"
+                assert not pid_file.exists(), (
+                    "slot must be released so the next hook fire isn't permanently blocked"
+                )
 
 
 def test_spawn_mine_passes_pid_file_env_var(tmp_path):

--- a/tests/test_hooks_shell.py
+++ b/tests/test_hooks_shell.py
@@ -123,13 +123,13 @@ class TestMempalPythonOverride:
             {"session_id": "abc", "stop_hook_active": False, "transcript_path": ""},
             env_overrides={"MEMPAL_PYTHON": str(fake), "HOME": str(tmp_path)},
         )
-        assert (
-            result.returncode == 0
-        ), f"hook exited non-zero: stderr={result.stderr!r} stdout={result.stdout!r}"
+        assert result.returncode == 0, (
+            f"hook exited non-zero: stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
         invocations = marker.read_text().splitlines() if marker.exists() else []
-        assert (
-            "override_python" in invocations
-        ), f"MEMPAL_PYTHON override was not used. Marker log: {invocations!r}"
+        assert "override_python" in invocations, (
+            f"MEMPAL_PYTHON override was not used. Marker log: {invocations!r}"
+        )
 
     def test_ignores_override_when_not_executable(self, tmp_path):
         """If MEMPAL_PYTHON is set but the file isn't executable, the
@@ -143,9 +143,9 @@ class TestMempalPythonOverride:
             {"session_id": "abc", "stop_hook_active": False, "transcript_path": ""},
             env_overrides={"MEMPAL_PYTHON": str(bogus), "HOME": str(tmp_path)},
         )
-        assert (
-            result.returncode == 0
-        ), f"hook crashed on non-executable MEMPAL_PYTHON: {result.stderr!r}"
+        assert result.returncode == 0, (
+            f"hook crashed on non-executable MEMPAL_PYTHON: {result.stderr!r}"
+        )
 
     def test_falls_back_to_path_when_unset(self, tmp_path):
         """With MEMPAL_PYTHON unset, the hook uses whatever ``python3``
@@ -165,6 +165,6 @@ class TestMempalPythonOverride:
         )
         assert result.returncode == 0
         invocations = marker.read_text().splitlines() if marker.exists() else []
-        assert (
-            "python3" in invocations
-        ), f"fallback-to-PATH did not use the shimmed python3. Marker log: {invocations!r}"
+        assert "python3" in invocations, (
+            f"fallback-to-PATH did not use the shimmed python3. Marker log: {invocations!r}"
+        )

--- a/tests/test_hybrid_candidate_union.py
+++ b/tests/test_hybrid_candidate_union.py
@@ -79,8 +79,7 @@ class TestCandidateUnion:
         result = search_memories(_NARRATIVE_QUERY, palace, n_results=5, candidate_strategy="union")
         ids = [h["source_file"] for h in result["results"]]
         assert "brand_voice_D4.md" in ids, (
-            "union mode must surface BM25-strong docs even when vector signal "
-            f"is weak; got {ids}"
+            f"union mode must surface BM25-strong docs even when vector signal is weak; got {ids}"
         )
 
     def test_union_preserves_vector_hits(self, tmp_path):
@@ -138,9 +137,9 @@ class TestCandidateUnion:
         # 4-doc corpus, n_results=2 → union pool can grow to ~8 candidates,
         # rerank reorders them, but final list must respect the cap.
         result = search_memories(_NARRATIVE_QUERY, palace, n_results=2, candidate_strategy="union")
-        assert (
-            len(result["results"]) <= 2
-        ), f"union must trim to n_results=2; got {len(result['results'])} results"
+        assert len(result["results"]) <= 2, (
+            f"union must trim to n_results=2; got {len(result['results'])} results"
+        )
 
     def test_union_skipped_when_max_distance_set(self, tmp_path):
         """``max_distance`` is a vector-distance threshold; BM25-only

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -155,7 +155,7 @@ def test_direct_address_key_is_singular_string_for_all_locales():
         )
         if "direct_address_pattern" in section:
             val = section["direct_address_pattern"]
-            assert isinstance(
-                val, str
-            ), f"{lang}: 'direct_address_pattern' must be str, got {type(val).__name__}"
+            assert isinstance(val, str), (
+                f"{lang}: 'direct_address_pattern' must be str, got {type(val).__name__}"
+            )
             assert val, f"{lang}: 'direct_address_pattern' is empty"

--- a/tests/test_i18n_lang_case.py
+++ b/tests/test_i18n_lang_case.py
@@ -74,9 +74,9 @@ def test_get_entity_patterns_shares_cache_across_cases():
     cache_keys = list(i18n._entity_cache.keys())
     get_entity_patterns(("ZH-CN",))
     get_entity_patterns(("zh-cn",))
-    assert len(i18n._entity_cache) == len(
-        cache_keys
-    ), "different casings of the same language must not create new cache entries"
+    assert len(i18n._entity_cache) == len(cache_keys), (
+        "different casings of the same language must not create new cache entries"
+    )
 
 
 def test_unknown_language_still_falls_back_to_english():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,15 +65,15 @@ def test_init_filters_sys_path_from_leaked_pythonpath(pythonpath):
     out = result.stdout
     # Env must be preserved verbatim: embedded callers may need it.
     expected_env = repr(pythonpath) if pythonpath is not None else repr(None)
-    assert (
-        f"ENV: {expected_env}" in out
-    ), f"PYTHONPATH should be preserved by package import: {diag}"
+    assert f"ENV: {expected_env}" in out, (
+        f"PYTHONPATH should be preserved by package import: {diag}"
+    )
     assert "SENTINEL_IN_PATH: False" in out, f"sentinel-prefix leak: {diag}"
     # Filter must not over-strip: the mempalace package itself must remain
     # importable, so its parent directory must survive on sys.path.
-    assert (
-        "MEMPALACE_PARENT_PRESENT: True" in out
-    ), f"filter over-stripped sys.path (mempalace parent gone): {diag}"
+    assert "MEMPALACE_PARENT_PRESENT: True" in out, (
+        f"filter over-stripped sys.path (mempalace parent gone): {diag}"
+    )
 
 
 def test_init_preserves_cwd_marker_when_pythonpath_collides():
@@ -94,7 +94,7 @@ def test_init_preserves_cwd_marker_when_pythonpath_collides():
         text=True,
         check=False,
     )
-    diag = f"rc={result.returncode}; stdout={result.stdout!r}; " f"stderr={result.stderr!r}"
+    diag = f"rc={result.returncode}; stdout={result.stdout!r}; stderr={result.stderr!r}"
     assert result.returncode == 0, f"subprocess failed: {diag}"
     assert "CWD_IN_PATH: True" in result.stdout, f"cwd marker dropped: {diag}"
     assert "DOT_IN_PATH: False" in result.stdout, f"dot leak survived: {diag}"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -445,9 +445,9 @@ def test_openai_compat_api_key_source_flag_when_explicit(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env-irrelevant")
     p = OpenAICompatProvider(model="x", endpoint="http://h", api_key="sk-from-flag")
     assert p.api_key == "sk-from-flag"
-    assert (
-        p.api_key_source == "flag"
-    ), f"Explicit api_key arg must produce api_key_source='flag'; got {p.api_key_source!r}"
+    assert p.api_key_source == "flag", (
+        f"Explicit api_key arg must produce api_key_source='flag'; got {p.api_key_source!r}"
+    )
 
 
 def test_openai_compat_api_key_source_env_when_fallback(monkeypatch):
@@ -458,9 +458,9 @@ def test_openai_compat_api_key_source_env_when_fallback(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
     p = OpenAICompatProvider(model="x", endpoint="http://h")
     assert p.api_key == "sk-from-env"
-    assert (
-        p.api_key_source == "env"
-    ), f"Env-fallback api_key must produce api_key_source='env'; got {p.api_key_source!r}"
+    assert p.api_key_source == "env", (
+        f"Env-fallback api_key must produce api_key_source='env'; got {p.api_key_source!r}"
+    )
 
 
 def test_anthropic_api_key_source_tracking(monkeypatch):
@@ -468,14 +468,14 @@ def test_anthropic_api_key_source_tracking(monkeypatch):
     passed explicitly, 'env' when resolved from ANTHROPIC_API_KEY env."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env")
     p_flag = AnthropicProvider(model="claude-haiku", api_key="sk-ant-flag")
-    assert (
-        p_flag.api_key_source == "flag"
-    ), f"Explicit api_key must produce 'flag'; got {p_flag.api_key_source!r}"
+    assert p_flag.api_key_source == "flag", (
+        f"Explicit api_key must produce 'flag'; got {p_flag.api_key_source!r}"
+    )
     p_env = AnthropicProvider(model="claude-haiku")
     assert p_env.api_key == "sk-ant-env"
-    assert (
-        p_env.api_key_source == "env"
-    ), f"Env-fallback must produce 'env'; got {p_env.api_key_source!r}"
+    assert p_env.api_key_source == "env", (
+        f"Env-fallback must produce 'env'; got {p_env.api_key_source!r}"
+    )
 
 
 def test_ollama_api_key_source_is_none():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -63,12 +63,12 @@ def test_mcp_main_strips_leaked_pythonpath_from_env():
     )
     diag = f"rc={result.returncode}; stdout={result.stdout!r}; stderr={result.stderr!r}"
     assert result.returncode == 0, f"subprocess failed: {diag}"
-    assert (
-        f"ENV_MID: {expected_env!r}" in result.stderr
-    ), f"package import unexpectedly stripped env (regression in __init__.py): {diag}"
-    assert (
-        "SENTINEL_IN_PATH: False" in result.stderr
-    ), f"package import did not filter sys.path (regression in __init__.py): {diag}"
+    assert f"ENV_MID: {expected_env!r}" in result.stderr, (
+        f"package import unexpectedly stripped env (regression in __init__.py): {diag}"
+    )
+    assert "SENTINEL_IN_PATH: False" in result.stderr, (
+        f"package import did not filter sys.path (regression in __init__.py): {diag}"
+    )
     assert "ENV_AFTER: None" in result.stderr, f"MCP server did not strip PYTHONPATH: {diag}"
 
 
@@ -250,9 +250,9 @@ class TestColdStartDiagnostics:
         )
         assert result.returncode == 0, f"stderr={result.stderr!r}"
         assert not marker.exists(), f"warmup ran for explicit-falsy value {value!r}"
-        assert (
-            "not recognized" not in result.stderr
-        ), f"explicit-falsy {value!r} should not log a warning; stderr={result.stderr!r}"
+        assert "not recognized" not in result.stderr, (
+            f"explicit-falsy {value!r} should not log a warning; stderr={result.stderr!r}"
+        )
 
     @pytest.mark.parametrize("value", ["tru", "maybe", "ENABLED", "2"])
     def test_eager_warmup_unrecognized_value_warns_and_skips_collection_open(self, tmp_path, value):
@@ -298,9 +298,9 @@ class TestColdStartDiagnostics:
             extra_code=extra,
         )
         assert result.returncode == 0, f"stderr={result.stderr!r}"
-        assert (
-            open_marker.exists()
-        ), f"_get_collection not called for {value!r}; stderr={result.stderr!r}"
+        assert open_marker.exists(), (
+            f"_get_collection not called for {value!r}; stderr={result.stderr!r}"
+        )
         assert query_marker.exists(), (
             f"col.query not invoked for {value!r} — warmup is a no-op "
             f"(would let cold-load hit first MCP call); stderr={result.stderr!r}"
@@ -1134,9 +1134,9 @@ class TestWriteTools:
 
         assert result1["success"] is True
         assert result2["success"] is True
-        assert (
-            result1["drawer_id"] != result2["drawer_id"]
-        ), "Documents with shared header but different content must have distinct drawer IDs"
+        assert result1["drawer_id"] != result2["drawer_id"], (
+            "Documents with shared header but different content must have distinct drawer IDs"
+        )
 
     def test_delete_drawer(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
@@ -2121,9 +2121,9 @@ class TestCacheInvalidation:
         all_calls = captured["get"] + captured["create"]
         assert all_calls, "expected get_collection or create_collection to be called"
         for kwargs in all_calls:
-            assert (
-                "embedding_function" in kwargs
-            ), f"missing embedding_function= in chromadb call: {kwargs}"
+            assert "embedding_function" in kwargs, (
+                f"missing embedding_function= in chromadb call: {kwargs}"
+            )
             assert kwargs["embedding_function"] is not None
 
         # Same expectation on the create=False (cache-miss) reopen path.
@@ -2561,9 +2561,9 @@ class TestKGLazyCache:
 
         result = mcp_server._canonicalize_kg_path("/some/Path/KG.sqlite3")
 
-        assert (
-            result == "<NC:<RP:/some/Path/KG.sqlite3>>"
-        ), f"expected normcase(realpath(p)) composition, got {result!r}"
+        assert result == "<NC:<RP:/some/Path/KG.sqlite3>>", (
+            f"expected normcase(realpath(p)) composition, got {result!r}"
+        )
 
     def test_get_kg_dedupes_symlink_alias_end_to_end(self, tmp_path, monkeypatch):
         """End-to-end: two ``_get_kg()`` calls via different symlink layers

--- a/tests/test_mcp_stdio_protection.py
+++ b/tests/test_mcp_stdio_protection.py
@@ -78,6 +78,6 @@ def test_mcp_server_no_stdout_noise_on_clean_exit():
         capture_output=True,
         timeout=60,
     )
-    assert (
-        proc.stdout == b""
-    ), f"stdout must be empty before the first JSON-RPC response, but got: {proc.stdout!r}"
+    assert proc.stdout == b"", (
+        f"stdout must be empty before the first JSON-RPC response, but got: {proc.stdout!r}"
+    )

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1336,11 +1336,7 @@ class TestStripNoiseRemovesSystemChrome:
 
     def test_strips_line_anchored_system_reminder_block(self):
         text = (
-            "> User:\n"
-            "<system-reminder>\n"
-            "Auto-save reminder...\n"
-            "</system-reminder>\n"
-            "> Real message."
+            "> User:\n<system-reminder>\nAuto-save reminder...\n</system-reminder>\n> Real message."
         )
         out = strip_noise(text)
         assert "system-reminder" not in out
@@ -1350,7 +1346,7 @@ class TestStripNoiseRemovesSystemChrome:
     def test_strips_system_reminder_with_blockquote_prefix(self):
         # _messages_to_transcript prefixes lines with "> ", so the line
         # anchor must also accept that shape.
-        text = "> User:\n" "> <system-reminder>Injected noise</system-reminder>\n" "> Real message."
+        text = "> User:\n> <system-reminder>Injected noise</system-reminder>\n> Real message."
         out = strip_noise(text)
         assert "Injected noise" not in out
         assert "Real message." in out

--- a/tests/test_palace_graph_tunnels.py
+++ b/tests/test_palace_graph_tunnels.py
@@ -63,9 +63,9 @@ class TestTunnelStorage:
         assert file_mode == 0o600, f"tunnels.json mode is {oct(file_mode)}, expected 0o600"
 
         parent_mode = stat.S_IMODE(os.stat(tunnel_file.parent).st_mode)
-        assert (
-            parent_mode == 0o700
-        ), f"tunnels.json parent dir mode is {oct(parent_mode)}, expected 0o700"
+        assert parent_mode == 0o700, (
+            f"tunnels.json parent dir mode is {oct(parent_mode)}, expected 0o700"
+        )
 
 
 class TestExplicitTunnels:

--- a/tests/test_palace_locks.py
+++ b/tests/test_palace_locks.py
@@ -199,9 +199,9 @@ def test_reentrant_same_thread_passes_through(tmp_path, monkeypatch):
         child = ctx.Process(target=_try_acquire_expect_busy, args=(palace, result_q))
         try:
             child.start()
-            assert (
-                result_q.get(timeout=10) == "busy"
-            ), "outer lock should still be held by parent after inner re-entrant exit"
+            assert result_q.get(timeout=10) == "busy", (
+                "outer lock should still be held by parent after inner re-entrant exit"
+            )
             child.join(timeout=5)
             assert child.exitcode == 0
         finally:
@@ -267,9 +267,9 @@ def test_lock_failure_message_names_holder(tmp_path, monkeypatch):
                 pytest.fail("second acquire of same palace should have raised")
 
         msg = str(excinfo.value)
-        assert (
-            f"PID {holder_pid}" in msg
-        ), f"lock-failure message must name the holder PID; got: {msg!r}"
+        assert f"PID {holder_pid}" in msg, (
+            f"lock-failure message must name the holder PID; got: {msg!r}"
+        )
     finally:
         open(release, "w").close()
         holder.join(timeout=5)

--- a/tests/test_readme_claims.py
+++ b/tests/test_readme_claims.py
@@ -597,13 +597,13 @@ class TestBackendAbstraction:
         """Claim: pluggable backends.
         backends/base.py must define an abstract base class."""
         path = MEMPALACE_PKG / "backends" / "base.py"
-        assert (
-            path.is_file()
-        ), "mempalace/backends/base.py does not exist. Backend abstraction layer is missing."
+        assert path.is_file(), (
+            "mempalace/backends/base.py does not exist. Backend abstraction layer is missing."
+        )
         src = _read(path)
-        assert (
-            "ABC" in src or "abstractmethod" in src
-        ), "backends/base.py does not define an abstract base class."
+        assert "ABC" in src or "abstractmethod" in src, (
+            "backends/base.py does not define an abstract base class."
+        )
 
     def test_backends_chroma_exists(self):
         """Claim: ChromaDB backend implementation.
@@ -611,9 +611,9 @@ class TestBackendAbstraction:
         path = MEMPALACE_PKG / "backends" / "chroma.py"
         assert path.is_file(), "mempalace/backends/chroma.py does not exist."
         src = _read(path)
-        assert (
-            "BaseCollection" in src or "base" in src
-        ), "backends/chroma.py does not reference the base class."
+        assert "BaseCollection" in src or "base" in src, (
+            "backends/chroma.py does not reference the base class."
+        )
 
     def test_backends_importable(self):
         """Both backend modules should be importable."""
@@ -650,9 +650,9 @@ class TestI18n:
     def test_english_baseline_exists(self):
         """en.json must exist as the baseline language file."""
         path = MEMPALACE_PKG / "i18n" / "en.json"
-        assert (
-            path.is_file()
-        ), "mempalace/i18n/en.json does not exist. English baseline is required."
+        assert path.is_file(), (
+            "mempalace/i18n/en.json does not exist. English baseline is required."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -737,9 +737,9 @@ class TestReadmeToolCountConsistency:
         counts = re.findall(r"(\d+)\s+tools", readme)
         if len(counts) > 1:
             unique = set(counts)
-            assert (
-                len(unique) == 1
-            ), f"README mentions different tool counts: {counts}. All occurrences must agree."
+            assert len(unique) == 1, (
+                f"README mentions different tool counts: {counts}. All occurrences must agree."
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1381,9 +1381,9 @@ def test_rebuild_index_runs_sqlite_preflight_before_chromadb_open(tmp_path, caps
     PAGE = 4096
     CORRUPT_BYTES = 16384  # 4 pages
     HEADER_GUARD = PAGE * 2  # leave header + root pages intact
-    assert (
-        pre_size >= HEADER_GUARD + CORRUPT_BYTES
-    ), f"sqlite db too small to mangle without truncating: {pre_size} bytes"
+    assert pre_size >= HEADER_GUARD + CORRUPT_BYTES, (
+        f"sqlite db too small to mangle without truncating: {pre_size} bytes"
+    )
     # Round (pre_size - CORRUPT_BYTES) down to a page boundary so we
     # mangle whole pages. Cap at offset 40960 (page 10) for stable
     # diagnostics across SQLite versions that may grow the file.

--- a/tests/test_save_hook_mines.py
+++ b/tests/test_save_hook_mines.py
@@ -33,12 +33,12 @@ class TestSaveHookAutoMines:
         # `--mode convos` so the convo miner runs (not the projects miner).
         assert "TRANSCRIPT_PATH" in src, "hook must read transcript_path"
         assert "mempalace mine" in src, "hook must invoke `mempalace mine`"
-        assert (
-            'dirname "$TRANSCRIPT_PATH"' in src
-        ), "hook must mine the transcript's parent directory"
-        assert (
-            "--mode convos" in src
-        ), "transcript mine must use --mode convos, not the projects miner"
+        assert 'dirname "$TRANSCRIPT_PATH"' in src, (
+            "hook must mine the transcript's parent directory"
+        )
+        assert "--mode convos" in src, (
+            "transcript mine must use --mode convos, not the projects miner"
+        )
 
     def test_mempal_dir_default_not_empty(self):
         """If MEMPAL_DIR is still used, it should have a sensible default,
@@ -86,16 +86,16 @@ class TestShellHookTranscriptValidation:
     def test_save_hook_defines_and_uses_validator(self):
         src = self._strip_comments(self._hook_src("mempal_save_hook.sh"))
         assert "is_valid_transcript_path() {" in src, "validator function must be defined"
-        assert (
-            'is_valid_transcript_path "$TRANSCRIPT_PATH"' in src
-        ), "validator must be invoked against TRANSCRIPT_PATH before mining"
+        assert 'is_valid_transcript_path "$TRANSCRIPT_PATH"' in src, (
+            "validator must be invoked against TRANSCRIPT_PATH before mining"
+        )
 
     def test_precompact_hook_defines_and_uses_validator(self):
         src = self._strip_comments(self._hook_src("mempal_precompact_hook.sh"))
         assert "is_valid_transcript_path() {" in src, "validator function must be defined"
-        assert (
-            'is_valid_transcript_path "$TRANSCRIPT_PATH"' in src
-        ), "validator must be invoked against TRANSCRIPT_PATH before mining"
+        assert 'is_valid_transcript_path "$TRANSCRIPT_PATH"' in src, (
+            "validator must be invoked against TRANSCRIPT_PATH before mining"
+        )
 
     @pytest.mark.skipif(
         sys.platform == "win32",
@@ -112,9 +112,7 @@ class TestShellHookTranscriptValidation:
             end = src.index("\n}\n", start) + 2
             func_src = src[start:end]
             script = tmp_path / "v.sh"
-            script.write_text(
-                f"{func_src}\n" 'is_valid_transcript_path "$1" && echo OK || echo NO\n'
-            )
+            script.write_text(f'{func_src}\nis_valid_transcript_path "$1" && echo OK || echo NO\n')
 
             def run(arg: str) -> str:
                 return subprocess.run(

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -184,12 +184,11 @@ class TestSearchMemories:
 
         # Invariants on every hit.
         for h in hits:
-            assert (
-                0.0 <= h["similarity"] <= 1.0
-            ), f"similarity out of range: {h['similarity']} for {h['source_file']}"
+            assert 0.0 <= h["similarity"] <= 1.0, (
+                f"similarity out of range: {h['similarity']} for {h['source_file']}"
+            )
             assert 0.0 <= h["effective_distance"] <= 2.0, (
-                f"effective_distance out of range: {h['effective_distance']} "
-                f"for {h['source_file']}"
+                f"effective_distance out of range: {h['effective_distance']} for {h['source_file']}"
             )
 
         # With the clamp, the closet-boosted a.md still ranks ahead of b.md —
@@ -338,9 +337,9 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         first_block, _, _ = captured.out.partition("[2]")
         # Lexical match must rank first
-        assert (
-            "b.md" in first_block
-        ), f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        assert "b.md" in first_block, (
+            f"expected lexical match 'b.md' at rank 1, got:\n{captured.out}"
+        )
         # Non-zero bm25 reported
         assert "bm25=" in first_block
         assert "bm25=0.0" not in first_block

--- a/tests/test_sweeper.py
+++ b/tests/test_sweeper.py
@@ -97,9 +97,9 @@ class TestSweeperParsing:
         records = list(parse_claude_jsonl(str(mock_claude_jsonl)))
         assistant_rec = records[1]
         assert assistant_rec["role"] == "assistant"
-        assert (
-            "Paris" in assistant_rec["content"]
-        ), f"Assistant content blocks must be flattened to text; got: {assistant_rec['content']!r}"
+        assert "Paris" in assistant_rec["content"], (
+            f"Assistant content blocks must be flattened to text; got: {assistant_rec['content']!r}"
+        )
 
     def test_parse_preserves_tool_blocks_verbatim(self, tmp_path):
         """Per the design principle "verbatim always", tool_use and

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -444,9 +444,9 @@ class TestSyncPalace:
         # Allow-list — params must be exactly the documented audit shape so
         # any future leak (source_file, content, ID lists, etc.) trips a
         # test failure rather than slipping through a deny-list.
-        assert set(params.keys()) <= {
-            "first_id"
-        }, f"WAL params drifted from the audit allow-list: {params.keys()}"
+        assert set(params.keys()) <= {"first_id"}, (
+            f"WAL params drifted from the audit allow-list: {params.keys()}"
+        )
 
     def test_registry_sentinels_preserved_on_apply(self, tmp_dir, palace_path):
         """F2 regression: convo miner `_reg_*` sentinels must survive sync apply.
@@ -567,9 +567,9 @@ class TestSyncPalace:
         inner_resolved = inner.resolve(strict=False)
         outer_resolved = outer.resolve(strict=False)
         assert inner_resolved in roots, f"expected inner in roots, got {roots}"
-        assert (
-            outer_resolved not in roots
-        ), f"deepest should win exclusively: roots={roots}, outer leaked"
+        assert outer_resolved not in roots, (
+            f"deepest should win exclusively: roots={roots}, outer leaked"
+        )
 
     def test_apply_with_empty_project_dirs_raises(self, palace_path):
         """Round-2 P1: `project_dirs=[]` (empty list) with apply must raise,
@@ -608,9 +608,9 @@ class TestSyncPalace:
                 project_dirs=[synced_world["repo_path"]],
                 dry_run=False,
             )
-        assert any(
-            "Closet purge skipped" in record.getMessage() for record in caplog.records
-        ), f"expected closet-skip warning, got: {[r.getMessage() for r in caplog.records]}"
+        assert any("Closet purge skipped" in record.getMessage() for record in caplog.records), (
+            f"expected closet-skip warning, got: {[r.getMessage() for r in caplog.records]}"
+        )
 
     def test_metadata_cache_cleared_on_exception(self, monkeypatch, config, synced_world, kg):
         """F9 regression: tool_sync's try/finally must clear `_metadata_cache`
@@ -651,9 +651,9 @@ class TestSyncPalace:
         assert result.get("success") is False
         assert "simulated" in result.get("error", "")
 
-        assert (
-            mcp_server._metadata_cache is None
-        ), "F9: cache must be cleared even when sync_palace raises"
+        assert mcp_server._metadata_cache is None, (
+            "F9: cache must be cleared even when sync_palace raises"
+        )
 
     def test_sync_report_keys_stable(self, synced_world):
         """Regression: SyncReport schema must not silently drop a field."""
@@ -946,9 +946,9 @@ class TestSyncPalace:
             wing="demo",
             dry_run=True,
         )
-        assert (
-            report["gitignored"] == 1
-        ), f"symmetric resolve broken: drawer mis-bucketed; report={report}"
+        assert report["gitignored"] == 1, (
+            f"symmetric resolve broken: drawer mis-bucketed; report={report}"
+        )
         assert report["out_of_scope"] == 0
 
     def test_classification_cache_avoids_redundant_disk_hits(
@@ -1005,9 +1005,9 @@ class TestSyncPalace:
         )
         assert report["scanned"] == 5
         assert report["gitignored"] == 5
-        assert (
-            call_count["n"] == 1
-        ), f"cache miss: expected 1 _classify_drawer call (4 cache hits), got {call_count['n']}"
+        assert call_count["n"] == 1, (
+            f"cache miss: expected 1 _classify_drawer call (4 cache hits), got {call_count['n']}"
+        )
 
     def test_closet_batch_purge_single_call(self, synced_world, monkeypatch):
         """Batched $in closet purge: one delete() call across all removable
@@ -1074,16 +1074,16 @@ class TestSyncPalace:
             str(repo_path / "deleted.py"),
         }
         expected = len(seeded_sources & set(report["by_source"].keys()))
-        assert (
-            report["removed_closets"] == expected
-        ), f"removed_closets ({report['removed_closets']}) != |seeded ∩ removable| ({expected})"
+        assert report["removed_closets"] == expected, (
+            f"removed_closets ({report['removed_closets']}) != |seeded ∩ removable| ({expected})"
+        )
         assert "wrapper" in captured, "get_closets_collection patch not invoked"
-        assert (
-            captured["wrapper"].delete_calls == 1
-        ), f"expected one batch delete call, got {captured['wrapper'].delete_calls}"
-        assert (
-            captured["wrapper"].get_calls == 1
-        ), f"expected one batch get call, got {captured['wrapper'].get_calls}"
+        assert captured["wrapper"].delete_calls == 1, (
+            f"expected one batch delete call, got {captured['wrapper'].delete_calls}"
+        )
+        assert captured["wrapper"].get_calls == 1, (
+            f"expected one batch get call, got {captured['wrapper'].get_calls}"
+        )
 
     def test_registry_check_runs_before_cache_lookup(self, tmp_dir, palace_path):
         """A non-registry drawer with the same source_file must NOT poison
@@ -1148,9 +1148,9 @@ class TestSyncPalace:
         finally:
             del client
         assert "a_regular" not in survivors
-        assert (
-            "_reg_zzz_sentinel" in survivors
-        ), "registry sentinel was incorrectly pruned via cached non-registry verdict"
+        assert "_reg_zzz_sentinel" in survivors, (
+            "registry sentinel was incorrectly pruned via cached non-registry verdict"
+        )
 
     def test_normalize_project_dirs_sort_stable_on_equal_length(self):
         """`_normalize_project_dirs` must sort by `(-len, str)` so equal-length

--- a/tools/render_jsonl.py
+++ b/tools/render_jsonl.py
@@ -70,7 +70,7 @@ def main():
     ]
     out.write("\n".join(header))
     for ts, role, text in turns:
-        out.write(f"\n[{ts}] {role.upper()}\n{text}\n\n{'-'*72}\n")
+        out.write(f"\n[{ts}] {role.upper()}\n{text}\n\n{'-' * 72}\n")
     if out is not sys.stdout:
         out.close()
         print(f"Wrote {len(turns)} turns to {sys.argv[2]}")

--- a/uv.lock
+++ b/uv.lock
@@ -1224,7 +1224,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.9" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
 provides-extras = ["dev", "spellcheck", "gpu", "dml", "coreml"]
@@ -1234,7 +1234,7 @@ dev = [
     { name = "psutil", specifier = ">=5.9" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-cov", specifier = ">=4.0" },
-    { name = "ruff", specifier = ">=0.4.0" },
+    { name = "ruff", specifier = "==0.15.9" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

CI installs `ruff>=0.4.0,<0.5` (resolves to **0.4.10**) while contributors run a modern ruff (0.5+). ruff 0.5 changed assert-message formatting, so code formatted by a current ruff fails CI's `ruff format --check .` on **layout alone**, with no actual code defect.

This has blocked three milestone v3.3.6 PRs already — #1438, #1445, #1528 — each requiring a manual "reformat with ruff 0.4.x and force-push" cycle. It will keep recurring for every new contributor on a current ruff.

## Fix

Pin an exact, modern ruff (`0.15.9`) in **both** dev dependency lists (`[project.optional-dependencies].dev` and `[dependency-groups].dev`) **and** in `ci.yml`, so CI and `pip install -e ".[dev]"` / `uv sync --extra dev` format and lint identically. Single source of truth, no version drift.

One-time mechanical `ruff format .` so the tree passes `ruff format --check .` under the new pin.

## Blast radius (measured)

- `ruff check .` under 0.15.9 with the existing `select = ["E","F","W","C901"]`: **All checks passed** — zero new lint violations.
- `ruff format .`: **29 files** — 28 under `tests/` + 1 `tools/` helper. **No core `mempalace/` modules touched.** Layout only (mostly assert-message parenthesization), no behavior change.

Commits are split so review is easy: [`96a3272`] is the pin only; [`2cab6f5`] is the pure mechanical reformat.

## Note for open PRs

The reformat will cause trivial rebase conflicts only for open PRs that touch the same 28 test files. Core-module PRs are unaffected. Recommend merging this promptly to minimize that window.
