### PR TITLE
feat: support Copilot CLI hooks

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1442,7 +1442,7 @@ def main():
     p_hook_run.add_argument(
         "--harness",
         required=True,
-        choices=["claude-code", "codex"],
+        choices=["claude-code", "codex", "copilot-cli"],
         help="Harness type (determines stdin JSON format)",
     )
 

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -459,6 +459,7 @@ def _is_ai_tool_path(path: Path) -> bool:
     or `.codex-archive` do NOT match):
       - any segment ``.codex`` (Codex CLI sessions / archives)
       - any segment ``.gemini`` (Gemini CLI sessions under ~/.gemini/tmp/...)
+      - the consecutive segment pair ``.copilot/session-state`` (Copilot CLI)
       - the consecutive segment pair ``.claude/projects`` (Claude Code).
         ``.claude`` alone is NOT matched — that is the settings/config dir,
         not a conversation source.
@@ -476,6 +477,8 @@ def _is_ai_tool_path(path: Path) -> bool:
     if ".gemini" in parts:
         return True
     for i in range(len(parts) - 1):
+        if parts[i] == ".copilot" and parts[i + 1] == "session-state":
+            return True
         if parts[i] == ".claude" and parts[i + 1] == "projects":
             return True
     return False

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -3,7 +3,7 @@ Hook logic for MemPalace — Python implementation of session-start, stop, and p
 
 Reads JSON from stdin, outputs JSON to stdout.
 Supported hooks: session-start, stop, precompact
-Supported harnesses: claude-code, codex (extensible to cursor, gemini, etc.)
+Supported harnesses: claude-code, codex, copilot-cli (extensible to cursor, gemini, etc.)
 """
 
 import hashlib
@@ -25,19 +25,29 @@ PALACE_ROOT = Path.home() / ".mempalace"
 def _detached_popen_kwargs() -> dict:
     """Kwargs that fully detach a Popen child so the hook process can exit.
 
-    Without these, Windows holds the parent open until the child closes the
-    inherited stdout/stderr handles — manifesting as "Stop hook hangs" at
-    session end (#1268). On POSIX the parent can already exit (orphan
-    reparents to init), but ``start_new_session`` makes the boundary
-    explicit so signals to the hook don't propagate to the background mine.
+    Without these, Windows can either flash a console window or hold the
+    parent open until the child closes inherited handles — manifesting as
+    "Stop hook hangs" at session end (#1268). On POSIX the parent can already
+    exit (orphan reparents to init), but ``start_new_session`` makes the
+    boundary explicit so signals to the hook don't propagate to the background
+    mine.
     """
     kwargs: dict = {"stdin": subprocess.DEVNULL, "close_fds": True}
     if os.name == "nt":
         flags = 0
-        for name in ("DETACHED_PROCESS", "CREATE_NEW_PROCESS_GROUP", "CREATE_BREAKAWAY_FROM_JOB"):
+        # CREATE_NO_WINDOW is the important flag for hook-launched console
+        # children. Do not combine it with DETACHED_PROCESS: Windows ignores
+        # CREATE_NO_WINDOW in that combination, which can still flash a window.
+        for name in ("CREATE_NO_WINDOW", "CREATE_NEW_PROCESS_GROUP", "CREATE_BREAKAWAY_FROM_JOB"):
             flags |= getattr(subprocess, name, 0)
         if flags:
             kwargs["creationflags"] = flags
+        startupinfo_cls = getattr(subprocess, "STARTUPINFO", None)
+        if startupinfo_cls is not None:
+            startupinfo = startupinfo_cls()
+            startupinfo.dwFlags |= getattr(subprocess, "STARTF_USESHOWWINDOW", 0)
+            startupinfo.wShowWindow = getattr(subprocess, "SW_HIDE", 0)
+            kwargs["startupinfo"] = startupinfo
     else:
         kwargs["start_new_session"] = True
     return kwargs
@@ -127,6 +137,59 @@ def _sanitize_session_id(session_id: str) -> str:
     return sanitized or "unknown"
 
 
+def _text_from_content(content) -> str:
+    """Extract text from common harness message content shapes."""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text", "")
+                if isinstance(text, str):
+                    parts.append(text)
+        return " ".join(p for p in parts if p).strip()
+    return ""
+
+
+def _is_hook_noise(text: str) -> bool:
+    return "<command-message>" in text or "<system-reminder>" in text
+
+
+def _user_message_text(entry: dict) -> str:
+    """Return user text from supported transcript schemas, or empty string."""
+    if not isinstance(entry, dict):
+        return ""
+
+    # Claude Code format
+    msg = entry.get("message", {})
+    if isinstance(msg, dict) and msg.get("role") == "user":
+        text = _text_from_content(msg.get("content", ""))
+        return "" if _is_hook_noise(text) else text
+
+    # Codex CLI format
+    if entry.get("type") == "event_msg":
+        payload = entry.get("payload", {})
+        if isinstance(payload, dict) and payload.get("type") == "user_message":
+            text = payload.get("message", "")
+            if isinstance(text, str):
+                text = text.strip()
+                return "" if _is_hook_noise(text) else text
+
+    # Copilot CLI format
+    if entry.get("type") == "user.message":
+        data = entry.get("data", {})
+        if isinstance(data, dict):
+            text = _text_from_content(data.get("content", ""))
+            if not text:
+                text = _text_from_content(data.get("transformedContent", ""))
+            return "" if _is_hook_noise(text) else text
+
+    return ""
+
+
 def _validate_transcript_path(transcript_path: str) -> Path:
     """Validate and resolve a transcript path, rejecting paths outside expected roots.
 
@@ -161,27 +224,8 @@ def _count_human_messages(transcript_path: str) -> int:
             for line in f:
                 try:
                     entry = json.loads(line)
-                    msg = entry.get("message", {})
-                    if isinstance(msg, dict) and msg.get("role") == "user":
-                        content = msg.get("content", "")
-                        if isinstance(content, str):
-                            if "<command-message>" in content:
-                                continue
-                        elif isinstance(content, list):
-                            text = " ".join(
-                                b.get("text", "") for b in content if isinstance(b, dict)
-                            )
-                            if "<command-message>" in text:
-                                continue
+                    if _user_message_text(entry):
                         count += 1
-                    # Also handle Codex CLI transcript format
-                    # {"type": "event_msg", "payload": {"type": "user_message", "message": "..."}}
-                    elif entry.get("type") == "event_msg":
-                        payload = entry.get("payload", {})
-                        if isinstance(payload, dict) and payload.get("type") == "user_message":
-                            msg_text = payload.get("message", "")
-                            if isinstance(msg_text, str) and "<command-message>" not in msg_text:
-                                count += 1
                 except (json.JSONDecodeError, AttributeError):
                     pass
     except OSError:
@@ -566,6 +610,7 @@ def _mine_sync():
                     stdout=log_f,
                     stderr=log_f,
                     timeout=60,
+                    **_detached_popen_kwargs(),
                 )
         except (OSError, subprocess.TimeoutExpired):
             pass
