### PR TITLE
fix(llm): set explicit User-Agent on urllib HTTP requests (#1570)

### DIFF
--- a/benchmarks/convomem_bench.py
+++ b/benchmarks/convomem_bench.py
@@ -34,6 +34,8 @@ from datetime import datetime
 
 import chromadb
 
+from mempalace.llm_client import USER_AGENT
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 HF_BASE = "https://huggingface.co/datasets/Salesforce/ConvoMem/resolve/main/core_benchmark/evidence_questions"
@@ -93,7 +95,7 @@ def discover_files(category, cache_dir):
             return json.load(f)
 
     try:
-        req = urllib.request.Request(api_url)
+        req = urllib.request.Request(api_url, headers={"User-Agent": USER_AGENT})
         with urllib.request.urlopen(req, timeout=15) as resp:
             files = json.loads(resp.read())
             paths = [

--- a/benchmarks/convomem_bench.py
+++ b/benchmarks/convomem_bench.py
@@ -34,7 +34,7 @@ from datetime import datetime
 
 import chromadb
 
-from mempalace.llm_client import USER_AGENT
+from mempalace.user_agent import USER_AGENT
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 

--- a/benchmarks/locomo_bench.py
+++ b/benchmarks/locomo_bench.py
@@ -33,6 +33,8 @@ from pathlib import Path
 from collections import Counter, defaultdict
 from datetime import datetime
 
+from mempalace.llm_client import USER_AGENT
+
 import chromadb
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -406,6 +408,7 @@ def _llm_call(prompt, api_key, model="claude-haiku-4-5-20251001", max_tokens=32)
         "https://api.anthropic.com/v1/messages",
         data=payload,
         headers={
+            "user-agent": USER_AGENT,
             "x-api-key": api_key,
             "anthropic-version": "2023-06-01",
             "content-type": "application/json",
@@ -570,6 +573,7 @@ def llm_rerank_locomo(
             "content-type": "application/json",
         }
 
+    headers["user-agent"] = USER_AGENT
     req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
 
     import socket as _socket

--- a/benchmarks/locomo_bench.py
+++ b/benchmarks/locomo_bench.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from collections import Counter, defaultdict
 from datetime import datetime
 
-from mempalace.llm_client import USER_AGENT
+from mempalace.user_agent import USER_AGENT
 
 import chromadb
 

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -39,6 +39,8 @@ from pathlib import Path
 from collections import defaultdict
 from datetime import datetime
 
+from mempalace.llm_client import USER_AGENT
+
 import chromadb
 
 # Add mempal to path
@@ -2420,6 +2422,7 @@ def diary_ingest_session(session, sess_id, api_key, model="claude-haiku-4-5-2025
         "https://api.anthropic.com/v1/messages",
         data=payload,
         headers={
+            "user-agent": USER_AGENT,
             "x-api-key": api_key,
             "anthropic-version": "2023-06-01",
             "content-type": "application/json",
@@ -2851,6 +2854,7 @@ def llm_rerank(
             "content-type": "application/json",
         }
 
+    headers["user-agent"] = USER_AGENT
     req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
 
     import socket as _socket

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from collections import defaultdict
 from datetime import datetime
 
-from mempalace.llm_client import USER_AGENT
+from mempalace.user_agent import USER_AGENT
 
 import chromadb
 

--- a/benchmarks/model_eval/metrics.py
+++ b/benchmarks/model_eval/metrics.py
@@ -1,4 +1,5 @@
 """Metrics: timing extraction, VRAM measurement, embedding similarity, percentiles."""
+
 from __future__ import annotations
 
 import json
@@ -11,6 +12,8 @@ from dataclasses import dataclass, field
 from typing import Optional
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+
+from mempalace.llm_client import USER_AGENT
 
 
 # ── Thinking-token stripping ─────────────────────────────────────────────
@@ -147,9 +150,10 @@ def vram_resident_mb(
     is missing in older Ollama versions (verified against 0.23.2).
     """
     try:
-        with urlopen(f"{endpoint}/api/ps", timeout=timeout) as resp:
+        req = Request(f"{endpoint}/api/ps", headers={"User-Agent": USER_AGENT})
+        with urlopen(req, timeout=timeout) as resp:
             data = json.loads(resp.read())
-    except (URLError, HTTPError, OSError, json.JSONDecodeError):
+    except (URLError, HTTPError, OSError, ValueError):
         return None
     for model in data.get("models", []) or []:
         if not isinstance(model, dict):
@@ -243,15 +247,15 @@ def embed_text(
 ) -> Optional[list[float]]:
     """Get an embedding from Ollama's /api/embeddings. Returns None on failure."""
     body = json.dumps({"model": model, "prompt": text}).encode("utf-8")
-    req = Request(
-        f"{endpoint}/api/embeddings",
-        data=body,
-        headers={"Content-Type": "application/json"},
-    )
     try:
+        req = Request(
+            f"{endpoint}/api/embeddings",
+            data=body,
+            headers={"User-Agent": USER_AGENT, "Content-Type": "application/json"},
+        )
         with urlopen(req, timeout=timeout) as resp:
             data = json.loads(resp.read())
-    except (URLError, HTTPError, OSError, json.JSONDecodeError):
+    except (URLError, HTTPError, OSError, ValueError):
         return None
     return data.get("embedding")
 
@@ -330,11 +334,13 @@ def gather_host_info() -> HostInfo:
             info.ram_gb = round(kb / (1024 * 1024), 1)
             break
 
-    nvidia = _run([
-        "nvidia-smi",
-        "--query-gpu=name,memory.total",
-        "--format=csv,noheader,nounits",
-    ])
+    nvidia = _run(
+        [
+            "nvidia-smi",
+            "--query-gpu=name,memory.total",
+            "--format=csv,noheader,nounits",
+        ]
+    )
     if nvidia:
         first = nvidia.strip().splitlines()[0]
         if "," in first:
@@ -347,7 +353,11 @@ def gather_host_info() -> HostInfo:
 
     info.ollama_version = (_run(["ollama", "--version"]) or "").strip()
 
-    info.os = (_read_file("/etc/os-release") or "").splitlines()[0] if _read_file("/etc/os-release") else ""
+    info.os = (
+        (_read_file("/etc/os-release") or "").splitlines()[0]
+        if _read_file("/etc/os-release")
+        else ""
+    )
     if info.os.startswith("PRETTY_NAME="):
         info.os = info.os.split("=", 1)[1].strip('"')
 

--- a/benchmarks/model_eval/metrics.py
+++ b/benchmarks/model_eval/metrics.py
@@ -13,7 +13,7 @@ from typing import Optional
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from mempalace.llm_client import USER_AGENT
+from mempalace.user_agent import USER_AGENT
 
 
 # ── Thinking-token stripping ─────────────────────────────────────────────

--- a/mempalace/backends/qdrant.py
+++ b/mempalace/backends/qdrant.py
@@ -24,7 +24,7 @@ from urllib import request as urlrequest
 
 import numpy as np
 
-from ..version import __version__
+from ..user_agent import USER_AGENT
 from ._sidecar import EMBEDDER_SIDECAR_FILENAME, read_embedder_sidecar, write_embedder_sidecar
 from .base import (
     BackendClosedError,
@@ -386,7 +386,7 @@ class _QdrantRESTClient:
         data = None
         headers = {
             "Content-Type": "application/json",
-            "User-Agent": f"mempalace/{__version__}",
+            "User-Agent": USER_AGENT,
         }
         if self._config.api_key:
             headers["api-key"] = self._config.api_key

--- a/mempalace/closet_llm.py
+++ b/mempalace/closet_llm.py
@@ -47,6 +47,7 @@ import urllib.error
 from datetime import datetime
 from typing import Optional
 
+from .llm_client import USER_AGENT
 from .palace import (
     NORMALIZE_VERSION,
     get_closets_collection,
@@ -152,7 +153,7 @@ def _call_llm(cfg: LLMConfig, source_file: str, wing: str, room: str, content: s
         }
     ).encode("utf-8")
 
-    headers = {"Content-Type": "application/json"}
+    headers = {"User-Agent": USER_AGENT, "Content-Type": "application/json"}
     if cfg.key:
         headers["Authorization"] = f"Bearer {cfg.key}"
 

--- a/mempalace/closet_llm.py
+++ b/mempalace/closet_llm.py
@@ -47,7 +47,6 @@ import urllib.error
 from datetime import datetime
 from typing import Optional
 
-from .llm_client import USER_AGENT
 from .palace import (
     NORMALIZE_VERSION,
     get_closets_collection,
@@ -57,6 +56,7 @@ from .palace import (
     purge_file_closets,
     upsert_closet_lines,
 )
+from .user_agent import USER_AGENT
 
 MAX_CONTENT_CHARS = 30000
 MAX_OUTPUT_TOKENS = 1500

--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -57,7 +57,7 @@ import os
 import threading
 from typing import Optional
 
-from .version import __version__
+from .user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -650,7 +650,7 @@ class OpenAICompatEmbeddingFunction:
             "Content-Type": "application/json",
             # Some hosted (Cloudflare-fronted) endpoints 403 the default
             # ``Python-urllib`` User-Agent — send our own (see issue #1570).
-            "User-Agent": f"mempalace/{__version__}",
+            "User-Agent": USER_AGENT,
         }
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"

--- a/mempalace/entity_registry.py
+++ b/mempalace/entity_registry.py
@@ -23,6 +23,8 @@ import urllib.parse
 from pathlib import Path
 from typing import Optional
 
+from .llm_client import USER_AGENT
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Common English words that could be confused with names
@@ -188,7 +190,7 @@ def _wikipedia_lookup(word: str) -> dict:
     """
     try:
         url = f"https://en.wikipedia.org/api/rest_v1/page/summary/{urllib.parse.quote(word)}"
-        req = urllib.request.Request(url, headers={"User-Agent": "MemPalace/1.0"})
+        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
         with urllib.request.urlopen(req, timeout=5) as resp:
             data = json.loads(resp.read())
 

--- a/mempalace/entity_registry.py
+++ b/mempalace/entity_registry.py
@@ -23,7 +23,7 @@ import urllib.parse
 from pathlib import Path
 from typing import Optional
 
-from .llm_client import USER_AGENT
+from .user_agent import USER_AGENT
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/mempalace/llm_client.py
+++ b/mempalace/llm_client.py
@@ -31,6 +31,15 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
+from .version import __version__
+
+# Cloudflare-fronted endpoints (Workers AI, AI Gateway, Together, ...) often
+# run a WAF "User Agent Blocking" rule against the stdlib default
+# ``Python-urllib/<py-version>`` and return a bare 403 before auth (#1570).
+# Sending an explicit identifier passes those checks and gives operators
+# something searchable in their WAF logs.
+USER_AGENT = f"mempalace/{__version__} (+https://github.com/MemPalace/mempalace)"
+
 
 # ── External-service heuristic (issue #24 — privacy warning support) ─────
 # Used by ``LLMProvider.is_external_service`` to decide whether the
@@ -178,12 +187,22 @@ class LLMProvider:
 
 def _http_post_json(url: str, body: dict, headers: dict, timeout: int) -> dict:
     """POST JSON and return the parsed response. Raises LLMError on any failure."""
-    req = Request(
-        url,
-        data=json.dumps(body).encode("utf-8"),
-        headers={"Content-Type": "application/json", **headers},
-    )
     try:
+        # ``User-Agent`` is set AFTER ``**headers`` so callers cannot accidentally
+        # shadow the WAF-bypass with a per-provider override (#1570). Callers that
+        # genuinely need a different UA should change ``USER_AGENT`` itself.
+        # ``Request()`` is inside the try block because it validates the URL eagerly
+        # and raises ``ValueError`` on malformed input; that needs to be wrapped as
+        # ``LLMError`` for the docstring contract.
+        req = Request(
+            url,
+            data=json.dumps(body).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                **headers,
+                "User-Agent": USER_AGENT,
+            },
+        )
         with urlopen(req, timeout=timeout) as resp:
             return json.loads(resp.read())
     except HTTPError as e:
@@ -193,10 +212,12 @@ def _http_post_json(url: str, body: dict, headers: dict, timeout: int) -> dict:
         except Exception:
             pass
         raise LLMError(f"HTTP {e.code} from {url}: {detail or e.reason}") from e
-    except (URLError, OSError) as e:
-        raise LLMError(f"Cannot reach {url}: {e}") from e
+    # JSONDecodeError is a subclass of ValueError; must come BEFORE the broader
+    # ValueError catch so malformed responses still classify as "Malformed".
     except json.JSONDecodeError as e:
         raise LLMError(f"Malformed response from {url}: {e}") from e
+    except (URLError, OSError, ValueError) as e:
+        raise LLMError(f"Cannot reach {url}: {e}") from e
 
 
 # ==================== OLLAMA ====================
@@ -223,9 +244,14 @@ class OllamaProvider(LLMProvider):
 
     def check_available(self) -> tuple[bool, str]:
         try:
-            with urlopen(f"{self.endpoint}/api/tags", timeout=5) as resp:
+            req = Request(f"{self.endpoint}/api/tags", headers={"User-Agent": USER_AGENT})
+            with urlopen(req, timeout=5) as resp:
                 data = json.loads(resp.read())
-        except (URLError, HTTPError, OSError, json.JSONDecodeError) as e:
+        # ValueError covers both malformed endpoints (Request() validates URLs
+        # eagerly now that we pass it explicitly) and JSONDecodeError on the
+        # response body (JSONDecodeError is a ValueError subclass). The prior
+        # bare-string urlopen path wrapped URL-validation failures as URLError.
+        except (URLError, HTTPError, OSError, ValueError) as e:
             return False, f"Cannot reach Ollama at {self.endpoint}: {e}"
         names = {m.get("name", "") for m in data.get("models", []) or []}
         # Ollama tags may or may not include ':latest' — accept either form
@@ -322,12 +348,14 @@ class OpenAICompatProvider(LLMProvider):
         base = self.endpoint.rstrip("/")
         base = base.removesuffix("/chat/completions").removesuffix("/v1")
         try:
-            req = Request(f"{base}/v1/models")
+            req = Request(f"{base}/v1/models", headers={"User-Agent": USER_AGENT})
             if self.api_key and (self.api_key_source != "env" or not self.is_external_service):
                 req.add_header("Authorization", f"Bearer {self.api_key}")
             with urlopen(req, timeout=5):
                 pass
-        except (URLError, HTTPError, OSError) as e:
+        # ValueError covers malformed endpoints (no scheme / unknown url type) since
+        # Request() validates eagerly. Same treatment as OllamaProvider.check_available.
+        except (URLError, HTTPError, OSError, ValueError) as e:
             return False, f"Cannot reach {self.endpoint}: {e}"
         return True, "ok"
 

--- a/mempalace/llm_client.py
+++ b/mempalace/llm_client.py
@@ -31,14 +31,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
-from .version import __version__
-
-# Cloudflare-fronted endpoints (Workers AI, AI Gateway, Together, ...) often
-# run a WAF "User Agent Blocking" rule against the stdlib default
-# ``Python-urllib/<py-version>`` and return a bare 403 before auth (#1570).
-# Sending an explicit identifier passes those checks and gives operators
-# something searchable in their WAF logs.
-USER_AGENT = f"mempalace/{__version__} (+https://github.com/MemPalace/mempalace)"
+from .user_agent import USER_AGENT
 
 
 # ── External-service heuristic (issue #24 — privacy warning support) ─────

--- a/mempalace/update_awareness.py
+++ b/mempalace/update_awareness.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.request import Request, urlopen
 
+from .user_agent import USER_AGENT
 from .version import __version__
 
 
@@ -86,7 +87,7 @@ def fetch_latest_stable() -> str:
     """Return the latest stable version advertised by the official PyPI project."""
     request = Request(
         "https://pypi.org/pypi/mempalace/json",
-        headers={"Accept": "application/json", "User-Agent": "mempalace-update-check"},
+        headers={"Accept": "application/json", "User-Agent": f"{USER_AGENT} (update-check)"},
     )
     with urlopen(request, timeout=2.0) as response:  # noqa: S310 -- fixed HTTPS origin
         payload = json.load(response)

--- a/mempalace/user_agent.py
+++ b/mempalace/user_agent.py
@@ -1,0 +1,16 @@
+"""The identifier MemPalace sends on outgoing HTTP requests.
+
+Cloudflare-fronted endpoints (Workers AI, AI Gateway, Together, OpenRouter, ...)
+commonly run a WAF "User Agent Blocking" rule against Python's stdlib default
+``Python-urllib/<py-version>`` and answer a bare 403 before auth (issue #1570).
+An explicit identifier passes those checks and gives operators something
+searchable in their logs.
+
+Call sites import ``USER_AGENT`` rather than formatting their own string, so the
+LLM client, the embedding function, the qdrant backend, the Wikipedia lookup and
+the release check cannot drift into spelling it differently.
+"""
+
+from .version import __version__
+
+USER_AGENT = f"mempalace/{__version__}"

--- a/tests/test_closet_llm.py
+++ b/tests/test_closet_llm.py
@@ -22,6 +22,7 @@ from mempalace.closet_llm import (
     _parsed_to_closet_lines,
     regenerate_closets,
 )
+from mempalace.llm_client import USER_AGENT
 
 
 # ── LLMConfig ─────────────────────────────────────────────────────────────
@@ -173,6 +174,28 @@ class TestCallLLM:
             _call_llm(cfg, "/tmp/x", "w", "r", "c")
 
         assert "authorization" not in captured_headers
+
+    def test_sends_user_agent_header(self):
+        """#1570: closet regeneration POSTs through the same OpenAI-compat
+        path as the main LLM client. Cloudflare-fronted endpoints WAF-block
+        ``Python-urllib/*`` before auth, so set the explicit MemPalace UA
+        for parity with ``mempalace.llm_client._http_post_json``."""
+        cfg = LLMConfig(endpoint="http://localhost:11434/v1", model="llama3:8b")
+        captured_headers = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured_headers.update({k.lower(): v for k, v in req.header_items()})
+            return _FakeResp(
+                {
+                    "choices": [{"message": {"content": '{"topics":[],"quotes":[],"summary":""}'}}],
+                    "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+                }
+            )
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _call_llm(cfg, "/tmp/x", "w", "r", "c")
+
+        assert captured_headers.get("user-agent") == USER_AGENT
 
     def test_strips_code_fences(self):
         cfg = self._make_cfg()

--- a/tests/test_closet_llm.py
+++ b/tests/test_closet_llm.py
@@ -22,7 +22,7 @@ from mempalace.closet_llm import (
     _parsed_to_closet_lines,
     regenerate_closets,
 )
-from mempalace.llm_client import USER_AGENT
+from mempalace.user_agent import USER_AGENT
 
 
 # ── LLMConfig ─────────────────────────────────────────────────────────────

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -11,6 +11,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from mempalace.llm_client import (
+    USER_AGENT,
     AnthropicProvider,
     LLMError,
     OllamaProvider,
@@ -87,6 +88,26 @@ def test_http_post_json_malformed_response():
             _http_post_json("http://x", {}, {}, timeout=5)
 
 
+def test_http_post_json_sends_user_agent_header():
+    """Cloudflare-fronted endpoints WAF-block the default Python-urllib UA
+    with bare 403 before auth (#1570). Verify every POST carries the
+    explicit MemPalace UA so the runtime classify() path works through
+    Cloudflare without manual config."""
+    captured = {}
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = b'{"ok": true}'
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.__exit__.return_value = False
+
+    def fake_urlopen(req, timeout=None):
+        captured["ua"] = req.get_header("User-agent")
+        return mock_resp
+
+    with patch("mempalace.llm_client.urlopen", side_effect=fake_urlopen):
+        _http_post_json("http://x/y", {"a": 1}, {}, timeout=5)
+    assert captured["ua"] == USER_AGENT
+
+
 # ── OllamaProvider ──────────────────────────────────────────────────────
 
 
@@ -144,6 +165,38 @@ def test_ollama_check_available_unreachable():
         ok, msg = p.check_available()
     assert not ok
     assert "Cannot reach Ollama" in msg
+
+
+def test_ollama_check_available_malformed_endpoint_returns_false_not_raise():
+    """``Request()`` validates URLs eagerly and raises ``ValueError`` on bad
+    input. The probe must surface as ``(False, msg)``, not propagate (#1570).
+    No mock: exercises the real ``Request()`` validation path."""
+    p = OllamaProvider(model="x", endpoint="not-a-url")
+    ok, msg = p.check_available()
+    assert ok is False
+    assert "Cannot reach Ollama" in msg
+
+
+def test_ollama_check_available_sends_user_agent():
+    """Ollama is usually localhost, but users running it behind a reverse
+    proxy (Tailscale gateway, nginx fronting a remote box, ...) can still
+    hit CF-style WAFs. Send an explicit UA so the probe survives (#1570)."""
+    captured = {}
+    tags = {"models": [{"name": "gemma4:e4b"}]}
+    mock = MagicMock()
+    mock.read.return_value = json.dumps(tags).encode()
+    mock.__enter__.return_value = mock
+    mock.__exit__.return_value = False
+
+    def fake_urlopen(req, *, timeout):
+        captured["ua"] = req.get_header("User-agent")
+        return mock
+
+    with patch("mempalace.llm_client.urlopen", side_effect=fake_urlopen):
+        p = OllamaProvider(model="gemma4:e4b")
+        ok, _ = p.check_available()
+    assert ok
+    assert captured["ua"] == USER_AGENT
 
 
 def test_ollama_classify_sends_json_format():
@@ -229,6 +282,84 @@ def test_openai_compat_sends_authorization_when_key_present():
     assert captured["auth"] == "Bearer sk-aaa"
 
 
+def test_openai_compat_check_available_sends_user_agent():
+    """#1570: Cloudflare-fronted openai-compat endpoints (Workers AI, AI
+    Gateway, Together, ...) WAF-block the default ``Python-urllib/*`` UA
+    with bare 403 before auth. Verify ``check_available`` sets an explicit
+    UA so the probe surfaces 401 / 200 instead of getting blackholed."""
+    captured = {}
+    mock = MagicMock()
+    mock.__enter__.return_value = mock
+    mock.__exit__.return_value = False
+
+    def fake_urlopen(req, *, timeout):
+        captured["ua"] = req.get_header("User-agent")
+        return mock
+
+    with patch("mempalace.llm_client.urlopen", side_effect=fake_urlopen):
+        p = OpenAICompatProvider(model="x", endpoint="http://h")
+        ok, _ = p.check_available()
+    assert ok
+    assert captured["ua"] == USER_AGENT
+
+
+def test_openai_compat_check_available_malformed_endpoint_returns_false_not_raise():
+    """Mirror of the Ollama variant: ``Request()`` raises ``ValueError`` on
+    malformed endpoint and ``check_available`` must wrap it as ``(False, msg)``
+    (#1570 / gemini-code-assist finding on PR #1577)."""
+    p = OpenAICompatProvider(model="x", endpoint="not-a-url")
+    ok, msg = p.check_available()
+    assert ok is False
+    assert "Cannot reach" in msg
+
+
+def test_user_agent_constant_format():
+    """Format-pin: WAF allowlists and operator log greps key off the full
+    ``mempalace/<semver> (+repo URL)`` shape. A future ``__version__`` refactor
+    that drops the version segment OR the URL suffix must fail loudly here."""
+    import re
+
+    assert re.fullmatch(
+        r"mempalace/\d+\.\d+\.\d+[^()]*\(\+https://github\.com/MemPalace/mempalace\)",
+        USER_AGENT,
+    ), f"USER_AGENT format mismatch: {USER_AGENT!r}"
+
+
+def test_http_post_json_malformed_url_raises_llm_error_not_value_error():
+    """``Request()`` validates URLs eagerly and raises ``ValueError`` on
+    malformed input. The function's docstring promises ``LLMError`` on any
+    failure, so ``ValueError`` must be wrapped (#1570 / gemini-code-assist
+    finding on PR #1577)."""
+    with pytest.raises(LLMError, match="Cannot reach"):
+        _http_post_json("not-a-url", {}, {}, timeout=5)
+
+
+@pytest.mark.parametrize("hdr_casing", ["User-Agent", "user-agent", "USER-AGENT", "User-agent"])
+def test_http_post_json_caller_cannot_override_user_agent(hdr_casing):
+    """Callers passing ``User-Agent`` in ``headers`` (any casing) MUST NOT
+    shadow the WAF-bypass default (#1570). urllib normalises header keys via
+    ``str.capitalize`` on insert, so all four casings collapse to the same
+    storage key and our dict-merge order must win regardless."""
+    captured = {}
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = b'{"ok": true}'
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.__exit__.return_value = False
+
+    def fake_urlopen(req, timeout=None):
+        captured["ua"] = req.get_header("User-agent")
+        return mock_resp
+
+    with patch("mempalace.llm_client.urlopen", side_effect=fake_urlopen):
+        _http_post_json(
+            "http://x/y",
+            {"a": 1},
+            {hdr_casing: "evil-override/0.0"},
+            timeout=5,
+        )
+    assert captured["ua"] == USER_AGENT
+
+
 def test_openai_compat_uses_env_var_fallback(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
     p = OpenAICompatProvider(model="x", endpoint="http://h")
@@ -301,6 +432,23 @@ def test_anthropic_classify_sends_version_and_key():
     assert captured["api_key"] == "sk-ant-abc"
     assert captured["version"] == AnthropicProvider.API_VERSION
     assert resp.text == '{"ok": true}'
+
+
+def test_anthropic_classify_sends_user_agent():
+    """``AnthropicProvider.classify`` routes through ``_http_post_json``
+    and inherits the WAF-bypass UA. ``api.anthropic.com`` is itself
+    Cloudflare-fronted, so a future Anthropic-specific refactor must
+    not regress UA propagation (#1570)."""
+    captured = {}
+
+    def fake_urlopen(req, *, timeout):
+        captured["ua"] = req.get_header("User-agent")
+        return _mock_anthropic_response('{"ok": true}')
+
+    with patch("mempalace.llm_client.urlopen", side_effect=fake_urlopen):
+        p = AnthropicProvider(model="claude-haiku", api_key="sk-ant-abc")
+        p.classify("s", "u")
+    assert captured["ua"] == USER_AGENT
 
 
 def test_anthropic_joins_multiple_text_blocks():

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -11,7 +11,6 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from mempalace.llm_client import (
-    USER_AGENT,
     AnthropicProvider,
     LLMError,
     OllamaProvider,
@@ -19,6 +18,7 @@ from mempalace.llm_client import (
     _http_post_json,
     get_provider,
 )
+from mempalace.user_agent import USER_AGENT
 
 
 # ── factory ─────────────────────────────────────────────────────────────
@@ -311,18 +311,6 @@ def test_openai_compat_check_available_malformed_endpoint_returns_false_not_rais
     ok, msg = p.check_available()
     assert ok is False
     assert "Cannot reach" in msg
-
-
-def test_user_agent_constant_format():
-    """Format-pin: WAF allowlists and operator log greps key off the full
-    ``mempalace/<semver> (+repo URL)`` shape. A future ``__version__`` refactor
-    that drops the version segment OR the URL suffix must fail loudly here."""
-    import re
-
-    assert re.fullmatch(
-        r"mempalace/\d+\.\d+\.\d+[^()]*\(\+https://github\.com/MemPalace/mempalace\)",
-        USER_AGENT,
-    ), f"USER_AGENT format mismatch: {USER_AGENT!r}"
 
 
 def test_http_post_json_malformed_url_raises_llm_error_not_value_error():

--- a/tests/test_update_awareness.py
+++ b/tests/test_update_awareness.py
@@ -10,12 +10,46 @@ from mempalace.update_awareness import (
     cached_update_status,
     check_updates,
     configure_updates,
+    fetch_latest_stable,
     prepare_upgrade,
     schedule_update_check,
 )
+from mempalace.user_agent import USER_AGENT
 
 
 NOW = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+
+
+class _FakePyPIResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_release_check_identifies_itself_by_version_and_purpose(monkeypatch):
+    """PyPI gets the shared versioned identifier, with the purpose kept as a
+    suffix so an update ping stays distinguishable from provider traffic."""
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["ua"] = request.get_header("User-agent")
+        captured["accept"] = request.get_header("Accept")
+        return _FakePyPIResponse({"info": {"version": "9.9.9"}})
+
+    monkeypatch.setattr("mempalace.update_awareness.urlopen", fake_urlopen)
+
+    assert fetch_latest_stable() == "9.9.9"
+    assert captured["ua"] == f"{USER_AGENT} (update-check)"
+    assert captured["ua"].startswith("mempalace/")
+    assert captured["accept"] == "application/json"
 
 
 def test_disabled_automatic_check_never_contacts_release_source(tmp_path):

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -1,0 +1,51 @@
+"""One spelling of the identifier MemPalace sends on outgoing HTTP requests.
+
+The Wikipedia lookup is exercised here because every test in
+``tests/test_entity_registry.py`` patches ``_wikipedia_lookup`` itself, so
+nothing else watches the header that function actually sends.
+"""
+
+import json
+import re
+
+from mempalace import entity_registry
+from mempalace.user_agent import USER_AGENT
+from mempalace.version import __version__
+
+
+def test_user_agent_is_a_versioned_mempalace_identifier():
+    """Format-pin: WAF allowlists and operator log greps key off the
+    ``mempalace/<semver>`` shape, and ``tests/test_qdrant_user_agent.py`` pins the
+    same spelling from the other side. A refactor that drops the version segment,
+    or grows a suffix on one site only, must fail loudly here."""
+    assert re.fullmatch(r"mempalace/\d+\.\d+\.\d+", USER_AGENT), (
+        f"USER_AGENT format mismatch: {USER_AGENT!r}"
+    )
+    assert __version__ in USER_AGENT
+
+
+class _FakeWikipediaResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps({"type": "standard", "title": "Ada", "extract": "A person."}).encode()
+
+
+def test_wikipedia_lookup_sends_the_shared_identifier(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["ua"] = req.get_header("User-agent")
+        captured["url"] = req.full_url
+        return _FakeWikipediaResponse()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    entity_registry._wikipedia_lookup("Ada")
+
+    assert captured["url"].startswith("https://en.wikipedia.org/api/rest_v1/page/summary/")
+    assert captured["ua"] == USER_AGENT


### PR DESCRIPTION
## What does this PR do?

Sets an explicit `User-Agent` on every MemPalace request to a third-party HTTP endpoint, and leaves the tree with one spelling for it, so `mempalace init --llm-provider openai-compat` works against Cloudflare-fronted endpoints. Closes #1570.

Cloudflare-fronted endpoints (Workers AI, AI Gateway, Together, OpenRouter, ...) commonly run a WAF "User Agent Blocking" rule against Python's stdlib default `Python-urllib/<py-version>` and return a bare HTTP 403 before auth. `mempalace init` then silently falls back to heuristics-only even when the endpoint and API key are valid. The same WAF also blocks runtime `classify()` POSTs, so a probe-only fix would still leave LLM-assisted classification broken after init.

**One constant instead of two spellings.** `develop` identifies itself two different ways at three call sites: `f"mempalace/{__version__}"` in `embedding.py` and `backends/qdrant.py`, and `"mempalace-update-check"` in `update_awareness.py`. New `mempalace/user_agent.py` holds `USER_AGENT = f"mempalace/{__version__}"`, the spelling the two newest sites already ship, and every caller imports it:

**Core LLM path (3 sites in `mempalace/llm_client.py`, 1 in `mempalace/closet_llm.py`):**
- `OpenAICompatProvider.check_available()` (the path #1570 hits)
- `OllamaProvider.check_available()` (reverse-proxy / Tailscale case)
- `_http_post_json()` (every runtime `classify()` POST; covers `AnthropicProvider` too, since `api.anthropic.com` answers with `server: cloudflare` and a `cf-ray` header)
- `closet_llm._call_llm()` (optional closet-regeneration feature)

**Sites that already sent something, now sharing the constant:**
- `mempalace/embedding.py`, `mempalace/backends/qdrant.py`: byte-identical on the wire, the literal moves behind the constant, and their existing tests (`test_embedding_api.py`, `test_qdrant_user_agent.py`) pass untouched
- `mempalace/update_awareness.py`: the PyPI release check now sends `mempalace/<version> (update-check)`, keeping its purpose marker and gaining the version
- `benchmarks/` (7 sites in 4 files). `benchmarks` is excluded from CI ruff (`extend-exclude = ["benchmarks"]`), so format/lint scope is unchanged.

Calls to a MemPalace hub or peer keep the stdlib default for now: `hub_client.py`, `server_registry.py`, `transport.py` and the `cli/_hub.py` health probes are bearer-authenticated requests to infrastructure the operator runs, rather than the third-party providers #1570 is about, so a header there is a separate change.

**Error handling hardening:**
- UA is set AFTER `**headers` in `_http_post_json` so a future caller passing `User-Agent` in headers cannot silently shadow the WAF bypass (verified by a parametrized test over 4 header casings).
- `Request()` is constructed inside the `try` block in `_http_post_json` because it validates URLs eagerly and raises `ValueError`; needs wrapping as `LLMError` per the docstring contract.
- `ValueError` added to `except` tuples in both `OllamaProvider.check_available` and `OpenAICompatProvider.check_available` for the same reason. `json.JSONDecodeError` is caught BEFORE the broader `ValueError` clause in `_http_post_json` to preserve "Malformed" classification (the former is a subclass of the latter).

No new CLI flags, no external SDK dependencies. Still stdlib urllib only per the module docstring contract.

## How to test

End-to-end against a CF-fronted public endpoint without auth:

```bash
curl -s -o /dev/null -w '%{http_code}\n' -H "User-Agent: Python-urllib/3.12" https://api.together.xyz/v1/models
# -> 403 (blocked before auth)

curl -s -o /dev/null -w '%{http_code}\n' -H "User-Agent: mempalace/3.10.0" https://api.together.xyz/v1/models
# -> 401 (WAF passed, missing API key surfaced as expected)
```

Through the actual provider class:

```bash
uv run python -c "
from mempalace.llm_client import OpenAICompatProvider
p = OpenAICompatProvider(model='llama3',
    endpoint='https://api.together.xyz/v1', api_key='sk-fake')
print(p.check_available())
"
# -> (False, 'Cannot reach https://api.together.xyz/v1: HTTP Error 401: Unauthorized')
```

Malformed endpoint surfaces cleanly (no `ValueError` propagation):

```bash
uv run python -c "
from mempalace.llm_client import OpenAICompatProvider
print(OpenAICompatProvider(model='x', endpoint='not-a-url').check_available())
"
# -> (False, "Cannot reach not-a-url: unknown url type: 'not-a-url/v1/models'")
```

The `401` (not `403`) confirms the WAF passes the request and only the missing-key check rejects it. That is the behavior the reporter needs for a valid endpoint and key combination.

Unit tests cover each fix site, the format of the constant, header-collision precedence (parametrized over 4 casings), Anthropic UA pass-through, `ValueError` handling on malformed endpoints, and the release check's identifier:

```bash
uv run pytest tests/test_llm_client.py tests/test_closet_llm.py tests/test_update_awareness.py \
  tests/test_qdrant_user_agent.py tests/test_embedding_api.py tests/test_user_agent.py -q
# -> 111 passed
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`uvx --from 'ruff==0.16.6' ruff check .` and `ruff format --check .`)

Full suite with `--ignore=tests/benchmarks`: 5421 passed, 53 skipped.
