### PR TITLE
feat(init): configurable init config path + optional empty startup mode

### DIFF
--- a/docs/issue-185-rubber-duck.md
+++ b/docs/issue-185-rubber-duck.md
@@ -1,0 +1,57 @@
+# Issue 185 Rubber Duck Log
+
+Date: 2026-05-26
+Issue: https://github.com/MemPalace/mempalace/issues/185
+
+## One-Sentence Bug Statement
+
+Expected: `mempalace init` should let users control where project config artifacts are written.  
+Actual: `mempalace.yaml` and `entities.json` are written to the project root by default with no init-time location choice.
+
+## Expected vs Actual
+
+- Expected behavior:
+  - Users can keep default project-root behavior, or choose a specific config directory during init.
+  - The resulting config location remains usable by downstream mining/config loading.
+- Actual behavior (current develop):
+  - `mempalace.yaml` is written in project root.
+  - `entities.json` is written in project root when entities are detected.
+  - Git repos get `.gitignore` protection (merged fix for commit-risk), but file location is still fixed to root.
+
+## Assumptions Called Out
+
+1. "Issue #185 is solved because `.gitignore` entries are auto-added."
+   - False: this only mitigates accidental commits; it does not provide location control.
+2. "Moving files would break mining because `load_config()` only reads root."
+   - True in current state unless loader fallback/pointer logic is added.
+3. "Non-interactive init can tolerate new prompts."
+   - False: scriptability must remain stable (`--yes` / explicit flags should avoid new blocking prompts).
+
+## Code-Path Walk (Relevant)
+
+1. `cmd_init()` discovers and confirms entities.
+2. `cmd_init()` writes `entities.json` to `<project>/entities.json`.
+3. `detect_rooms_local()` writes `<project>/mempalace.yaml`.
+4. `load_config()` in `miner.py` currently reads `<project>/mempalace.yaml` (legacy fallback: `mempal.yaml`).
+5. `_ensure_mempalace_files_gitignored()` protects root filenames in git repos.
+
+## Contradiction Found
+
+The system currently assumes project-root config paths in both write and read flows, while the product expectation in #185 is configurable placement. The commit-risk mitigation fixed one symptom, not the root location constraint.
+
+## Root Cause (One Sentence)
+
+Config artifact paths are hardcoded to project-root conventions in init and loader paths, and init has no location-selection interface.
+
+## Enhancement Direction
+
+Add an init-time config-location choice (default vs custom path), persist/resolve that location safely, and ensure loader compatibility via explicit resolution logic.
+
+## Adjacent Startup/Config Issues Reviewed
+
+- #1313 (`--palace` ignored by `init`)  
+  Status in this branch: addressed; `cmd_init` now honors top-level `--palace`.
+- #557 (`init --empty`)  
+  Added in this branch: `mempalace init --empty` for startup wiring without file scanning/entity or room detection.
+- #462 (`setup-hooks` one-step install)  
+  Not folded into this branch: larger installer/UX scope than #185 path control; should remain a dedicated follow-up.

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -42,6 +42,7 @@ from .version import __version__
 
 
 _MEMPALACE_PROJECT_FILES = ("mempalace.yaml", "entities.json")
+_PROJECT_CONFIG_POINTER = Path(".mempalace") / "config_dir.txt"
 
 # Pass 0 corpus-origin sampling caps. Tier 1 reads FULL file content (no
 # front-bias sampling) but bounds total memory on enormous corpora. Tier 2
@@ -199,7 +200,7 @@ def _run_pass_zero(project_dir, palace_dir, llm_provider) -> dict:
     return wrapped
 
 
