### PR TITLE
fix(mcp): surface create_tunnel ValueError instead of masking it (#1473)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1033,15 +1033,22 @@ def tool_create_tunnel(
         target_room = sanitize_name(target_room, "target_room")
     except ValueError as e:
         return {"error": str(e)}
-    return create_tunnel(
-        source_wing,
-        source_room,
-        target_wing,
-        target_room,
-        label=label,
-        source_drawer_id=source_drawer_id,
-        target_drawer_id=target_drawer_id,
-    )
+    # create_tunnel raises ValueError for invalid/missing endpoints
+    # (empty/non-string names, and room-existence checks). Surface the
+    # real reason instead of letting it escape and be wrapped as the
+    # opaque "Internal tool error" (#1473), mirroring sibling tools.
+    try:
+        return create_tunnel(
+            source_wing,
+            source_room,
+            target_wing,
+            target_room,
+            label=label,
+            source_drawer_id=source_drawer_id,
+            target_drawer_id=target_drawer_id,
+        )
+    except ValueError as e:
+        return {"error": str(e)}
 
 
 def tool_list_tunnels(wing: str = None):

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1026,18 +1026,16 @@ def tool_create_tunnel(
     Example: an API design discussion in project_api connects to the
     database schema in project_database.
     """
+    # sanitize_name and create_tunnel both raise ValueError for invalid or
+    # missing endpoints (empty/non-string names, and create_tunnel's
+    # room-existence checks). Catch both so the real reason is surfaced
+    # instead of escaping and being wrapped as the opaque "Internal tool
+    # error" (#1473), mirroring sibling tools.
     try:
         source_wing = sanitize_name(source_wing, "source_wing")
         source_room = sanitize_name(source_room, "source_room")
         target_wing = sanitize_name(target_wing, "target_wing")
         target_room = sanitize_name(target_room, "target_room")
-    except ValueError as e:
-        return {"error": str(e)}
-    # create_tunnel raises ValueError for invalid/missing endpoints
-    # (empty/non-string names, and room-existence checks). Surface the
-    # real reason instead of letting it escape and be wrapped as the
-    # opaque "Internal tool error" (#1473), mirroring sibling tools.
-    try:
         return create_tunnel(
             source_wing,
             source_room,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1386,6 +1386,28 @@ class TestWriteTools:
         assert len(mcp_server.tool_list_tunnels(wing="my-wing")) == 1
         assert len(mcp_server.tool_list_tunnels(wing="my_wing")) == 1
 
+    def test_tool_create_tunnel_surfaces_value_error(self, monkeypatch):
+        """Regression for #1473: a ValueError from create_tunnel (e.g. a
+        missing room) must be returned to the caller as a clear error,
+        not escape and get wrapped as the opaque 'Internal tool error'."""
+        from mempalace import mcp_server
+
+        msg = "Target room 'does-not-exist-probe' does not exist in wing 'wing_minerva'"
+
+        def _raise(*args, **kwargs):
+            raise ValueError(msg)
+
+        monkeypatch.setattr(mcp_server, "create_tunnel", _raise)
+
+        result = mcp_server.tool_create_tunnel(
+            source_wing="wing_minerva",
+            source_room="fx-invariants",
+            target_wing="wing_minerva",
+            target_room="does-not-exist-probe",
+        )
+
+        assert result == {"error": msg}
+
 
 # ── KG Tools ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem
`tool_create_tunnel` sanitizes names inside a `try/except ValueError` but calls `create_tunnel()` **outside** it. Any `ValueError` from `create_tunnel` (empty/non-string endpoints now; room-existence checks once #1469 lands) escapes and the MCP framework wraps it as the opaque `Internal tool error`, so callers never see which room/wing was missing (#1473).

## Fix
Wrap the `create_tunnel()` call in the same `try/except ValueError` and return `{"error": str(e)}`, mirroring sibling tools (`tool_add_drawer`, `tool_list_tunnels`). Independent of #1469 — it makes the masking impossible regardless of which `ValueError` `create_tunnel` raises, and complements #1469's room-existence validation when that lands.

## Test
`test_tool_create_tunnel_surfaces_value_error`: monkeypatches `create_tunnel` to raise a missing-room `ValueError`, asserts `tool_create_tunnel` returns `{"error": <message>}` instead of propagating. Decoupled from #1469 so it pins the contract now. ruff 0.15.9 check + format clean; tunnel tests green.

Closes #1473