### PR TITLE
test(hooks): isolate test_hooks_cli from test_cli side effect (#1510)

### DIFF
--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -43,15 +43,23 @@ def _isolated_existing_palace_root(monkeypatch, tmp_path):
 
     Defaulting every test to a per-test palace root that exists makes
     them robust on their own and protects future tests from the same
-    trap. Tests that exercise the absent-root kill-switch path call
+    trap. ``_MINE_PID_DIR`` is patched too: it is derived from
+    ``STATE_DIR`` *at module import* (hooks_cli.py:277), so patching
+    ``STATE_DIR`` alone would leave mine-spawning tests writing PID files
+    under the import-time location instead of the per-test root. The
+    state dir is created so the docstring's "existing" promise holds.
+
+    Tests that exercise the absent-root kill-switch path call
     ``_redirect_palace_root`` (or set their own PALACE_ROOT) *after* this
     fixture; ``monkeypatch``'s last-write-wins means they keep their
     absent/file root and teardown still restores the real module value.
     """
     root = tmp_path / ".mempalace"
-    root.mkdir(exist_ok=True)
+    state_dir = root / "hook_state"
+    state_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(hooks_cli_mod, "PALACE_ROOT", root)
-    monkeypatch.setattr(hooks_cli_mod, "STATE_DIR", root / "hook_state")
+    monkeypatch.setattr(hooks_cli_mod, "STATE_DIR", state_dir)
+    monkeypatch.setattr(hooks_cli_mod, "_MINE_PID_DIR", state_dir / "mine_pids")
     monkeypatch.setattr(hooks_cli_mod, "_state_dir_initialized", False)
     return root
 

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -31,6 +31,31 @@ from mempalace.hooks_cli import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolated_existing_palace_root(monkeypatch, tmp_path):
+    """Give every test an isolated, *existing* PALACE_ROOT/STATE_DIR.
+
+    Regression for #1510: nine save / log / precompact tests assumed
+    ``~/.mempalace`` existed and only passed in the full suite because an
+    earlier test file (``test_cli.py``) created it as a side effect, so
+    the ``_palace_root_exists()`` kill-switch was satisfied. Run in
+    isolation they short-circuited and failed.
+
+    Defaulting every test to a per-test palace root that exists makes
+    them robust on their own and protects future tests from the same
+    trap. Tests that exercise the absent-root kill-switch path call
+    ``_redirect_palace_root`` (or set their own PALACE_ROOT) *after* this
+    fixture; ``monkeypatch``'s last-write-wins means they keep their
+    absent/file root and teardown still restores the real module value.
+    """
+    root = tmp_path / ".mempalace"
+    root.mkdir(exist_ok=True)
+    monkeypatch.setattr(hooks_cli_mod, "PALACE_ROOT", root)
+    monkeypatch.setattr(hooks_cli_mod, "STATE_DIR", root / "hook_state")
+    monkeypatch.setattr(hooks_cli_mod, "_state_dir_initialized", False)
+    return root
+
+
 # --- _mempalace_python ---
 
 


### PR DESCRIPTION
## Problem
Nine save/log/precompact tests in `test_hooks_cli.py` only pass in the full suite because `test_cli.py` (alphabetically earlier) creates `~/.mempalace` in the session tmp HOME as a side effect, satisfying the `_palace_root_exists()` kill-switch. Run in isolation (`pytest tests/test_hooks_cli.py`) they short-circuit: **9 failed, 80 passed, 1 skipped**.

## Fix
Module-scoped `autouse` fixture that points `PALACE_ROOT`/`STATE_DIR` at a per-test palace root that **exists**, so every test is robust standalone and future tests don't inherit the same trap. Tests that exercise the absent-root kill-switch call `_redirect_palace_root` (or set their own root) *after* the fixture; `monkeypatch`'s last-write-wins keeps their absent/file root and teardown still restores the real module value. Chose this over decorating the 9 tests (fragile — new tests re-trap) and over mkdir-ing real `~/.mempalace` (the coupling the issue warned against).

## Verification
- Issue repro: `pytest tests/test_hooks_cli.py` → **100 passed, 1 skipped** (was 9 failed).
- No ordering regression: `pytest tests/test_cli.py tests/test_hooks_cli.py` → 165 passed, 1 skipped.
- ruff 0.15.9 check + format clean.

Closes #1510