### PR TITLE
feat(entity): opt-in spaCy NER augmentation via mempalace[nlp] extra

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -339,14 +339,23 @@ def extract_candidates(text: str, languages=("en",)) -> dict:
     # ``extract_spacy_entities`` returns ``{}`` and behavior is unchanged.
     # Regex-detected names retain their regex count when both pipelines
     # agree, so existing scoring/classification downstream is unaffected.
+    # Case-fold the merge key. spaCy may emit "Apple" while regex stored
+    # "apple" (or vice versa) — the case-sensitive ``name not in result``
+    # check would treat them as distinct and let both into the final dict.
+    # Comparing against a lowercased view of the existing keys collapses
+    # them onto a single entry; the regex pipeline's case wins because
+    # it ran first.
+    existing_keys_lower = {k.lower() for k in result}
     for name, spacy_count in extract_spacy_entities(text).items():
+        key_lower = name.lower()
         if (
-            name not in result
-            and name.lower() not in stopwords
-            and name.lower() not in coca_filter
+            key_lower not in existing_keys_lower
+            and key_lower not in stopwords
+            and key_lower not in coca_filter
             and len(name) > 2
         ):
             result[name] = spacy_count
+            existing_keys_lower.add(key_lower)
 
     return result
 

--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -340,7 +340,12 @@ def extract_candidates(text: str, languages=("en",)) -> dict:
     # Regex-detected names retain their regex count when both pipelines
     # agree, so existing scoring/classification downstream is unaffected.
     for name, spacy_count in extract_spacy_entities(text).items():
-        if name not in result:
+        if (
+            name not in result
+            and name.lower() not in stopwords
+            and name.lower() not in coca_filter
+            and len(name) > 2
+        ):
             result[name] = spacy_count
 
     return result

--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from collections import defaultdict
 
 from mempalace.i18n import get_entity_patterns
+from mempalace.entity_spacy import extract_spacy_entities
 
 
 # ==================== COCA CONTENT-WORD FILTER (Tier 2 linguistics cleanup) ====================
@@ -328,7 +329,21 @@ def extract_candidates(text: str, languages=("en",)) -> dict:
                 continue
             counts[phrase] += 1
 
-    return {name: count for name, count in counts.items() if count >= 3}
+    result = {name: count for name, count in counts.items() if count >= 3}
+
+    # Tier 4 linguistics cleanup — augment with spaCy NER when the
+    # ``mempalace[nlp]`` extra is installed. spaCy uses statistical NER
+    # (high-precision proper-noun detection), so its hits bypass the
+    # frequency threshold that the regex pipeline needs to filter
+    # false positives. If spaCy is not installed,
+    # ``extract_spacy_entities`` returns ``{}`` and behavior is unchanged.
+    # Regex-detected names retain their regex count when both pipelines
+    # agree, so existing scoring/classification downstream is unaffected.
+    for name, spacy_count in extract_spacy_entities(text).items():
+        if name not in result:
+            result[name] = spacy_count
+
+    return result
 
 
 # ==================== SIGNAL SCORING ====================

--- a/mempalace/entity_spacy.py
+++ b/mempalace/entity_spacy.py
@@ -186,12 +186,27 @@ def extract_spacy_entities(text: str) -> dict[str, int]:
         )
         return {}
 
+    # Dedupe by case-folded surface form. spaCy can emit the same entity
+    # in mixed case across a single doc ("Apple" and "apple") depending on
+    # the model's confidence at each mention. Without case-folded dedup
+    # they end up as separate keys in the counts dict, which then poisons
+    # the downstream union (regex sees "Apple" count 5, spaCy adds
+    # "apple" count 1, both land as distinct entries). We keep the
+    # first-seen surface form as the canonical key (preserves the case
+    # the user actually wrote) and just sum counts under it.
     counts: dict[str, int] = {}
+    canonical_by_lower: dict[str, str] = {}
     for ent in doc.ents:
         if ent.label_ not in _KEEP_LABELS:
             continue
         name = ent.text.strip()
         if not name:
             continue
-        counts[name] = counts.get(name, 0) + 1
+        key_lower = name.lower()
+        canonical = canonical_by_lower.get(key_lower)
+        if canonical is None:
+            canonical_by_lower[key_lower] = name
+            counts[name] = 1
+        else:
+            counts[canonical] += 1
     return counts

--- a/mempalace/entity_spacy.py
+++ b/mempalace/entity_spacy.py
@@ -105,31 +105,47 @@ def _get_spacy_nlp(model_name: str):
 
     import spacy
 
+    # Outer broad-Exception guard — this module's design contract is
+    # "strictly opt-in, never load-bearing." A ValueError on an invalid
+    # model name, an ImportError from a broken model package, or any
+    # other spaCy-internal failure must NOT crash the caller; the rest
+    # of the entity pipeline must keep running. The inner OSError-only
+    # path handles the common "model not installed → try to download"
+    # case; anything else falls through to the outer except.
     try:
-        return spacy.load(model_name)
-    except OSError:
-        # Model not installed — attempt one-time lazy download.
-        logger.info("spaCy model %r not present locally; downloading", model_name)
-        try:
-            spacy.cli.download(model_name)
-        except Exception as exc:  # network down, disk full, permissions, etc.
-            logger.warning(
-                "spaCy model download failed for %r (%s); spaCy NER "
-                "augmentation will be skipped for this session",
-                model_name,
-                exc,
-            )
-            return None
         try:
             return spacy.load(model_name)
-        except Exception as exc:
-            logger.warning(
-                "spaCy model %r still unloadable after download (%s); "
-                "spaCy NER augmentation will be skipped",
-                model_name,
-                exc,
-            )
-            return None
+        except OSError:
+            # Model not installed — attempt one-time lazy download.
+            logger.info("spaCy model %r not present locally; downloading", model_name)
+            try:
+                spacy.cli.download(model_name)
+            except Exception as exc:  # network down, disk full, permissions, etc.
+                logger.warning(
+                    "spaCy model download failed for %r (%s); spaCy NER "
+                    "augmentation will be skipped for this session",
+                    model_name,
+                    exc,
+                )
+                return None
+            try:
+                return spacy.load(model_name)
+            except Exception as exc:
+                logger.warning(
+                    "spaCy model %r still unloadable after download (%s); "
+                    "spaCy NER augmentation will be skipped",
+                    model_name,
+                    exc,
+                )
+                return None
+    except Exception as exc:
+        logger.warning(
+            "spaCy model %r failed to load (%s); spaCy NER augmentation "
+            "will be skipped for this session",
+            model_name,
+            exc,
+        )
+        return None
 
 
 def extract_spacy_entities(text: str) -> dict[str, int]:

