### PR TITLE
feat(codex-plugin): bring Codex CLI to Claude parity (30 MCP tools)

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,6 +1,6 @@
 # MemPalace Claude Code Plugin
 
-A Claude Code plugin that gives your AI a persistent memory system. Mine projects and conversations into a searchable palace backed by ChromaDB, with 19 MCP tools, auto-save hooks, and 5 guided skills.
+A Claude Code plugin that gives your AI a persistent memory system. Mine projects and conversations into a searchable palace backed by ChromaDB, with 30 MCP tools, auto-save hooks, and 5 guided skills.
 
 ## Prerequisites
 
@@ -50,7 +50,7 @@ Set the `MEMPAL_DIR` environment variable to a directory path to automatically r
 
 ## MCP Server
 
-The plugin automatically configures a local MCP server with 19 tools for storing, searching, and managing memories. No manual MCP setup is required -- `/mempalace:init` handles everything.
+The plugin automatically configures a local MCP server with 30 tools for storing, searching, and managing memories. No manual MCP setup is required -- `/mempalace:init` handles everything.
 
 ## Full Documentation
 

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mempalace",
   "version": "3.3.6",
-  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
+  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 30 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"
   },

--- a/.codex-plugin/.mcp.json
+++ b/.codex-plugin/.mcp.json
@@ -1,0 +1,5 @@
+{
+  "mempalace": {
+    "command": "mempalace-mcp"
+  }
+}

--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -1,6 +1,6 @@
 # MemPalace - Codex CLI Plugin
 
-Give your AI a persistent memory -- mine projects and conversations into a searchable palace backed by ChromaDB, with 19 MCP tools, auto-save hooks, and guided skills.
+Give your AI a persistent memory -- mine projects and conversations into a searchable palace backed by ChromaDB, with 30 MCP tools, auto-save hooks, and guided skills.
 
 ## Prerequisites
 
@@ -62,6 +62,7 @@ codex /init
 
 | Skill | Description |
 |-------|-------------|
+| `/mempalace` | Generic MemPalace skill that routes to `mempalace instructions <command>` |
 | `/help` | Show available commands and usage tips |
 | `/init` | Initialize a new memory palace |
 | `/search` | Semantic search across all mined memories |
@@ -73,6 +74,11 @@ codex /init
 The plugin includes auto-save hooks that run on session stop (every 15 messages) and before context compaction, automatically preserving conversation context into your palace.
 
 Set the `MEMPAL_DIR` environment variable to a directory path to automatically run `mempalace mine` on that directory during each save trigger.
+
+## MCP Server
+
+The plugin ships `.codex-plugin/.mcp.json` pointing to `mempalace-mcp` and
+references it from `plugin.json` via `mcpServers`.
 
 ## Support
 

--- a/.codex-plugin/hooks.json
+++ b/.codex-plugin/hooks.json
@@ -1,4 +1,5 @@
 {
+  "description": "MemPalace auto-save and pre-compact hooks for Codex CLI",
   "hooks": {
     "SessionStart": [
       {
@@ -6,7 +7,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CODEX_PLUGIN_ROOT}/hooks/mempal-hook.sh\" session-start"
+            "command": "\"${PLUGIN_ROOT}/hooks/mempal-hook.sh\" session-start",
+            "timeout": 10
           }
         ]
       }
@@ -17,7 +19,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CODEX_PLUGIN_ROOT}/hooks/mempal-hook.sh\" stop"
+            "command": "\"${PLUGIN_ROOT}/hooks/mempal-hook.sh\" stop",
+            "timeout": 20
           }
         ]
       }
@@ -28,7 +31,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CODEX_PLUGIN_ROOT}/hooks/mempal-hook.sh\" precompact"
+            "command": "\"${PLUGIN_ROOT}/hooks/mempal-hook.sh\" precompact",
+            "timeout": 75
           }
         ]
       }