-def _ensure_mempalace_files_gitignored(project_dir) -> bool:
+def _ensure_mempalace_files_gitignored(project_dir, config_dir=None) -> bool:
     """If project_dir is a git repo, ensure MemPalace's per-project files
     are listed in .gitignore so they don't get committed by accident.
 
@@ -211,12 +212,23 @@ def _ensure_mempalace_files_gitignored(project_dir) -> bool:
     from pathlib import Path
 
     project_path = Path(project_dir).expanduser().resolve()
+    resolved_config_dir = (
+        Path(config_dir).expanduser().resolve() if config_dir else project_path
+    )
     if not (project_path / ".git").exists():
         return False
     gitignore = project_path / ".gitignore"
     existing = gitignore.read_text() if gitignore.exists() else ""
     existing_lines = {line.strip() for line in existing.splitlines()}
-    missing = [p for p in _MEMPALACE_PROJECT_FILES if p not in existing_lines]
+    missing = []
+    for filename in _MEMPALACE_PROJECT_FILES:
+        artifact_path = resolved_config_dir / filename
+        try:
+            rel = artifact_path.relative_to(project_path).as_posix()
+        except ValueError:
+            continue
+        if rel not in existing_lines:
+            missing.append(rel)
     if not missing:
         return False
     prefix = "" if not existing or existing.endswith("\n") else "\n"
@@ -227,12 +239,60 @@ def _ensure_mempalace_files_gitignored(project_dir) -> bool:
     return True
 
 
+def _resolve_init_project_config_dir(args, project_dir: str) -> Path:
+    """Choose where init writes per-project config artifacts."""
+    project_path = Path(project_dir).expanduser().resolve()
+    explicit = getattr(args, "project_config_dir", None)
+    if explicit:
+        selected = Path(explicit).expanduser()
+        if not selected.is_absolute():
+            selected = project_path / selected
+        return selected.resolve()
+
+    if getattr(args, "yes", False):
+        return project_path
+
+    if not sys.stdin.isatty():
+        return project_path
+
+    print("\n  Project config file location")
+    print(f"    1) Default: project root ({project_path})")
+    print("    2) Custom directory")
+    choice = input("  Choose [1/2] (default 1): ").strip().lower()
+    if choice not in {"2", "custom", "c"}:
+        return project_path
+
+    custom = input("  Config directory path (absolute or project-relative): ").strip()
+    if not custom:
+        return project_path
+    selected = Path(custom).expanduser()
+    if not selected.is_absolute():
+        selected = project_path / selected
+    return selected.resolve()
+
+
+def _write_project_config_pointer(project_dir: Path, config_dir: Path) -> None:
+    """Persist non-default config directory so loader paths can resolve it."""
+    pointer_path = project_dir / _PROJECT_CONFIG_POINTER
+    if config_dir == project_dir:
+        if pointer_path.exists():
+            pointer_path.unlink()
+        return
+
+    pointer_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        pointer_value = config_dir.relative_to(project_dir).as_posix()
+    except ValueError:
+        pointer_value = str(config_dir)
+    pointer_path.write_text(pointer_value + "\n", encoding="utf-8")
+
+
 def cmd_init(args):
     import json
     from pathlib import Path
     from .entity_detector import confirm_entities
     from .project_scanner import discover_entities
-    from .room_detector_local import detect_rooms_local
+    from .room_detector_local import detect_rooms_local, save_config
 
     # Honor --palace (issue #1313): without this, init silently ignored the
     # flag and always used ~/.mempalace. Mirror the env-var pattern used by
@@ -242,6 +302,29 @@ def cmd_init(args):
         os.environ["MEMPALACE_PALACE_PATH"] = os.path.abspath(os.path.expanduser(args.palace))
 
     cfg = MempalaceConfig()
+    project_path = Path(args.dir).expanduser().resolve()
+    config_dir = _resolve_init_project_config_dir(args=args, project_dir=args.dir)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    _write_project_config_pointer(project_dir=project_path, config_dir=config_dir)
+
+    # Optional startup mode (issue #557): initialize MemPalace wiring for a
+    # project without scanning files, detecting entities, or creating rooms.
+    # Users can later run `mempalace mine` when they actually want ingest.
+    if bool(getattr(args, "empty", False)):
+        from .config import normalize_wing_name
+
+        wing = normalize_wing_name(project_path.name)
+        print("\n  Empty init requested (--empty): skipping entity and room detection.")
+        save_config(
+            project_dir=args.dir,
+            project_name=wing,
+            rooms=[],
+            config_dir=str(config_dir),
+        )
+        cfg.init()
+        _ensure_mempalace_files_gitignored(args.dir, config_dir=str(config_dir))
+        print(f"  Empty init complete. Run `mempalace mine {shlex.quote(args.dir)}` when ready.")
+        return
 
     # Resolve entity-detection languages: --lang overrides config.
     lang_arg = getattr(args, "lang", None)
@@ -358,8 +441,7 @@ def cmd_init(args):
         # separately so the miner can later compute cross-wing tunnels
         # from shared topics (see palace_graph.compute_topic_tunnels).
         if confirmed["people"] or confirmed["projects"] or confirmed.get("topics"):
-            project_path = Path(args.dir).expanduser().resolve()
-            entities_path = project_path / "entities.json"
+            entities_path = config_dir / "entities.json"
             with open(entities_path, "w", encoding="utf-8") as f:
                 json.dump(confirmed, f, indent=2, ensure_ascii=False)
             print(f"  Entities saved: {entities_path}")
@@ -378,11 +460,15 @@ def cmd_init(args):
         print("  No entities detected — proceeding with directory-based rooms.")
 
     # Pass 2: detect rooms from folder structure
-    detect_rooms_local(project_dir=args.dir, yes=getattr(args, "yes", False))
+    detect_rooms_local(
+        project_dir=args.dir,
+        yes=getattr(args, "yes", False),
+        config_dir=str(config_dir),
+    )
     cfg.init()
 
     # Pass 3: protect git repos from accidentally committing per-project files
-    _ensure_mempalace_files_gitignored(args.dir)
+    _ensure_mempalace_files_gitignored(args.dir, config_dir=str(config_dir))
 
     # Pass 4: offer to run mine immediately. The directory just had its
     # rooms + entities set up, so 99% of users will mine next anyway —
@@ -1224,6 +1310,14 @@ def main():
         ),
     )
     p_init.add_argument(
+        "--empty",
+        action="store_true",
+        help=(
+            "Initialize palace/project config only. Skip entity detection, room "
+            "detection, and post-init mine prompt."
+        ),
+    )
+    p_init.add_argument(
         "--lang",
         default=None,
         help=(
@@ -1286,6 +1380,15 @@ def main():
             "LLM is configured via an environment-variable API key (issue #26). "
             "Use this in CI / non-interactive runs where you've already decided "
             "the external send is acceptable."
+        ),
+    )
+    p_init.add_argument(
+        "--project-config-dir",
+        default=None,
+        help=(
+            "Directory where init writes mempalace.yaml and entities.json. "
+            "Absolute path or path relative to <dir>. If omitted, init prompts "
+            "in interactive mode and defaults to project root in non-interactive mode."
         ),
     )
 

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -258,13 +258,17 @@ def _resolve_init_project_config_dir(args, project_dir: str) -> Path:
     print("\n  Project config file location")
     print(f"    1) Default: project root ({project_path})")
     print("    2) Custom directory")
-    choice = input("  Choose [1/2] (default 1): ").strip().lower()
-    if choice not in {"2", "custom", "c"}:
+    try:
+        choice = input("  Choose [1/2] (default 1): ").strip().lower()
+        if choice not in {"2", "custom", "c"}:
+            return project_path
+        custom = input("  Config directory path (absolute or project-relative): ").strip()
+    except EOFError:
         return project_path
 
-    custom = input("  Config directory path (absolute or project-relative): ").strip()
     if not custom:
         return project_path
+
     selected = Path(custom).expanduser()
     if not selected.is_absolute():
         selected = project_path / selected

--- a/mempalace/instructions/init.md
+++ b/mempalace/instructions/init.md
@@ -55,6 +55,18 @@ before continuing.
 
 Run `mempalace init --yes <dir>` where `<dir>` is the directory from Step 4.
 
+If the user wants project config files (`mempalace.yaml`, `entities.json`) in a
+specific directory, use:
+
+`mempalace init --yes <dir> --project-config-dir <path>`
+
+`<path>` may be absolute or relative to `<dir>`.
+
+If the user wants startup wiring only (no entity/room detection, no ingest
+prompt), use:
+
+`mempalace init --yes --empty <dir>`
+
 If this fails, report the error and stop.
 
 ## Step 6: Configure MCP server

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -365,12 +365,15 @@ def load_config(project_dir: str) -> dict:
 
     pointer_path = resolved_project_dir / ".mempalace" / "config_dir.txt"
     if pointer_path.exists():
-        pointer_value = pointer_path.read_text(encoding="utf-8").strip()
-        if pointer_value:
-            pointer_dir = Path(pointer_value).expanduser()
-            if not pointer_dir.is_absolute():
-                pointer_dir = resolved_project_dir / pointer_dir
-            candidates.insert(0, pointer_dir.resolve() / "mempalace.yaml")
+        try:
+            pointer_value = pointer_path.read_text(encoding="utf-8").strip()
+            if pointer_value:
+                pointer_dir = Path(pointer_value).expanduser()
+                if not pointer_dir.is_absolute():
+                    pointer_dir = resolved_project_dir / pointer_dir
+                candidates.insert(0, pointer_dir.resolve() / "mempalace.yaml")
+        except (OSError, RuntimeError):
+            pass
 
     config_path = next((candidate for candidate in candidates if candidate.exists()), None)
     if config_path is None:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -354,43 +354,60 @@ def is_force_included(path: Path, project_path: Path, include_paths: set) -> boo
 
 
 def load_config(project_dir: str) -> dict:
-    """Load mempalace.yaml from project directory (falls back to mempal.yaml)."""
+    """Load mempalace config with project-pointer and legacy fallbacks."""
     import yaml
 
     resolved_project_dir = Path(project_dir).expanduser().resolve()
-    config_path = resolved_project_dir / "mempalace.yaml"
-    if not config_path.exists():
-        # Fallback to legacy name
-        legacy_path = resolved_project_dir / "mempal.yaml"
-        if legacy_path.exists():
-            config_path = legacy_path
-        else:
-            from .config import normalize_wing_name
+    candidates = [
+        resolved_project_dir / "mempalace.yaml",
+        resolved_project_dir / ".mempalace" / "mempalace.yaml",
+    ]
 
-            # Normalize the dirname-derived fallback wing the same way
-            # ``cmd_init`` and ``room_detector_local`` do — otherwise a
-            # hyphenated project mined without a yaml file lands under a
-            # raw-name wing while ``topics_by_wing`` was keyed under the
-            # normalized slug, silently dropping every topic tunnel
-            # (the no-yaml branch of issue #1194).
-            wing_name = normalize_wing_name(resolved_project_dir.name)
-            print(
-                f"  No mempalace.yaml found in {resolved_project_dir} "
-                f"— using auto-detected defaults (wing='{wing_name}'). "
-                "Directories with the same basename will share a wing; "
-                "add mempalace.yaml to disambiguate.",
-                file=sys.stderr,
-            )
-            return {
-                "wing": wing_name,
-                "rooms": [
-                    {
-                        "name": "general",
-                        "description": "All project files",
-                        "keywords": ["general"],
-                    }
-                ],
-            }
+    pointer_path = resolved_project_dir / ".mempalace" / "config_dir.txt"
+    if pointer_path.exists():
+        pointer_value = pointer_path.read_text(encoding="utf-8").strip()
+        if pointer_value:
+            pointer_dir = Path(pointer_value).expanduser()
+            if not pointer_dir.is_absolute():
+                pointer_dir = resolved_project_dir / pointer_dir
+            candidates.insert(0, pointer_dir.resolve() / "mempalace.yaml")
+
+    config_path = next((candidate for candidate in candidates if candidate.exists()), None)
+    if config_path is None:
+        # Fallback to legacy names
+        legacy_candidates = [
+            resolved_project_dir / "mempal.yaml",
+            resolved_project_dir / ".mempalace" / "mempal.yaml",
+        ]
+        config_path = next((candidate for candidate in legacy_candidates if candidate.exists()), None)
+
+    if config_path is None:
+        from .config import normalize_wing_name
+
+        # Normalize the dirname-derived fallback wing the same way
+        # ``cmd_init`` and ``room_detector_local`` do — otherwise a
+        # hyphenated project mined without a yaml file lands under a
+        # raw-name wing while ``topics_by_wing`` was keyed under the
+        # normalized slug, silently dropping every topic tunnel
+        # (the no-yaml branch of issue #1194).
+        wing_name = normalize_wing_name(resolved_project_dir.name)
+        print(
+            f"  No mempalace.yaml found in {resolved_project_dir} "
+            f"— using auto-detected defaults (wing='{wing_name}'). "
+            "Directories with the same basename will share a wing; "
+            "add mempalace.yaml to disambiguate.",
+            file=sys.stderr,
+        )
+        return {
+            "wing": wing_name,
+            "rooms": [
+                {
+                    "name": "general",
+                    "description": "All project files",
+                    "keywords": ["general"],
+                }
+            ],
+        }
     with open(config_path) as f:
         return yaml.safe_load(f)
 

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -291,10 +291,13 @@ def save_config(project_dir: str, project_name: str, rooms: list, config_dir: st
             for r in rooms
         ],
     }
-    config_root = Path(config_dir).expanduser().resolve() if config_dir else Path(project_dir).expanduser().resolve()
+    if config_dir:
+        config_root = Path(config_dir).expanduser().resolve()
+    else:
+        config_root = Path(project_dir).expanduser().resolve()
     config_root.mkdir(parents=True, exist_ok=True)
     config_path = config_root / "mempalace.yaml"
-    with open(config_path, "w") as f:
+    with open(config_path, "w", encoding="utf-8") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
 
     print(f"\n  Config saved: {config_path}")

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -279,7 +279,7 @@ def get_user_approval(rooms: list) -> list:
     return rooms
 
 
-def save_config(project_dir: str, project_name: str, rooms: list):
+def save_config(project_dir: str, project_name: str, rooms: list, config_dir: str = None):
     config = {
         "wing": project_name,
         "rooms": [
@@ -291,7 +291,9 @@ def save_config(project_dir: str, project_name: str, rooms: list):
             for r in rooms
         ],
     }
-    config_path = Path(project_dir).expanduser().resolve() / "mempalace.yaml"
+    config_root = Path(config_dir).expanduser().resolve() if config_dir else Path(project_dir).expanduser().resolve()
+    config_root.mkdir(parents=True, exist_ok=True)
+    config_path = config_root / "mempalace.yaml"
     with open(config_path, "w") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
 
@@ -301,7 +303,7 @@ def save_config(project_dir: str, project_name: str, rooms: list):
     print(f"\n{'=' * 55}\n")
 
 
-def detect_rooms_local(project_dir: str, yes: bool = False):
+def detect_rooms_local(project_dir: str, yes: bool = False, config_dir: str = None):
     """Main entry point for local setup."""
     from .config import normalize_wing_name
 
@@ -336,4 +338,4 @@ def detect_rooms_local(project_dir: str, yes: bool = False):
         approved_rooms = rooms
     else:
         approved_rooms = get_user_approval(rooms)
-    save_config(project_dir, project_name, approved_rooms)
+    save_config(project_dir, project_name, approved_rooms, config_dir=config_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,7 +177,11 @@ def test_cmd_init_no_entities(mock_config_cls, tmp_path):
         patch("mempalace.cli._maybe_run_mine_after_init"),
     ):
         cmd_init(args)
-        mock_rooms.assert_called_once_with(project_dir=str(tmp_path), yes=True)
+        mock_rooms.assert_called_once_with(
+            project_dir=str(tmp_path),
+            yes=True,
+            config_dir=str(tmp_path),
+        )
         mock_config_cls.return_value.init.assert_called_once()
 
 

--- a/tests/test_init_config_path_option.py
+++ b/tests/test_init_config_path_option.py
@@ -50,6 +50,19 @@ def test_resolve_init_project_config_dir_prompts_for_custom_path(tmp_path):
     assert resolved == (project / ".mempalace" / "config").resolve()
 
 
+def test_resolve_init_project_config_dir_eof_falls_back_to_project_root(tmp_path):
+    from mempalace.cli import _resolve_init_project_config_dir
+
+    project = tmp_path / "project"
+    project.mkdir()
+    args = _base_args(project, yes=False, project_config_dir=None)
+
+    with patch("sys.stdin.isatty", return_value=True), patch("builtins.input", side_effect=EOFError):
+        resolved = _resolve_init_project_config_dir(args=args, project_dir=str(project))
+
+    assert resolved == project.resolve()
+
+
 def test_cmd_init_writes_entities_to_selected_config_dir_and_passes_room_target(tmp_path):
     from mempalace.cli import cmd_init
 

--- a/tests/test_init_config_path_option.py
+++ b/tests/test_init_config_path_option.py
@@ -1,0 +1,135 @@
+"""TDD coverage for issue #185 enhancement: configurable init config path."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mempalace.miner import load_config
+
+
+def _base_args(project_dir: Path, **overrides):
+    args = argparse.Namespace(
+        dir=str(project_dir),
+        yes=True,
+        auto_mine=False,
+        empty=False,
+        no_llm=True,
+        project_config_dir=None,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def test_resolve_init_project_config_dir_defaults_to_project_root_when_yes(tmp_path):
+    from mempalace.cli import _resolve_init_project_config_dir
+
+    project = tmp_path / "project"
+    project.mkdir()
+    args = _base_args(project, yes=True, project_config_dir=None)
+
+    resolved = _resolve_init_project_config_dir(args=args, project_dir=str(project))
+    assert resolved == project.resolve()
+
+
+def test_resolve_init_project_config_dir_prompts_for_custom_path(tmp_path):
+    from mempalace.cli import _resolve_init_project_config_dir
+
+    project = tmp_path / "project"
+    project.mkdir()
+    args = _base_args(project, yes=False, project_config_dir=None)
+
+    with (
+        patch("sys.stdin.isatty", return_value=True),
+        patch("builtins.input", side_effect=["2", ".mempalace/config"]),
+    ):
+        resolved = _resolve_init_project_config_dir(args=args, project_dir=str(project))
+
+    assert resolved == (project / ".mempalace" / "config").resolve()
+
+
+def test_cmd_init_writes_entities_to_selected_config_dir_and_passes_room_target(tmp_path):
+    from mempalace.cli import cmd_init
+
+    project = tmp_path / "my-project"
+    project.mkdir()
+    (project / "README.md").write_text("hello", encoding="utf-8")
+    args = _base_args(project, project_config_dir=".mempalace/config")
+    expected_dir = (project / ".mempalace" / "config").resolve()
+
+    detected = {"people": ["Alice"], "projects": [], "topics": [], "uncertain": []}
+    confirmed = {"people": ["Alice"], "projects": [], "topics": []}
+
+    with (
+        patch("mempalace.cli.MempalaceConfig") as mock_cfg_cls,
+        patch("mempalace.cli._run_pass_zero", return_value=None),
+        patch("mempalace.project_scanner.discover_entities", return_value=detected),
+        patch("mempalace.entity_detector.confirm_entities", return_value=confirmed),
+        patch("mempalace.miner.add_to_known_entities", return_value=str(tmp_path / "registry.json")),
+        patch("mempalace.room_detector_local.detect_rooms_local") as mock_rooms,
+        patch("mempalace.cli._maybe_run_mine_after_init"),
+    ):
+        cfg = MagicMock()
+        cfg.palace_path = str(tmp_path / "palace")
+        mock_cfg_cls.return_value = cfg
+        cmd_init(args)
+
+    assert (expected_dir / "entities.json").exists()
+    assert not (project / "entities.json").exists()
+    pointer = project / ".mempalace" / "config_dir.txt"
+    assert pointer.exists()
+    mock_rooms.assert_called_once_with(
+        project_dir=str(project),
+        yes=True,
+        config_dir=str(expected_dir),
+    )
+
+
+def test_load_config_uses_project_config_pointer_file(tmp_path):
+    project = tmp_path / "proj"
+    config_dir = project / ".mempalace" / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "mempalace.yaml").write_text("wing: pointer_wing\nrooms: []\n", encoding="utf-8")
+
+    marker_dir = project / ".mempalace"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    (marker_dir / "config_dir.txt").write_text(".mempalace/config\n", encoding="utf-8")
+
+    loaded = load_config(str(project))
+    assert loaded["wing"] == "pointer_wing"
+
+
+def test_cmd_init_empty_skips_detection_and_mine(tmp_path):
+    from mempalace.cli import cmd_init
+
+    project = tmp_path / "empty-project"
+    project.mkdir()
+    args = _base_args(project, empty=True, project_config_dir=".mempalace/config")
+    expected_dir = (project / ".mempalace" / "config").resolve()
+
+    with (
+        patch("mempalace.cli.MempalaceConfig") as mock_cfg_cls,
+        patch("mempalace.cli._run_pass_zero") as mock_pass_zero,
+        patch("mempalace.project_scanner.discover_entities") as mock_discover,
+        patch("mempalace.room_detector_local.detect_rooms_local") as mock_detect_rooms,
+        patch("mempalace.room_detector_local.save_config") as mock_save_config,
+        patch("mempalace.cli._maybe_run_mine_after_init") as mock_after_init_mine,
+    ):
+        cfg = MagicMock()
+        cfg.palace_path = str(tmp_path / "palace")
+        mock_cfg_cls.return_value = cfg
+        cmd_init(args)
+
+    mock_pass_zero.assert_not_called()
+    mock_discover.assert_not_called()
+    mock_detect_rooms.assert_not_called()
+    mock_after_init_mine.assert_not_called()
+    mock_save_config.assert_called_once_with(
+        project_dir=str(project),
+        project_name="empty_project",
+        rooms=[],
+        config_dir=str(expected_dir),
+    )
+    assert (project / ".mempalace" / "config_dir.txt").exists()

