### PR TITLE
fix(hallways): paginate compute_hallways_for_wing to survive large wings

### DIFF
--- a/mempalace/hallways.py
+++ b/mempalace/hallways.py
@@ -198,16 +198,31 @@ def compute_hallways_for_wing(
 
     min_count = max(1, int(min_count))
 
-    # 1. Query drawers for this wing.
+    # 1. Query drawers for this wing. Paginate the fetch — a single
+    #    get(where={"wing": wing}) binds one SQL variable per matching id and
+    #    trips SQLite's SQLITE_MAX_VARIABLE_NUMBER (32766) inside chromadb once
+    #    the wing exceeds ~32k drawers, crashing the post-mine hallway step on
+    #    exactly the large wings that most need it. Mirrors the paginated fetch
+    #    already used in miner.py (#851) and closet_llm.py (#1073): walk the
+    #    collection in batches of 5000 and filter to this wing client-side.
+    metadatas: list = []
     try:
-        results = col.get(where={"wing": wing}, include=["metadatas"])
+        total = col.count()
+        batch_size = 5000
+        offset = 0
+        while offset < total:
+            batch = col.get(limit=batch_size, offset=offset, include=["metadatas"])
+            batch_metas = (batch or {}).get("metadatas") or []
+            if not batch_metas:
+                break
+            metadatas.extend(m for m in batch_metas if (m or {}).get("wing") == wing)
+            offset += len(batch_metas)
     except Exception:
         logger.warning(
             "compute_hallways_for_wing: collection.get failed for %s", wing, exc_info=True
         )
         return []
 
-    metadatas = (results or {}).get("metadatas") or []
     if not metadatas:
         return []
 

--- a/tests/test_hallways.py
+++ b/tests/test_hallways.py
@@ -27,10 +27,16 @@ def _use_tmp_hallway_file(monkeypatch, tmp_path):
 
 
 def _fake_collection(drawers):
-    """Build a MagicMock collection whose .get() returns the given drawer set."""
+    """Build a MagicMock collection whose paginated .get() returns the drawer set.
+
+    compute_hallways_for_wing now paginates via ``count()`` + ``get(limit=,
+    offset=)`` (to dodge SQLITE_MAX_VARIABLE_NUMBER on large wings), so the
+    mock exposes ``count()`` and returns the full set on the single batch.
+    """
     col = MagicMock()
     metadatas = [d for d in drawers]
     ids = [f"drawer_{i}" for i in range(len(drawers))]
+    col.count.return_value = len(drawers)
     col.get.return_value = {"ids": ids, "metadatas": metadatas}
     return col
 


### PR DESCRIPTION
## What
Paginate `compute_hallways_for_wing`'s drawer fetch so it survives wings larger than SQLite's `SQLITE_MAX_VARIABLE_NUMBER` (32766).

Fixes #1619.

## Why
The within-wing hallways post-mine step (#1558) fetches the whole wing in a single `col.get(where={"wing": wing})`. ChromaDB binds one SQL variable per matching id, so once a wing exceeds ~32k drawers the call raises `InternalError: ... too many SQL variables`. The exception is caught (the mine completes) but the wing's hallway graph **silently never builds** — on exactly the large wings that benefit most; cross-wing tunnel promotion (#1565) is starved for them too. This is the same hazard already fixed by paginating in `miner.py` (#851) and `regenerate_closets` (#1073/#1107); the new #1558 path just didn't inherit the pattern.

## How
Walk the collection in `batch_size=5000` pages via `count()` + `get(limit=, offset=)` and filter to the wing client-side — mirroring the existing idiom in `miner.py`'s status counter. Sibling features are unaffected (`dynamics.py` doesn't fetch drawers; `palace_graph.py` tunnels already paginate via limit/offset).

## Validation
- Against a real **42,062-drawer** wing: previously raised "too many SQL variables"; now completes in ~3.7s computing 5,525 hallways.
- `tests/test_hallways.py`: mock updated for the `count()` + paginated-`get` path; **all 21 tests pass**, `ruff` clean.

## Scope
One function (`compute_hallways_for_wing`) + its test. No behavior change for wings under the limit.