--- a/.codex-plugin/hooks/mempal-hook.sh
+++ b/.codex-plugin/hooks/mempal-hook.sh
@@ -1,9 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
-HOOK_NAME="${1:?Usage: mempal-hook.sh <hook-name>}"
-INPUT_FILE=$(mktemp) || { echo "Failed to create temp file" >&2; exit 1; }
-cat > "$INPUT_FILE"
-cat "$INPUT_FILE" | mempalace hook run --hook "$HOOK_NAME" --harness codex
-EXIT_CODE=$?
-rm -f "$INPUT_FILE" 2>/dev/null
-exit $EXIT_CODE
+HOOK_NAME="${1:-}"
+if [ -z "$HOOK_NAME" ]; then
+  echo "Usage: mempal-hook.sh <hook-name>" >&2
+  exit 1
+fi
+
+run_mempalace_hook() {
+  if command -v mempalace >/dev/null 2>&1; then
+    mempalace hook run "$@"
+    return $?
+  fi
+
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import mempalace" >/dev/null 2>&1; then
+    python3 -m mempalace hook run "$@"
+    return $?
+  fi
+
+  if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
+    python -m mempalace hook run "$@"
+    return $?
+  fi
+
+  echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
+  return 1
+}
+
+run_mempalace_hook --hook "$HOOK_NAME" --harness codex

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "mempalace",
-      "source": "./.claude-plugin",
+      "source": "./.codex-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 30 MCP tools, auto-save hooks, guided setup.",
       "version": "3.3.6",
       "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mempalace",
   "version": "3.3.6",
-  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 19 MCP tools, auto-save hooks, and guided setup.",
+  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 30 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"
   },
@@ -19,15 +19,11 @@
   ],
   "skills": "./skills/",
   "hooks": "./hooks.json",
-  "mcpServers": {
-    "mempalace": {
-      "command": "mempalace-mcp"
-    }
-  },
+  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "MemPalace",
     "shortDescription": "AI memory system for Codex",
