### PR TITLE
feat: add OpenCode MCP integration

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "mempalace": {
+      "type": "local",
+      "command": ["mempalace-mcp"],
+      "enabled": true
+    }
+  }
+}

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "mempalace": {
       "type": "local",
-      "command": ["mempalace-mcp"],
+      "command": ["python", "-m", "mempalace.mcp_server"],
       "enabled": true
     }
   }


### PR DESCRIPTION
## Summary

Adds OpenCode configuration so users can connect MemPalace as an MCP server with zero manual setup.

## What

- `.opencode/opencode.json` — declares the `mempalace-mcp` server as a local MCP endpoint in OpenCode format

OpenCode reads this file automatically when opened in the repo root, so `opencode mcp list` shows MemPalace as connected without any user configuration.

## Context

OpenCode is an open-source AI coding agent (opencode.ai). It supports MCP servers natively via `.opencode/opencode.json` or `.mcp.json`. Existing integrations:

- `.claude-plugin/` — Claude Code
- `.codex-plugin/` — Codex
- `.opencode/` — this PR

No API keys, no external services, no build steps. The user just needs `uv tool install mempalace` and OpenCode picks up the config automatically.