### PR TITLE
Expose candidate_strategy on the MCP search tool

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -882,6 +882,7 @@ def tool_search(
     max_distance: float = 1.5,
     min_similarity: float = None,
     context: str = None,
+    candidate_strategy: str = "vector",
 ):
     limit = max(1, min(limit, _MAX_RESULTS))
     try:
@@ -909,6 +910,7 @@ def tool_search(
         max_distance=dist,
         vector_disabled=_vector_disabled,
         collection_name=_config.collection_name,
+        candidate_strategy=candidate_strategy,
     )
     if _is_transient_index_error(result):
         # Post-bulk-write HNSW flush window (#1315): drop caches, give
@@ -925,6 +927,7 @@ def tool_search(
             n_results=limit,
             max_distance=dist,
             vector_disabled=_vector_disabled,
+            candidate_strategy=candidate_strategy,
         )
         if not _is_transient_index_error(result):
             result["index_recovered"] = True
@@ -2206,6 +2209,11 @@ TOOLS = {
                 "context": {
                     "type": "string",
                     "description": "Background context for the search (optional). NOT used for embedding — only for future re-ranking.",
+                },
+                "candidate_strategy": {
+                    "type": "string",
+                    "enum": ["vector", "union"],
+                    "description": "How candidates for the hybrid re-rank are gathered. 'vector' (default) ranks the vector-recall pool only. 'union' also merges top BM25 candidates from the sqlite FTS5 index, recalling drawers a keyword matches but the embedding missed.",
                 },
             },
             "required": ["query"],


### PR DESCRIPTION
## What

Adds a `candidate_strategy` parameter to the MCP `mempalace_search` tool, plumbing it through both `search_memories` calls in `tool_search` and adding it to the tool's input schema. Defaults to `"vector"`, so existing behavior is unchanged.

## Why

`search_memories(candidate_strategy="union")` is fully implemented in `searcher.py` and meaningfully improves recall — it merges top BM25 candidates from the sqlite FTS5 index, surfacing drawers that a keyword matches but the embedding missed. But MCP clients had no way to reach it: `tool_search` never passed the argument, so MCP search was hard-pinned to `"vector"`.

Verified locally by calling `search_memories` directly with both strategies on the same query — `"union"` returned a BM25-only hit (`distance=None`) that `"vector"` never surfaced.

## Changes

- `tool_search(...)` gains `candidate_strategy: str = "vector"`
- Both `search_memories(...)` calls forward it
- `mempalace_search` input schema gains the `candidate_strategy` enum (`vector` | `union`)

Back-compatible: omitting the param keeps the current `"vector"` behavior. Invalid values are already rejected by the existing `_validate_candidate_strategy`.