@@ -595,27 +640,9 @@ def _extract_recent_messages(transcript_path: str, count: int = _RECENT_MSG_COUN
             for line in f:
                 try:
                     entry = json.loads(line)
-                    # Claude Code format
-                    msg = entry.get("message") or entry.get("event_message") or {}
-                    if isinstance(msg, dict) and msg.get("role") == "user":
-                        content = msg.get("content", "")
-                        if isinstance(content, list):
-                            content = " ".join(
-                                b.get("text", "") for b in content if isinstance(b, dict)
-                            )
-                        if not isinstance(content, str) or not content.strip():
-                            continue
-                        if "<command-message>" in content or "<system-reminder>" in content:
-                            continue
-                        messages.append(content.strip()[:200])
-                    # Codex CLI format
-                    elif entry.get("type") == "event_msg":
-                        payload = entry.get("payload", {})
-                        if isinstance(payload, dict) and payload.get("type") == "user_message":
-                            text = payload.get("message", "")
-                            if isinstance(text, str) and text.strip():
-                                if "<command-message>" not in text:
-                                    messages.append(text.strip()[:200])
+                    text = _user_message_text(entry)
+                    if text:
+                        messages.append(text[:200])
                 except (json.JSONDecodeError, AttributeError):
                     pass
     except OSError:
@@ -712,7 +739,7 @@ def _save_diary_direct(
 
 
 def _ingest_transcript(transcript_path: str):
-    """Mine a Claude Code session transcript into the palace as a conversation."""
+    """Mine a session transcript into the palace as a conversation."""
     path = Path(transcript_path).expanduser()
     if not path.is_file() or path.stat().st_size < 100:
         return
@@ -746,18 +773,68 @@ def _ingest_transcript(transcript_path: str):
         pass
 
 
-SUPPORTED_HARNESSES = {"claude-code", "codex"}
+SUPPORTED_HARNESSES = {"claude-code", "codex", "copilot-cli"}
+
+
+def _copilot_hook_payload(data: dict) -> dict:
+    """Return the Copilot hook input payload regardless of wrapper shape."""
+    if not isinstance(data, dict):
+        return {}
+
+    # Copilot CLI gives hook commands the input object, but stores the same
+    # payload in events.jsonl under hook.start.data.input. Accept both shapes
+    # so tests and future callers can replay recorded hook events directly.
+    if isinstance(data.get("input"), dict):
+        return data["input"]
+    event_data = data.get("data")
+    if isinstance(event_data, dict) and isinstance(event_data.get("input"), dict):
+        return event_data["input"]
+    return data
+
+
+def _copilot_transcript_path(payload: dict, session_id: str) -> str:
+    """Return the Copilot transcript path from payload or session-state fallback."""
+    if not isinstance(payload, dict):
+        return ""
+
+    transcript_path = str(payload.get("transcriptPath") or payload.get("transcript_path") or "")
+    if transcript_path or session_id == "unknown":
+        return transcript_path
+
+    # Some Copilot hook payloads can be partial; session-state has a stable
+    # layout, so a valid sessionId is enough to recover the events.jsonl path.
+    candidate = Path.home() / ".copilot" / "session-state" / session_id / "events.jsonl"
+    return str(candidate) if candidate.is_file() else ""
 
 
 def _parse_harness_input(data: dict, harness: str) -> dict:
     """Parse stdin JSON according to the harness type."""
+    if not isinstance(data, dict):
+        data = {}
+
     if harness not in SUPPORTED_HARNESSES:
         print(f"Unknown harness: {harness}", file=sys.stderr)
         sys.exit(1)
+    if harness == "copilot-cli":
+        payload = _copilot_hook_payload(data)
+        # Copilot CLI uses camelCase names; accept snake_case too so tests and
+        # any future normalized wrappers can reuse the same harness parser.
+        session_id = _sanitize_session_id(
+            str(payload.get("sessionId") or payload.get("session_id", ""))
+        )
+        return {
+            "session_id": session_id,
+            "stop_hook_active": payload.get(
+                "stopHookActive", payload.get("stop_hook_active", False)
+            ),
+            "transcript_path": _copilot_transcript_path(payload, session_id),
+            "cwd": str(payload.get("cwd", "")),
+        }
     return {
         "session_id": _sanitize_session_id(str(data.get("session_id", "unknown"))),
         "stop_hook_active": data.get("stop_hook_active", False),
         "transcript_path": str(data.get("transcript_path", "")),
+        "cwd": str(data.get("cwd", "")),
     }
 
 
@@ -803,29 +880,43 @@ def _wing_from_jsonl_cwd(transcript_path: str) -> Optional[str]:
                 except (json.JSONDecodeError, ValueError):
                     continue
                 cwd = data.get("cwd")
-                if not cwd or not isinstance(cwd, str):
-                    continue
-                cwd_norm = cwd.replace("\\", "/").rstrip("/")
-                if not cwd_norm:
-                    continue
-                project = cwd_norm.rsplit("/", 1)[-1]
-                if project:
-                    slug = project.lower().replace(" ", "_").replace("-", "_")
-                    return f"wing_{slug}"
+                nested = data.get("data")
+                if not cwd and isinstance(nested, dict):
+                    cwd = nested.get("cwd")
+                    context = nested.get("context")
+                    if not cwd and isinstance(context, dict):
+                        cwd = context.get("cwd")
+                wing = _wing_from_cwd(cwd)
+                if wing:
+                    return wing
     except OSError:
         pass
     return None
 
 
-def _wing_from_transcript_path(transcript_path: str) -> str:
-    """Derive a project wing name from a Claude Code transcript path.
+def _wing_from_cwd(cwd: str) -> Optional[str]:
+    """Derive a wing from a harness-provided working directory."""
+    if not cwd or not isinstance(cwd, str):
+        return None
+    cwd_norm = cwd.replace("\\", "/").rstrip("/")
+    if not cwd_norm:
+        return None
+    project = cwd_norm.rsplit("/", 1)[-1]
+    if not project:
+        return None
+    slug = project.lower().replace(" ", "_").replace("-", "_")
+    return f"wing_{slug}" if slug else None
+
+
+def _wing_from_transcript_path(transcript_path: str, cwd: str = "") -> str:
+    """Derive a project wing name from hook cwd, JSONL metadata, or transcript path.
 
     Strategy (in priority order):
 
-    1. PRIMARY — Read ``cwd`` from the JSONL transcript. Claude Code records
-       the absolute working directory on most message types, so the project
-       name is whatever the leaf path segment of cwd is. This is the
-       canonical answer when present.
+    1. PRIMARY — Read ``cwd`` from the hook payload or JSONL transcript.
+       Claude Code records it on most message types; Copilot CLI records it
+       in the hook payload and may include it under ``data.context``. The
+       project name is whatever the leaf path segment of cwd is.
 
     2. FALLBACK — Decode the encoded folder under ``.claude/projects/``.
        Claude Code flattens path separators to dashes (``/Users/me/code/foo``
@@ -844,7 +935,10 @@ def _wing_from_transcript_path(transcript_path: str) -> str:
 
     Closes #1410.
     """
-    # 1. Primary — cwd from JSONL is the canonical source of truth
+    # 1. Primary — explicit hook cwd, then cwd from JSONL, is the canonical source of truth.
+    hook_cwd_wing = _wing_from_cwd(cwd)
+    if hook_cwd_wing:
+        return hook_cwd_wing
     cwd_wing = _wing_from_jsonl_cwd(transcript_path)
     if cwd_wing:
         return cwd_wing
@@ -891,6 +985,7 @@ def hook_stop(data: dict, harness: str):
     session_id = parsed["session_id"]
     stop_hook_active = parsed["stop_hook_active"]
     transcript_path = parsed["transcript_path"]
+    cwd = parsed.get("cwd", "")
 
     # If already in a block-mode save cycle, let through (infinite-loop prevention).
     # Silent mode saves directly without returning {"decision":"block"}, so there's
@@ -946,8 +1041,12 @@ def hook_stop(data: dict, harness: str):
         except Exception:
             silent = True
             toast = False
+        if harness == "copilot-cli":
+            # Copilot CLI's agentStop payload does not expose Claude Code's
+            # stop_hook_active recursion flag, so never return a block decision.
+            silent = True
 
-        project_wing = _wing_from_transcript_path(transcript_path)
+        project_wing = _wing_from_transcript_path(transcript_path, cwd=cwd)
 
         if silent:
             # Save directly via Python API — systemMessage renders in terminal

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -9,6 +9,7 @@ Supported:
     - Claude Code JSONL (with tool_use/tool_result block capture)
     - OpenAI Codex CLI JSONL
     - Gemini CLI JSONL (~/.gemini/tmp/<project_hash>/chats/session-*.jsonl)
+    - GitHub Copilot CLI JSONL (~/.copilot/session-state/<session-id>/events.jsonl)
     - Slack JSON export
     - Plain text (pass through for paragraph chunking)
 
@@ -159,6 +160,10 @@ def _try_normalize_json(content: str) -> Optional[str]:
         return normalized
 
     normalized = _try_gemini_jsonl(content)
+    if normalized:
+        return normalized
+
+    normalized = _try_copilot_cli_jsonl(content)
     if normalized:
         return normalized
 
@@ -349,6 +354,61 @@ def _try_gemini_jsonl(content: str) -> Optional[str]:
             messages.append(("assistant", joined))
 
     if len(messages) >= 2 and has_session_metadata:
+        return _messages_to_transcript(messages)
+    return None
+
+
+def _try_copilot_cli_jsonl(content: str) -> Optional[str]:
+    """GitHub Copilot CLI sessions (~/.copilot/session-state/<id>/events.jsonl).
+
+    Copilot CLI stores an event stream with top-level ``type`` and ``data``
+    fields. Conversation text lives in ``user.message`` and
+    ``assistant.message`` records. Detection requires a ``session.start``
+    sentinel so ordinary JSONL files with similarly named fields do not
+    false-positive.
+    """
+    lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+    messages = []
+    has_session_start = False
+    has_copilot_message = False
+
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+
+        entry_type = entry.get("type", "")
+        if entry_type == "session.start":
+            data = entry.get("data", {})
+            if isinstance(data, dict) and "sessionId" in data:
+                has_session_start = True
+            continue
+
+        if entry_type not in ("user.message", "assistant.message"):
+            continue
+
+        data = entry.get("data", {})
+        if not isinstance(data, dict):
+            continue
+
+        text = _extract_content(data.get("content", ""))
+        if not text and entry_type == "user.message":
+            text = _extract_content(data.get("transformedContent", ""))
+        if text:
+            text = strip_noise(text)
+        if not text:
+            continue
+
+        has_copilot_message = True
+        if entry_type == "user.message":
+            messages.append(("user", text))
+        else:
+            messages.append(("assistant", text))
+
+    if len(messages) >= 2 and has_session_start and has_copilot_message:
         return _messages_to_transcript(messages)
     return None
 

--- a/tests/test_claude_plugin_hook_wrappers.py
+++ b/tests/test_claude_plugin_hook_wrappers.py
@@ -11,10 +11,27 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PLUGIN_HOOKS_DIR = REPO_ROOT / ".claude-plugin" / "hooks"
 BASH = shutil.which("bash")
 
-pytestmark = pytest.mark.skipif(
-    BASH is None,
-    reason="bash required for Claude plugin hook wrapper tests",
-)
+
+def _bash_skip_reason() -> str:
+    if BASH is None:
+        return "bash required for Claude plugin hook wrapper tests"
+    try:
+        result = subprocess.run(
+            [BASH, "-c", "true"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"bash is not runnable for Claude plugin hook wrapper tests: {exc}"
+    if result.returncode != 0:
+        return "bash is not runnable for Claude plugin hook wrapper tests"
+    return ""
+
+
+_BASH_SKIP_REASON = _bash_skip_reason()
+pytestmark = pytest.mark.skipif(bool(_BASH_SKIP_REASON), reason=_BASH_SKIP_REASON)
 
 SCRIPT_CASES = [
     ("mempal-stop-hook.sh", "stop"),

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -303,9 +303,10 @@ def test_mine_convos_dry_run_bypasses_palace_lock(tmp_path, monkeypatch):
 # When a user runs `mempalace mine --mode convos` against a directory
 # inside a known AI-tool storage path (Claude Code's
 # ~/.claude/projects/, OpenAI Codex's ~/.codex/, Google Gemini CLI's
-# ~/.gemini/), the wing auto-defaults to "wing_api" rather than the
-# directory basename. This keeps API-sourced conversations grouped
-# under a single dedicated wing for visibility and privacy isolation.
+# ~/.gemini/, GitHub Copilot CLI's ~/.copilot/session-state/), the wing
+# auto-defaults to "wing_api" rather than the directory basename. This keeps
+# API-sourced conversations grouped under a single dedicated wing for
+# visibility and privacy isolation.
 #
 # Explicit user-passed --wing always wins. Unrelated directories use
 # the existing basename fallback unchanged.
@@ -347,6 +348,13 @@ def test_is_ai_tool_path_gemini_root(tmp_path):
 def test_is_ai_tool_path_gemini_chats(tmp_path):
     """Gemini stores sessions under ~/.gemini/tmp/<hash>/chats/."""
     target = tmp_path / ".gemini" / "tmp" / "abc123" / "chats"
+    target.mkdir(parents=True)
+    assert _is_ai_tool_path(target) is True
+
+
+def test_is_ai_tool_path_copilot_session_state(tmp_path):
+    """Copilot CLI stores sessions under ~/.copilot/session-state/<session-id>/."""
+    target = tmp_path / ".copilot" / "session-state" / "abc-123"
     target.mkdir(parents=True)
     assert _is_ai_tool_path(target) is True
 
@@ -397,6 +405,12 @@ def test_resolve_wing_codex_auto_routes_to_wing_api(tmp_path):
 
 def test_resolve_wing_gemini_auto_routes_to_wing_api(tmp_path):
     target = tmp_path / ".gemini" / "tmp" / "abc" / "chats"
+    target.mkdir(parents=True)
+    assert _resolve_wing(target, wing=None) == "wing_api"
+
+
+def test_resolve_wing_copilot_auto_routes_to_wing_api(tmp_path):
+    target = tmp_path / ".copilot" / "session-state" / "abc-123"
     target.mkdir(parents=True)
     assert _resolve_wing(target, wing=None) == "wing_api"
 

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -175,6 +175,21 @@ def test_count_skips_command_messages(tmp_path):
     assert _count_human_messages(str(transcript)) == 1
 
 
+def test_count_handles_copilot_cli_user_messages(tmp_path):
+    transcript = tmp_path / "events.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            {"type": "session.start", "data": {"sessionId": "s1"}},
+            {"type": "user.message", "data": {"content": "first"}},
+            {"type": "assistant.message", "data": {"content": "reply"}},
+            {"type": "user.message", "data": {"content": "<system-reminder>x</system-reminder>"}},
+            {"type": "user.message", "data": {"content": "", "transformedContent": "fallback"}},
+        ],
+    )
+    assert _count_human_messages(str(transcript)) == 2
+
+
 def test_count_handles_list_content(tmp_path):
     transcript = tmp_path / "t.jsonl"
     _write_transcript(
@@ -208,6 +223,15 @@ def test_count_malformed_json_lines(tmp_path):
     assert _count_human_messages(str(transcript)) == 1
 
 
+def test_count_ignores_non_object_json_lines(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(
+        'null\n[]\n"string"\n{"message": {"role": "user", "content": "ok"}}\n',
+        encoding="utf-8",
+    )
+    assert _count_human_messages(str(transcript)) == 1
+
+
 # --- _extract_recent_messages ---
 
 
@@ -238,6 +262,22 @@ def test_extract_recent_messages_skips_commands(tmp_path):
     assert msgs[0] == "real msg"
 
 
+def test_extract_recent_messages_handles_copilot_cli(tmp_path):
+    transcript = tmp_path / "events.jsonl"
+    _write_transcript(
+        transcript,
+        [
+            {"type": "user.message", "data": {"content": "copilot msg 1"}},
+            {"type": "assistant.message", "data": {"content": "reply"}},
+            {"type": "user.message", "data": {"content": "copilot msg 2"}},
+        ],
+    )
+    assert _extract_recent_messages(str(transcript), count=2) == [
+        "copilot msg 1",
+        "copilot msg 2",
+    ]
+
+
 def test_extract_recent_messages_missing_file():
     assert _extract_recent_messages("/nonexistent.jsonl") == []
 
@@ -245,7 +285,7 @@ def test_extract_recent_messages_missing_file():
 # --- hook_stop ---
 
 
-def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None):
+def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None, silent=True):
     """Run a hook and capture its JSON stdout output."""
     import io
     from unittest.mock import PropertyMock
@@ -256,7 +296,7 @@ def _capture_hook_output(hook_fn, data, harness="claude-code", state_dir=None):
         patches.append(patch("mempalace.hooks_cli.STATE_DIR", state_dir))
     # Mock MempalaceConfig so tests don't depend on user's ~/.mempalace/config.json
     mock_config = MagicMock()
-    type(mock_config).hook_silent_save = PropertyMock(return_value=True)
+    type(mock_config).hook_silent_save = PropertyMock(return_value=silent)
     type(mock_config).hook_desktop_toast = PropertyMock(return_value=False)
     patches.append(patch("mempalace.config.MempalaceConfig", return_value=mock_config))
     with contextlib.ExitStack() as stack:
@@ -289,8 +329,7 @@ def test_stop_hook_passthrough_when_active_string(tmp_path):
 def test_stop_hook_passthrough_below_interval(tmp_path):
     transcript = tmp_path / "t.jsonl"
     _write_transcript(
-        transcript,
-        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(SAVE_INTERVAL - 1)],
+        transcript, [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(3)]
     )
     result = _capture_hook_output(
         hook_stop,
@@ -318,6 +357,36 @@ def test_stop_hook_saves_silently_at_interval(tmp_path):
     assert "hooks" in result["systemMessage"]
     # tmp_path has no "-Projects-" segment, so _wing_from_transcript_path falls back to "wing_sessions"
     mock_save.assert_called_once_with(str(transcript), "test", wing="wing_sessions", toast=False)
+
+
+def test_stop_hook_copilot_cli_forces_silent_and_uses_cwd_wing(tmp_path):
+    transcript = tmp_path / "events.jsonl"
+    _write_transcript(
+        transcript,
+        [{"type": "user.message", "data": {"content": f"msg {i}"}} for i in range(SAVE_INTERVAL)],
+    )
+    save_result = {"count": 15, "themes": []}
+    with (
+        patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result) as mock_save,
+        patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+    ):
+        result = _capture_hook_output(
+            hook_stop,
+            {
+                "sessionId": "copilot-session",
+                "transcriptPath": str(transcript),
+                "cwd": "C:\\workspace\\sample-project",
+            },
+            harness="copilot-cli",
+            state_dir=tmp_path,
+            silent=False,
+        )
+    assert "systemMessage" in result
+    assert "decision" not in result
+    mock_save.assert_called_once_with(
+        str(transcript), "copilot-session", wing="wing_sample_project", toast=False
+    )
+    mock_ingest.assert_called_once_with(str(transcript))
 
 
 def test_stop_hook_derives_wing_from_transcript_path(tmp_path):
@@ -572,6 +641,21 @@ def test_wing_from_transcript_path_cwd_handles_non_string_cwd(tmp_path):
         encoding="utf-8",
     )
     assert _wing_from_transcript_path(str(transcript)) == "wing_proper_name"
+
+
+def test_wing_from_transcript_path_reads_copilot_nested_context_cwd(tmp_path):
+    transcript = tmp_path / "events.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "session.start",
+                "data": {"sessionId": "s1", "context": {"cwd": "C:\\workspace\\sample-project"}},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert _wing_from_transcript_path(str(transcript)) == "wing_sample_project"
 
 
 # --- _log ---
@@ -861,11 +945,11 @@ def test_detached_popen_kwargs_posix(monkeypatch):
 
 
 def test_detached_popen_kwargs_windows(monkeypatch):
-    """On Windows, kwargs include creationflags that fully detach the child.
+    """On Windows, kwargs include creationflags that hide the child.
 
-    Without these, the parent hook hangs at session end on Windows because
-    the child's inherited stdout/stderr handles keep the parent's exit
-    blocked (#1268 root cause for the Python hook path).
+    Without these, hook-launched child processes can flash a console window,
+    and inherited handles can keep the parent's exit blocked (#1268 root cause
+    for the Python hook path).
     """
     from mempalace.hooks_cli import _detached_popen_kwargs
 
@@ -873,17 +957,19 @@ def test_detached_popen_kwargs_windows(monkeypatch):
     # Simulate Windows-only Popen flag constants. Patch on the imported
     # subprocess module within hooks_cli so getattr() picks them up.
     monkeypatch.setattr(
-        "mempalace.hooks_cli.subprocess.DETACHED_PROCESS", 0x00000008, raising=False
+        "mempalace.hooks_cli.subprocess.CREATE_NEW_PROCESS_GROUP", 0x00000200, raising=False
     )
     monkeypatch.setattr(
-        "mempalace.hooks_cli.subprocess.CREATE_NEW_PROCESS_GROUP", 0x00000200, raising=False
+        "mempalace.hooks_cli.subprocess.CREATE_NO_WINDOW", 0x08000000, raising=False
     )
     kwargs = _detached_popen_kwargs()
     assert kwargs.get("stdin") is subprocess.DEVNULL
     assert kwargs.get("close_fds") is True
     flags = kwargs.get("creationflags", 0)
-    assert flags & 0x00000008, "DETACHED_PROCESS must be set"
+    assert not flags & 0x00000008, "DETACHED_PROCESS must not mask CREATE_NO_WINDOW"
     assert flags & 0x00000200, "CREATE_NEW_PROCESS_GROUP must be set"
+    assert flags & 0x08000000, "CREATE_NO_WINDOW must be set"
+    assert kwargs.get("startupinfo") is not None
 
 
 def test_spawn_mine_uses_detached_kwargs(tmp_path):
@@ -1005,6 +1091,20 @@ def test_ingest_transcript_uses_detached_kwargs(tmp_path):
                 kwargs = mock_popen.call_args.kwargs
                 assert kwargs.get("stdin") is subprocess.DEVNULL
                 assert kwargs.get("close_fds") is True
+
+
+def test_mine_sync_uses_detached_kwargs(tmp_path):
+    """Precompact's synchronous mine path also hides/detaches child processes."""
+    mempal_dir = tmp_path / "project"
+    mempal_dir.mkdir()
+    with patch.dict("os.environ", {"MEMPAL_DIR": str(mempal_dir)}):
+        with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
+            with patch("mempalace.hooks_cli.subprocess.run") as mock_run:
+                _mine_sync()
+
+    kwargs = mock_run.call_args.kwargs
+    assert kwargs.get("stdin") is subprocess.DEVNULL
+    assert kwargs.get("close_fds") is True
 
 
 def test_ingest_transcript_skips_when_target_running(tmp_path):
@@ -1286,6 +1386,83 @@ def test_parse_harness_input_valid():
     assert result["stop_hook_active"] is True
 
 
+def test_parse_harness_input_non_object_json_payload():
+    result = _parse_harness_input(["not", "an", "object"], "copilot-cli")
+    assert result == {
+        "session_id": "unknown",
+        "stop_hook_active": False,
+        "transcript_path": "",
+        "cwd": "",
+    }
+
+
+def test_parse_harness_input_copilot_cli_camel_case():
+    result = _parse_harness_input(
+        {
+            "sessionId": "abc-123",
+            "transcriptPath": "C:\\Users\\me\\.copilot\\session-state\\abc-123\\events.jsonl",
+            "cwd": "C:\\workspace\\sample-project",
+        },
+        "copilot-cli",
+    )
+    assert result["session_id"] == "abc-123"
+    assert result["transcript_path"].endswith("events.jsonl")
+    assert result["cwd"] == "C:\\workspace\\sample-project"
+    assert result["stop_hook_active"] is False
+
+
+def test_parse_harness_input_copilot_cli_hook_wrapper():
+    result = _parse_harness_input(
+        {
+            "hookInvocationId": "hook-1",
+            "hookType": "agentStop",
+            "input": {
+                "sessionId": "abc-123",
+                "transcriptPath": "C:\\Users\\me\\.copilot\\session-state\\abc-123\\events.jsonl",
+                "cwd": "C:\\workspace\\sample-project",
+            },
+        },
+        "copilot-cli",
+    )
+    assert result["session_id"] == "abc-123"
+    assert result["transcript_path"].endswith("events.jsonl")
+    assert result["cwd"] == "C:\\workspace\\sample-project"
+
+
+def test_parse_harness_input_copilot_cli_event_wrapper():
+    result = _parse_harness_input(
+        {
+            "type": "hook.start",
+            "data": {
+                "hookInvocationId": "hook-1",
+                "hookType": "preCompact",
+                "input": {
+                    "sessionId": "abc-123",
+                    "transcriptPath": "C:\\Users\\me\\.copilot\\session-state\\abc-123\\events.jsonl",
+                    "cwd": "C:\\workspace\\sample-project",
+                },
+            },
+        },
+        "copilot-cli",
+    )
+    assert result["session_id"] == "abc-123"
+    assert result["transcript_path"].endswith("events.jsonl")
+    assert result["cwd"] == "C:\\workspace\\sample-project"
+
+
+def test_parse_harness_input_copilot_cli_session_state_fallback(tmp_path):
+    session_id = "abc-123"
+    transcript = tmp_path / ".copilot" / "session-state" / session_id / "events.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text("{}", encoding="utf-8")
+
+    with patch("mempalace.hooks_cli.Path.home", return_value=tmp_path):
+        result = _parse_harness_input({"sessionId": session_id}, "copilot-cli")
+
+    assert result["session_id"] == session_id
+    assert result["transcript_path"] == str(transcript)
+
+
 # --- hook_stop with OSError on write ---
 
 
@@ -1429,7 +1606,8 @@ def test_run_hook_dispatches_session_start(tmp_path):
 def test_run_hook_dispatches_stop(tmp_path):
     transcript = tmp_path / "t.jsonl"
     _write_transcript(
-        transcript, [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(3)]
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(SAVE_INTERVAL - 1)],
     )
     stdin_data = json.dumps(
         {
@@ -1443,6 +1621,49 @@ def test_run_hook_dispatches_stop(tmp_path):
             with patch("mempalace.hooks_cli._output") as mock_output:
                 run_hook("stop", "claude-code")
     mock_output.assert_called_once_with({})
+
+
+def test_run_hook_dispatches_copilot_wrapped_stop_payload(tmp_path):
+    transcript = tmp_path / "events.jsonl"
+    _write_transcript(
+        transcript,
+        [{"type": "user.message", "data": {"content": f"msg {i}"}} for i in range(SAVE_INTERVAL)],
+    )
+    stdin_data = json.dumps(
+        {
+            "hookInvocationId": "hook-1",
+            "hookType": "agentStop",
+            "input": {
+                "sessionId": "3662f2c2-7f30-4954-98f6-fd7cc238a56f",
+                "transcriptPath": str(transcript),
+                "cwd": "C:\\workspace\\sample-project",
+            },
+        }
+    )
+    mock_config = MagicMock()
+    mock_config.hook_silent_save = True
+    mock_config.hook_desktop_toast = False
+    save_result = {"count": SAVE_INTERVAL, "themes": []}
+    with (
+        patch("sys.stdin", io.StringIO(stdin_data)),
+        patch("mempalace.hooks_cli.STATE_DIR", tmp_path),
+        patch("mempalace.config.MempalaceConfig", return_value=mock_config),
+        patch("mempalace.hooks_cli._save_diary_direct", return_value=save_result) as mock_save,
+        patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+        patch("mempalace.hooks_cli._output") as mock_output,
+    ):
+        run_hook("stop", "copilot-cli")
+
+    mock_output.assert_called_once_with(
+        {"systemMessage": f"\u2726 {SAVE_INTERVAL} memories woven into the palace"}
+    )
+    mock_save.assert_called_once_with(
+        str(transcript),
+        "3662f2c2-7f30-4954-98f6-fd7cc238a56f",
+        wing="wing_sample_project",
+        toast=False,
+    )
+    mock_ingest.assert_called_once_with(str(transcript))
 
 
 def test_run_hook_dispatches_precompact(tmp_path):
@@ -1468,6 +1689,15 @@ def test_run_hook_invalid_json(tmp_path):
         with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
             with patch("mempalace.hooks_cli._output") as mock_output:
                 run_hook("session-start", "claude-code")
+    mock_output.assert_called_once_with({})
+
+
+def test_run_hook_non_object_json_payload(tmp_path):
+    """Valid but non-object stdin JSON should not crash."""
+    with patch("sys.stdin", io.StringIO("[]")):
+        with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
+            with patch("mempalace.hooks_cli._output") as mock_output:
+                run_hook("stop", "copilot-cli")
     mock_output.assert_called_once_with({})
 
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -11,6 +11,7 @@ from mempalace.normalize import (
     _try_claude_ai_json,
     _try_claude_code_jsonl,
     _try_codex_jsonl,
+    _try_copilot_cli_jsonl,
     _try_gemini_jsonl,
     _try_normalize_json,
     _try_slack_json,
@@ -611,6 +612,81 @@ def test_gemini_jsonl_messages_before_session_metadata_discarded():
     assert "preamble A" not in result
     assert "> real Q" in result
     assert "real A" in result
+
+
+# ── _try_copilot_cli_jsonl ─────────────────────────────────────────────
+
+
+def test_copilot_cli_jsonl_valid():
+    lines = [
+        json.dumps({"type": "session.start", "data": {"sessionId": "s1"}}),
+        json.dumps({"type": "user.message", "data": {"content": "What is Copilot CLI?"}}),
+        json.dumps(
+            {"type": "assistant.message", "data": {"content": "Copilot CLI runs in a terminal."}}
+        ),
+    ]
+    result = _try_copilot_cli_jsonl("\n".join(lines))
+    assert result is not None
+    assert "> What is Copilot CLI?" in result
+    assert "Copilot CLI runs in a terminal." in result
+
+
+def test_copilot_cli_jsonl_too_few_messages():
+    lines = [
+        json.dumps({"type": "session.start", "data": {"sessionId": "s1"}}),
+        json.dumps({"type": "user.message", "data": {"content": "Only one turn"}}),
+    ]
+    assert _try_copilot_cli_jsonl("\n".join(lines)) is None
+
+
+def test_copilot_cli_jsonl_ignores_non_conversation_fields():
+    lines = [
+        json.dumps({"type": "session.start", "data": {"sessionId": "s1"}}),
+        json.dumps(
+            {"type": "system.message", "data": {"content": "system prompt", "role": "system"}}
+        ),
+        json.dumps({"type": "hook.start", "data": {"input": {"transcriptPath": "x"}}}),
+        json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {"encryptedContent": "secret", "reasoningOpaque": "hidden"},
+            }
+        ),
+        json.dumps({"type": "user.message", "data": {"content": "Real question"}}),
+        json.dumps(
+            {
+                "type": "assistant.message",
+                "data": {
+                    "content": "Real answer",
+                    "encryptedContent": "do-not-include",
+                    "reasoningOpaque": "do-not-include",
+                },
+            }
+        ),
+    ]
+    result = _try_copilot_cli_jsonl("\n".join(lines))
+    assert result is not None
+    assert "Real question" in result
+    assert "Real answer" in result
+    assert "system prompt" not in result
+    assert "do-not-include" not in result
+
+
+def test_copilot_cli_jsonl_requires_session_start():
+    lines = [
+        json.dumps({"type": "user.message", "data": {"content": "Q"}}),
+        json.dumps({"type": "assistant.message", "data": {"content": "A"}}),
+    ]
+    assert _try_copilot_cli_jsonl("\n".join(lines)) is None
+
+
+def test_copilot_cli_jsonl_does_not_match_codex():
+    lines = [
+        json.dumps({"type": "session_meta", "payload": {}}),
+        json.dumps({"type": "event_msg", "payload": {"type": "user_message", "message": "Q"}}),
+        json.dumps({"type": "event_msg", "payload": {"type": "agent_message", "message": "A"}}),
+    ]
+    assert _try_copilot_cli_jsonl("\n".join(lines)) is None
 
 
 # ── _try_claude_ai_json ───────────────────────────────────────────────

--- a/website/guide/hooks.md
+++ b/website/guide/hooks.md
@@ -1,6 +1,6 @@
 # Auto-Save Hooks
 
-Two hooks for Claude Code and Codex that automatically save memories during work. No manual "save" commands needed.
+Hooks for Claude Code, Codex, and GitHub Copilot CLI that automatically save memories during work. No manual "save" commands needed.
 
 ## What They Do
 
@@ -61,6 +61,101 @@ Add to `.codex/hooks.json`:
 }
 ```
 
+## Install — GitHub Copilot CLI
+
+Add a repo-scoped hook file such as `.github/hooks/mempalace.json`:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "mempalace hook run --hook stop --harness copilot-cli",
+        "powershell": "$payload = [Console]::In.ReadToEnd(); $payload | & 'mempalace.exe' hook run --hook stop --harness copilot-cli",
+        "timeoutSec": 30
+      }
+    ],
+    "preCompact": [
+      {
+        "type": "command",
+        "bash": "mempalace hook run --hook precompact --harness copilot-cli",
+        "powershell": "$payload = [Console]::In.ReadToEnd(); $payload | & 'mempalace.exe' hook run --hook precompact --harness copilot-cli",
+        "timeoutSec": 30
+      }
+    ]
+  }
+}
+```
+
+On Windows, the `powershell` command must explicitly forward stdin. Copilot CLI writes the hook JSON to the PowerShell process's stdin, but PowerShell's native-command invocation does not reliably pass that original process stdin through to a child executable. Without the bridge, `mempalace.exe` may receive empty stdin and the hook will log `Session unknown: 0 exchanges`.
+
+The `ReadToEnd()` bridge is intentionally explicit:
+
+```powershell
+$payload = [Console]::In.ReadToEnd(); $payload | & 'mempalace.exe' hook run --hook stop --harness copilot-cli
+```
+
+It reads the complete hook JSON payload from PowerShell's process stdin, then pipes that payload into `mempalace.exe`, where MemPalace can parse `sessionId`, `transcriptPath`, and `cwd`.
+
+Alternatives exist, but are less predictable for this use case:
+
+- `$Input | & 'mempalace.exe' ...` uses PowerShell's pipeline input enumerator, which can line-buffer/objectize input and is less clear than reading the raw JSON payload.
+- `cmd /c mempalace.exe ...` may behave more like a transparent stdin pass-through, but adds another shell layer and `cmd.exe` quoting/escaping rules.
+- A separate `.ps1` wrapper can hide the long command, but it still needs the same stdin-forwarding step internally.
+
+For Bash, no bridge is needed because Bash normally leaves its stdin connected to the child command:
+
+```bash
+mempalace hook run --hook stop --harness copilot-cli
+```
+
+If `mempalace.exe` is not on `PATH`, use its absolute path:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "mempalace hook run --hook stop --harness copilot-cli",
+        "powershell": "$payload = [Console]::In.ReadToEnd(); $payload | & 'C:\\Users\\you\\.local\\bin\\mempalace.exe' hook run --hook stop --harness copilot-cli",
+        "timeoutSec": 30
+      }
+    ],
+    "preCompact": [
+      {
+        "type": "command",
+        "bash": "mempalace hook run --hook precompact --harness copilot-cli",
+        "powershell": "$payload = [Console]::In.ReadToEnd(); $payload | & 'C:\\Users\\you\\.local\\bin\\mempalace.exe' hook run --hook precompact --harness copilot-cli",
+        "timeoutSec": 30
+      }
+    ]
+  }
+}
+```
+
+Copilot CLI stores local session event streams under:
+
+```powershell
+$HOME\.copilot\session-state
+```
+
+To mine them manually:
+
+```powershell
+mempalace mine $HOME\.copilot\session-state --mode convos --wing sessions
+```
+
+Or from a session-state directory:
+
+```powershell
+cd $HOME\.copilot\session-state
+mempalace mine . --mode convos --wing sessions
+```
+
 ## Configuration
 
 Edit `mempal_save_hook.sh` to change:
@@ -87,7 +182,7 @@ User sends message → AI responds → Stop hook fires
                                                     AI stops (flag set)
 ```
 