--- a/tests/test_init_gitignore_protection.py
+++ b/tests/test_init_gitignore_protection.py
@@ -60,3 +60,13 @@ def test_handles_gitignore_without_trailing_newline(tmp_path):
     assert "dist\n" in contents
     assert "mempalace.yaml" in contents
     assert "entities.json" in contents
+
+
+def test_custom_config_dir_adds_relative_paths(tmp_path):
+    _git_init(tmp_path)
+    cfg_dir = tmp_path / ".mempalace" / "config"
+    cfg_dir.mkdir(parents=True)
+    assert _ensure_mempalace_files_gitignored(tmp_path, config_dir=cfg_dir) is True
+    contents = (tmp_path / ".gitignore").read_text()
+    assert ".mempalace/config/mempalace.yaml" in contents
+    assert ".mempalace/config/entities.json" in contents

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -280,6 +280,19 @@ def test_load_config_no_yaml_normalizes_hyphenated_wing():
         shutil.rmtree(parent)
 
 
+def test_load_config_pointer_read_error_falls_back_to_project_yaml(tmp_path):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / "mempalace.yaml").write_text("wing: root_wing\nrooms: []\n", encoding="utf-8")
+    marker_dir = project_root / ".mempalace"
+    marker_dir.mkdir()
+    # Directory at pointer path forces pointer read_text() to raise IsADirectoryError.
+    (marker_dir / "config_dir.txt").mkdir()
+
+    config = load_config(str(project_root))
+    assert config["wing"] == "root_wing"
+
+
 def test_scan_project_skips_mempalace_generated_files():
     with tempfile.TemporaryDirectory() as tmpdir:
         project_root = Path(tmpdir).resolve()

