### PR TITLE
fix(ingest): make all 4 miners additive — verbatim history never destroyed (#1593, #1580)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -773,7 +773,13 @@ def cmd_delete(args):
         return
 
     if not args.force:
-        confirm = input(f"  Destroy {len(affected_ids)} drawer(s)? [y/N]: ").strip().lower()
+        # ``input()`` raises EOFError in non-TTY environments (CI pipelines,
+        # piped invocations). Treat that as a "no" — destruction is opt-in,
+        # so the safe default when we can't ask is to abort.
+        try:
+            confirm = input(f"  Destroy {len(affected_ids)} drawer(s)? [y/N]: ").strip().lower()
+        except EOFError:
+            confirm = "n"
         if confirm != "y":
             print("  Aborted. No drawers were destroyed.")
             return
@@ -845,7 +851,10 @@ def cmd_show(args):
 
     layers = sorted(
         zip(result["ids"], result["documents"], result["metadatas"]),
-        key=lambda triple: (triple[2] or {}).get("filed_at", ""),
+        # ``or ""`` guards against an explicit ``filed_at: None`` in metadata
+        # (which would crash sort with TypeError: '>' not supported between
+        # str and NoneType). Returns "" for both missing AND None.
+        key=lambda triple: (triple[2] or {}).get("filed_at") or "",
         reverse=True,  # latest first
     )
     total = len(layers)
@@ -874,7 +883,10 @@ def cmd_show(args):
         try:
             requested_int = int(requested)
             if requested_int < 1 or requested_int > total:
-                print(f"  ERROR: layer {requested_int} out of range (stack has {total} layers).")
+                print(
+                    f"  ERROR: layer {requested_int} out of range (stack has {total} layers).",
+                    file=sys.stderr,
+                )
                 sys.exit(2)
             idx = requested_int - 1
         except ValueError:

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -709,6 +709,202 @@ def cmd_search(args):
         sys.exit(1)
 
 
+def cmd_delete(args):
+    """The SOLE destruction path: removes drawers by drawer_id, stack_id,
+    or parent_drawer_id. Re-mining never destroys; only this verb does.
+
+    The identifier prefix selects the scope:
+        ``drawer_*``  one specific layer (one ChromaDB row)
+        ``stack_*``   every layer of one logical chunk position (all versions)
+        ``parent_*``  every chunk from one mining pass
+
+    Default behavior prompts for confirmation; ``--force`` skips the prompt;
+    ``--dry-run`` shows what would be removed without removing anything.
+    """
+    from .backends import CollectionNotInitializedError, PalaceNotFoundError
+    from .palace import get_collection
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+
+    identifier = args.identifier
+    if identifier.startswith("drawer_"):
+        scope_field = None  # delete by exact ID
+        where = None
+    elif identifier.startswith("stack_"):
+        scope_field = "stack_id"
+        where = {"stack_id": identifier}
+    elif identifier.startswith("parent_"):
+        scope_field = "parent_drawer_id"
+        where = {"parent_drawer_id": identifier}
+    else:
+        print(
+            f"  ERROR: identifier '{identifier}' has no recognized prefix.\n"
+            "  Expected one of: drawer_*, stack_*, parent_*",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    try:
+        col = get_collection(palace_path, create=False)
+    except (CollectionNotInitializedError, PalaceNotFoundError) as exc:
+        print(f"  ERROR: cannot open palace at {palace_path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    # Resolve which IDs will be affected — show them before destruction.
+    if scope_field is None:
+        existing = col.get(ids=[identifier], include=["metadatas"])
+    else:
+        existing = col.get(where=where, include=["metadatas"])
+    affected_ids = existing["ids"] if existing and existing.get("ids") else []
+
+    if not affected_ids:
+        print(f"  No drawers found for {identifier}.")
+        return
+
+    print(f"\n  Drawers matching {identifier}: {len(affected_ids)}")
+    for did in affected_ids[:10]:
+        print(f"    - {did}")
+    if len(affected_ids) > 10:
+        print(f"    ... and {len(affected_ids) - 10} more")
+    print()
+
+    if args.dry_run:
+        print("  [DRY RUN] No drawers were destroyed.")
+        return
+
+    if not args.force:
+        confirm = input(f"  Destroy {len(affected_ids)} drawer(s)? [y/N]: ").strip().lower()
+        if confirm != "y":
+            print("  Aborted. No drawers were destroyed.")
+            return
+
+    col.delete(ids=affected_ids)
+    print(f"  Destroyed {len(affected_ids)} drawer(s) for {identifier}.")
+
+
+def cmd_show(args):
+    """Display a drawer or a stack of layers.
+
+    ``mempalace show <drawer_id>`` renders one specific layer.
+    ``mempalace show <stack_id>`` renders the latest layer of the stack
+    with a ``[layer N of M]`` indicator and prev/next navigation hints.
+
+    Flags:
+        ``--layer older``  jump to the layer immediately older than current
+        ``--layer newer``  jump to the layer immediately newer than current
+        ``--layer N``      jump to specific layer number (1-indexed; 1 = latest)
+        ``--all-layers``   flatten and display every layer in the stack
+    """
+    from .backends import CollectionNotInitializedError, PalaceNotFoundError
+    from .palace import get_collection
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+
+    identifier = args.identifier
+    if identifier.startswith("drawer_"):
+        # Single layer — show that row.
+        try:
+            col = get_collection(palace_path, create=False)
+        except (CollectionNotInitializedError, PalaceNotFoundError) as exc:
+            print(f"  ERROR: cannot open palace at {palace_path}: {exc}", file=sys.stderr)
+            sys.exit(2)
+        result = col.get(ids=[identifier], include=["documents", "metadatas"])
+        if not result or not result.get("ids"):
+            print(f"  No drawer found for {identifier}.")
+            sys.exit(1)
+        meta = result["metadatas"][0] or {}
+        doc = result["documents"][0] or ""
+        wing = meta.get("wing", "?")
+        room = meta.get("room", "?")
+        filed_at = meta.get("filed_at", "?")
+        print(f"\n  Drawer: {identifier}")
+        print(f"  {wing} / {room}  ingested {filed_at}")
+        print(f"  {'─' * 56}")
+        for line in doc.split("\n"):
+            print(f"  {line}")
+        return
+
+    if not identifier.startswith("stack_"):
+        print(
+            f"  ERROR: identifier '{identifier}' has no recognized prefix.\n"
+            "  Expected one of: drawer_*, stack_*",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # Stack — gather all layers, sort latest-first.
+    try:
+        col = get_collection(palace_path, create=False)
+    except (CollectionNotInitializedError, PalaceNotFoundError) as exc:
+        print(f"  ERROR: cannot open palace at {palace_path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+    result = col.get(where={"stack_id": identifier}, include=["documents", "metadatas"])
+    if not result or not result.get("ids"):
+        print(f"  No stack found for {identifier}.")
+        sys.exit(1)
+
+    layers = sorted(
+        zip(result["ids"], result["documents"], result["metadatas"]),
+        key=lambda triple: (triple[2] or {}).get("filed_at", ""),
+        reverse=True,  # latest first
+    )
+    total = len(layers)
+
+    if args.all_layers:
+        print(f"\n  Stack: {identifier}  ({total} layer{'s' if total != 1 else ''})")
+        for idx, (did, doc, meta) in enumerate(layers, 1):
+            print(f"  {'═' * 56}")
+            filed_at = (meta or {}).get("filed_at", "?")
+            print(f"  ─── Layer {idx} of {total} ({filed_at}) ───")
+            for line in (doc or "").split("\n"):
+                print(f"  {line}")
+        return
+
+    # Resolve which layer to show.
+    requested = args.layer or "latest"
+    if requested in ("latest", "newest"):
+        idx = 0
+    elif requested == "oldest":
+        idx = total - 1
+    elif requested in ("older", "prev", "previous"):
+        idx = 1 if total > 1 else 0
+    elif requested in ("newer", "next"):
+        idx = 0  # already latest; no "newer than latest"
+    else:
+        try:
+            requested_int = int(requested)
+            if requested_int < 1 or requested_int > total:
+                print(f"  ERROR: layer {requested_int} out of range (stack has {total} layers).")
+                sys.exit(2)
+            idx = requested_int - 1
+        except ValueError:
+            print(
+                f"  ERROR: --layer must be 'older'/'newer'/'latest'/'oldest' or a "
+                f"1-indexed number; got {requested!r}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    did, doc, meta = layers[idx]
+    meta = meta or {}
+    filed_at = meta.get("filed_at", "?")
+    wing = meta.get("wing", "?")
+    room = meta.get("room", "?")
+    print(f"\n  Stack: {identifier}  [layer {idx + 1} of {total}]")
+    print(f"  {wing} / {room}  ingested {filed_at}")
+    print(f"  {'─' * 56}")
+    for line in (doc or "").split("\n"):
+        print(f"  {line}")
+    print(f"  {'─' * 56}")
+    if total > 1:
+        if idx > 0:
+            newer_filed = (layers[idx - 1][2] or {}).get("filed_at", "?")
+            print(f"  ▲ newer:  --layer newer  ({newer_filed})")
+        if idx < total - 1:
+            older_filed = (layers[idx + 1][2] or {}).get("filed_at", "?")
+            print(f"  ▼ older:  --layer older  ({older_filed})")
+
+
 def cmd_wakeup(args):
     """Show L0 (identity) + L1 (essential story) — the wake-up context."""
     from .layers import MemoryStack
@@ -1577,6 +1773,47 @@ def main():
 
     sub.add_parser("status", help="Show what's been filed")
 
+    # delete — the SOLE destruction path. Mining is purely additive; this verb
+    # is the only way drawers are ever removed from the palace.
+    p_delete = sub.add_parser(
+        "delete",
+        help="Destroy drawer(s) by drawer_id / stack_id / parent_drawer_id (sole destruction path)",
+    )
+    p_delete.add_argument(
+        "identifier",
+        help="ID of what to destroy. Prefix selects scope: drawer_* = one layer, stack_* = all layers of one chunk, parent_* = all chunks from one mining pass",
+    )
+    p_delete.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be destroyed without destroying anything",
+    )
+    p_delete.add_argument(
+        "--force",
+        action="store_true",
+        help="Skip the y/N confirmation prompt",
+    )
+
+    # show — render a drawer or a stack of layers with vertical navigation.
+    p_show = sub.add_parser(
+        "show",
+        help="Display a drawer (drawer_*) or a stack of layers (stack_*)",
+    )
+    p_show.add_argument(
+        "identifier",
+        help="ID of what to display. Prefix selects scope: drawer_* = one layer, stack_* = stack with layer navigation",
+    )
+    p_show.add_argument(
+        "--layer",
+        default=None,
+        help="Which layer of a stack to display: 'older' / 'newer' / 'latest' / 'oldest' / 1-indexed number (1 = latest)",
+    )
+    p_show.add_argument(
+        "--all-layers",
+        action="store_true",
+        help="Flatten the stack and display every layer top-down",
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -1614,6 +1851,8 @@ def main():
         "repair-status": cmd_repair_status,
         "migrate": cmd_migrate,
         "status": cmd_status,
+        "delete": cmd_delete,
+        "show": cmd_show,
     }
     dispatch[args.command](args)
 

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -25,6 +25,7 @@ from .palace import (
     _validate_palace_fts5_after_mine,
     file_already_mined,
     get_collection,
+    make_id,
     mine_lock,
     mine_palace_lock,
     prefetch_mined_set,
@@ -409,8 +410,12 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
         # Batch chunks into bounded upserts so large transcripts keep most of
         # the embedding speedup without one huge Chroma/SQLite request. Keep
         # one filed_at per source file so all transcript drawers share an
-        # ingest timestamp.
+        # ingest timestamp. ``filed_at`` participates in the drawer_id hash
+        # so re-mining is additive (per-version layers) instead of
+        # silently overwriting via the upsert path.
         filed_at = datetime.now().isoformat()
+        # ``parent_drawer_id`` is per-mining-pass — searcher scope key.
+        parent_drawer_id = make_id("parent_", wing, source_file, extract_mode, filed_at)
         for batch_start in range(0, len(chunks), DRAWER_UPSERT_BATCH_SIZE):
             batch_docs: list = []
             batch_ids: list = []
@@ -419,11 +424,12 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                 chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
                 if extract_mode == "general":
                     room_counts_delta[chunk_room] += 1
-                drawer_key = f"{source_file}:{extract_mode}:{chunk['chunk_index']}"
+                drawer_key = f"{source_file}:{extract_mode}:{chunk['chunk_index']}:{filed_at}"
                 drawer_id = (
                     f"drawer_{wing}_{chunk_room}_"
                     f"{hashlib.sha256(drawer_key.encode()).hexdigest()[:24]}"
                 )
+                stack_id = make_id("stack_", source_file, extract_mode, chunk["chunk_index"])
                 batch_docs.append(chunk["content"])
                 batch_ids.append(drawer_id)
                 batch_metas.append(
@@ -438,6 +444,9 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                         "ingest_mode": "convos",
                         "extract_mode": extract_mode,
                         "normalize_version": NORMALIZE_VERSION,
+                        "parent_drawer_id": parent_drawer_id,
+                        "stack_id": stack_id,
+                        "superseded_at": None,
                     }
                 )
             try:

--- a/mempalace/diary_ingest.py
+++ b/mempalace/diary_ingest.py
@@ -23,6 +23,7 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 from .config import MempalaceConfig
 from .miner import _extract_entities_for_metadata
@@ -30,6 +31,7 @@ from .palace import (
     build_closet_lines,
     get_closets_collection,
     get_collection,
+    make_id,
     mine_lock,
     purge_file_closets,
     upsert_closet_lines,
@@ -77,19 +79,32 @@ def _diary_drawer_id(wing: str, date_str: str) -> str:
     return f"drawer_diary_{suffix}"
 
 
-def _diary_drawer_id_entry(wing: str, date_str: str, entry_idx: int, entry_chunk_idx: int) -> str:
-    """Per-entry, per-chunk drawer ID introduced in #1539.
+def _diary_drawer_id_entry(
+    wing: str,
+    date_str: str,
+    entry_idx: int,
+    entry_chunk_idx: int,
+    filed_at: Optional[str] = None,
+) -> str:
+    """Per-entry, per-chunk drawer ID, version-stamped by ``filed_at``.
 
-    The ``v2_`` prefix distinguishes new IDs from the legacy file-level
-    scheme (one drawer per file). Legacy drawers from pre-#1539 palaces
-    are auto-purged on any ``ingest_diaries`` call that triggers a full
-    rebuild (``force=True`` or detected content change). The per-source
-    ``delete(where=...)`` step on full rebuild collects both legacy and
-    stale v2 drawers via the ``source_file`` metadata key, so the
-    schema migration runs as a side effect of normal use.
+    The ``v2_`` prefix distinguishes these IDs from the legacy file-level
+    scheme (one drawer per file). ``filed_at`` participates in the hash so
+    each ingest pass produces unique IDs — re-ingesting an edited diary
+    INSERTS new layers alongside the prior versions instead of overwriting
+    them. The only path to drawer destruction is the explicit
+    ``ingest_diaries(..., force=True)`` invocation (which today also runs
+    the legacy schema migration via per-source delete).
+
+    ``filed_at`` defaults to ``None`` for callers that don't yet pass
+    it (legacy / migration paths); ``None`` participates in the hash as
+    an empty string so legacy IDs remain stable. Production ingest
+    passes the per-day ``now_iso`` so all chunks of one day's ingest
+    share a stamp.
     """
+    filed_at_part = filed_at if filed_at is not None else ""
     suffix = hashlib.sha256(
-        f"{wing}|{date_str}|{entry_idx}|{entry_chunk_idx}".encode()
+        f"{wing}|{date_str}|{entry_idx}|{entry_chunk_idx}|{filed_at_part}".encode()
     ).hexdigest()[:24]
     return f"drawer_diary_v2_{suffix}"
 
@@ -180,8 +195,21 @@ def ingest_diaries(
         with mine_lock(source_file):
             entries = _split_entries(text)
             prev_entry_count = state.get(state_key, {}).get("entry_count", 0)
-            full_rebuild = force or content_changed
+            # Re-ingestion is additive: ``full_rebuild`` (which fires the
+            # destructive delete below) only triggers on explicit
+            # ``force=True``. When the file content has changed but force
+            # is not set, ``reprocess_all`` causes every entry to be
+            # re-ingested as NEW drawers (version-stamped via filed_at)
+            # alongside the prior versions — preserves edit history rather
+            # than destroying it.
+            full_rebuild = force
+            reprocess_all = force or content_changed
 
+            # ``parent_drawer_id`` is per-day-per-ingest-pass (groups every
+            # entry-chunk of one day's ingest for searcher scope, closes
+            # #1580). ``stack_id`` and ``superseded_at`` are attached per
+            # entry-chunk below since they vary by (entry_idx, chunk_idx).
+            parent_drawer_id = make_id("parent_diary_", wing, date_str, now_iso)
             base_meta = {
                 "date": date_str,
                 "wing": wing,
@@ -189,6 +217,8 @@ def ingest_diaries(
                 "source_file": source_file,
                 "source_session": "daily_diary",
                 "filed_at": now_iso,
+                "parent_drawer_id": parent_drawer_id,
+                "superseded_at": None,
             }
             if entities:
                 base_meta["entities"] = entities
@@ -240,8 +270,9 @@ def ingest_diaries(
             for entry_idx, (header, body) in enumerate(entries):
                 entry_text = f"{header}\n{body}" if body else header
                 if len(entry_text) <= chunk_size:
-                    batch_ids.append(_diary_drawer_id_entry(wing, date_str, entry_idx, 0))
+                    batch_ids.append(_diary_drawer_id_entry(wing, date_str, entry_idx, 0, now_iso))
                     batch_docs.append(entry_text)
+                    entry_stack_id = make_id("stack_diary_", wing, date_str, entry_idx, 0)
                     batch_metas.append(
                         {
                             **base_meta,
@@ -249,15 +280,21 @@ def ingest_diaries(
                             "entry_index": entry_idx,
                             "entry_chunk_index": 0,
                             "entry_header_preview": header[:120],
+                            "stack_id": entry_stack_id,
                         }
                     )
                     global_chunk_index += 1
                 else:
                     for entry_chunk_idx, start in enumerate(range(0, len(entry_text), chunk_size)):
                         batch_ids.append(
-                            _diary_drawer_id_entry(wing, date_str, entry_idx, entry_chunk_idx)
+                            _diary_drawer_id_entry(
+                                wing, date_str, entry_idx, entry_chunk_idx, now_iso
+                            )
                         )
                         batch_docs.append(entry_text[start : start + chunk_size])
+                        entry_stack_id = make_id(
+                            "stack_diary_", wing, date_str, entry_idx, entry_chunk_idx
+                        )
                         batch_metas.append(
                             {
                                 **base_meta,
@@ -265,6 +302,7 @@ def ingest_diaries(
                                 "entry_index": entry_idx,
                                 "entry_chunk_index": entry_chunk_idx,
                                 "entry_header_preview": header[:120],
+                                "stack_id": entry_stack_id,
                             }
                         )
                         global_chunk_index += 1
@@ -276,17 +314,17 @@ def ingest_diaries(
                     metadatas=batch_metas,
                 )
 
-            new_entries = entries if full_rebuild else entries[prev_entry_count:]
+            new_entries = entries if reprocess_all else entries[prev_entry_count:]
             if new_entries:
                 all_lines = []
                 for offset, (header, body) in enumerate(new_entries):
-                    entry_idx = offset if full_rebuild else prev_entry_count + offset
+                    entry_idx = offset if reprocess_all else prev_entry_count + offset
                     entry_text = f"{header}\n{body}" if body else header
                     # Closet references the canonical (entry_chunk_idx=0)
                     # drawer for the entry. Searcher._expand_with_neighbors
                     # stitches sibling chunks back via the
                     # (source_file, chunk_index) pair.
-                    entry_drawer_id = _diary_drawer_id_entry(wing, date_str, entry_idx, 0)
+                    entry_drawer_id = _diary_drawer_id_entry(wing, date_str, entry_idx, 0, now_iso)
                     entry_lines = build_closet_lines(
                         source_file, [entry_drawer_id], entry_text, wing, "daily"
                     )
@@ -303,9 +341,10 @@ def ingest_diaries(
                     }
                     if entities:
                         closet_meta["entities"] = entities
-                    # On any full rebuild (force or detected content edit),
-                    # wipe leftover closets from a prior run before re-writing.
-                    if full_rebuild:
+                    # Closets are derived metadata (regenerable from drawers),
+                    # so they can safely be rebuilt whenever we reprocess all
+                    # entries — additive drawer preservation is not affected.
+                    if reprocess_all:
                         purge_file_closets(closets_col, source_file)
                     n = upsert_closet_lines(closets_col, closet_id_base, all_lines, closet_meta)
                     closets_created += n

--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -75,6 +75,7 @@ from .palace import (
     _validate_palace_fts5_after_mine,
     file_already_mined,
     get_collection,
+    make_id,
     mine_lock,
 )
 
@@ -629,20 +630,25 @@ def _file_chunks_locked(
         if file_already_mined(collection, source_file, check_mtime=True, extract_mode="format"):
             return 0, True
 
-        try:
-            collection.delete(where={"source_file": source_file})
-        except Exception:
-            logger.debug("Stale-drawer purge failed for %s", source_file, exc_info=True)
-
+        # Re-mining is additive, never destructive: ``filed_at`` participates
+        # in the drawer_id hash so each mining pass produces unique IDs and
+        # the upsert below INSERTS new rows alongside any existing ones rather
+        # than overwriting them. The only path to drawer destruction is the
+        # explicit ``mempalace delete`` verb.
         filed_at = datetime.now().isoformat()
+        # ``parent_drawer_id`` is per-mining-pass (used as searcher scope key
+        # to fix #1580). ``stack_id`` groups versions of one chunk position
+        # across re-mines (used by searcher rollup for layer history).
+        parent_drawer_id = make_id("parent_", wing, room, source_file, filed_at)
         for batch_start in range(0, len(chunks), DRAWER_UPSERT_BATCH_SIZE):
             batch_docs: list = []
             batch_ids: list = []
             batch_metas: list = []
             for chunk in chunks[batch_start : batch_start + DRAWER_UPSERT_BATCH_SIZE]:
-                key = (source_file + str(chunk["chunk_index"])).encode()
+                key = (source_file + str(chunk["chunk_index"]) + filed_at).encode()
                 drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256(key).hexdigest()[:24]}"
                 content = chunk["content"]
+                stack_id = make_id("stack_", source_file, chunk["chunk_index"])
                 meta: dict = {
                     "wing": wing,
                     "room": room,
@@ -654,6 +660,9 @@ def _file_chunks_locked(
                     "extract_mode": "format",
                     "normalize_version": NORMALIZE_VERSION,
                     "hall": detect_hall(content),
+                    "parent_drawer_id": parent_drawer_id,
+                    "stack_id": stack_id,
+                    "superseded_at": None,
                 }
                 if source_mtime is not None:
                     meta["source_mtime"] = source_mtime

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -31,6 +31,7 @@ from .palace import (
     file_already_mined,
     get_closets_collection,
     get_collection,
+    make_id,
     mine_lock,
     mine_palace_lock,
     purge_file_closets,
@@ -1201,6 +1202,7 @@ def _build_drawer_metadata(
     line_start: Optional[int] = None,
     line_end: Optional[int] = None,
     content_date: Optional[str] = None,
+    filed_at: Optional[str] = None,
 ) -> dict:
     """Build the metadata dict for one drawer without upserting.
 
@@ -1217,14 +1219,38 @@ def _build_drawer_metadata(
     returned dict and downstream code falls back to ``filed_at`` for the
     date and the 3-segment closet pointer format.
     """
+    # ``filed_at`` is hoisted to the caller for the batched process_file
+    # path so all chunks of one mining pass share the same timestamp (and
+    # participate identically in the drawer_id hash that keeps re-mines
+    # additive). Legacy single-shot callers that don't pass filed_at get
+    # a fresh timestamp here for backward compatibility.
+    resolved_filed_at = filed_at if filed_at is not None else datetime.now().isoformat()
+
+    # ``parent_drawer_id`` groups every chunk produced by ONE mining pass
+    # of ONE source file together — searcher.expand_with_neighbors uses
+    # it as a scope key so neighbor expansion never stitches across
+    # unrelated drawer groups (closes #1580 once the searcher fix lands).
+    #
+    # ``stack_id`` groups every VERSION of one chunk position over time
+    # (same source_file + chunk_index, across re-mines). Searcher rollup
+    # uses it to surface one result per logical chunk with layer history.
+    #
+    # ``superseded_at`` is null infrastructure for the cooldown / archive
+    # mechanic: set on a prior layer when a newer one supersedes it.
+    parent_drawer_id = make_id("parent_", wing, room, source_file, resolved_filed_at)
+    stack_id = make_id("stack_", source_file, chunk_index)
+
     metadata = {
         "wing": wing,
         "room": room,
         "source_file": source_file,
         "chunk_index": chunk_index,
         "added_by": agent,
-        "filed_at": datetime.now().isoformat(),
+        "filed_at": resolved_filed_at,
         "normalize_version": NORMALIZE_VERSION,
+        "parent_drawer_id": parent_drawer_id,
+        "stack_id": stack_id,
+        "superseded_at": None,
     }
     if source_mtime is not None:
         metadata["source_mtime"] = source_mtime
@@ -1338,23 +1364,19 @@ def process_file(
         print(f"    [DRY RUN] {filepath.name} -> room:{room} ({len(chunks)} drawers)")
         return len(chunks), room, None
 
-    # Lock this file so concurrent agents don't interleave delete+insert.
-    # Without the lock, two agents can both pass file_already_mined(),
-    # both delete, and both insert — creating duplicates or losing data.
+    # Lock this file so concurrent re-mines don't interleave writes.
     with mine_lock(source_file):
         # Re-check after acquiring lock — another agent may have just finished
         if file_already_mined(collection, source_file, check_mtime=True):
             return 0, room, None
 
-        # Purge stale drawers for this file before re-inserting the fresh chunks.
-        # Converts modified-file re-mines from upsert-over-existing-IDs (which hits
-        # hnswlib's thread-unsafe updatePoint path and can segfault on macOS ARM
-        # with chromadb 0.6.3) into a clean delete+insert, bypassing the update
-        # path entirely.
-        try:
-            collection.delete(where={"source_file": source_file})
-        except Exception:
-            logger.debug("Stale-drawer purge failed for %s", source_file, exc_info=True)
+        # Re-mining is additive, never destructive: prior versions of this
+        # source_file remain in the palace untouched. Each mining pass gets a
+        # unique ``pass_filed_at`` that participates in the drawer_id hash,
+        # guaranteeing fresh IDs so the upsert below INSERTS new rows
+        # alongside any existing ones rather than overwriting them. The only
+        # path to drawer destruction is the explicit ``mempalace delete`` verb.
+        pass_filed_at = datetime.now().isoformat()
 
         # Batch chunks into bounded upserts so the embedding model sees many
         # chunks per forward pass without building one huge Chroma/SQLite
@@ -1383,7 +1405,10 @@ def process_file(
             batch_ids: list = []
             batch_metas: list = []
             for chunk in chunks[batch_start : batch_start + DRAWER_UPSERT_BATCH_SIZE]:
-                drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
+                # ``pass_filed_at`` participates in the hash so each mining
+                # pass produces a unique drawer_id even when source_file +
+                # chunk_index match — preserves prior versions, additive only.
+                drawer_id = f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(chunk['chunk_index']) + pass_filed_at).encode()).hexdigest()[:24]}"
                 batch_docs.append(chunk["content"])
                 batch_ids.append(drawer_id)
                 batch_metas.append(
@@ -1398,6 +1423,7 @@ def process_file(
                         line_start=chunk.get("line_start"),
                         line_end=chunk.get("line_end"),
                         content_date=file_content_date,
+                        filed_at=pass_filed_at,
                     )
                 )
             collection.upsert(
@@ -1413,7 +1439,7 @@ def process_file(
         # fully replace the prior closets, not append to them.
         if closets_col and drawers_added > 0:
             drawer_ids = [
-                f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(c['chunk_index'])).encode()).hexdigest()[:24]}"
+                f"drawer_{wing}_{room}_{hashlib.sha256((source_file + str(c['chunk_index']) + pass_filed_at).encode()).hexdigest()[:24]}"
                 for c in chunks
             ]
             # Pass drawer_metas so build_closet_lines can emit the Tier 6a

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -58,6 +58,23 @@ _DEFAULT_BACKEND = ChromaBackend()
 NORMALIZE_VERSION = 2
 
 
+def make_id(prefix: str, *parts) -> str:
+    """Compose a deterministic ID: ``prefix + sha256(parts joined by |)[:24]``.
+
+    Single helper for the grouping identifiers introduced in PR A
+    (``parent_drawer_id``, ``stack_id``, and their diary variants). The
+    pipe separator avoids ambiguity for parts that contain underscores
+    or other characters that might collide if concatenated without a
+    separator. Centralising the formula keeps all four miner write
+    paths consistent and gives a single place to evolve the scheme.
+
+    Parts are coerced to ``str`` before joining, so ``int`` chunk
+    indexes and other numeric values can be passed directly.
+    """
+    body = "|".join(str(p) for p in parts)
+    return f"{prefix}{hashlib.sha256(body.encode()).hexdigest()[:24]}"
+
+
 def get_collection(
     palace_path: str,
     collection_name: Optional[str] = None,

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -205,8 +205,11 @@ def _rollup_by_stack(hits: list) -> list:
             output.append(hit)
         else:
             best_hit, count = seen_stacks[stack_id]
-            best_filed = (best_hit.get("metadata") or {}).get("filed_at", "")
-            this_filed = meta.get("filed_at", "")
+            # ``or ""`` guards against ``filed_at: None`` in metadata (which
+            # would crash ``this_filed > best_filed`` with TypeError). Returns
+            # "" for both missing AND None.
+            best_filed = (best_hit.get("metadata") or {}).get("filed_at") or ""
+            this_filed = meta.get("filed_at") or ""
             # Keep the latest layer (highest filed_at). Ties resolved by
             # whichever was seen first (preserves rank order).
             if this_filed > best_filed:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -285,24 +285,48 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
     # the expanded text — exactly the bug #1580 surfaced. Legacy drawers
     # written before the parent_drawer_id field existed fall back to the
     # source_file + chunk_index scope, preserving prior behavior.
+    # ChromaDB's ``$and`` operator only accepts EXACTLY two dictionaries —
+    # passing a list of three raises a validation error that the except
+    # block below silently swallows, falling back to "just the matched
+    # drawer." So we branch the filter shape based on whether
+    # ``parent_drawer_id`` is present. When it is, querying by
+    # parent_drawer_id alone already implicitly scopes to one source file
+    # (parent_drawer_id is constructed from wing + room + source_file +
+    # filed_at in the miners), so we drop the source_file clause to stay
+    # within the two-dict limit while preserving the intended scope.
+    target_indexes = [chunk_idx + offset for offset in range(-radius, radius + 1)]
     parent_id = matched_meta.get("parent_drawer_id")
-    where_filters: list[dict] = [
-        {"source_file": src},
-        {"chunk_index": {"$in": [chunk_idx + offset for offset in range(-radius, radius + 1)]}},
-    ]
     if parent_id:
-        where_filters.append({"parent_drawer_id": parent_id})
+        where_filter = {
+            "$and": [
+                {"parent_drawer_id": parent_id},
+                {"chunk_index": {"$in": target_indexes}},
+            ]
+        }
+    else:
+        where_filter = {
+            "$and": [
+                {"source_file": src},
+                {"chunk_index": {"$in": target_indexes}},
+            ]
+        }
     try:
         neighbors = drawers_col.get(
-            where={"$and": where_filters},
+            where=where_filter,
             include=["documents", "metadatas"],
         )
     except Exception:
         return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
 
+    # ChromaDB returns a dict from ``get(...)``, not a typed object — use
+    # subscript access (``neighbors["documents"]``) rather than attribute
+    # access. The earlier attribute-access pattern raised AttributeError
+    # in every code path, but the broad except above silently caught it
+    # and returned the fallback, masking the bug for as long as the
+    # outer $and filter also failed.
     indexed_docs = []
-    for doc, meta in zip(neighbors.documents, neighbors.metadatas):
-        ci = meta.get("chunk_index")
+    for doc, meta in zip(neighbors["documents"], neighbors["metadatas"]):
+        ci = (meta or {}).get("chunk_index")
         if isinstance(ci, int):
             indexed_docs.append((ci, doc))
     indexed_docs.sort(key=lambda pair: pair[0])
@@ -323,7 +347,8 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
             all_meta = drawers_col.get(where={"parent_drawer_id": parent_id}, include=["metadatas"])
         else:
             all_meta = drawers_col.get(where={"source_file": src}, include=["metadatas"])
-        total_drawers = len(all_meta.ids) if all_meta.ids else None
+        ids = all_meta["ids"] if isinstance(all_meta, dict) else getattr(all_meta, "ids", None)
+        total_drawers = len(ids) if ids else None
     except Exception:
         logger.debug("total_drawers lookup failed for %s", src, exc_info=True)
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -166,70 +166,6 @@ def _hybrid_rank(
     return results
 
 
-def _rollup_by_stack(hits: list) -> list:
-    """Collapse hits that share a ``stack_id`` to one result per stack —
-    the LATEST layer (highest ``filed_at``). Surfaces the chosen layer
-    alongside a ``layer_count`` so callers can render an indicator like
-    ``[layer 3 of 4]``.
-
-    Layers within a stack are versions of the same logical chunk across
-    re-mines (per #1593's additive model). Default search should show one
-    result per logical chunk, not one per physical row — otherwise a
-    re-mined file produces N duplicate-looking results when there's
-    really one logical drawer with version history beneath it.
-
-    Hits without a ``stack_id`` (legacy drawers written before the field
-    existed) pass through unchanged — backward compat preserved.
-
-    Mutates each surfaced hit's ``metadata`` to add ``layer_count``.
-    Returns a new list in the same relative order as the input.
-    """
-    if not hits:
-        return hits
-
-    seen_stacks: dict = {}  # stack_id → (best_hit, count)
-    output: list = []
-    output_positions: dict = {}  # stack_id → index in output
-
-    for hit in hits:
-        meta = hit.get("metadata") or {}
-        stack_id = meta.get("stack_id")
-        if not stack_id:
-            # Legacy drawer (no stack_id) — pass through.
-            output.append(hit)
-            continue
-
-        if stack_id not in seen_stacks:
-            seen_stacks[stack_id] = (hit, 1)
-            output_positions[stack_id] = len(output)
-            output.append(hit)
-        else:
-            best_hit, count = seen_stacks[stack_id]
-            # ``or ""`` guards against ``filed_at: None`` in metadata (which
-            # would crash ``this_filed > best_filed`` with TypeError). Returns
-            # "" for both missing AND None.
-            best_filed = (best_hit.get("metadata") or {}).get("filed_at") or ""
-            this_filed = meta.get("filed_at") or ""
-            # Keep the latest layer (highest filed_at). Ties resolved by
-            # whichever was seen first (preserves rank order).
-            if this_filed > best_filed:
-                seen_stacks[stack_id] = (hit, count + 1)
-                output[output_positions[stack_id]] = hit
-            else:
-                seen_stacks[stack_id] = (best_hit, count + 1)
-
-    # Stamp layer_count onto each surfaced hit so callers can render it.
-    for hit in output:
-        meta = hit.get("metadata") or {}
-        stack_id = meta.get("stack_id")
-        if stack_id and stack_id in seen_stacks:
-            _, count = seen_stacks[stack_id]
-            meta["layer_count"] = count
-            hit["metadata"] = meta
-
-    return output
-
-
 def build_where_filter(wing: str = None, room: str = None) -> dict:
     """Build ChromaDB where filter for wing/room filtering."""
     if wing and room:
@@ -255,6 +191,31 @@ def _extract_drawer_ids_from_closet(closet_doc: str) -> list:
     return list(seen.keys())
 
 
+def _scoped_source_filter(source_file: str, parent_drawer_id=None) -> dict:
+    """Build a Chroma ``where`` clause that scopes a query to ``source_file``,
+    additionally constrained by ``parent_drawer_id`` when one is supplied.
+
+    Two unrelated oversized ``tool_add_drawer`` writes (chunked path from
+    #1539) can pass the same ``source_file`` (e.g. two pastes tagged
+    ``"chat.log"``); each call stores its own ``parent_drawer_id`` group
+    of chunks but the bare ``source_file`` filter pulls chunks from both
+    groups as if they were siblings (#1580). When the matched chunk
+    carries a ``parent_drawer_id`` the filter narrows to that logical
+    group. Otherwise (pre-#1539 drawers, single-chunk writes, and
+    ``diary_ingest`` drawers grouped by real file path) the original
+    file-global shape is preserved. Mirrors the conditional-``$and``
+    precedent in ``build_where_filter``.
+    """
+    if parent_drawer_id:
+        return {
+            "$and": [
+                {"source_file": source_file},
+                {"parent_drawer_id": parent_drawer_id},
+            ]
+        }
+    return {"source_file": source_file}
+
+
 def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, radius: int = 1):
     """Expand a matched drawer with its ±radius sibling chunks in the same source file.
 
@@ -278,55 +239,28 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
     if not src or not isinstance(chunk_idx, int):
         return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
 
-    # Scope neighbor expansion by ``parent_drawer_id`` when the matched
-    # drawer carries one. Without this scope, two unrelated drawer groups
-    # that share a source_file (e.g. two MCP pastes with no source_file,
-    # or two re-mines of the same file) would interleave their chunks in
-    # the expanded text — exactly the bug #1580 surfaced. Legacy drawers
-    # written before the parent_drawer_id field existed fall back to the
-    # source_file + chunk_index scope, preserving prior behavior.
-    # ChromaDB's ``$and`` operator only accepts EXACTLY two dictionaries —
-    # passing a list of three raises a validation error that the except
-    # block below silently swallows, falling back to "just the matched
-    # drawer." So we branch the filter shape based on whether
-    # ``parent_drawer_id`` is present. When it is, querying by
-    # parent_drawer_id alone already implicitly scopes to one source file
-    # (parent_drawer_id is constructed from wing + room + source_file +
-    # filed_at in the miners), so we drop the source_file clause to stay
-    # within the two-dict limit while preserving the intended scope.
-    target_indexes = [chunk_idx + offset for offset in range(-radius, radius + 1)]
+    # Narrow by ``parent_drawer_id`` when present so chunks from unrelated
+    # logical drawers sharing ``source_file`` do not stitch (#1580). See
+    # ``_scoped_source_filter`` for the contract.
     parent_id = matched_meta.get("parent_drawer_id")
+    target_indexes = [chunk_idx + offset for offset in range(-radius, radius + 1)]
+    neighbor_clauses = [
+        {"source_file": src},
+        {"chunk_index": {"$in": target_indexes}},
+    ]
     if parent_id:
-        where_filter = {
-            "$and": [
-                {"parent_drawer_id": parent_id},
-                {"chunk_index": {"$in": target_indexes}},
-            ]
-        }
-    else:
-        where_filter = {
-            "$and": [
-                {"source_file": src},
-                {"chunk_index": {"$in": target_indexes}},
-            ]
-        }
+        neighbor_clauses.append({"parent_drawer_id": parent_id})
     try:
         neighbors = drawers_col.get(
-            where=where_filter,
+            where={"$and": neighbor_clauses},
             include=["documents", "metadatas"],
         )
     except Exception:
         return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
 
-    # ChromaDB returns a dict from ``get(...)``, not a typed object — use
-    # subscript access (``neighbors["documents"]``) rather than attribute
-    # access. The earlier attribute-access pattern raised AttributeError
-    # in every code path, but the broad except above silently caught it
-    # and returned the fallback, masking the bug for as long as the
-    # outer $and filter also failed.
     indexed_docs = []
-    for doc, meta in zip(neighbors["documents"], neighbors["metadatas"]):
-        ci = (meta or {}).get("chunk_index")
+    for doc, meta in zip(neighbors.documents, neighbors.metadatas):
+        ci = meta.get("chunk_index")
         if isinstance(ci, int):
             indexed_docs.append((ci, doc))
     indexed_docs.sort(key=lambda pair: pair[0])
@@ -336,19 +270,17 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
     else:
         combined_text = "\n\n".join(doc for _, doc in indexed_docs)
 
-    # Cheap total_drawers lookup: metadata-only scan, scoped by
-    # parent_drawer_id when present so the count reflects "chunks in THIS
-    # mining pass" rather than over-reporting across multiple re-mines of
-    # the same source_file. Legacy drawers without parent_drawer_id fall
-    # back to the source_file scope.
+    # Cheap total_drawers lookup. When ``parent_drawer_id`` is present the
+    # count is scoped to that group so the returned number matches the
+    # text the caller gets back. Without a parent id, the legacy
+    # file-global count is preserved.
     total_drawers = None
     try:
-        if parent_id:
-            all_meta = drawers_col.get(where={"parent_drawer_id": parent_id}, include=["metadatas"])
-        else:
-            all_meta = drawers_col.get(where={"source_file": src}, include=["metadatas"])
-        ids = all_meta["ids"] if isinstance(all_meta, dict) else getattr(all_meta, "ids", None)
-        total_drawers = len(ids) if ids else None
+        all_meta = drawers_col.get(
+            where=_scoped_source_filter(src, parent_id),
+            include=["metadatas"],
+        )
+        total_drawers = len(all_meta.ids) if all_meta.ids else None
     except Exception:
         logger.debug("total_drawers lookup failed for %s", src, exc_info=True)
 
@@ -469,11 +401,6 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         for doc, meta, dist in zip(docs, metas, dists)
     ]
     hits = _hybrid_rank(hits, query)
-    # Collapse multiple layers of the same logical drawer to a single
-    # result (the latest layer), tagged with layer_count so the renderer
-    # can surface an indicator like ``[layer 3 of 4]``. Legacy drawers
-    # without stack_id pass through unchanged.
-    hits = _rollup_by_stack(hits)
 
     print(f"\n{'=' * 60}")
     print(f'  Results for: "{query}"')
@@ -490,10 +417,8 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         source = Path(meta.get("source_file", "?")).name
         wing_name = meta.get("wing", "?")
         room_name = meta.get("room", "?")
-        layer_count = meta.get("layer_count", 1)
 
-        layer_indicator = f"  [{layer_count} layers]" if layer_count > 1 else ""
-        print(f"  [{i}] {wing_name} / {room_name}{layer_indicator}")
+        print(f"  [{i}] {wing_name} / {room_name}")
         print(f"      Source: {source}")
         print(f"      Match:  cosine={vec_sim}  bm25={bm25}")
         print()
@@ -1030,6 +955,7 @@ def search_memories(
             "_sort_key": effective_dist,
             "_source_file_full": source,
             "_chunk_index": meta.get("chunk_index"),
+            "_parent_drawer_id": meta.get("parent_drawer_id"),
         }
         if closet_preview:
             entry["closet_preview"] = closet_preview
@@ -1050,9 +976,11 @@ def search_memories(
         full_source = h.get("_source_file_full") or ""
         if not full_source:
             continue
+        # Narrow by ``parent_drawer_id`` when present so unrelated
+        # chunked drawers sharing ``source_file`` do not stitch (#1580).
         try:
             source_drawers = drawers_col.get(
-                where={"source_file": full_source},
+                where=_scoped_source_filter(full_source, h.get("_parent_drawer_id")),
                 include=["documents", "metadatas"],
             )
         except Exception:
@@ -1121,6 +1049,7 @@ def search_memories(
         h.pop("_sort_key", None)
         h.pop("_source_file_full", None)
         h.pop("_chunk_index", None)
+        h.pop("_parent_drawer_id", None)
 
     return {
         "query": query,

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -166,6 +166,67 @@ def _hybrid_rank(
     return results
 
 
+def _rollup_by_stack(hits: list) -> list:
+    """Collapse hits that share a ``stack_id`` to one result per stack —
+    the LATEST layer (highest ``filed_at``). Surfaces the chosen layer
+    alongside a ``layer_count`` so callers can render an indicator like
+    ``[layer 3 of 4]``.
+
+    Layers within a stack are versions of the same logical chunk across
+    re-mines (per #1593's additive model). Default search should show one
+    result per logical chunk, not one per physical row — otherwise a
+    re-mined file produces N duplicate-looking results when there's
+    really one logical drawer with version history beneath it.
+
+    Hits without a ``stack_id`` (legacy drawers written before the field
+    existed) pass through unchanged — backward compat preserved.
+
+    Mutates each surfaced hit's ``metadata`` to add ``layer_count``.
+    Returns a new list in the same relative order as the input.
+    """
+    if not hits:
+        return hits
+
+    seen_stacks: dict = {}  # stack_id → (best_hit, count)
+    output: list = []
+    output_positions: dict = {}  # stack_id → index in output
+
+    for hit in hits:
+        meta = hit.get("metadata") or {}
+        stack_id = meta.get("stack_id")
+        if not stack_id:
+            # Legacy drawer (no stack_id) — pass through.
+            output.append(hit)
+            continue
+
+        if stack_id not in seen_stacks:
+            seen_stacks[stack_id] = (hit, 1)
+            output_positions[stack_id] = len(output)
+            output.append(hit)
+        else:
+            best_hit, count = seen_stacks[stack_id]
+            best_filed = (best_hit.get("metadata") or {}).get("filed_at", "")
+            this_filed = meta.get("filed_at", "")
+            # Keep the latest layer (highest filed_at). Ties resolved by
+            # whichever was seen first (preserves rank order).
+            if this_filed > best_filed:
+                seen_stacks[stack_id] = (hit, count + 1)
+                output[output_positions[stack_id]] = hit
+            else:
+                seen_stacks[stack_id] = (best_hit, count + 1)
+
+    # Stamp layer_count onto each surfaced hit so callers can render it.
+    for hit in output:
+        meta = hit.get("metadata") or {}
+        stack_id = meta.get("stack_id")
+        if stack_id and stack_id in seen_stacks:
+            _, count = seen_stacks[stack_id]
+            meta["layer_count"] = count
+            hit["metadata"] = meta
+
+    return output
+
+
 def build_where_filter(wing: str = None, room: str = None) -> dict:
     """Build ChromaDB where filter for wing/room filtering."""
     if wing and room:
@@ -214,15 +275,23 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
     if not src or not isinstance(chunk_idx, int):
         return {"text": matched_doc, "drawer_index": chunk_idx, "total_drawers": None}
 
-    target_indexes = [chunk_idx + offset for offset in range(-radius, radius + 1)]
+    # Scope neighbor expansion by ``parent_drawer_id`` when the matched
+    # drawer carries one. Without this scope, two unrelated drawer groups
+    # that share a source_file (e.g. two MCP pastes with no source_file,
+    # or two re-mines of the same file) would interleave their chunks in
+    # the expanded text — exactly the bug #1580 surfaced. Legacy drawers
+    # written before the parent_drawer_id field existed fall back to the
+    # source_file + chunk_index scope, preserving prior behavior.
+    parent_id = matched_meta.get("parent_drawer_id")
+    where_filters: list[dict] = [
+        {"source_file": src},
+        {"chunk_index": {"$in": [chunk_idx + offset for offset in range(-radius, radius + 1)]}},
+    ]
+    if parent_id:
+        where_filters.append({"parent_drawer_id": parent_id})
     try:
         neighbors = drawers_col.get(
-            where={
-                "$and": [
-                    {"source_file": src},
-                    {"chunk_index": {"$in": target_indexes}},
-                ]
-            },
+            where={"$and": where_filters},
             include=["documents", "metadatas"],
         )
     except Exception:
@@ -240,10 +309,17 @@ def _expand_with_neighbors(drawers_col, matched_doc: str, matched_meta: dict, ra
     else:
         combined_text = "\n\n".join(doc for _, doc in indexed_docs)
 
-    # Cheap total_drawers lookup: metadata-only scan of the source file.
+    # Cheap total_drawers lookup: metadata-only scan, scoped by
+    # parent_drawer_id when present so the count reflects "chunks in THIS
+    # mining pass" rather than over-reporting across multiple re-mines of
+    # the same source_file. Legacy drawers without parent_drawer_id fall
+    # back to the source_file scope.
     total_drawers = None
     try:
-        all_meta = drawers_col.get(where={"source_file": src}, include=["metadatas"])
+        if parent_id:
+            all_meta = drawers_col.get(where={"parent_drawer_id": parent_id}, include=["metadatas"])
+        else:
+            all_meta = drawers_col.get(where={"source_file": src}, include=["metadatas"])
         total_drawers = len(all_meta.ids) if all_meta.ids else None
     except Exception:
         logger.debug("total_drawers lookup failed for %s", src, exc_info=True)
@@ -365,6 +441,11 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         for doc, meta, dist in zip(docs, metas, dists)
     ]
     hits = _hybrid_rank(hits, query)
+    # Collapse multiple layers of the same logical drawer to a single
+    # result (the latest layer), tagged with layer_count so the renderer
+    # can surface an indicator like ``[layer 3 of 4]``. Legacy drawers
+    # without stack_id pass through unchanged.
+    hits = _rollup_by_stack(hits)
 
     print(f"\n{'=' * 60}")
     print(f'  Results for: "{query}"')
@@ -381,8 +462,10 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         source = Path(meta.get("source_file", "?")).name
         wing_name = meta.get("wing", "?")
         room_name = meta.get("room", "?")
+        layer_count = meta.get("layer_count", 1)
 
-        print(f"  [{i}] {wing_name} / {room_name}")
+        layer_indicator = f"  [{layer_count} layers]" if layer_count > 1 else ""
+        print(f"  [{i}] {wing_name} / {room_name}{layer_indicator}")
         print(f"      Source: {source}")
         print(f"      Match:  cosine={vec_sim}  bm25={bm25}")
         print()

--- a/tests/test_additive_mining_preservation.py
+++ b/tests/test_additive_mining_preservation.py
@@ -582,56 +582,90 @@ class TestNeighborExpansionScopedByParentDrawerId:
     """#1580 — searcher._expand_with_neighbors must not stitch chunks
     across unrelated drawers that share an empty source_file."""
 
-    def test_neighbors_do_not_cross_parent_drawer_id(self):
-        """Two unrelated oversized MCP pastes (no source_file) must not
-        have their chunks interleave during neighbor expansion.
+    def test_neighbors_do_not_cross_parent_drawer_id(self, tmp_path):
+        """Two unrelated drawer-groups that share a non-empty source_file
+        must NOT interleave their chunks during neighbor expansion.
 
-        EXPECTED: expanding neighbors of chunk 0 from drawer A never
-                  returns content that was originally part of drawer B.
-        FAIL SIGNAL: drawer B's content appears in the neighbor-expansion
-                     result for drawer A's chunk 0.
+        EXPECTED: expanding neighbors of chunk 0 from group A returns
+                  content from group A only. Group B's distinctive marker
+                  is NEVER in the expanded text.
+        FAIL SIGNAL: group B's content appears in the expansion result —
+                     parent_drawer_id scope is not being applied.
 
-        Reproducer is Igor's exact code from issue #1580.
+        Uses non-empty source_file with two parent_drawer_ids deliberately
+        sharing it. This is the case where the ``if not src`` early-return
+        guard in _expand_with_neighbors does NOT short-circuit — so the
+        $and-filter logic actually runs. (The earlier version of this test
+        was a false-positive: it used empty source_file, which short-
+        circuits before reaching the filter, so the test passed regardless
+        of whether the filter was correct. Gemini caught the underlying
+        ChromaDB $and-limit-2 bug in the filter when the real path was
+        exercised; this test now pins the failure space.)
         """
-        pytest.importorskip("mempalace.mcp_server")
-        from mempalace.mcp_server import tool_add_drawer
-        from mempalace.searcher import _expand_with_neighbors
-        from mempalace.config import MempalaceConfig
+        palace = tmp_path / "palace"
+        client = chromadb.PersistentClient(path=str(palace))
+        col = client.get_or_create_collection("mempalace_drawers")
 
-        wing = "repro_1580"
-        room = "paste"
-
-        # Two unrelated oversized pastes, no source_file — both chunk into
-        # multiple drawers that share the same empty source_file key.
-        marker_a = "DRAWER_A_UNIQUE_MARKER"
-        marker_b = "DRAWER_B_UNIQUE_MARKER"
-        result_a = tool_add_drawer(wing=wing, room=room, content=marker_a + " " + "AAAA " * 250)
-        tool_add_drawer(wing=wing, room=room, content=marker_b + " " + "BBBB " * 250)
-
-        # Open the MCP's default palace (HOME redirected to tmp via conftest).
-        palace_path = MempalaceConfig().palace_path
-        client = chromadb.PersistentClient(path=palace_path)
-        col = client.get_collection("mempalace_drawers")
-
-        # Fetch chunk 0 of drawer A.
-        a_chunks = col.get(
-            where={"parent_drawer_id": result_a["drawer_id"]},
-            include=["documents", "metadatas"],
+        # Two distinct mining passes of the same source_file produce two
+        # parent_drawer_ids that share source_file — the exact shape #1580
+        # protects against.
+        source_file = str(tmp_path / "shared.md")
+        marker_a = "DRAWER_A_UNIQUE_MARKER_1580"
+        marker_b = "DRAWER_B_UNIQUE_MARKER_1580"
+        col.add(
+            ids=["a_chunk_0", "a_chunk_1"],
+            documents=[f"chunk 0 of group A — {marker_a}", "chunk 1 of group A"],
+            metadatas=[
+                {
+                    "source_file": source_file,
+                    "chunk_index": 0,
+                    "parent_drawer_id": "parent_GROUP_A",
+                    "filed_at": "2026-01-01T00:00:00",
+                },
+                {
+                    "source_file": source_file,
+                    "chunk_index": 1,
+                    "parent_drawer_id": "parent_GROUP_A",
+                    "filed_at": "2026-01-01T00:00:00",
+                },
+            ],
         )
-        a_chunk_0_doc = None
-        a_chunk_0_meta = None
-        for doc, meta in zip(a_chunks["documents"], a_chunks["metadatas"]):
-            if meta.get("chunk_index") == 0:
-                a_chunk_0_doc = doc
-                a_chunk_0_meta = meta
-                break
+        col.add(
+            ids=["b_chunk_0", "b_chunk_1"],
+            documents=[f"chunk 0 of group B — {marker_b}", "chunk 1 of group B"],
+            metadatas=[
+                {
+                    "source_file": source_file,
+                    "chunk_index": 0,
+                    "parent_drawer_id": "parent_GROUP_B",
+                    "filed_at": "2026-02-01T00:00:00",
+                },
+                {
+                    "source_file": source_file,
+                    "chunk_index": 1,
+                    "parent_drawer_id": "parent_GROUP_B",
+                    "filed_at": "2026-02-01T00:00:00",
+                },
+            ],
+        )
 
-        assert a_chunk_0_doc is not None, "Could not locate chunk 0 of drawer A"
+        # Expand neighbors of group A's chunk 0.
+        from mempalace.searcher import _expand_with_neighbors
 
+        a_chunk_0_doc = f"chunk 0 of group A — {marker_a}"
+        a_chunk_0_meta = {
+            "source_file": source_file,
+            "chunk_index": 0,
+            "parent_drawer_id": "parent_GROUP_A",
+            "filed_at": "2026-01-01T00:00:00",
+        }
         expanded = _expand_with_neighbors(col, a_chunk_0_doc, a_chunk_0_meta)
         expanded_text = expanded.get("text", "")
 
+        assert marker_a in expanded_text, (
+            "Group A's own content is missing from its own neighbor expansion"
+        )
         assert marker_b not in expanded_text, (
-            "Neighbor expansion of drawer A's chunk 0 returned drawer B's content — "
-            "violates #1580; expansion must be scoped by parent_drawer_id"
+            "Neighbor expansion of group A's chunk 0 returned group B's content — "
+            "violates #1580; parent_drawer_id scope is not being applied"
         )

--- a/tests/test_additive_mining_preservation.py
+++ b/tests/test_additive_mining_preservation.py
@@ -1,0 +1,637 @@
+"""Additive mining — verbatim history is never destroyed by re-mining.
+
+Closes #1593 (miner.py + format_miner.py + diary_ingest.py stop
+destroying prior drawers on re-mine) and #1580 (searcher neighbor
+expansion scoped by parent_drawer_id, not just source_file).
+
+Each test states EXPECTED behavior in its docstring. Tests fail
+against pre-fix code because the current miners run
+``collection.delete(where={"source_file": source_file})`` before
+re-inserting fresh chunks — destroying prior versions.
+"""
+
+from pathlib import Path
+
+import chromadb
+import pytest
+
+from mempalace.miner import mine
+
+
+def _palace_collection(palace_path: Path):
+    """Open the drawers collection from a freshly-built palace."""
+    client = chromadb.PersistentClient(path=str(palace_path))
+    return client.get_collection("mempalace_drawers")
+
+
+def _drawer_contents_for_source(col, source_file: str) -> list[str]:
+    """Return every drawer's content for a given source_file, ordered by
+    filed_at (oldest first). Used to assert prior versions remain after
+    re-mine of an edited file.
+    """
+    result = col.get(where={"source_file": source_file}, include=["documents", "metadatas"])
+    pairs = list(zip(result["documents"], result["metadatas"]))
+    pairs.sort(key=lambda pair: pair[1].get("filed_at", ""))
+    return [doc for doc, _ in pairs]
+
+
+class TestMinerPreservation:
+    """miner.py — re-mining a project file must never destroy prior versions."""
+
+    def test_remine_unchanged_file_preserves_drawer_count(self, tmp_path):
+        """Re-mining a file that has NOT changed produces no destruction.
+
+        EXPECTED: drawer count is identical before and after the second mine.
+                  No drawer's content silently changes.
+        FAIL SIGNAL: drawer count differs OR content shifts unexpectedly.
+        """
+        project = tmp_path / "project"
+        project.mkdir()
+        notes = project / "notes.md"
+        notes.write_text("This is a stable note.\n" * 50, encoding="utf-8")
+
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace))
+
+        col = _palace_collection(palace)
+        first_count = col.count()
+        first_contents = sorted(_drawer_contents_for_source(col, str(notes)))
+
+        # Re-mine the same unchanged file.
+        mine(str(project), str(palace))
+        col = _palace_collection(palace)
+        second_count = col.count()
+        second_contents = sorted(_drawer_contents_for_source(col, str(notes)))
+
+        assert second_count == first_count, (
+            f"Unchanged re-mine inflated drawer count from {first_count} to {second_count}"
+        )
+        assert second_contents == first_contents, "Unchanged re-mine altered drawer content"
+
+    def test_remine_edited_file_preserves_prior_version(self, tmp_path):
+        """When a file is edited and re-mined, the PRIOR version's content
+        must still be retrievable from the palace.
+
+        EXPECTED: a drawer containing the original phrase ("ALPHA_MARKER")
+                  remains in the palace AFTER the file has been edited and
+                  re-mined with that phrase replaced by "BETA_MARKER".
+        FAIL SIGNAL: the ALPHA_MARKER content cannot be found anywhere
+                     in the drawers collection.
+        """
+        project = tmp_path / "project"
+        project.mkdir()
+        notes = project / "notes.md"
+        original = "The first version contains ALPHA_MARKER as the key phrase.\n" * 30
+        notes.write_text(original, encoding="utf-8")
+
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace))
+
+        # Edit the file: replace ALPHA_MARKER with BETA_MARKER.
+        edited = original.replace("ALPHA_MARKER", "BETA_MARKER")
+        notes.write_text(edited, encoding="utf-8")
+        mine(str(project), str(palace))
+
+        col = _palace_collection(palace)
+        all_docs = col.get(where={"source_file": str(notes)}, include=["documents"])
+        joined = "\n".join(all_docs["documents"])
+
+        assert "ALPHA_MARKER" in joined, (
+            "ALPHA_MARKER (prior version's content) was destroyed by re-mine — "
+            "violates #1593 verbatim-preservation principle"
+        )
+        assert "BETA_MARKER" in joined, (
+            "BETA_MARKER (current version's content) is missing after re-mine"
+        )
+
+    def test_three_version_cycle_all_accessible(self, tmp_path):
+        """A file edited and re-mined three times must yield all three
+        versions retrievable from the palace.
+
+        EXPECTED: drawers contain phrases from version 1 AND version 2 AND
+                  version 3 simultaneously.
+        FAIL SIGNAL: any earlier version's distinctive phrase is missing.
+        """
+        project = tmp_path / "project"
+        project.mkdir()
+        notes = project / "notes.md"
+        palace = tmp_path / "palace"
+
+        for version_marker in ("V1_PHRASE", "V2_PHRASE", "V3_PHRASE"):
+            notes.write_text(
+                f"This iteration uses {version_marker} as the distinctive marker.\n" * 30,
+                encoding="utf-8",
+            )
+            mine(str(project), str(palace))
+
+        col = _palace_collection(palace)
+        all_docs = col.get(where={"source_file": str(notes)}, include=["documents"])
+        joined = "\n".join(all_docs["documents"])
+
+        for marker in ("V1_PHRASE", "V2_PHRASE", "V3_PHRASE"):
+            assert marker in joined, (
+                f"{marker} is missing — re-mine cycle destroyed an intermediate "
+                "version, violating #1593"
+            )
+
+    def test_source_mtime_change_never_destroys_prior_content(self, tmp_path):
+        """Touching a file's mtime (without changing content) must NEVER
+        destroy prior drawer content. PR A is additive — a re-mine
+        triggered by mtime change MAY add new layers (until PR B's
+        content-hash dedup makes the no-op explicit), but it must never
+        remove any prior drawer.
+
+        EXPECTED: after touch() and re-mine, every prior chunk's content
+                  is still retrievable from the palace (count may rise,
+                  must not fall; content may duplicate, must not vanish).
+        FAIL SIGNAL: any prior chunk's distinctive content is missing.
+        """
+        import os
+        import time
+
+        project = tmp_path / "project"
+        project.mkdir()
+        notes = project / "notes.md"
+        marker = "UNIQUE_MTIME_PRESERVATION_MARKER"
+        notes.write_text(f"Content with {marker} inside.\n" * 30, encoding="utf-8")
+
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace))
+        col = _palace_collection(palace)
+        before_count = col.count()
+
+        # Bump mtime without touching content.
+        future = time.time() + 60
+        os.utime(notes, (future, future))
+
+        mine(str(project), str(palace))
+        col = _palace_collection(palace)
+
+        # Count must not DROP (destruction would shrink it).
+        assert col.count() >= before_count, (
+            f"mtime bump caused drawer count to DROP "
+            f"({before_count} -> {col.count()}) — destruction occurred"
+        )
+        # Marker must still be findable.
+        all_docs = col.get(where={"source_file": str(notes)}, include=["documents"])
+        joined = "\n".join(all_docs["documents"])
+        assert marker in joined, "mtime bump destroyed prior content — violates #1593"
+
+
+class TestFormatMinerPreservation:
+    """format_miner.py — re-mining an RTF (or other office format) file
+    must never destroy prior versions. Same #1593 architectural fix as
+    miner.py, separately tested because the delete site is duplicated
+    in format_miner.py:633.
+    """
+
+    def test_format_miner_remine_edited_preserves_prior_version(self, tmp_path):
+        """Edit an RTF file, re-mine via format_miner — prior version's
+        content must still be retrievable.
+
+        EXPECTED: drawer for the source file contains both ALPHA_MARKER
+                  (original) and BETA_MARKER (current) after the edit.
+        FAIL SIGNAL: ALPHA_MARKER is missing — format_miner destroyed it.
+        """
+        pytest.importorskip("striprtf")
+        from mempalace.format_miner import mine_formats
+
+        project = tmp_path / "formats"
+        project.mkdir()
+        rtf_file = project / "letter.rtf"
+
+        def _rtf(payload: str) -> str:
+            return "{\\rtf1\\ansi\\deff0 " + payload + "}"
+
+        # Need enough content to clear format_miner's MIN_CHUNK_SIZE (50 chars)
+        rtf_file.write_text(
+            _rtf("Original content with ALPHA_MARKER inside the letter.\n" * 20),
+            encoding="utf-8",
+        )
+
+        palace = tmp_path / "palace"
+        mine_formats(str(project), str(palace))
+
+        rtf_file.write_text(
+            _rtf("Edited content with BETA_MARKER inside the letter.\n" * 20),
+            encoding="utf-8",
+        )
+        mine_formats(str(project), str(palace))
+
+        col = _palace_collection(palace)
+        all_docs = col.get(where={"source_file": str(rtf_file)}, include=["documents"])
+        joined = "\n".join(all_docs["documents"])
+
+        assert "ALPHA_MARKER" in joined, (
+            "ALPHA_MARKER destroyed by format_miner re-mine — "
+            "violates #1593 (format_miner.py:633 delete-on-remine)"
+        )
+        assert "BETA_MARKER" in joined, "BETA_MARKER missing after re-mine"
+
+
+class TestDiaryIngestPreservation:
+    """diary_ingest.py — re-ingesting a diary file must never destroy
+    prior versions. Closes the hidden #1593 violation: today,
+    diary_ingest fires destructive full_rebuild whenever
+    ``content_changed`` is True — meaning ANY edit to a diary file
+    silently destroys the prior version.
+    """
+
+    def test_diary_content_change_does_not_destroy_prior_version(self, tmp_path):
+        """Edit a diary entry's content (NOT just append) and re-ingest —
+        the prior content must still be retrievable. This is the
+        content_changed = True path that today triggers destructive
+        full_rebuild.
+
+        EXPECTED: drawer for the diary date contains both ORIGINAL_PHRASE
+                  and EDITED_PHRASE after the edit.
+        FAIL SIGNAL: ORIGINAL_PHRASE missing — content_changed branch
+                     destroyed the prior version.
+        """
+        from mempalace.diary_ingest import ingest_diaries
+
+        diary_dir = tmp_path / "diary"
+        diary_dir.mkdir()
+        diary_file = diary_dir / "2026-05-25.md"
+        diary_file.write_text(
+            "## Morning\n"
+            "Today I worked on the project and noted ORIGINAL_PHRASE as the key idea "
+            "behind the architecture decision I am writing about right now.\n",
+            encoding="utf-8",
+        )
+
+        palace = tmp_path / "palace"
+        ingest_diaries(str(diary_dir), str(palace))
+
+        # Edit the diary entry's CONTENT (in-place rewrite, not append).
+        diary_file.write_text(
+            "## Morning\n"
+            "Today I worked on the project and noted EDITED_PHRASE as the key idea "
+            "behind the architecture decision I am writing about right now.\n",
+            encoding="utf-8",
+        )
+        ingest_diaries(str(diary_dir), str(palace))
+
+        col = _palace_collection(palace)
+        all_docs = col.get(include=["documents", "metadatas"])
+        joined = "\n".join(all_docs["documents"])
+
+        assert "ORIGINAL_PHRASE" in joined, (
+            "ORIGINAL_PHRASE destroyed by diary_ingest re-ingest — "
+            "violates #1593; the content_changed=True branch at "
+            "diary_ingest.py:183 still triggers destructive full_rebuild"
+        )
+        assert "EDITED_PHRASE" in joined, "EDITED_PHRASE missing after re-ingest"
+
+
+class TestDeleteVerb:
+    """``mempalace delete`` — the SOLE destruction path under the
+    additive-only ingestion model. These tests verify the verb destroys
+    what it should, refuses what it shouldn't, and honors --dry-run /
+    --force flags as specified."""
+
+    def _mine_and_get_first_metadata(self, tmp_path):
+        """Helper — mines a one-file palace, returns palace + first drawer's metadata."""
+        project = tmp_path / "project"
+        project.mkdir()
+        notes = project / "notes.md"
+        notes.write_text("Content for delete-verb tests.\n" * 30, encoding="utf-8")
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace))
+        col = _palace_collection(palace)
+        first = col.get(include=["metadatas"], limit=1)
+        return palace, first["ids"][0], first["metadatas"][0]
+
+    def test_delete_drawer_id_removes_one_layer_with_force(self, tmp_path):
+        """``mempalace delete <drawer_id> --force`` removes exactly that
+        one drawer row and no others.
+
+        EXPECTED: count drops by 1; the named drawer is gone; others remain.
+        FAIL SIGNAL: count drops by more than 1, or the named drawer still
+                     present, or unrelated drawers got removed.
+        """
+        import subprocess
+        import sys as _sys
+
+        palace, drawer_id, _meta = self._mine_and_get_first_metadata(tmp_path)
+        col = _palace_collection(palace)
+        before_count = col.count()
+
+        result = subprocess.run(
+            [
+                _sys.executable,
+                "-m",
+                "mempalace",
+                "--palace",
+                str(palace),
+                "delete",
+                drawer_id,
+                "--force",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"delete failed: {result.stderr}"
+
+        col = _palace_collection(palace)
+        after_count = col.count()
+        assert after_count == before_count - 1, (
+            f"delete drawer_id removed wrong count: {before_count} -> {after_count}"
+        )
+        remaining = col.get(ids=[drawer_id])
+        assert not remaining["ids"], "deleted drawer still present"
+
+    def test_delete_stack_id_removes_all_layers(self, tmp_path):
+        """``mempalace delete <stack_id> --force`` removes every layer of
+        one logical chunk position, leaving other stacks alone.
+
+        EXPECTED: every row with the target stack_id is gone; rows with
+                  other stack_ids remain.
+        FAIL SIGNAL: a row with the target stack_id survives, or rows
+                     with other stack_ids got destroyed too.
+        """
+        import subprocess
+        import sys as _sys
+
+        # Mine, edit, re-mine → at least one stack has 2 layers.
+        project = tmp_path / "project"
+        project.mkdir()
+        notes = project / "notes.md"
+        notes.write_text("First version content marker FIRST_V.\n" * 30, encoding="utf-8")
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace))
+
+        notes.write_text("Second version content marker SECOND_V.\n" * 30, encoding="utf-8")
+        mine(str(project), str(palace))
+
+        col = _palace_collection(palace)
+        all_meta = col.get(include=["metadatas"])
+        # Find any stack_id with > 1 layer.
+        from collections import Counter
+
+        stack_counts = Counter(
+            m.get("stack_id") for m in all_meta["metadatas"] if m.get("stack_id")
+        )
+        target_stack_id, layer_count = stack_counts.most_common(1)[0]
+        assert layer_count >= 2, "test setup: expected at least one multi-layer stack"
+
+        before_count = col.count()
+        result = subprocess.run(
+            [
+                _sys.executable,
+                "-m",
+                "mempalace",
+                "--palace",
+                str(palace),
+                "delete",
+                target_stack_id,
+                "--force",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"delete failed: {result.stderr}"
+
+        col = _palace_collection(palace)
+        after_count = col.count()
+        assert after_count == before_count - layer_count, (
+            f"delete stack_id removed wrong count: {before_count} -> {after_count}, "
+            f"expected to remove {layer_count} layers"
+        )
+        remaining_in_stack = col.get(where={"stack_id": target_stack_id})
+        assert not remaining_in_stack["ids"], "deleted stack still has layers"
+
+    def test_delete_dry_run_destroys_nothing(self, tmp_path):
+        """``mempalace delete <id> --dry-run`` reports what would be
+        destroyed but destroys nothing.
+
+        EXPECTED: drawer count unchanged; named drawer still present.
+        FAIL SIGNAL: count drops at all.
+        """
+        import subprocess
+        import sys as _sys
+
+        palace, drawer_id, _meta = self._mine_and_get_first_metadata(tmp_path)
+        col = _palace_collection(palace)
+        before_count = col.count()
+
+        result = subprocess.run(
+            [
+                _sys.executable,
+                "-m",
+                "mempalace",
+                "--palace",
+                str(palace),
+                "delete",
+                drawer_id,
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "DRY RUN" in result.stdout
+
+        col = _palace_collection(palace)
+        after_count = col.count()
+        assert after_count == before_count, (
+            f"--dry-run destroyed drawers: {before_count} -> {after_count}"
+        )
+
+    def test_delete_unrecognized_prefix_errors_cleanly(self, tmp_path):
+        """An identifier without a recognized prefix exits nonzero with a
+        clear message — no silent fall-through to mass destruction.
+
+        EXPECTED: exit code 2; stderr explains the prefix requirement.
+        FAIL SIGNAL: exit 0 (success), or any drawer destroyed.
+        """
+        import subprocess
+        import sys as _sys
+
+        palace, _drawer_id, _meta = self._mine_and_get_first_metadata(tmp_path)
+        col = _palace_collection(palace)
+        before_count = col.count()
+
+        result = subprocess.run(
+            [
+                _sys.executable,
+                "-m",
+                "mempalace",
+                "--palace",
+                str(palace),
+                "delete",
+                "junk-identifier-no-prefix",
+                "--force",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 2, (
+            f"expected exit 2 for unrecognized prefix; got {result.returncode}"
+        )
+        assert "no recognized prefix" in result.stderr.lower()
+
+        col = _palace_collection(palace)
+        assert col.count() == before_count, "unrecognized prefix triggered destruction"
+
+
+class TestShowVerb:
+    """``mempalace show`` — display a drawer or a stack of layers with
+    vertical navigation indicators."""
+
+    def test_show_drawer_id_renders_single_layer(self, tmp_path):
+        """``mempalace show <drawer_id>`` renders that one row's content
+        with wing/room/filed_at header.
+
+        EXPECTED: stdout contains the drawer's text and a header line
+                  with wing/room.
+        FAIL SIGNAL: empty stdout, missing content, or missing header.
+        """
+        import subprocess
+        import sys as _sys
+
+        project = tmp_path / "project"
+        project.mkdir()
+        notes = project / "notes.md"
+        unique = "UNIQUE_SHOW_VERB_MARKER_42"
+        notes.write_text(f"Content with {unique} inside it.\n" * 30, encoding="utf-8")
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace))
+
+        col = _palace_collection(palace)
+        first = col.get(include=["metadatas"], limit=1)
+        drawer_id = first["ids"][0]
+
+        result = subprocess.run(
+            [
+                _sys.executable,
+                "-m",
+                "mempalace",
+                "--palace",
+                str(palace),
+                "show",
+                drawer_id,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"show failed: {result.stderr}"
+        assert unique in result.stdout, "show output missing the drawer's content"
+        assert "Drawer:" in result.stdout, "show output missing the Drawer: header"
+
+    def test_show_stack_id_renders_layer_indicator(self, tmp_path):
+        """``mempalace show <stack_id>`` for a multi-layer stack renders
+        the latest layer with ``[layer 1 of N]`` indicator + a navigation
+        hint to the older layer.
+
+        EXPECTED: header includes 'layer 1 of N' (N >= 2); navigation
+                  hint mentions 'older'.
+        FAIL SIGNAL: missing layer indicator, missing nav hint.
+        """
+        import subprocess
+        import sys as _sys
+
+        # Mine, edit, re-mine → multi-layer stack exists.
+        project = tmp_path / "project"
+        project.mkdir()
+        notes = project / "notes.md"
+        notes.write_text("First version V1_SHOW_MARKER content.\n" * 30, encoding="utf-8")
+        palace = tmp_path / "palace"
+        mine(str(project), str(palace))
+
+        notes.write_text("Second version V2_SHOW_MARKER content.\n" * 30, encoding="utf-8")
+        mine(str(project), str(palace))
+
+        col = _palace_collection(palace)
+        all_meta = col.get(include=["metadatas"])
+        from collections import Counter
+
+        stack_counts = Counter(
+            m.get("stack_id") for m in all_meta["metadatas"] if m.get("stack_id")
+        )
+        target_stack_id, layer_count = stack_counts.most_common(1)[0]
+        assert layer_count >= 2, "test setup: expected multi-layer stack"
+
+        result = subprocess.run(
+            [
+                _sys.executable,
+                "-m",
+                "mempalace",
+                "--palace",
+                str(palace),
+                "show",
+                target_stack_id,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"show failed: {result.stderr}"
+        assert f"layer 1 of {layer_count}" in result.stdout, (
+            f"show output missing 'layer 1 of {layer_count}' indicator"
+        )
+        assert "older" in result.stdout.lower(), "show output missing 'older' navigation hint"
+
+
+class TestNeighborExpansionScopedByParentDrawerId:
+    """#1580 — searcher._expand_with_neighbors must not stitch chunks
+    across unrelated drawers that share an empty source_file."""
+
+    def test_neighbors_do_not_cross_parent_drawer_id(self):
+        """Two unrelated oversized MCP pastes (no source_file) must not
+        have their chunks interleave during neighbor expansion.
+
+        EXPECTED: expanding neighbors of chunk 0 from drawer A never
+                  returns content that was originally part of drawer B.
+        FAIL SIGNAL: drawer B's content appears in the neighbor-expansion
+                     result for drawer A's chunk 0.
+
+        Reproducer is Igor's exact code from issue #1580.
+        """
+        pytest.importorskip("mempalace.mcp_server")
+        from mempalace.mcp_server import tool_add_drawer
+        from mempalace.searcher import _expand_with_neighbors
+        from mempalace.config import MempalaceConfig
+
+        wing = "repro_1580"
+        room = "paste"
+
+        # Two unrelated oversized pastes, no source_file — both chunk into
+        # multiple drawers that share the same empty source_file key.
+        marker_a = "DRAWER_A_UNIQUE_MARKER"
+        marker_b = "DRAWER_B_UNIQUE_MARKER"
+        result_a = tool_add_drawer(wing=wing, room=room, content=marker_a + " " + "AAAA " * 250)
+        tool_add_drawer(wing=wing, room=room, content=marker_b + " " + "BBBB " * 250)
+
+        # Open the MCP's default palace (HOME redirected to tmp via conftest).
+        palace_path = MempalaceConfig().palace_path
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection("mempalace_drawers")
+
+        # Fetch chunk 0 of drawer A.
+        a_chunks = col.get(
+            where={"parent_drawer_id": result_a["drawer_id"]},
+            include=["documents", "metadatas"],
+        )
+        a_chunk_0_doc = None
+        a_chunk_0_meta = None
+        for doc, meta in zip(a_chunks["documents"], a_chunks["metadatas"]):
+            if meta.get("chunk_index") == 0:
+                a_chunk_0_doc = doc
+                a_chunk_0_meta = meta
+                break
+
+        assert a_chunk_0_doc is not None, "Could not locate chunk 0 of drawer A"
+
+        expanded = _expand_with_neighbors(col, a_chunk_0_doc, a_chunk_0_meta)
+        expanded_text = expanded.get("text", "")
+
+        assert marker_b not in expanded_text, (
+            "Neighbor expansion of drawer A's chunk 0 returned drawer B's content — "
+            "violates #1580; expansion must be scoped by parent_drawer_id"
+        )

--- a/tests/test_additive_mining_preservation.py
+++ b/tests/test_additive_mining_preservation.py
@@ -595,16 +595,19 @@ class TestNeighborExpansionScopedByParentDrawerId:
         Uses non-empty source_file with two parent_drawer_ids deliberately
         sharing it. This is the case where the ``if not src`` early-return
         guard in _expand_with_neighbors does NOT short-circuit — so the
-        $and-filter logic actually runs. (The earlier version of this test
-        was a false-positive: it used empty source_file, which short-
-        circuits before reaching the filter, so the test passed regardless
-        of whether the filter was correct. Gemini caught the underlying
-        ChromaDB $and-limit-2 bug in the filter when the real path was
-        exercised; this test now pins the failure space.)
+        $and-filter logic actually runs.
+
+        Uses ``palace.get_collection()`` (the production path through the
+        ``ChromaCollection`` wrapper) rather than a raw chromadb client.
+        The wrapper's ``GetResult`` dataclass supports both ``.documents``
+        and ``["documents"]`` access; the raw client only supports the
+        latter. Testing through the wrapper matches what production
+        actually exercises — flagged by @mvalentsev on PR #1628.
         """
+        from mempalace.palace import get_collection
+
         palace = tmp_path / "palace"
-        client = chromadb.PersistentClient(path=str(palace))
-        col = client.get_or_create_collection("mempalace_drawers")
+        col = get_collection(str(palace), create=True)
 
         # Two distinct mining passes of the same source_file produce two
         # parent_drawer_ids that share source_file — the exact shape #1580

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -1710,3 +1710,112 @@ class TestDrawerGrepExpansion:
             "group B's content leaked into group A's enriched result — "
             "violates #1580 at the search_memories enrichment site"
         )
+
+    def test_expand_backwards_compat_no_parent_drawer_id_returns_all_source_neighbors(
+        self, palace_path
+    ):
+        """Drawers without a ``parent_drawer_id`` (single-chunk writes,
+        legacy palaces, ``diary_ingest`` chunks grouped by real file path)
+        must take the 2-clause fallback (``source_file + chunk_index``)
+        unchanged, so neighbor expansion still works file-globally for
+        those callers.
+        """
+        col, _ = self._seed_source_file(palace_path, "/proj/legacy.md", n_chunks=5)
+        matched_meta = {"source_file": "/proj/legacy.md", "chunk_index": 2}
+        out = _expand_with_neighbors(
+            col, "chunk_2 content about topic alpha", matched_meta, radius=1
+        )
+        # Same expectations as test_expand_returns_matched_plus_neighbors:
+        # no parent_drawer_id anywhere, so behavior is unchanged.
+        assert out["total_drawers"] == 5
+        assert out["drawer_index"] == 2
+        text = out["text"]
+        assert "chunk_1" in text
+        assert "chunk_2" in text
+        assert "chunk_3" in text
+
+    def test_expand_isolates_asymmetric_groups_under_shared_source_file(self, palace_path):
+        """Asymmetric coverage: group A has 1 chunk, group B has 3 chunks
+        under the shared ``source_file``. Catches a regression where
+        ``total_drawers`` accidentally drifts back to the unscoped
+        file-global count (4) when one group dominates the row mix.
+        """
+        col = get_collection(palace_path)
+        source = "asym.log"
+        col.upsert(
+            ids=["drawer_solo_chunk_000000"],
+            documents=["solo-A-chunk-0 content"],
+            metadatas=[
+                {
+                    "wing": "w",
+                    "room": "r",
+                    "source_file": source,
+                    "chunk_index": 0,
+                    "parent_drawer_id": "drawer_solo",
+                    "filed_at": "2026-04-13T00:00:00",
+                }
+            ],
+        )
+        col.upsert(
+            ids=[
+                "drawer_trio_chunk_000000",
+                "drawer_trio_chunk_000001",
+                "drawer_trio_chunk_000002",
+            ],
+            documents=[
+                "trio-B-chunk-0 content",
+                "trio-B-chunk-1 content",
+                "trio-B-chunk-2 content",
+            ],
+            metadatas=[
+                {
+                    "wing": "w",
+                    "room": "r",
+                    "source_file": source,
+                    "chunk_index": i,
+                    "parent_drawer_id": "drawer_trio",
+                    "filed_at": "2026-04-13T00:00:00",
+                }
+                for i in range(3)
+            ],
+        )
+
+        out = _expand_with_neighbors(
+            col,
+            "solo-A-chunk-0 content",
+            {
+                "source_file": source,
+                "chunk_index": 0,
+                "parent_drawer_id": "drawer_solo",
+            },
+            radius=1,
+        )
+        # Singleton group A: text is the matched chunk, total_drawers == 1.
+        assert "solo-A-chunk-0" in out["text"]
+        assert "trio-B-chunk" not in out["text"]
+        assert out["total_drawers"] == 1
+        assert out["drawer_index"] == 0
+
+    def test_expand_empty_string_parent_drawer_id_treated_as_absent(self, palace_path):
+        """Contract pin: an empty-string ``parent_drawer_id`` value
+        degrades to the 2-clause file-global filter (matches the
+        ``if not src`` empty-string handling for ``source_file`` at
+        ``searcher.py:239``). Writers in the codebase never emit an
+        empty parent id, but pinning the contract guards against a
+        future migration that does and avoids a silent narrow-then-
+        miss surprise.
+        """
+        col, _ = self._seed_source_file(palace_path, "/proj/empty_parent.md", n_chunks=3)
+        matched_meta = {
+            "source_file": "/proj/empty_parent.md",
+            "chunk_index": 1,
+            "parent_drawer_id": "",
+        }
+        out = _expand_with_neighbors(
+            col, "chunk_1 content about topic alpha", matched_meta, radius=1
+        )
+        # Empty parent_drawer_id is treated as absent; full file-global
+        # neighborhood is returned. Mirrors backwards-compat behavior.
+        assert out["total_drawers"] == 3
+        assert "chunk_0" in out["text"]
+        assert "chunk_1" in out["text"]

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -1557,3 +1557,156 @@ class TestDrawerGrepExpansion:
         # Enriched text must include the grep-best chunk plus one neighbor
         # on each side (chunk boundary may clip).
         assert "chunk_" in top["text"]
+
+    def test_expand_isolates_chunks_by_parent_drawer_id_when_source_file_shared(self, palace_path):
+        """Regression for #1580 — first code path: ``_expand_with_neighbors``.
+        Two unrelated logical drawer groups sharing the same
+        ``source_file`` (e.g. two pastes labelled ``source_file="chat.log"``)
+        must not have their chunks stitched together as if they were
+        sequential neighbors. Scoping by ``parent_drawer_id`` when present
+        keeps each logical group isolated. Adapted from mvalentsev's PR #1582.
+        """
+        col = get_collection(palace_path)
+        source = "shared.log"
+        col.upsert(
+            ids=["drawer_A_chunk_000000", "drawer_A_chunk_000001"],
+            documents=["alpha-A-chunk-0 content", "alpha-A-chunk-1 content"],
+            metadatas=[
+                {
+                    "wing": "w",
+                    "room": "r",
+                    "source_file": source,
+                    "chunk_index": 0,
+                    "parent_drawer_id": "drawer_A",
+                    "filed_at": "2026-04-13T00:00:00",
+                },
+                {
+                    "wing": "w",
+                    "room": "r",
+                    "source_file": source,
+                    "chunk_index": 1,
+                    "parent_drawer_id": "drawer_A",
+                    "filed_at": "2026-04-13T00:00:00",
+                },
+            ],
+        )
+        col.upsert(
+            ids=["drawer_B_chunk_000000", "drawer_B_chunk_000001"],
+            documents=["bravo-B-chunk-0 content", "bravo-B-chunk-1 content"],
+            metadatas=[
+                {
+                    "wing": "w",
+                    "room": "r",
+                    "source_file": source,
+                    "chunk_index": 0,
+                    "parent_drawer_id": "drawer_B",
+                    "filed_at": "2026-04-13T00:00:00",
+                },
+                {
+                    "wing": "w",
+                    "room": "r",
+                    "source_file": source,
+                    "chunk_index": 1,
+                    "parent_drawer_id": "drawer_B",
+                    "filed_at": "2026-04-13T00:00:00",
+                },
+            ],
+        )
+        matched_doc = "alpha-A-chunk-0 content"
+        matched_meta = {
+            "source_file": source,
+            "chunk_index": 0,
+            "parent_drawer_id": "drawer_A",
+        }
+        out = _expand_with_neighbors(col, matched_doc, matched_meta, radius=1)
+        text = out["text"]
+        assert "alpha-A-chunk-0" in text
+        assert "alpha-A-chunk-1" in text
+        assert "bravo-B-chunk-0" not in text
+        assert "bravo-B-chunk-1" not in text
+        assert out["total_drawers"] == 2
+
+    def test_search_memories_enrichment_isolates_by_parent_drawer_id(self, palace_path):
+        """Regression for #1580 — SECOND code path: the drawer-grep
+        enrichment block in ``search_memories`` (the
+        ``# Drawer-grep enrichment`` section at ``searcher.py:1054``).
+        Distinct from ``_expand_with_neighbors``. Flagged by fatkobra
+        after gemini cleared the original site.
+
+        Setup: two unrelated logical drawer groups sharing
+        ``source_file="shared.log"``, plus a closet pointing at group A's
+        chunk so the hybrid path promotes the source to
+        ``matched_via == "drawer+closet"`` and triggers the enrichment
+        block. After the fix, the enriched text MUST contain only group
+        A's chunks; group B's content MUST NOT leak in.
+        """
+        col = get_collection(palace_path)
+        source = "shared.log"
+        col.upsert(
+            ids=["drawer_A_chunk_000000", "drawer_A_chunk_000001"],
+            documents=[
+                "ALPHA_GROUP_A chunk 0 — discusses the JWT auth pattern in detail",
+                "ALPHA_GROUP_A chunk 1 — follows up on the JWT discussion",
+            ],
+            metadatas=[
+                {
+                    "wing": "w",
+                    "room": "r",
+                    "source_file": source,
+                    "chunk_index": 0,
+                    "parent_drawer_id": "drawer_A",
+                    "filed_at": "2026-04-13T00:00:00",
+                },
+                {
+                    "wing": "w",
+                    "room": "r",
+                    "source_file": source,
+                    "chunk_index": 1,
+                    "parent_drawer_id": "drawer_A",
+                    "filed_at": "2026-04-13T00:00:00",
+                },
+            ],
+        )
+        col.upsert(
+            ids=["drawer_B_chunk_000000", "drawer_B_chunk_000001"],
+            documents=[
+                "BRAVO_GROUP_B chunk 0 — unrelated content about postgres tuning",
+                "BRAVO_GROUP_B chunk 1 — more on postgres",
+            ],
+            metadatas=[
+                {
+                    "wing": "w",
+                    "room": "r",
+                    "source_file": source,
+                    "chunk_index": 0,
+                    "parent_drawer_id": "drawer_B",
+                    "filed_at": "2026-04-13T00:00:00",
+                },
+                {
+                    "wing": "w",
+                    "room": "r",
+                    "source_file": source,
+                    "chunk_index": 1,
+                    "parent_drawer_id": "drawer_B",
+                    "filed_at": "2026-04-13T00:00:00",
+                },
+            ],
+        )
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_w_r_shared_01"],
+            documents=["JWT auth|;|→drawer_A_chunk_000000"],
+            metadatas=[{"wing": "w", "room": "r", "source_file": source}],
+        )
+
+        result = search_memories("JWT auth", palace_path)
+        boosted = [h for h in result["results"] if h["matched_via"] == "drawer+closet"]
+        assert boosted, "hybrid search should mark the closet-agreeing source as drawer+closet"
+        top = boosted[0]
+        assert "ALPHA_GROUP_A" in top["text"], (
+            "group A's content is missing from its own enriched result"
+        )
+        assert "BRAVO_GROUP_B" not in top["text"], (
+            "group B's content leaked into group A's enriched result — "
+            "violates #1580 at the search_memories enrichment site"
+        )

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -806,19 +806,24 @@ class TestDiaryIngest:
         result = ingest_diaries(str(diary_dir), str(palace_dir))
         assert result["days_updated"] == 1, "same-size content edit must trigger re-ingest"
 
-        # Drawer must hold the corrected text.
+        # Drawer must hold the corrected text. Under the verbatim-preservation
+        # principle, the original "Teh" version is ALSO preserved as a prior
+        # layer — both versions coexist; the corrected version is the latest
+        # (current default) and that is the assertion that matters.
         drawers = get_collection(str(palace_dir)).get(where={"source_file": str(diary_file)})
         joined_drawers = "\n".join(drawers["documents"])
-        assert "The elaborate" in joined_drawers
-        assert "Teh elaborate" not in joined_drawers, "drawer still holds pre-edit content"
+        assert "The elaborate" in joined_drawers, "drawer is missing the corrected text"
 
-        # And the closet (search index) must reflect the edit too — not just the
-        # drawer. Otherwise searches would surface stale text.
+        # And the closet (search index) must exist for the source file —
+        # closets are AAAK-compressed pointers (topic|entities|→drawer_id),
+        # not full text, so the load-bearing assertion is the closet entry
+        # PRESENT for the re-ingested source, not the text contents inside
+        # it. The corrected text living in the drawer (asserted above) is
+        # what actually answers a search.
         closets = get_closets_collection(str(palace_dir)).get(
             where={"source_file": str(diary_file)}
         )
-        joined_closets = "\n".join(closets["documents"])
-        assert "Teh elaborate" not in joined_closets, "closet index still holds stale content"
+        assert closets["ids"], "closet index has no entries for the re-ingested source"
 
     def test_legacy_state_backfills_content_hash(self, tmp_path):
         # Upgraded users can carry legacy state entries without ``content_hash``.
@@ -909,25 +914,32 @@ class TestDiaryIngest:
 
         palace_dir = tmp_path / "palace"
 
-        from mempalace.diary_ingest import _diary_drawer_id_entry, ingest_diaries
+        from mempalace.diary_ingest import ingest_diaries
 
         ingest_diaries(str(personal_dir), str(palace_dir), wing="personal", force=True)
         ingest_diaries(str(work_dir), str(palace_dir), wing="work", force=True)
 
         col = get_collection(str(palace_dir))
-        # Post-#1539: per-entry drawers. Each single-entry diary produces
-        # one drawer keyed by (wing, date, entry_idx=0, chunk_idx=0). The
-        # wing component still keeps work vs personal collisions apart.
-        personal_id = _diary_drawer_id_entry("personal", "2026-04-13", 0, 0)
-        work_id = _diary_drawer_id_entry("work", "2026-04-13", 0, 0)
-        assert personal_id != work_id
+        # Per-entry drawers keyed by (wing, date, entry_idx, chunk_idx, filed_at).
+        # The wing component still keeps work vs personal collisions apart —
+        # query by wing + content marker instead of constructing the exact ID
+        # (which depends on the runtime-set filed_at).
+        personal = col.get(where={"wing": "personal"})
+        work = col.get(where={"wing": "work"})
+        assert personal["ids"], "expected at least one drawer in personal wing"
+        assert work["ids"], "expected at least one drawer in work wing"
 
-        personal = col.get(ids=[personal_id])
-        work = col.get(ids=[work_id])
-        assert personal["ids"] == [personal_id]
-        assert work["ids"] == [work_id]
-        assert "Personal-only marker." in personal["documents"][0]
-        assert "Work-only marker." in work["documents"][0]
+        # No drawer ID overlaps between wings — wing-prefix isolation holds.
+        assert set(personal["ids"]).isdisjoint(set(work["ids"])), (
+            "personal and work wings collided on drawer IDs"
+        )
+
+        personal_text = "\n".join(personal["documents"])
+        work_text = "\n".join(work["documents"])
+        assert "Personal-only marker." in personal_text
+        assert "Work-only marker." in work_text
+        assert "Personal-only marker." not in work_text, "personal content leaked into work wing"
+        assert "Work-only marker." not in personal_text, "work content leaked into personal wing"
 
     # ── #1539: per-entry drawers, oversized-entry chunking ─────────
 
@@ -987,9 +999,15 @@ class TestDiaryIngest:
             f"oversized middle entry must produce multiple drawers; got {len(docs)} total drawers"
         )
 
-    def test_incremental_appends_new_entry_only(self, tmp_path):
-        """Regression for #1539: incremental ingest must add exactly the
-        delta when one new entry is appended (not re-rewrite all)."""
+    def test_incremental_append_grows_palace_and_new_entry_is_findable(self, tmp_path):
+        """Appending a new entry to a diary file must result in (a) the
+        palace growing — never shrinking — and (b) the new entry's
+        distinctive content being retrievable. Under the additive-only
+        principle (#1593), prior entries are preserved as layers; the
+        exact post-append count depends on whether the re-ingest also
+        re-layers the prior entries (which it currently does, until
+        per-entry content-hash dedup is added). The promise is:
+        nothing is lost AND the new content is present."""
         diary_dir = tmp_path / "diaries"
         diary_dir.mkdir()
         diary_file = diary_dir / "2026-04-13.md"
@@ -1011,8 +1029,17 @@ class TestDiaryIngest:
             + "\n## 12:00 — third\n\nthird body, newly added on second run.\n"
         )
         ingest_diaries(str(diary_dir), str(palace_dir))
-        final = get_collection(str(palace_dir)).count()
-        assert final == 3, f"after appending 1 entry: 3 drawers total; got {final}"
+        col = get_collection(str(palace_dir))
+
+        final = col.count()
+        assert final >= initial + 1, (
+            f"appending an entry must grow the palace by at least 1; "
+            f"initial={initial}, final={final}"
+        )
+        joined = "\n".join(col.get()["documents"])
+        assert "third body, newly added on second run." in joined, (
+            "newly appended entry's content is missing from the palace"
+        )
 
     def test_entry_count_watermark_matches_drawer_count(self, tmp_path):
         """Regression for #1539: persisted ``entry_count`` watermark
@@ -1078,20 +1105,23 @@ class TestDiaryIngest:
         sources = {m["source_file"] for m in all_drawers["metadatas"]}
         assert len(sources) == 1, f"all drawers must share one source_file; got {sources}"
 
-    def test_diary_entry_deletion_purges_orphan_drawers(self, tmp_path):
-        """Regression for #1539 review: if a diary shrinks (entries
-        deleted), the full-rebuild step must purge prior-pass drawers
-        for that ``source_file`` before re-writing — otherwise trailing
-        drawers from the longer prior pass remain as orphans and
-        pollute search results forever."""
+    def test_diary_entry_deletion_preserves_prior_entries_as_history(self, tmp_path):
+        """The verbatim-preservation principle: when entries are deleted
+        from a diary file and the file is re-ingested, the deleted
+        entries' content MUST remain in the palace as historical layers.
+        Only the explicit ``mempalace delete`` verb (or ``force=True``)
+        may destroy drawers. Replaces the prior "purges orphan drawers"
+        test whose premise — that shrinking a file should silently
+        destroy the removed entries' content — directly contradicted
+        the project's stated verbatim-preservation contract."""
         diary_dir = tmp_path / "diaries"
         diary_dir.mkdir()
         diary_file = diary_dir / "2026-04-13.md"
         diary_file.write_text(
             "# 2026-04-13\n\n"
             "## 10:00 — first\n\nfirst body content with enough length here.\n\n"
-            "## 11:00 — second\n\nsecond body content with enough length here.\n\n"
-            "## 12:00 — third\n\nthird body content with enough length here.\n"
+            "## 11:00 — second\n\nsecond body content with PRESERVE_MARKER_TWO here.\n\n"
+            "## 12:00 — third\n\nthird body content with PRESERVE_MARKER_THREE here.\n"
         )
         palace_dir = tmp_path / "palace"
 
@@ -1101,16 +1131,25 @@ class TestDiaryIngest:
         col = get_collection(str(palace_dir))
         assert col.count() == 3, f"baseline: 3 entries → 3 drawers; got {col.count()}"
 
-        # Shrink the file to 1 entry. Hash changes → content_changed=True
-        # → full_rebuild=True → purge step must remove the trailing 2 drawers.
+        # Shrink the file to 1 entry. Under additive ingestion, the deleted
+        # entries' content must remain retrievable from the palace.
         diary_file.write_text(
             "# 2026-04-13\n\n## 10:00 — first\n\nfirst body content with enough length here.\n"
         )
         ingest_diaries(str(diary_dir), str(palace_dir))
+        col = get_collection(str(palace_dir))
+
         final = col.count()
-        assert final == 1, (
-            f"after shrinking 3 entries → 1 entry: exactly 1 drawer; "
-            f"got {final} (orphans from prior pass not purged)"
+        assert final >= 3, (
+            f"deleting entries must NOT destroy prior layers; "
+            f"baseline was 3 drawers, final count is {final} (drawers were destroyed)"
+        )
+        joined = "\n".join(col.get()["documents"])
+        assert "PRESERVE_MARKER_TWO" in joined, (
+            "deleted entry's content (entry 2) was destroyed — violates verbatim-preservation"
+        )
+        assert "PRESERVE_MARKER_THREE" in joined, (
+            "deleted entry's content (entry 3) was destroyed — violates verbatim-preservation"
         )
 
     def test_diary_header_only_entry_produces_drawer(self, tmp_path):


### PR DESCRIPTION
## Summary

Re-mining a source file used to silently destroy every prior drawer for that file. This PR makes all four miner write paths purely additive: re-mining INSERTS new layers alongside any existing ones rather than overwriting them. The only path to drawer destruction is the new explicit `mempalace delete` verb.

The user story (from #1593):

> *"there is a difference between someone fixing typos and someone scrapping a document because they thought it sucked or it was embarrassing at the time, but then years later you would go, wow i wish i could look at that now, with a new set of eyes and remember who I was then, or that idea that seemed stupid actually was really relevant now... and it would be there."*

## What changed

### Stop destroying history on re-mine (closes #1593)

- Removed `collection.delete(where={"source_file": ...})` from `miner.py`, `format_miner.py`.
- Split `diary_ingest.full_rebuild` (force-only, destructive) from `reprocess_all` (force OR content_changed, additive re-run). Removes the hidden #1593 violation where ANY diary edit silently destroyed the prior version.
- `drawer_id` formula now includes `filed_at` (or its equivalent per miner) so each mining pass produces unique IDs — the upsert path INSERTS instead of overwrites.

### Three new metadata fields on every drawer

| Field | Purpose |
|---|---|
| `parent_drawer_id` | Groups every chunk of one mining pass. Used as the searcher scope key — closes #1580 by giving neighbor expansion a real boundary. |
| `stack_id` | Groups every VERSION of one chunk position across re-mines. One logical chunk → N layers across time. |
| `superseded_at` | Null infrastructure for the future cooldown / archive mechanic (PR B will populate). |

### Searcher fix (closes #1580)

`searcher._expand_with_neighbors` now scopes by `parent_drawer_id` when present, with a fallback to `source_file` for legacy drawers. Igor's exact repro from #1580 is included as a test.

`searcher.search()` now rolls up multi-layer hits to one result per `stack_id`, surfacing the latest layer with a `[N layers]` badge in the CLI output.

### Two new CLI verbs (sole destruction + display surface)

```
mempalace delete <id>   destroys by drawer_id / stack_id / parent_drawer_id
                        with --dry-run + confirmation prompt by default;
                        --force skips the prompt.

mempalace show <id>     renders a single drawer (drawer_*) or a stack of
                        layers (stack_*) with vertical navigation:
                          --layer older / newer / latest / oldest / N
                          --all-layers           flatten the whole stack
```

## Test plan

- [x] **13 new tests** in `tests/test_additive_mining_preservation.py`:
      - 7 preservation (miner, format_miner, diary_ingest)
      - 1 #1580 neighbor scope
      - 4 `mempalace delete` verb (subprocess end-to-end)
      - 2 `mempalace show` verb (subprocess end-to-end with multi-layer stacks)
- [x] **4 existing tests** in `tests/test_closets.py` updated to match the additive model (one was inverted; its prior premise contradicted #1593)
- [x] **Verification matrix:**
      - macOS Python 3.12 (local) → 2279 passed, 4 skipped, 0 failed
      - Linux Python 3.9.25 (orb) → 2272 passed, 11 skipped, 0 failed
      - Linux Python 3.11.15 (orb) → 2273 passed, 10 skipped, 0 failed
      - Linux Python 3.13.13 (orb) → 2273 passed, 10 skipped, 0 failed
- [x] Coverage: **84.45%** (above 80% threshold)
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — clean
- [x] `palace.make_id(prefix, *parts)` helper centralises all parent_drawer_id / stack_id construction across the 4 miners (kills hash-formula duplication)
- [x] `cmd_delete` / `cmd_show` catch specific exceptions instead of bare Exception
- [x] `_diary_drawer_id_entry` uses `Optional[str] = None` (idiomatic)

## What this does NOT do (deferred to PR B / PR C)

- **At-ingestion content-hash dedup.** Re-mining an unchanged file currently produces new layers (because mtime change triggers re-mine). PR B adds strict-hash dedup to skip identical content.
- **Session-marker splitting** for legacy `.md` monolith files. PR B adds Claude compaction-bar detection to `normalize.py`.
- **Archive chamber** (compressed-rehydratable storage for old layers). PR C.
- **Real-edit detection** (WordNet-based typo-vs-real-edit). Likely subsumed by PR B's session-split approach.

## Backwards compatibility

- Existing palaces continue to work: drawers without the new metadata fields are gracefully handled. Searcher rollup treats missing `stack_id` as singleton stacks; neighbor expansion falls back to `source_file` scope when `parent_drawer_id` is absent.
- The destructive deletes that have already happened (data lost to past re-mines) cannot be recovered. Going forward, nothing is lost.
- No migration step required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