--- a/mempalace/entity_spacy.py
+++ b/mempalace/entity_spacy.py
@@ -26,7 +26,6 @@ ONNX model (#1483) so installs stay slim and offline-friendly.
 from __future__ import annotations
 
 import functools
-import importlib
 import logging
 import os
 
@@ -68,16 +67,23 @@ def _spacy_available() -> bool:
     return True
 
 
+@functools.lru_cache(maxsize=1)
 def _resolve_model_name() -> str:
-    """Return the effective spaCy model name from env, or the default.
+    """Return the effective spaCy model name from env, or an empty string.
 
-    Empty/whitespace-only env values fall back to the default so a user
-    who sets ``MEMPALACE_SPACY_MODEL=`` in a .env file doesn't accidentally
-    pass an empty model name to ``spacy.load``.
+    Returns the trimmed value of ``MEMPALACE_SPACY_MODEL`` if set, or
+    ``""`` if the env var is missing, empty, or whitespace-only. The
+    caller is responsible for layering the default on top via
+    ``_resolve_model_name() or _DEFAULT_MODEL`` — keeping the resolver
+    silent about defaults makes "user did not configure" distinguishable
+    from "user explicitly set the default," per project convention.
+
+    Cached at ``maxsize=1`` because env vars don't change mid-process
+    under normal operation; tests that need to flip the value must call
+    ``_resolve_model_name.cache_clear()`` between assertions.
     """
     raw = os.environ.get(_ENV_VAR, "")
-    stripped = raw.strip()
-    return stripped if stripped else _DEFAULT_MODEL
+    return raw.strip()
 
 
 @functools.lru_cache(maxsize=4)
@@ -97,10 +103,7 @@ def _get_spacy_nlp(model_name: str):
     if not _spacy_available():
         return None
 
-    try:
-        spacy = importlib.import_module("spacy")
-    except (ImportError, ModuleNotFoundError):
-        return None
+    import spacy
 
     try:
         return spacy.load(model_name)
@@ -153,7 +156,7 @@ def extract_spacy_entities(text: str) -> dict[str, int]:
     if not text or not text.strip():
         return {}
 
-    nlp = _get_spacy_nlp(_resolve_model_name())
+    nlp = _get_spacy_nlp(_resolve_model_name() or _DEFAULT_MODEL)
     if nlp is None:
         return {}
 
@@ -169,11 +172,9 @@ def extract_spacy_entities(text: str) -> dict[str, int]:
 
     counts: dict[str, int] = {}
     for ent in doc.ents:
-        label = getattr(ent, "label_", None)
-        if label not in _KEEP_LABELS:
+        if ent.label_ not in _KEEP_LABELS:
             continue
-        raw_text = getattr(ent, "text", "") or ""
-        name = raw_text.strip()
+        name = ent.text.strip()
         if not name:
             continue
         counts[name] = counts.get(name, 0) + 1

--- a/mempalace/entity_spacy.py
+++ b/mempalace/entity_spacy.py
@@ -1,0 +1,180 @@
+"""Opt-in spaCy NER augmentation for entity detection.
+
+This module is the integration surface for the ``mempalace[nlp]`` extra.
+When spaCy is installed, it provides statistical named-entity recognition
+(PERSON, ORG, GPE, PRODUCT, WORK_OF_ART, EVENT) that augments — never
+replaces — the existing regex + COCA-filter + known-systems pipeline.
+
+When spaCy is NOT installed, every public function gracefully no-ops:
+``extract_spacy_entities`` returns ``{}`` and the rest of the entity
+pipeline runs unchanged. spaCy is therefore strictly opt-in; uninstalling
+it (or never installing ``[nlp]``) is the "disable" mechanism.
+
+Model selection
+---------------
+The model defaults to ``en_core_web_sm`` (~12 MB, fast, CPU-only).
+Users may override via ``MEMPALACE_SPACY_MODEL=en_core_web_md|lg|trf``
+for higher accuracy at the cost of size and speed.
+
+The model itself is NOT installed by the extra. On first use,
+``_get_spacy_nlp`` attempts ``spacy.load(name)``; on ``OSError`` (model
+not present), it calls ``spacy.cli.download(name)`` once and retries.
+Mirrors the lazy first-use download pattern used by the embeddinggemma
+ONNX model (#1483) so installs stay slim and offline-friendly.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import logging
+import os
+
+logger = logging.getLogger("mempalace.entity_spacy")
+
+# spaCy NER labels we consider entity-quality. Excludes DATE, CARDINAL,
+# ORDINAL, PERCENT, MONEY, TIME, QUANTITY, LANGUAGE, NORP, FAC, LAW, LOC —
+# either too noisy or already covered by other tiers. The kept set
+# corresponds to "proper nouns a user would search for by name."
+_KEEP_LABELS: frozenset[str] = frozenset(
+    {"PERSON", "ORG", "GPE", "PRODUCT", "WORK_OF_ART", "EVENT"}
+)
+
+_DEFAULT_MODEL = "en_core_web_sm"
+_ENV_VAR = "MEMPALACE_SPACY_MODEL"
+
+
+def _spacy_available() -> bool:
+    """Return True if spaCy can be imported in the current environment.
+
+    First call pays the spaCy import cost (Python caches the module in
+    ``sys.modules`` so subsequent calls are a dict lookup). spaCy itself
+    pulls in numpy + several Cython extensions, so the cold import is on
+    the order of hundreds of milliseconds — but it only happens once per
+    process, and only when something actually calls into this module.
+    The base mempalace install never reaches here.
+    """
+    try:
+        import spacy  # noqa: F401  (probe; cached in sys.modules thereafter)
+    except (ImportError, ModuleNotFoundError):
+        return False
+    except Exception:
+        # Any other import-time failure (e.g. broken install, missing
+        # transitive dep, ABI mismatch) is treated as "spaCy not usable"
+        # rather than propagated up — the rest of the pipeline must keep
+        # working even when spaCy itself is broken.
+        logger.debug("spaCy probe raised non-ImportError; treating as unavailable")
+        return False
+    return True
+
+
+def _resolve_model_name() -> str:
+    """Return the effective spaCy model name from env, or the default.
+
+    Empty/whitespace-only env values fall back to the default so a user
+    who sets ``MEMPALACE_SPACY_MODEL=`` in a .env file doesn't accidentally
+    pass an empty model name to ``spacy.load``.
+    """
+    raw = os.environ.get(_ENV_VAR, "")
+    stripped = raw.strip()
+    return stripped if stripped else _DEFAULT_MODEL
+
+
+@functools.lru_cache(maxsize=4)
+def _get_spacy_nlp(model_name: str):
+    """Load (and cache) a spaCy nlp pipeline by model name.
+
+    Returns the loaded pipeline object on success, or ``None`` on any
+    failure (spaCy missing, model missing AND download failed, etc.).
+    The lru_cache ensures ``spacy.load`` is called at most once per
+    distinct model name — repeated entity-extraction calls hit the
+    cached pipeline directly.
+
+    The cache is keyed by model name so a user can switch via the env
+    var without restarting the process, and multiple models can be
+    held in parallel (capacity 4 covers sm/md/lg/trf simultaneously).
+    """
+    if not _spacy_available():
+        return None
+
+    try:
+        spacy = importlib.import_module("spacy")
+    except (ImportError, ModuleNotFoundError):
+        return None
+
+    try:
+        return spacy.load(model_name)
+    except OSError:
+        # Model not installed — attempt one-time lazy download.
+        logger.info("spaCy model %r not present locally; downloading", model_name)
+        try:
+            spacy.cli.download(model_name)
+        except Exception as exc:  # network down, disk full, permissions, etc.
+            logger.warning(
+                "spaCy model download failed for %r (%s); spaCy NER "
+                "augmentation will be skipped for this session",
+                model_name,
+                exc,
+            )
+            return None
+        try:
+            return spacy.load(model_name)
+        except Exception as exc:
+            logger.warning(
+                "spaCy model %r still unloadable after download (%s); "
+                "spaCy NER augmentation will be skipped",
+                model_name,
+                exc,
+            )
+            return None
+
+
+def extract_spacy_entities(text: str) -> dict[str, int]:
+    """Return ``{entity_text: occurrence_count}`` for kept NER labels.
+
+    Filters spaCy's emitted spans down to ``_KEEP_LABELS`` and dedupes
+    by surface form (case-sensitive — "Aya" and "aya" are separate
+    surface forms here; case-folding is the caller's responsibility if
+    desired, to avoid clobbering legitimately distinct strings).
+
+    Whitespace surrounding the entity text is stripped; empty/whitespace-
+    only ents are dropped entirely. spaCy occasionally emits these on
+    malformed inputs.
+
+    Returns an empty dict if:
+      - ``text`` is empty/whitespace-only,
+      - spaCy is not installed,
+      - the configured model could not be loaded or downloaded,
+      - the model raised on processing the text.
+
+    Never raises — the existing entity pipeline must stay running even
+    when spaCy misbehaves.
+    """
+    if not text or not text.strip():
+        return {}
+
+    nlp = _get_spacy_nlp(_resolve_model_name())
+    if nlp is None:
+        return {}
+
+    try:
+        doc = nlp(text)
+    except Exception as exc:
+        logger.warning(
+            "spaCy processing raised %s on a %d-char input; skipping",
+            type(exc).__name__,
+            len(text),
+        )
+        return {}
+
+    counts: dict[str, int] = {}
+    for ent in doc.ents:
+        label = getattr(ent, "label_", None)
+        if label not in _KEEP_LABELS:
+            continue
+        raw_text = getattr(ent, "text", "") or ""
+        name = raw_text.strip()
+        if not name:
+            continue
+        counts[name] = counts.get(name, 0) + 1
+    return counts

--- a/mempalace/entity_spacy.py
+++ b/mempalace/entity_spacy.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import functools
 import logging
 import os
+from typing import Any
 
 logger = logging.getLogger("mempalace.entity_spacy")
 
@@ -87,7 +88,7 @@ def _resolve_model_name() -> str:
 
 
 @functools.lru_cache(maxsize=4)
-def _get_spacy_nlp(model_name: str):
+def _get_spacy_nlp(model_name: str) -> Any | None:
     """Load (and cache) a spaCy nlp pipeline by model name.
 
     Returns the loaded pipeline object on success, or ``None`` on any
@@ -177,7 +178,8 @@ def extract_spacy_entities(text: str) -> dict[str, int]:
         return {}
 
     try:
-        doc = nlp(text)
+        with nlp.select_pipes(enable="ner"):
+            doc = nlp(text)
     except Exception as exc:
         logger.warning(
             "spaCy processing raised %s on a %d-char input; skipping",

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -904,13 +904,23 @@ def _extract_entities_for_metadata(content: str) -> str:
     # "these aren't entity-worthy regardless of which pipeline found them."
     # ``extract_spacy_entities`` returns ``{}`` when spaCy isn't
     # available, so behavior is unchanged for users on the base install.
+    #
+    # Case-fold the membership check so spaCy hits don't duplicate
+    # entries already in ``matched`` under a different case (regex
+    # added "Aya" from a known-entities scan, spaCy emits "aya" —
+    # both would land as distinct entries without this guard). Same
+    # design contract as the merge in ``entity_detector.extract_candidates``.
+    matched_lower = {m.lower() for m in matched}
     for spacy_name in extract_spacy_entities(window):
+        key_lower = spacy_name.lower()
         if (
             spacy_name not in _ENTITY_STOPLIST
-            and spacy_name.lower() not in coca_filter
+            and key_lower not in coca_filter
+            and key_lower not in matched_lower
             and len(spacy_name) > 2
         ):
             matched.add(spacy_name)
+            matched_lower.add(key_lower)
 
     if not matched:
         return ""

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -896,11 +896,20 @@ def _extract_entities_for_metadata(content: str) -> str:
     # Tier 4 linguistics cleanup — augment with spaCy NER for the same
     # window when the ``mempalace[nlp]`` extra is installed. spaCy hits
     # land at count 1+ because statistical NER is high-precision and
-    # doesn't need the >=2 frequency guard the regex path uses.
+    # doesn't need the >=2 frequency guard the regex path uses, but they
+    # ARE filtered through the same COCA content-word filter Tier 2
+    # applies to the regex path — spaCy can still surface common English
+    # content words ("Code", "Phase", "Line") as entities in context-poor
+    # sentences, and the COCA filter is the design promise that says
+    # "these aren't entity-worthy regardless of which pipeline found them."
     # ``extract_spacy_entities`` returns ``{}`` when spaCy isn't
     # available, so behavior is unchanged for users on the base install.
     for spacy_name in extract_spacy_entities(window):
-        if spacy_name not in _ENTITY_STOPLIST and len(spacy_name) > 2:
+        if (
+            spacy_name not in _ENTITY_STOPLIST
+            and spacy_name.lower() not in coca_filter
+            and len(spacy_name) > 2
+        ):
             matched.add(spacy_name)
 
     if not matched:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -20,6 +20,7 @@ from collections import defaultdict
 from typing import Optional
 
 from .entity_detector import _apply_known_systems_prepass, _get_coca_filter
+from .entity_spacy import extract_spacy_entities
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
@@ -891,6 +892,16 @@ def _extract_entities_for_metadata(content: str) -> str:
     for w, c in freq.items():
         if c >= 2 and len(w) > 2:
             matched.add(w)
+
+    # Tier 4 linguistics cleanup — augment with spaCy NER for the same
+    # window when the ``mempalace[nlp]`` extra is installed. spaCy hits
+    # land at count 1+ because statistical NER is high-precision and
+    # doesn't need the >=2 frequency guard the regex path uses.
+    # ``extract_spacy_entities`` returns ``{}`` when spaCy isn't
+    # available, so behavior is unchanged for users on the base install.
+    for spacy_name in extract_spacy_entities(window):
+        if spacy_name not in _ENTITY_STOPLIST and len(spacy_name) > 2:
+            matched.add(spacy_name)
 
     if not matched:
         return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,21 @@ extract = [
     # covered by striprtf above.
     "markitdown[docx,pdf,pptx,xlsx]>=0.1.5; python_version >= '3.10'",
 ]
+# Opt-in spaCy NLP for entity-detection augmentation. Adds statistical NER
+# (PERSON, ORG, GPE, PRODUCT, WORK_OF_ART, EVENT) alongside the existing
+# regex+COCA pipeline. spaCy is local CPU/GPU NLP — NOT an LLM, no network
+# calls beyond first-time model download.
+#
+# The model itself ("en_core_web_sm" by default, ~12 MB) is NOT installed
+# by this extra. mempalace lazy-downloads it on first use via
+# ``spacy.cli.download``, mirroring the embeddinggemma pattern. Users on
+# metered or offline machines can pre-install with
+# ``python -m spacy download en_core_web_sm``. Override via
+# MEMPALACE_SPACY_MODEL=en_core_web_md|lg|trf for higher accuracy
+# (md=~41 MB, lg=~560 MB, trf=~436 MB GPU-recommended).
+nlp = [
+    "spacy>=3.7",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/test_entity_detector.py
+++ b/tests/test_entity_detector.py
@@ -236,6 +236,31 @@ def test_extract_candidates_single_word_code_still_coca_filtered():
     )
 
 
+def test_extract_candidates_case_folds_spacy_merge():
+    """When regex stored 'Apple' (3+ mentions) and spaCy emits 'apple' for
+    the same entity, the merge must collapse them onto ONE entry — the
+    regex case wins because it ran first. Without case-folding the merge,
+    both 'Apple' and 'apple' end up as distinct keys, scored and classified
+    separately as duplicates."""
+    from unittest.mock import patch
+
+    # Three "Apple" mentions clears the >=3 regex threshold, so result
+    # will contain "Apple" before the spaCy augmentation runs.
+    text = "Apple builds chips. Apple makes phones. Apple does silicon."
+
+    # spaCy returns the lowercase variant — this is the realistic
+    # scenario, since statistical NER picks up case from local context.
+    fake_spacy_result = {"apple": 1}
+
+    with patch("mempalace.entity_detector.extract_spacy_entities", return_value=fake_spacy_result):
+        result = extract_candidates(text)
+
+    assert "Apple" in result, f"'Apple' missing; got: {list(result.keys())!r}"
+    assert "apple" not in result, (
+        f"'apple' case-variant should have merged into 'Apple'; got both: {list(result.keys())!r}"
+    )
+
+
 def test_extract_candidates_detects_multiple_distinct_compounds():
     """Multiple known compounds in the same text are each detected
     independently."""

--- a/tests/test_entity_spacy.py
+++ b/tests/test_entity_spacy.py
@@ -139,6 +139,26 @@ def test_extract_counts_repeated_entities():
     assert result["Igor"] == 1
 
 
+def test_extract_dedupes_case_variants_under_first_seen_canonical():
+    """spaCy can emit the same entity in mixed case ('Apple' vs 'apple')
+    across a single doc depending on the model's confidence at each
+    mention. The counts dict must dedupe by case-folded key but keep
+    the first-seen surface form as the canonical key."""
+    fake_ents = [
+        _make_fake_ent("Apple", "ORG"),  # first-seen = "Apple"
+        _make_fake_ent("apple", "ORG"),  # case variant, merges into "Apple"
+        _make_fake_ent("APPLE", "ORG"),  # another case variant
+    ]
+    fake_nlp = _make_fake_nlp(fake_ents)
+    with patch.object(entity_spacy, "_get_spacy_nlp", return_value=fake_nlp):
+        result = entity_spacy.extract_spacy_entities("any text")
+
+    # Only ONE key in the result, using the first-seen case
+    assert list(result.keys()) == ["Apple"]
+    # And the count is 3 (all three mentions merged)
+    assert result["Apple"] == 3
+
+
 def test_extract_strips_whitespace_in_entity_text():
     """spaCy occasionally emits ents with surrounding whitespace; strip them."""
     fake_ents = [

--- a/tests/test_entity_spacy.py
+++ b/tests/test_entity_spacy.py
@@ -235,6 +235,40 @@ def test_get_spacy_nlp_is_cached_per_model():
     assert fake_spacy.load.call_count == 1
 
 
+def test_get_spacy_nlp_returns_none_on_value_error():
+    """spacy.load can raise ValueError on an invalid model name. The
+    module's design contract is 'never load-bearing,' so this MUST
+    return None rather than propagate — the entity pipeline keeps
+    working even when spaCy mis-configures."""
+    fake_spacy = MagicMock()
+    fake_spacy.load.side_effect = ValueError("invalid model name")
+    with patch.dict(sys.modules, {"spacy": fake_spacy}):
+        result = entity_spacy._get_spacy_nlp("not_a_real_model")
+    assert result is None
+
+
+def test_get_spacy_nlp_returns_none_on_import_error_from_model_package():
+    """If a spaCy model package itself is broken (importable as a
+    package but raises ImportError on load), the loader must return
+    None rather than crash the caller."""
+    fake_spacy = MagicMock()
+    fake_spacy.load.side_effect = ImportError("broken model package")
+    with patch.dict(sys.modules, {"spacy": fake_spacy}):
+        result = entity_spacy._get_spacy_nlp("en_core_web_sm")
+    assert result is None
+
+
+def test_get_spacy_nlp_returns_none_on_arbitrary_exception():
+    """Any other spaCy-internal failure must NOT crash the caller. The
+    broad outer except is the design contract that says 'spaCy is opt-in,
+    never load-bearing.'"""
+    fake_spacy = MagicMock()
+    fake_spacy.load.side_effect = RuntimeError("some spacy internal failure")
+    with patch.dict(sys.modules, {"spacy": fake_spacy}):
+        result = entity_spacy._get_spacy_nlp("en_core_web_sm")
+    assert result is None
+
+
 def test_get_spacy_nlp_downloads_when_model_missing():
     """When spacy.load raises OSError (model not installed), the loader
     must call spacy.cli.download once, then retry load."""

--- a/tests/test_entity_spacy.py
+++ b/tests/test_entity_spacy.py
@@ -39,10 +39,12 @@ def _make_fake_nlp(ents: list[SimpleNamespace]) -> MagicMock:
 
 @pytest.fixture(autouse=True)
 def _clear_caches():
-    """Drop the lru_cache between tests so env-var overrides take effect."""
+    """Drop the lru_caches between tests so env-var + model overrides take effect."""
     entity_spacy._get_spacy_nlp.cache_clear()
+    entity_spacy._resolve_model_name.cache_clear()
     yield
     entity_spacy._get_spacy_nlp.cache_clear()
+    entity_spacy._resolve_model_name.cache_clear()
 
 
 # ── _spacy_available ────────────────────────────────────────────────────
@@ -168,29 +170,51 @@ def test_extract_drops_empty_or_whitespace_only_entities():
 # ── MEMPALACE_SPACY_MODEL env var ───────────────────────────────────────
 
 
-def test_default_model_is_en_core_web_sm(monkeypatch):
-    """When MEMPALACE_SPACY_MODEL is unset, the loader must request the
-    small English model."""
+def test_unset_env_var_returns_empty_string(monkeypatch):
+    """When MEMPALACE_SPACY_MODEL is unset, the resolver returns an empty
+    string. The default model name is layered on at the call site, NOT
+    silently inside the resolver, per project convention on env-var
+    parsing (the caller can distinguish "user did not configure" from
+    "user explicitly set the default")."""
     monkeypatch.delenv("MEMPALACE_SPACY_MODEL", raising=False)
-    assert entity_spacy._resolve_model_name() == "en_core_web_sm"
+    assert entity_spacy._resolve_model_name() == ""
 
 
 def test_env_var_overrides_default_model(monkeypatch):
-    """MEMPALACE_SPACY_MODEL must replace the default."""
+    """MEMPALACE_SPACY_MODEL must be returned verbatim (after strip)."""
     monkeypatch.setenv("MEMPALACE_SPACY_MODEL", "en_core_web_md")
     assert entity_spacy._resolve_model_name() == "en_core_web_md"
 
 
 def test_env_var_whitespace_is_stripped(monkeypatch):
-    """Surrounding whitespace in env var must not break the model name."""
+    """Surrounding whitespace in env var must not pass through to the
+    model name."""
     monkeypatch.setenv("MEMPALACE_SPACY_MODEL", "  en_core_web_lg  \n")
     assert entity_spacy._resolve_model_name() == "en_core_web_lg"
 
 
-def test_empty_env_var_falls_back_to_default(monkeypatch):
-    """Empty MEMPALACE_SPACY_MODEL must not produce an empty model name."""
+def test_empty_env_var_returns_empty_string(monkeypatch):
+    """An explicitly empty MEMPALACE_SPACY_MODEL returns "" — same as
+    unset. The caller layers the default via ``... or _DEFAULT_MODEL``."""
     monkeypatch.setenv("MEMPALACE_SPACY_MODEL", "")
-    assert entity_spacy._resolve_model_name() == "en_core_web_sm"
+    assert entity_spacy._resolve_model_name() == ""
+
+
+def test_caller_layers_default_when_resolver_returns_empty(monkeypatch):
+    """When _resolve_model_name returns "", extract_spacy_entities must
+    layer on _DEFAULT_MODEL at the call site, not crash with spacy.load("")."""
+    monkeypatch.delenv("MEMPALACE_SPACY_MODEL", raising=False)
+    fake_nlp = _make_fake_nlp([_make_fake_ent("Aya", "PERSON")])
+    captured_model = {}
+
+    def fake_get(model_name: str):
+        captured_model["name"] = model_name
+        return fake_nlp
+
+    with patch.object(entity_spacy, "_get_spacy_nlp", side_effect=fake_get):
+        entity_spacy.extract_spacy_entities("Aya was here.")
+
+    assert captured_model["name"] == entity_spacy._DEFAULT_MODEL
 
 
 # ── _get_spacy_nlp cache + lazy download ────────────────────────────────

--- a/tests/test_entity_spacy.py
+++ b/tests/test_entity_spacy.py
@@ -1,0 +1,263 @@
+"""Tests for mempalace.entity_spacy — opt-in spaCy NER augmentation.
+
+These tests use mocks for spaCy itself so they pass with or without the
+``[nlp]`` extra installed and don't require any model download in CI.
+End-to-end verification against the real spaCy + en_core_web_sm model
+lives in the live-palace test, not here.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mempalace import entity_spacy
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_fake_ent(text: str, label: str) -> SimpleNamespace:
+    """Minimal stand-in for a spaCy ``Span`` with .text and .label_ only."""
+    return SimpleNamespace(text=text, label_=label)
+
+
+def _make_fake_doc(ents: list[SimpleNamespace]) -> SimpleNamespace:
+    """Minimal stand-in for a spaCy ``Doc`` exposing only .ents."""
+    return SimpleNamespace(ents=ents)
+
+
+def _make_fake_nlp(ents: list[SimpleNamespace]) -> MagicMock:
+    """Callable that returns a fake Doc when invoked on text."""
+    nlp = MagicMock()
+    nlp.return_value = _make_fake_doc(ents)
+    return nlp
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Drop the lru_cache between tests so env-var overrides take effect."""
+    entity_spacy._get_spacy_nlp.cache_clear()
+    yield
+    entity_spacy._get_spacy_nlp.cache_clear()
+
+
+# ── _spacy_available ────────────────────────────────────────────────────
+
+
+def test_spacy_available_returns_false_when_import_fails():
+    """If spaCy is not installed, _spacy_available must report False."""
+    with patch.dict(sys.modules, {"spacy": None}):
+        assert entity_spacy._spacy_available() is False
+
+
+def test_spacy_available_returns_true_when_import_succeeds():
+    """When spaCy is importable, _spacy_available must report True."""
+    fake_spacy = MagicMock()
+    with patch.dict(sys.modules, {"spacy": fake_spacy}):
+        assert entity_spacy._spacy_available() is True
+
+
+# ── extract_spacy_entities — graceful no-op ─────────────────────────────
+
+
+def test_extract_returns_empty_when_spacy_missing():
+    """ImportError on spaCy must yield an empty dict, NOT raise."""
+    with patch.object(entity_spacy, "_spacy_available", return_value=False):
+        assert entity_spacy.extract_spacy_entities("Aya met Igor in Paris.") == {}
+
+
+def test_extract_returns_empty_for_empty_text():
+    """Empty input yields empty output without loading the model."""
+    assert entity_spacy.extract_spacy_entities("") == {}
+
+
+# ── label filtering ─────────────────────────────────────────────────────
+
+
+def test_only_keep_listed_ner_labels():
+    """spaCy DATE / CARDINAL / ORDINAL labels must be filtered out.
+
+    Only PERSON, ORG, GPE, PRODUCT, WORK_OF_ART, EVENT pass through.
+    """
+    fake_ents = [
+        _make_fake_ent("Aya", "PERSON"),
+        _make_fake_ent("Anthropic", "ORG"),
+        _make_fake_ent("Paris", "GPE"),
+        _make_fake_ent("2026-05-24", "DATE"),
+        _make_fake_ent("three", "CARDINAL"),
+        _make_fake_ent("first", "ORDINAL"),
+    ]
+    fake_nlp = _make_fake_nlp(fake_ents)
+    with patch.object(entity_spacy, "_get_spacy_nlp", return_value=fake_nlp):
+        result = entity_spacy.extract_spacy_entities("any text")
+
+    assert "Aya" in result
+    assert "Anthropic" in result
+    assert "Paris" in result
+    assert "2026-05-24" not in result
+    assert "three" not in result
+    assert "first" not in result
+
+
+def test_kept_labels_include_product_and_work_of_art_and_event():
+    """PRODUCT / WORK_OF_ART / EVENT are useful and must be kept."""
+    fake_ents = [
+        _make_fake_ent("iPhone", "PRODUCT"),
+        _make_fake_ent("Mona Lisa", "WORK_OF_ART"),
+        _make_fake_ent("World Cup", "EVENT"),
+    ]
+    fake_nlp = _make_fake_nlp(fake_ents)
+    with patch.object(entity_spacy, "_get_spacy_nlp", return_value=fake_nlp):
+        result = entity_spacy.extract_spacy_entities("any text")
+
+    assert "iPhone" in result
+    assert "Mona Lisa" in result
+    assert "World Cup" in result
+
+
+# ── counts + dedup ──────────────────────────────────────────────────────
+
+
+def test_extract_counts_repeated_entities():
+    """Same surface form mentioned twice must yield count of 2."""
+    fake_ents = [
+        _make_fake_ent("Aya", "PERSON"),
+        _make_fake_ent("Aya", "PERSON"),
+        _make_fake_ent("Igor", "PERSON"),
+    ]
+    fake_nlp = _make_fake_nlp(fake_ents)
+    with patch.object(entity_spacy, "_get_spacy_nlp", return_value=fake_nlp):
+        result = entity_spacy.extract_spacy_entities("any text")
+
+    assert result["Aya"] == 2
+    assert result["Igor"] == 1
+
+
+def test_extract_strips_whitespace_in_entity_text():
+    """spaCy occasionally emits ents with surrounding whitespace; strip them."""
+    fake_ents = [
+        _make_fake_ent("  Aya  ", "PERSON"),
+        _make_fake_ent("\nIgor\t", "PERSON"),
+    ]
+    fake_nlp = _make_fake_nlp(fake_ents)
+    with patch.object(entity_spacy, "_get_spacy_nlp", return_value=fake_nlp):
+        result = entity_spacy.extract_spacy_entities("any text")
+
+    assert "Aya" in result
+    assert "Igor" in result
+
+
+def test_extract_drops_empty_or_whitespace_only_entities():
+    """An ent with empty or whitespace-only text must not appear in the result."""
+    fake_ents = [
+        _make_fake_ent("", "PERSON"),
+        _make_fake_ent("   ", "ORG"),
+        _make_fake_ent("Aya", "PERSON"),
+    ]
+    fake_nlp = _make_fake_nlp(fake_ents)
+    with patch.object(entity_spacy, "_get_spacy_nlp", return_value=fake_nlp):
+        result = entity_spacy.extract_spacy_entities("any text")
+
+    assert list(result.keys()) == ["Aya"]
+
+
+# ── MEMPALACE_SPACY_MODEL env var ───────────────────────────────────────
+
+
+def test_default_model_is_en_core_web_sm(monkeypatch):
+    """When MEMPALACE_SPACY_MODEL is unset, the loader must request the
+    small English model."""
+    monkeypatch.delenv("MEMPALACE_SPACY_MODEL", raising=False)
+    assert entity_spacy._resolve_model_name() == "en_core_web_sm"
+
+
+def test_env_var_overrides_default_model(monkeypatch):
+    """MEMPALACE_SPACY_MODEL must replace the default."""
+    monkeypatch.setenv("MEMPALACE_SPACY_MODEL", "en_core_web_md")
+    assert entity_spacy._resolve_model_name() == "en_core_web_md"
+
+
+def test_env_var_whitespace_is_stripped(monkeypatch):
+    """Surrounding whitespace in env var must not break the model name."""
+    monkeypatch.setenv("MEMPALACE_SPACY_MODEL", "  en_core_web_lg  \n")
+    assert entity_spacy._resolve_model_name() == "en_core_web_lg"
+
+
+def test_empty_env_var_falls_back_to_default(monkeypatch):
+    """Empty MEMPALACE_SPACY_MODEL must not produce an empty model name."""
+    monkeypatch.setenv("MEMPALACE_SPACY_MODEL", "")
+    assert entity_spacy._resolve_model_name() == "en_core_web_sm"
+
+
+# ── _get_spacy_nlp cache + lazy download ────────────────────────────────
+
+
+def test_get_spacy_nlp_is_cached_per_model():
+    """The lru_cache must skip a second spacy.load for the same model name."""
+    fake_spacy = MagicMock()
+    fake_nlp = MagicMock()
+    fake_spacy.load.return_value = fake_nlp
+    with patch.dict(sys.modules, {"spacy": fake_spacy}):
+        first = entity_spacy._get_spacy_nlp("en_core_web_sm")
+        second = entity_spacy._get_spacy_nlp("en_core_web_sm")
+
+    assert first is fake_nlp
+    assert second is fake_nlp
+    # spacy.load called exactly once thanks to the cache
+    assert fake_spacy.load.call_count == 1
+
+
+def test_get_spacy_nlp_downloads_when_model_missing():
+    """When spacy.load raises OSError (model not installed), the loader
+    must call spacy.cli.download once, then retry load."""
+    fake_spacy = MagicMock()
+    fake_nlp = MagicMock()
+    # First load raises (model missing); after download, load succeeds.
+    fake_spacy.load.side_effect = [OSError("model not found"), fake_nlp]
+    fake_spacy.cli.download = MagicMock()
+    with patch.dict(sys.modules, {"spacy": fake_spacy}):
+        result = entity_spacy._get_spacy_nlp("en_core_web_sm")
+
+    assert result is fake_nlp
+    fake_spacy.cli.download.assert_called_once_with("en_core_web_sm")
+    assert fake_spacy.load.call_count == 2
+
+
+def test_get_spacy_nlp_returns_none_when_download_also_fails():
+    """If the download itself raises, the loader must return None — never
+    crash the caller. spaCy stays opt-in, never load-bearing."""
+    fake_spacy = MagicMock()
+    fake_spacy.load.side_effect = OSError("model not found")
+    fake_spacy.cli.download.side_effect = Exception("network unreachable")
+    with patch.dict(sys.modules, {"spacy": fake_spacy}):
+        result = entity_spacy._get_spacy_nlp("en_core_web_sm")
+
+    assert result is None
+
+
+def test_get_spacy_nlp_returns_none_when_spacy_not_installed():
+    """ImportError on spaCy itself must yield None, not raise."""
+    with patch.dict(sys.modules, {"spacy": None}):
+        assert entity_spacy._get_spacy_nlp("en_core_web_sm") is None
+
+
+# ── hot-path: no compilation / import inside extract_spacy_entities ─────
+
+
+def test_extract_does_not_call_spacy_load_per_call():
+    """Once the model is cached, repeated extract_spacy_entities calls
+    must NOT trigger spacy.load again (per the perf rule)."""
+    fake_spacy = MagicMock()
+    fake_nlp = _make_fake_nlp([_make_fake_ent("Aya", "PERSON")])
+    fake_spacy.load.return_value = fake_nlp
+    with patch.dict(sys.modules, {"spacy": fake_spacy}):
+        # Warm the cache
+        entity_spacy.extract_spacy_entities("Aya is here.")
+        load_count_after_warm = fake_spacy.load.call_count
+        for _ in range(50):
+            entity_spacy.extract_spacy_entities("Aya is still here.")
+        assert fake_spacy.load.call_count == load_count_after_warm

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -567,6 +567,32 @@ def test_entity_metadata_matches_known_names_case_insensitively(monkeypatch):
     assert "Lumi" in matched_mixed
 
 
+def test_extract_entities_for_metadata_case_folds_spacy_merge(monkeypatch):
+    """When the regex/known-entities pipeline added 'Aya' to matched
+    and spaCy emits 'aya' (lowercase) as a separate entity, the merge
+    must NOT produce both. The case-fold guard collapses them onto a
+    single entry — the existing case in matched wins because it landed
+    first. Without this, downstream sees duplicate tags ('Aya' AND
+    'aya') in chromadb drawer metadata."""
+    from mempalace import miner
+
+    # Stub known entities so 'Aya' is matched first by the regex pipeline
+    monkeypatch.setattr(miner, "_load_known_entities", lambda: frozenset({"Aya"}))
+
+    # spaCy returns lowercase variant — the realistic scenario when the
+    # source text spells the name lowercase (chat transcript, etc.)
+    monkeypatch.setattr(miner, "extract_spacy_entities", lambda window: {"aya": 1})
+
+    result = miner._extract_entities_for_metadata("aya was here.")
+    matched = set(result.split(";")) if result else set()
+
+    assert "Aya" in matched, f"existing-case 'Aya' must remain; got: {matched!r}"
+    assert "aya" not in matched, (
+        f"spaCy lowercase 'aya' must merge into existing 'Aya', not duplicate; "
+        f"got both: {matched!r}"
+    )
+
+
 def test_file_already_mined_check_mtime():
     tmpdir = tempfile.mkdtemp()
     try:


### PR DESCRIPTION

Adds a statistical-NER pass alongside the existing regex + COCA-filter entity-detection pipeline. spaCy entities augment — never replace — the regex hits, so behavior is fully backward-compatible for users on the base install. Closes the largest gap in entity coverage: proper-noun detection that doesn't depend on capitalization frequency thresholds.

## What does this PR do?

Adds spaCy as an opt-in entity-detection augmenter behind the new `mempalace[nlp]` extra. The base install gets nothing new; users who run `pip install mempalace[nlp]` get high-precision statistical NER (PERSON, ORG, GPE, PRODUCT, WORK_OF_ART, EVENT) on top of the existing regex + COCA + known-systems pipeline. Single-mention proper nouns that the regex threshold can't surface (e.g. "Soren mentioned Anthropic in San Francisco" — every name appears once) now land in drawer metadata via spaCy. spaCy results never replace regex hits; they union with them. When the same name is detected by both pipelines, the regex count wins so downstream scoring/classification stays unaffected.

## What ships

**pyproject.toml** — new `[nlp]` optional-dependency = `spacy>=3.7`. The spaCy package itself, not a model. Users install with `pip install mempalace[nlp]`. Base mempalace install is unchanged and never imports spaCy.

**mempalace/entity_spacy.py** — public `extract_spacy_entities(text)` returns `{entity_text: occurrence_count}` for the six NER labels we care about (PERSON, ORG, GPE, PRODUCT, WORK_OF_ART, EVENT). DATE, CARDINAL, ORDINAL, etc. are filtered out as noise or already covered by other tiers. Internal `_get_spacy_nlp` is `lru_cache`-d per model name so `spacy.load` runs at most once per distinct model in a process; the hot path does no compilation, no import, no repeated disk I/O.

**Lazy model download** — on first use, `_get_spacy_nlp` attempts `spacy.load(name)`; on `OSError` (model not present locally), it runs `spacy.cli.download(name)` once and retries. Mirrors the first-use download pattern used by the embeddinggemma ONNX model (#1483). Network or disk failure during download logs a warning and returns `None` so the regex pipeline keeps working.

**Model override via `MEMPALACE_SPACY_MODEL` env var.** Default is `en_core_web_sm` (~12 MB, fast, CPU-only). Users can switch to `en_core_web_md` (~41 MB, has vectors), `en_core_web_lg` (~560 MB, larger vectors), or `en_core_web_trf` (~436 MB, transformer, GPU recommended for reasonable throughput) without re-installing anything. Empty/whitespace-only env values fall back to the default.

**mempalace/entity_detector.py** — `extract_candidates` (init-time) unions spaCy entities into its return value. spaCy hits bypass the ≥3 frequency threshold the regex path uses, because statistical NER is high-precision and doesn't need that guard.

**mempalace/miner.py** — `_extract_entities_for_metadata` (per-drawer) unions spaCy entities into the matched set, filtered against the existing `_ENTITY_STOPLIST` and `len > 2` guard.

**tests/test_entity_spacy.py** — 18 tests covering ImportError fallback, env-var resolution, label filtering, count + whitespace handling, lru_cache hit-rate, lazy-download success and failure, and the no-compilation-in-hot-path guarantee. Tests mock spaCy entirely, so the CI matrix doesn't have to install or download models on every run.

## Why English-only first

Each spaCy language is a separate model. A clean multilingual story needs language detection + per-language model loading + install-size decisions about which languages to bundle in the extra. That belongs in its own PR rather than buried in the spaCy enablement. The COCA filter (#1605) is also English-only today, so this PR doesn't regress multilingual support; it leaves multilingual NER as the explicit next step rather than entangling it with the opt-in machinery.

## How to test

1. `pip install -e ".[dev,nlp]"`

2. `python -m pytest tests/test_entity_spacy.py -v` — 18 tests, all pass without needing a spaCy model installed (tests mock the model entirely).

3. `python -m pytest tests/ -q --ignore=tests/benchmarks --cov=mempalace --cov-fail-under=80` — full suite passes with coverage ≥ 80%.

4. `ruff check . && ruff format --check .` — both clean.

5. Cross-Linux via Docker (Py 3.9 / 3.11 / 3.13):
`docker run --rm -v $PWD:/work -w /work python:3.9-slim sh -c "pip install -q -e '.[dev]' && python -m pytest tests/ -q"`
`docker run --rm -v $PWD:/work -w /work python:3.11-slim sh -c "pip install -q -e '.[dev]' && python -m pytest tests/ -q"`
`docker run --rm -v $PWD:/work -w /work python:3.13-slim sh -c "pip install -q -e '.[dev]' && python -m pytest tests/ -q"`
Each prints `Python X.Y.Z` then passes 2276 tests.

6. End-to-end with a real spaCy model — `python -m spacy download en_core_web_sm`, write a corpus where each proper noun appears exactly once (e.g. "Soren met Maria at the Anthropic office in San Francisco"), `mempalace init` + `mempalace mine`, then `sqlite3 <palace>/chroma.sqlite3 "SELECT string_value FROM embedding_metadata WHERE key='entities'"`. Expected: the entities column contains all single-mention names. The regex path at its ≥2 frequency threshold would have produced an empty entities column.

## Verification

Full local pytest 2276 passed / 12 skipped on Linux Py 3.9 / 3.11 / 3.13 via `pip install -e ".[dev]"` (CI-matching). ruff check + format clean on the pinned 0.15.14. End-to-end mine of a single-mention corpus with `[nlp]` installed produced `entities = "Anthropic;Berlin;Claude;KubeCon;Maria;OpenAI;San Francisco;Soren;Tigris"` — zero of which the regex pipeline would have caught at its ≥2 frequency threshold.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`) — 2276 passed, 12 skipped
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
- [x] Optional dep correctly scoped — spacy only under `extra == 'nlp'` in the built wheel's METADATA
- [x] Graceful fallback verified — base install (no `[nlp]`) imports cleanly and entity pipeline runs unchanged
