### PR TITLE
Fix: Write placeholder PID when claiming mine slot

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -344,6 +344,25 @@ def _mine_already_running(cmd: list[str]) -> bool:
     return _pid_alive(int(recorded))
 
 
+def _create_mine_slot_with_placeholder(pid_file: Path) -> Path:
+    """Atomically create a mine PID slot and write this hook PID into it."""
+    fd = os.open(str(pid_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="ascii") as f:
+            f.write(str(os.getpid()))
+    except OSError:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            pid_file.unlink()
+        except OSError:
+            pass
+        raise
+    return pid_file
+
+
 def _claim_mine_slot(cmd: list[str]) -> Optional[Path]:
     """Atomically reserve the per-target PID slot for ``cmd``.
 
@@ -359,17 +378,14 @@ def _claim_mine_slot(cmd: list[str]) -> Optional[Path]:
     pid_file = _pid_file_for_cmd(cmd)
     pid_file.parent.mkdir(parents=True, exist_ok=True)
     try:
-        fd = os.open(str(pid_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        try:
-            os.write(fd, str(os.getpid()).encode("ascii"))
-        finally:
-            os.close(fd)
-        return pid_file
+        return _create_mine_slot_with_placeholder(pid_file)
     except FileExistsError:
         pass
+
     # Slot exists. If the holder is alive, defer.
     if _mine_already_running(cmd):
         return None
+
     # Stale entry; reclaim. The unlink+create is racy against another hook
     # firing right now, but the second create's O_EXCL will fail and that
     # caller will see the live PID via the next round.
@@ -379,13 +395,9 @@ def _claim_mine_slot(cmd: list[str]) -> Optional[Path]:
         pass
     except OSError:
         return None
+
     try:
-        fd = os.open(str(pid_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        try:
-            os.write(fd, str(os.getpid()).encode("ascii"))
-        finally:
-            os.close(fd)
-        return pid_file
+        return _create_mine_slot_with_placeholder(pid_file)
     except FileExistsError:
         return None
 

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -360,7 +360,10 @@ def _claim_mine_slot(cmd: list[str]) -> Optional[Path]:
     pid_file.parent.mkdir(parents=True, exist_ok=True)
     try:
         fd = os.open(str(pid_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        os.close(fd)
+        try:
+            os.write(fd, str(os.getpid()).encode("ascii"))
+        finally:
+            os.close(fd)
         return pid_file
     except FileExistsError:
         pass
@@ -378,7 +381,10 @@ def _claim_mine_slot(cmd: list[str]) -> Optional[Path]:
         return None
     try:
         fd = os.open(str(pid_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        os.close(fd)
+        try:
+            os.write(fd, str(os.getpid()).encode("ascii"))
+        finally:
+            os.close(fd)
         return pid_file
     except FileExistsError:
         return None

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -28,6 +28,8 @@ from mempalace.hooks_cli import (
     hook_session_start,
     hook_precompact,
     run_hook,
+    _claim_mine_slot,
+    _pid_file_for_cmd,
 )
 
 
@@ -648,6 +650,39 @@ def test_mine_sync_uses_mempalace_python(tmp_path):
                     _mine_sync()
                     cmd = mock_run.call_args[0][0]
                     assert cmd[0] == "/fake/venv/python"
+
+
+def test_claim_mine_slot_writes_live_placeholder_pid(tmp_path):
+    """Regression #1443: claimed slots must not be empty during spawn startup."""
+    cmd = ["mempalace", "mine", "/tmp/proj", "--mode", "projects"]
+    pid_dir = tmp_path / "mine_pids"
+
+    with patch("mempalace.hooks_cli._MINE_PID_DIR", pid_dir):
+        pid_file = _claim_mine_slot(cmd)
+
+        assert pid_file == _pid_file_for_cmd(cmd)
+        assert pid_file.read_text().strip() == str(os.getpid())
+        assert _mine_already_running(cmd) is True
+        assert _claim_mine_slot(cmd) is None
+
+
+def test_claim_mine_slot_reclaimed_slot_writes_live_placeholder_pid(tmp_path):
+    """Regression #1443: stale-slot reclaim must also write a live placeholder."""
+    cmd = ["mempalace", "mine", "/tmp/proj", "--mode", "projects"]
+    pid_dir = tmp_path / "mine_pids"
+
+    with (
+        patch("mempalace.hooks_cli._MINE_PID_DIR", pid_dir),
+        patch("mempalace.hooks_cli._pid_alive", return_value=False),
+    ):
+        pid_file = _pid_file_for_cmd(cmd)
+        pid_file.parent.mkdir(parents=True, exist_ok=True)
+        pid_file.write_text("12345")
+
+        reclaimed = _claim_mine_slot(cmd)
+
+        assert reclaimed == pid_file
+        assert pid_file.read_text().strip() == str(os.getpid())
 
 
 def test_maybe_auto_ingest_ignores_transcript_arg_path(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Fixes #1443.

`_claim_mine_slot()` reserved a per-target mine slot with `O_CREAT | O_EXCL`, but left the slot empty until `_spawn_mine()` later wrote the child PID. A second hook firing during that gap could treat the empty slot as stale, reclaim it, and spawn another mine for the same target.

## What changed

- Write the current hook process PID into the slot immediately after atomic creation
- Do the same for the stale-slot reclaim path
- Keep the existing child PID overwrite behavior after `subprocess.Popen(...)`
- Add regression tests for initial claim and stale-slot reclaim

## Why

The placeholder PID closes the startup race. While the hook is alive and spawning the child, another hook sees a live PID and skips instead of reclaiming the slot.


## How to test


```bash
ruff format mempalace/hooks_cli.py tests/test_hooks_cli.py
ruff check mempalace/hooks_cli.py tests/test_hooks_cli.py
python -m pytest tests/test_hooks_cli.py -k "claim_mine_slot or spawn_mine"
python -m ruff check mempalace/hooks_cli.py tests/test_hooks_cli.py
python -m pytest tests/ -v
```
## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)