### PR TITLE
docs: render palace and architecture diagrams as Mermaid

### DIFF
--- a/benchmarks/BENCHMARKS.md
+++ b/benchmarks/BENCHMARKS.md
@@ -294,12 +294,11 @@ The target session said "I still remember the happy high school experiences such
 Built independently from the hybrid track. Different architecture, same ceiling.
 
 **Architecture:**
-```
-PALACE
-  └── HALL (concept: travel, work, health, relationships, general)
-        └── Two-pass retrieval:
-              Pass 1: tight search within inferred hall
-              Pass 2: full haystack with hall-based score bonuses
+```mermaid
+flowchart TD
+    PA[PALACE] --> HA["HALL<br/>(travel · work · health · relationships · general)"]
+    HA --> P1["Pass 1 — tight search within inferred hall"]
+    HA --> P2["Pass 2 — full haystack with hall-based score bonuses"]
 ```
 
 The palace classifies each question into one of 5 halls. Pass 1 searches only within that hall — high precision, catches the obvious match. Pass 2 searches the full corpus with the hall affinity as a tiebreaker — catches cases where the relevant session was miscategorized.

--- a/benchmarks/HYBRID_MODE.md
+++ b/benchmarks/HYBRID_MODE.md
@@ -257,12 +257,12 @@ Palace mode is a structural upgrade that uses the full MemPal hall/wing/closet/d
 
 ### The Palace Structure
 
-```
-PALACE
-  └── HALL (content type: preferences / facts / events / assistant_advice / general)
-        └── CLOSET (user turns per session — the primary index)
-              └── DRAWER (assistant turns — opened on demand for assistant-reference questions)
-  └── PREFERENCE WING (synthetic docs extracted from user expressions — separate from halls)
+```mermaid
+flowchart TD
+    PA[PALACE] --> HA["HALL<br/>(preferences · facts · events · assistant_advice · general)"]
+    PA --> PW["PREFERENCE WING<br/>(synthetic docs — separate from halls)"]
+    HA --> CL["CLOSET<br/>(user turns per session — primary index)"]
+    CL --> DR["DRAWER<br/>(assistant turns — opened on demand)"]
 ```
 
 ### Hall Classification

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -108,9 +108,7 @@ flowchart TD
     A([Context window getting full]) --> B[Claude Code fires PreCompact]
     B --> C["Find transcript (from input or session_id lookup)"]
     C --> D["Auto-mine transcript → palace (tool output captured)"]
-    D --> E["Block: save tool output verbatim..."]
-    E --> F[AI saves everything]
-    F --> G([Compaction proceeds])
+    D --> G([Compaction proceeds])
 ```
 
 No counting needed — compaction always warrants a save. The auto-mine captures raw tool output before the AI gets a chance to summarize it away.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -85,44 +85,32 @@ The hooks resolve the repo root automatically from their own path, so they work 
 
 ### Save Hook (Stop event)
 
-```
-User sends message → AI responds → Claude Code fires Stop hook
-                                            ↓
-                                    Hook counts human messages in JSONL transcript
-                                            ↓
-                              ┌─── < 15 since last save ──→ echo "{}" (let AI stop)
-                              │
-                              └─── ≥ 15 since last save
-                                            ↓
-                                    Auto-mine transcript → palace (tool output captured)
-                                            ↓
-                                    {"decision": "block", "reason": "save tool output verbatim..."}
-                                            ↓
-                                    AI saves to palace (topics, decisions, quotes)
-                                            ↓
-                                    AI tries to stop again
-                                            ↓
-                                    stop_hook_active = true
-                                            ↓
-                                    Hook sees flag → echo "{}" (let it through)
+```mermaid
+flowchart TD
+    A([User sends message]) --> B[AI responds] --> C[Claude Code fires Stop hook]
+    C --> D[Hook counts human messages in JSONL transcript]
+    D --> E{"≥ 15 since last save?"}
+    E -- No --> F["echo '{}' — let AI stop"]
+    E -- Yes --> G["Auto-mine transcript → palace (tool output captured)"]
+    G --> H["Block: save tool output verbatim..."]
+    H --> I["AI saves to palace (topics, decisions, quotes)"]
+    I --> J[AI tries to stop again]
+    J --> K[stop_hook_active = true]
+    K --> L["Hook sees flag → echo '{}'"]
 ```
 
 The `stop_hook_active` flag prevents infinite loops: block once → AI saves → tries to stop → flag is true → we let it through.
 
 ### PreCompact Hook
 
-```
-Context window getting full → Claude Code fires PreCompact
-                                        ↓
-                                Find transcript (from input or session_id lookup)
-                                        ↓
-                                Auto-mine transcript → palace (tool output captured)
-                                        ↓
-                                {"decision": "block", "reason": "save tool output verbatim..."}
-                                        ↓
-                                AI saves everything
-                                        ↓
-                                Compaction proceeds
+```mermaid
+flowchart TD
+    A([Context window getting full]) --> B[Claude Code fires PreCompact]
+    B --> C["Find transcript (from input or session_id lookup)"]
+    C --> D["Auto-mine transcript → palace (tool output captured)"]
+    D --> E["Block: save tool output verbatim..."]
+    E --> F[AI saves everything]
+    F --> G([Compaction proceeds])
 ```
 
 No counting needed — compaction always warrants a save. The auto-mine captures raw tool output before the AI gets a chance to summarize it away.

--- a/mempalace/README.md
+++ b/mempalace/README.md
@@ -27,14 +27,15 @@ The Python package that powers MemPalace. All modules, all logic.
 
 ## Architecture
 
-```
-User → CLI → miner/convo_miner → ChromaDB (palace)
-                                     ↕
-                              knowledge_graph (SQLite)
-                                     ↕
-User → MCP Server → searcher → results
-                  → kg_query → entity facts
-                  → diary    → agent journal
+```mermaid
+flowchart TD
+    U1([User]) --> CLI --> MM["miner / convo_miner"] --> C[(ChromaDB palace)]
+    C <--> KG[(knowledge_graph SQLite)]
+    U2([User]) --> MCP[MCP Server]
+    MCP --> SE[searcher] --> RE[results]
+    MCP --> KQ[kg_query] --> EF[entity facts]
+    MCP --> DI[diary] --> AJ[agent journal]
+    KG <--> SE
 ```
 
 The palace (ChromaDB) stores verbatim content. The knowledge graph (SQLite) stores structured relationships. The MCP server exposes both to any AI tool.


### PR DESCRIPTION
## Summary

Replaces ASCII box/flow diagrams in markdown with fenced \`\`\`mermaid\`\`\` blocks so they render on GitHub and other Mermaid-aware viewers.

## Files

- `mempalace/README.md` — package architecture (CLI ingest, MCP tools, ChromaDB ↔ SQLite)
- `hooks/README.md` — Stop hook decision flow and PreCompact sequence
- `benchmarks/HYBRID_MODE.md` — palace structure under Palace Mode
- `benchmarks/BENCHMARKS.md` — parallel palace-mode architecture blurb

## Notes

- Directory trees (`├──` project layout) are unchanged; they stay as plain text trees.
- Fresh branch from current `develop` — replaces #393 which was 779 commits behind and had conflicts in all four files.

## Testing

`pytest tests/ -v` — 2004 passed, docs-only change (pre-existing ChromaDB failures unrelated to this PR).