-    "longDescription": "Give your AI a persistent memory — mine projects and conversations into a searchable palace backed by ChromaDB, with 19 MCP tools, auto-save hooks, and guided skills.",
+    "longDescription": "Give your AI a persistent memory — mine projects and conversations into a searchable palace backed by ChromaDB, with 30 MCP tools, auto-save hooks, and guided skills.",
     "developerName": "milla-jovovich",
     "category": "Coding",
     "capabilities": [

--- a/.codex-plugin/skills/mempalace/SKILL.md
+++ b/.codex-plugin/skills/mempalace/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: mempalace
+description: MemPalace — mine projects and conversations into a searchable memory palace. Use when asked about mempalace, memory palace, mining memories, searching memories, or palace setup.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+---
+
+# MemPalace
+
+A searchable memory palace for AI — mine projects and conversations, then search them semantically.
+
+## Prerequisites
+
+Ensure `mempalace` is installed:
+
+```bash
+mempalace --version
+```
+
+If not installed (uv recommended):
+
+```bash
+uv tool install mempalace   # or: pip install mempalace
+```
+
+## Usage
+
+MemPalace provides dynamic instructions via the CLI. To get instructions for any operation:
+
+```bash
+mempalace instructions <command>
+```
+
+Where `<command>` is one of: `help`, `init`, `mine`, `search`, `status`.
+
+Run the appropriate instructions command, then follow the returned instructions step by step.

--- a/docs/codex-cli-parity-test-results.md
+++ b/docs/codex-cli-parity-test-results.md
@@ -1,0 +1,93 @@
+# Codex CLI Parity Test Results
+
+Date: 2026-05-26
+Branch: `feat/codex-cli-support-enablement`
+
+## Goal
+
+Validate full Codex CLI plugin parity with the Claude plugin and the live MemPalace MCP runtime surface.
+
+## Environment
+
+- Repository: `MemPalace/mempalace`
+- Default upstream branch target: `develop`
+- Codex plugin install under test:
+  - Marketplace: `mempalace-local-test`
+  - Plugin: `mempalace@mempalace-local-test`
+  - Version: `3.3.5`
+
+## Live Plugin Verification
+
+Commands executed:
+
+```bash
+codex plugin marketplace list
+codex plugin list
+```
+
+Observed:
+- Marketplace registered: `mempalace-local-test`
+- Plugin state: `installed, enabled`
+
+## Live MCP Tool Sweep (All 30 Tools)
+
+Isolated test namespaces used:
+- `codex_plugin_live_test_a_20260526`
+- `codex_plugin_live_test_b_20260526`
+
+Coverage exercised:
+- Palace read: `status`, `list_wings`, `list_rooms`, `get_taxonomy`, `search`,
+  `check_duplicate`, `get_aaak_spec`, `get_drawer`, `list_drawers`
+- Palace write: `add_drawer`, `update_drawer`, `delete_drawer`, `sync`
+- Knowledge graph: `kg_add`, `kg_query`, `kg_timeline`, `kg_stats`,
+  `kg_invalidate`
+- Navigation: `traverse`, `find_tunnels`, `graph_stats`, `create_tunnel`,
+  `list_tunnels`, `follow_tunnels`, `delete_tunnel`
+- Diary: `diary_write`, `diary_read`
+- Runtime/system: `hook_settings`, `memories_filed_away`, `reconnect`
+
+Result:
+- All tool paths executed successfully with expected outputs.
+- Test artifacts (drawers/tunnels/diary test entries) were cleaned up.
+
+## Hook Runtime Verification
+
+Direct wrapper execution validated for:
+- `session-start`
+- `stop`
+- `precompact`
+
+All exited successfully (`exit=0`) after setting executable mode on:
+- `.codex-plugin/hooks/mempal-hook.sh`
+
+## Automated Tests
+
+### Command A
+
+```bash
+uv run pytest -v \
+  tests/test_plugin_feature_parity.py \
+  tests/test_codex_plugin_hook_config.py \
+  tests/test_codex_plugin_hook_wrappers.py \
+  tests/test_hooks_shell.py
+```
+
+Result: **27 passed**
+
+### Command B
+
+```bash
+uv run pytest -v \
+  tests/test_plugin_feature_parity.py \
+  tests/test_codex_plugin_hook_config.py \
+  tests/test_codex_plugin_hook_wrappers.py \
+  tests/test_readme_claims.py::TestToolCount::test_readme_tool_count_matches_code
+```
+
+Result: **25 passed**
+
+## Documentation/Manifest Parity Outcome
+
+- Codex plugin docs/manifests updated from `19` to `30` MCP tools.
+- Claude plugin docs/manifests aligned to the same value for cross-plugin parity.
+- `mempalace instructions help` now advertises the full 30-tool surface.

--- a/mempalace/README.md
+++ b/mempalace/README.md
@@ -16,7 +16,7 @@ The Python package that powers MemPalace. All modules, all logic.
 | `dialect.py` | AAAK compression — entity codes, emotion markers, 30x lossless ratio |
 | `knowledge_graph.py` | Temporal entity-relationship graph — SQLite, time-filtered queries, fact invalidation |
 | `palace_graph.py` | Room-based navigation graph — BFS traversal, tunnel detection across wings |
-| `mcp_server.py` | MCP server — 19 tools, AAAK auto-teach, Palace Protocol, agent diary |
+| `mcp_server.py` | MCP server — 30 tools, AAAK auto-teach, Palace Protocol, agent diary |
 | `onboarding.py` | Guided first-run setup — asks about people/projects, generates AAAK bootstrap + wing config |
 | `entity_registry.py` | Entity code registry — maps names to AAAK codes, handles ambiguous names |
 | `entity_detector.py` | Auto-detect people and projects from file content |

--- a/mempalace/instructions/help.md
+++ b/mempalace/instructions/help.md
@@ -16,7 +16,7 @@ AI memory system. Store everything, find anything. Local, free, no API key.
 
 ---
 
-## MCP Tools (19)
+## MCP Tools (30)
 
 ### Palace (read)
 - mempalace_status -- Palace status and stats
@@ -26,10 +26,14 @@ AI memory system. Store everything, find anything. Local, free, no API key.
 - mempalace_search -- Search memories by query
 - mempalace_check_duplicate -- Check if a memory already exists
 - mempalace_get_aaak_spec -- Get the AAAK specification
+- mempalace_get_drawer -- Fetch one drawer by ID
+- mempalace_list_drawers -- List drawers with pagination and filters
 
 ### Palace (write)
 - mempalace_add_drawer -- Add a new memory (drawer)
+- mempalace_update_drawer -- Update drawer content or metadata
 - mempalace_delete_drawer -- Delete a memory (drawer)
+- mempalace_sync -- Prune drawers whose source files are gone/ignored
 
 ### Knowledge Graph
 - mempalace_kg_query -- Query the knowledge graph
@@ -42,10 +46,19 @@ AI memory system. Store everything, find anything. Local, free, no API key.
 - mempalace_traverse -- Traverse the palace structure
 - mempalace_find_tunnels -- Find cross-wing connections
 - mempalace_graph_stats -- Graph connectivity statistics
+- mempalace_create_tunnel -- Create explicit cross-wing tunnel
+- mempalace_list_tunnels -- List explicit tunnels
+- mempalace_delete_tunnel -- Delete explicit tunnel
+- mempalace_follow_tunnels -- Follow tunnels from a room
 
 ### Agent Diary
 - mempalace_diary_write -- Write a diary entry
 - mempalace_diary_read -- Read diary entries
+
+### System / Runtime
+- mempalace_hook_settings -- Get or set hook behavior
+- mempalace_memories_filed_away -- Check recent checkpoint status
+- mempalace_reconnect -- Reconnect and refresh in-memory indexes
 
 ---
 

--- a/tests/test_codex_plugin_hook_config.py
+++ b/tests/test_codex_plugin_hook_config.py
@@ -1,0 +1,79 @@
+"""Schema tests for Codex plugin hook config."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_CONFIG = REPO_ROOT / ".codex-plugin" / "hooks.json"
+
+# Per-event timeout bounds (seconds): (floor, ceiling).
+# - SessionStart is lightweight and should complete quickly.
+# - Stop may do synchronous diary save before detached mine spawn.
+# - PreCompact runs synchronous mining and needs a longer bound.
+EVENT_TIMEOUT_BOUNDS: dict[str, tuple[int, int]] = {
+    "SessionStart": (5, 30),
+    "Stop": (10, 30),
+    "PreCompact": (60, 90),
+}
+
+
+@pytest.fixture(scope="module")
+def hook_config() -> dict:
+    return json.loads(HOOK_CONFIG.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("event", sorted(EVENT_TIMEOUT_BOUNDS))
+def test_codex_plugin_hook_timeout_within_bounds(hook_config: dict, event: str) -> None:
+    floor, ceiling = EVENT_TIMEOUT_BOUNDS[event]
+    assert event in hook_config.get("hooks", {}), f"missing event {event!r} in hook config"
+    entries = hook_config["hooks"][event]
+    assert isinstance(entries, list) and entries, f"no entries declared for {event}"
+    assert len(entries) == 1, (
+        f"{event} expected exactly one entry, found {len(entries)}; "
+        "duplicate entries would double-fire the hook"
+    )
+    for entry in entries:
+        sub_hooks = entry.get("hooks")
+        assert isinstance(sub_hooks, list) and sub_hooks, (
+            f"{event} entry missing non-empty 'hooks' array"
+        )
+        assert len(sub_hooks) == 1, (
+            f"{event} entry expected exactly one hook command, found {len(sub_hooks)}"
+        )
+        for hook in sub_hooks:
+            assert hook.get("type") == "command", (
+                f"unexpected hook type for {event}: {hook.get('type')!r}"
+            )
+            assert "timeout" in hook, f"{event} hook missing 'timeout' key"
+            timeout = hook["timeout"]
+            is_real_int = isinstance(timeout, int) and not isinstance(timeout, bool)
+            assert is_real_int and floor <= timeout <= ceiling, (
+                f"{event} hook timeout must be an int in [{floor}, {ceiling}]s; got {timeout!r}"
+            )
+
+
+def test_codex_plugin_hook_command_uses_plugin_root_env(hook_config: dict) -> None:
+    """Codex passes PLUGIN_ROOT/CLAUDE_PLUGIN_ROOT for plugin-bundled hooks."""
+    for event, entries in hook_config.get("hooks", {}).items():
+        for entry in entries:
+            for hook in entry.get("hooks", []):
+                if hook.get("type") != "command":
+                    continue
+                command = hook.get("command", "")
+                has_plugin_root = "${PLUGIN_ROOT}" in command or "${CLAUDE_PLUGIN_ROOT}" in command
+                assert has_plugin_root, (
+                    f"{event} command should reference PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT: {command!r}"
+                )
+
+
+def test_codex_plugin_hook_no_unbounded_events(hook_config: dict) -> None:
+    declared_events = set(hook_config.get("hooks", {}).keys())
+    bounded_events = set(EVENT_TIMEOUT_BOUNDS)
+    unbounded = declared_events - bounded_events
+    assert not unbounded, (
+        f"plugin hook events without timeout bounds: {sorted(unbounded)}. "
+        "Add a (floor, ceiling) entry to EVENT_TIMEOUT_BOUNDS in this test "
+        "after deciding the event's acceptable max runtime."
+    )

--- a/tests/test_codex_plugin_hook_wrappers.py
+++ b/tests/test_codex_plugin_hook_wrappers.py
@@ -1,0 +1,187 @@
+"""Execution tests for Codex plugin hook wrapper script."""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_HOOK = REPO_ROOT / ".codex-plugin" / "hooks" / "mempal-hook.sh"
+BASH = shutil.which("bash")
+
+pytestmark = pytest.mark.skipif(
+    BASH is None,
+    reason="bash required for Codex plugin hook wrapper tests",
+)
+
+HOOK_NAMES = ("session-start", "stop", "precompact")
+
+
+def _shell_path(path: Path) -> str:
+    return path.as_posix()
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _make_bin_dir(tmp_path: Path, executables: dict[str, str]) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name, content in executables.items():
+        _write_executable(bin_dir / name, content)
+    return bin_dir
+
+
+def _capture_stdin_to(output_path: Path) -> str:
+    return (
+        'stdin_payload=""\n'
+        'while IFS= read -r line || [ -n "$line" ]; do\n'
+        '  stdin_payload="${stdin_payload}${line}"\n'
+        "done\n"
+        f'printf \'%s\' "$stdin_payload" > "{_shell_path(output_path)}"\n'
+    )
+
+
+def _run_hook(
+    hook_name: str,
+    payload: str,
+    bin_dir: Path,
+) -> subprocess.CompletedProcess[str]:
+    assert BASH is not None
+
+    env = os.environ.copy()
+    env["PATH"] = str(bin_dir)
+
+    return subprocess.run(
+        [BASH, _shell_path(PLUGIN_HOOK), hook_name],
+        input=payload,
+        text=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+
+@pytest.mark.parametrize("hook_name", HOOK_NAMES)
+def test_codex_plugin_hook_wrapper_prefers_mempalace_cli(tmp_path: Path, hook_name: str) -> None:
+    args_file = tmp_path / "args.txt"
+    stdin_file = tmp_path / "stdin.json"
+
+    bin_dir = _make_bin_dir(
+        tmp_path,
+        {
+            "mempalace": (
+                "#!/bin/sh\n"
+                f'printf \'%s\' "$*" > "{_shell_path(args_file)}"\n'
+                f"{_capture_stdin_to(stdin_file)}"
+                "printf '{}\\n'\n"
+            ),
+            "python": "#!/bin/sh\nexit 99\n",
+            "python3": "#!/bin/sh\nexit 99\n",
+        },
+    )
+
+    payload = '{"session_id":"abc123"}'
+    result = _run_hook(hook_name, payload, bin_dir)
+
+    assert result.returncode == 0
+    assert result.stdout == "{}\n"
+    assert (
+        args_file.read_text(encoding="utf-8")
+        == f"hook run --hook {hook_name} --harness codex"
+    )
+    assert stdin_file.read_text(encoding="utf-8") == payload
+
+
+@pytest.mark.parametrize("hook_name", HOOK_NAMES)
+@pytest.mark.parametrize("python_name", ["python3", "python"])
+def test_codex_plugin_hook_wrapper_falls_back_to_importable_python(
+    tmp_path: Path, hook_name: str, python_name: str
+) -> None:
+    args_file = tmp_path / "args.txt"
+    stdin_file = tmp_path / "stdin.json"
+
+    python_stub = (
+        "#!/bin/sh\n"
+        'if [ "$1" = "-c" ]; then\n'
+        "  exit 0\n"
+        "fi\n"
+        f'printf \'%s\' "$*" > "{_shell_path(args_file)}"\n'
+        f"{_capture_stdin_to(stdin_file)}"
+        "printf '{}\\n'\n"
+    )
+    bin_dir = _make_bin_dir(tmp_path, {python_name: python_stub})
+
+    payload = '{"session_id":"xyz789"}'
+    result = _run_hook(hook_name, payload, bin_dir)
+
+    assert result.returncode == 0
+    assert result.stdout == "{}\n"
+    assert (
+        args_file.read_text(encoding="utf-8")
+        == f"-m mempalace hook run --hook {hook_name} --harness codex"
+    )
+    assert stdin_file.read_text(encoding="utf-8") == payload
+
+
+@pytest.mark.parametrize("hook_name", HOOK_NAMES)
+def test_codex_plugin_hook_wrapper_errors_cleanly_when_no_runner_exists(
+    tmp_path: Path, hook_name: str
+) -> None:
+    bin_dir = _make_bin_dir(tmp_path, {})
+
+    payload = '{"session_id":"no-runner"}'
+    result = _run_hook(hook_name, payload, bin_dir)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "could not find a runnable mempalace command or module" in result.stderr
+
+
+@pytest.mark.parametrize("hook_name", HOOK_NAMES)
+def test_codex_plugin_hook_wrapper_falls_back_to_python_when_python3_cannot_import(
+    tmp_path: Path, hook_name: str
+) -> None:
+    args_file = tmp_path / "args.txt"
+    stdin_file = tmp_path / "stdin.json"
+    bad_python3_used = tmp_path / "bad_python3_used.txt"
+
+    bin_dir = _make_bin_dir(
+        tmp_path,
+        {
+            "python3": (
+                "#!/bin/sh\n"
+                'if [ "$1" = "-c" ]; then\n'
+                "  exit 1\n"
+                "fi\n"
+                f"printf 'used' > \"{_shell_path(bad_python3_used)}\"\n"
+                "echo 'No module named mempalace' >&2\n"
+                "exit 1\n"
+            ),
+            "python": (
+                "#!/bin/sh\n"
+                'if [ "$1" = "-c" ]; then\n'
+                "  exit 0\n"
+                "fi\n"
+                f'printf \'%s\' "$*" > "{_shell_path(args_file)}"\n'
+                f"{_capture_stdin_to(stdin_file)}"
+                "printf '{}\\n'\n"
+            ),
+        },
+    )
+
+    payload = '{"session_id":"fallback"}'
+    result = _run_hook(hook_name, payload, bin_dir)
+
+    assert result.returncode == 0
+    assert result.stdout == "{}\n"
+    assert (
+        args_file.read_text(encoding="utf-8")
+        == f"-m mempalace hook run --hook {hook_name} --harness codex"
+    )
+    assert stdin_file.read_text(encoding="utf-8") == payload
+    assert not bad_python3_used.exists()

--- a/tests/test_plugin_feature_parity.py
+++ b/tests/test_plugin_feature_parity.py
@@ -1,0 +1,82 @@
+"""Cross-plugin parity checks for Claude and Codex plugin bundles."""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLAUDE_PLUGIN_DIR = REPO_ROOT / ".claude-plugin"
+CODEX_PLUGIN_DIR = REPO_ROOT / ".codex-plugin"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_mcp_servers(manifest: dict, plugin_dir: Path) -> dict:
+    """Accept either inline map or file path (as documented in Codex build docs)."""
+    source = manifest.get("mcpServers")
+    if isinstance(source, str):
+        mcp = _load_json(plugin_dir / source.removeprefix("./"))
+        if "mcp_servers" in mcp and isinstance(mcp["mcp_servers"], dict):
+            return mcp["mcp_servers"]
+        return mcp
+    if isinstance(source, dict):
+        return source
+    return {}
+
+
+def _hook_event_names(hook_cfg: dict) -> set[str]:
+    hooks = hook_cfg.get("hooks", {})
+    if isinstance(hooks, dict):
+        return set(hooks.keys())
+    return set()
+
+
+def test_plugin_manifests_share_core_identity_fields() -> None:
+    claude_manifest = _load_json(CLAUDE_PLUGIN_DIR / "plugin.json")
+    codex_manifest = _load_json(CODEX_PLUGIN_DIR / "plugin.json")
+
+    for field in ("name", "version", "description", "license", "repository", "keywords"):
+        assert claude_manifest.get(field) == codex_manifest.get(field), (
+            f"manifest field drift for {field!r}: "
+            f"claude={claude_manifest.get(field)!r}, codex={codex_manifest.get(field)!r}"
+        )
+
+    assert claude_manifest.get("author", {}).get("name") == codex_manifest.get("author", {}).get(
+        "name"
+    )
+
+
+def test_plugins_expose_common_workflow_entrypoints() -> None:
+    claude_commands = {p.stem for p in (CLAUDE_PLUGIN_DIR / "commands").glob("*.md")}
+    codex_skills = {p.name for p in (CODEX_PLUGIN_DIR / "skills").iterdir() if p.is_dir()}
+
+    expected = {"help", "init", "mine", "search", "status"}
+    assert expected.issubset(claude_commands), (
+        f"missing claude commands: {sorted(expected - claude_commands)}"
+    )
+    assert expected.issubset(codex_skills), f"missing codex skills: {sorted(expected - codex_skills)}"
+
+    # Keep the Codex bundle's generic umbrella skill in parity with Claude's
+    # single-skill entrypoint style.
+    assert "mempalace" in codex_skills
+
+
+def test_plugins_wire_the_same_mcp_server_command() -> None:
+    claude_manifest = _load_json(CLAUDE_PLUGIN_DIR / "plugin.json")
+    codex_manifest = _load_json(CODEX_PLUGIN_DIR / "plugin.json")
+
+    claude_mcp = _load_mcp_servers(claude_manifest, CLAUDE_PLUGIN_DIR)
+    codex_mcp = _load_mcp_servers(codex_manifest, CODEX_PLUGIN_DIR)
+
+    assert claude_mcp.get("mempalace", {}).get("command") == "mempalace-mcp"
+    assert codex_mcp.get("mempalace", {}).get("command") == "mempalace-mcp"
+
+
+def test_plugins_include_stop_and_precompact_hooks() -> None:
+    claude_hooks = _load_json(CLAUDE_PLUGIN_DIR / "hooks" / "hooks.json")
+    codex_hooks = _load_json(CODEX_PLUGIN_DIR / "hooks.json")
+
+    required = {"Stop", "PreCompact"}
+    assert required.issubset(_hook_event_names(claude_hooks))
+    assert required.issubset(_hook_event_names(codex_hooks))


### PR DESCRIPTION
## Summary
This PR brings the Codex CLI plugin surface to full parity with the Claude plugin and with the current live MCP runtime surface.

Primary outcomes:
- Align plugin manifests/docs/help text from `19` -> `30` MCP tools
- Keep Claude/Codex plugin identity fields in lockstep via parity tests
- Harden Codex hook wrapper execution/fallback behavior and timeout schema coverage
- Add full environment parity evidence document for reproducible validation

Closes #1625

## What changed
- Codex plugin:
  - update tool-count claims in `.codex-plugin/README.md`, `.codex-plugin/plugin.json`, `.codex-plugin/marketplace.json`
  - add/ensure `.codex-plugin/.mcp.json`
  - add umbrella skill `.codex-plugin/skills/mempalace/SKILL.md`
  - harden hook config + wrapper (`.codex-plugin/hooks.json`, `.codex-plugin/hooks/mempal-hook.sh`)
- Claude plugin:
  - align descriptions/tool-count claims to match Codex (`30` tools)
- Instructions/docs:
  - expand `mempalace/instructions/help.md` MCP section to full 30-tool surface
  - align module doc line in `mempalace/README.md`
  - add full live validation report: `docs/codex-cli-parity-test-results.md`
- Tests:
  - `tests/test_plugin_feature_parity.py`
  - `tests/test_codex_plugin_hook_config.py`
  - `tests/test_codex_plugin_hook_wrappers.py`

## Related / partial prior work
Issues:
- #27
- #184
- #295
- #408
- #462

Open PRs with partial overlap/context:
- #325
- #334
- #410
- #670
- #1187
- #1381

Merged prior context:
- #61, #1077, #1231, #1436, #1470, #1562

## Test evidence
Detailed run log is committed in:
- `docs/codex-cli-parity-test-results.md`

Automated tests executed:
```bash
uv run pytest -v tests/test_plugin_feature_parity.py tests/test_codex_plugin_hook_config.py tests/test_codex_plugin_hook_wrappers.py tests/test_hooks_shell.py
# 27 passed

uv run pytest -v tests/test_plugin_feature_parity.py tests/test_codex_plugin_hook_config.py tests/test_codex_plugin_hook_wrappers.py tests/test_readme_claims.py::TestToolCount::test_readme_tool_count_matches_code
# 25 passed
```

Live environment exercise included:
- plugin marketplace + install verification
- full 30-tool MCP live sweep across read/write/KG/navigation/diary/system paths
- cleanup verification for test artifacts