-The `stop_hook_active` flag prevents infinite loops.
+The `stop_hook_active` flag prevents infinite loops in Claude Code. Copilot CLI does not expose that flag, so MemPalace uses silent direct saves for Copilot stop hooks instead of returning a blocking decision.
 
 ### PreCompact Hook
 


### PR DESCRIPTION
I do not think that this PR is quiet ready for merge, but I wanted to share to solicit feedback.

## What does this PR do?

Adds GitHub Copilot CLI hook support and Copilot conversation mining.

- Adds copilot-cli as a supported hook harness.
- Parses Copilot CLI hook payloads, including wrapped input and data.input payloads.
- Normalizes Copilot CLI events.jsonl conversations from .copilot/session-state.
- Mines Copilot transcripts into the sessions wing.
- Forces Copilot stop hooks to silent saves to avoid block-loop behavior.
- Derives project diary wings from Copilot hook/session cwd.
- Documents Copilot CLI hook setup, including Windows PowerShell stdin forwarding.
- Suppresses Windows console popups for hook-spawned mining subprocesses.
- Skips Bash wrapper tests when bash exists but is not runnable, such as the WindowsApps/WSL stub without a configured distro.

## How to test

 ruff check .
 python -m pytest tests/ -q --ignore=tests/benchmarks

Local result:

 2110 passed, 56 skipped, 1 warning

Some Bash wrapper tests are skipped on Windows when bash exists but is not runnable, such as the WindowsApps/WSL stub without a configureddistro.

Optional manual test:

 mempalace mine "$HOME\.copilot\session-state" --mode convos --wing sessions
 mempalace status

## Checklist

- [X]  Tests pass (python -m pytest tests/ -v) — local equivalent passed with expected environment skips: 2110 passed, 56 skipped
- [X]  No hardcoded paths
- [X]  Linter passes (ruff check .)