--- a/tests/test_room_detector_local.py
+++ b/tests/test_room_detector_local.py
@@ -238,6 +238,16 @@ def test_save_config_valid_yaml(tmp_path):
     assert data["rooms"][0]["name"] == "general"
 
 
+def test_save_config_writes_utf8(tmp_path):
+    import yaml
+
+    rooms = [{"name": "général", "description": "All files", "keywords": []}]
+    save_config(str(tmp_path), "test_proj", rooms)
+    config_file = tmp_path / "mempalace.yaml"
+    data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+    assert data["rooms"][0]["name"] == "général"
+
+
 # ── print_proposed_structure ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

This PR extends the issue-185 fix so `mempalace init` supports configurable startup behavior instead of fixed project-root artifact writes.

What is included:
- Add `--project-config-dir` to `mempalace init`.
- Add interactive init-time choice for config artifact location (default project root vs custom directory) when no explicit flag is passed.
- Persist non-default config location via `.mempalace/config_dir.txt` pointer.
- Update config load path resolution to honor the pointer with backward-compatible fallbacks.
- Ensure `.gitignore` protection writes correct relative entries for non-root config locations.
- Add `--empty` init mode to initialize project/palace wiring without entity detection, room detection, or post-init mine prompt.

## Related Issues

- Refs #185 (config artifacts in project root with no location control)
- Refs #557 (`init --empty` request)
- Refs #462 (setup-hooks request reviewed; intentionally deferred from this PR)
- Regression context: #1313 (`--palace` behavior remains covered)

## Why #462 is not in this PR

`setup-hooks` is a larger install/UX workflow and should remain a dedicated change. This PR stays scoped to init startup/config path behavior.

## Test Evidence

Executed locally in the issue worktree branch:

```bash
uv run pytest tests/test_init_config_path_option.py tests/test_init_gitignore_protection.py
# 11 passed

uv run pytest tests/test_cli.py -k "cmd_init or init_project_config or maybe_run_mine_after_init"
# 9 passed

uv run pytest tests/test_miner.py -k "load_config or no_yaml"
# 2 passed

uv run ruff check mempalace/cli.py tests/test_init_config_path_option.py
# All checks passed
```

## Checklist

- [x] Adds init-time configurable project config path
- [x] Preserves backward compatibility for existing `mempalace.yaml` layouts
- [x] Adds/updates focused tests for new behavior
- [x] Documents the new init options in `mempalace/instructions/init.md`
- [x] Keeps #462 out-of-scope intentionally (documented above)
