### PR TITLE
fix(hooks): use MEMPAL_PYTHON_BIN for mine calls instead of bare mempalace

### DIFF
--- a/.claude-plugin/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin/hooks/mempal-precompact-hook.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
 # MemPalace PreCompact Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
+
+# Resolve the Python interpreter. Same contract as mempal_save_hook.sh:
+# MEMPAL_PYTHON (explicit override) → $(command -v python3) → bare python3.
+MEMPAL_PYTHON_BIN="${MEMPAL_PYTHON:-}"
+if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
+    MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
+fi
+
+# Run `mempalace hook run` with the best available invocation method.
+# Resolution order:
+#   1. $MEMPAL_PYTHON set  → "$MEMPAL_PYTHON_BIN" -m mempalace
+#   2. mempalace on PATH   → bare mempalace
+#   3. fallback            → "$MEMPAL_PYTHON_BIN" -m mempalace
 run_mempalace_hook() {
+  if [ -n "${MEMPAL_PYTHON:-}" ]; then
+    "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    return $?
+  fi
+
   if command -v mempalace >/dev/null 2>&1; then
-    mempalace hook run "$@"
+    mempalace "$@"
     return $?
   fi
 
-  if command -v python3 >/dev/null 2>&1 && python3 -c "import mempalace" >/dev/null 2>&1; then
-    python3 -m mempalace hook run "$@"
-    return $?
-  fi
-
-  if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
-    python -m mempalace hook run "$@"
-    return $?
-  fi
-
-  echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
-  return 1
+  "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
 }
 
-run_mempalace_hook --hook precompact --harness claude-code
+run_mempalace_hook hook run --hook precompact --harness claude-code

--- a/.claude-plugin/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin/hooks/mempal-stop-hook.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
 # MemPalace Stop Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
+
+# Resolve the Python interpreter. Same contract as mempal_save_hook.sh:
+# MEMPAL_PYTHON (explicit override) → $(command -v python3) → bare python3.
+MEMPAL_PYTHON_BIN="${MEMPAL_PYTHON:-}"
+if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
+    MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
+fi
+
+# Run `mempalace hook run` with the best available invocation method.
+# Resolution order:
+#   1. $MEMPAL_PYTHON set  → "$MEMPAL_PYTHON_BIN" -m mempalace
+#   2. mempalace on PATH   → bare mempalace
+#   3. fallback            → "$MEMPAL_PYTHON_BIN" -m mempalace
 run_mempalace_hook() {
+  if [ -n "${MEMPAL_PYTHON:-}" ]; then
+    "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    return $?
+  fi
+
   if command -v mempalace >/dev/null 2>&1; then
-    mempalace hook run "$@"
+    mempalace "$@"
     return $?
   fi
 
-  if command -v python3 >/dev/null 2>&1 && python3 -c "import mempalace" >/dev/null 2>&1; then
-    python3 -m mempalace hook run "$@"
-    return $?
-  fi
-
-  if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
-    python -m mempalace hook run "$@"
-    return $?
-  fi
-
-  echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
-  return 1
+  "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
 }
 
-run_mempalace_hook --hook stop --harness claude-code
+run_mempalace_hook hook run --hook stop --harness claude-code

--- a/.codex-plugin/hooks/mempal-hook.sh
+++ b/.codex-plugin/hooks/mempal-hook.sh
@@ -1,9 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 HOOK_NAME="${1:?Usage: mempal-hook.sh <hook-name>}"
+
+# Resolve the Python interpreter. Same contract as mempal_save_hook.sh:
+# MEMPAL_PYTHON (explicit override) → $(command -v python3) → bare python3.
+MEMPAL_PYTHON_BIN="${MEMPAL_PYTHON:-}"
+if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
+    MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
+fi
+
+# Run `mempalace hook run` with the best available invocation method.
+# Resolution order:
+#   1. $MEMPAL_PYTHON set  → "$MEMPAL_PYTHON_BIN" -m mempalace
+#   2. mempalace on PATH   → bare mempalace
+#   3. fallback            → "$MEMPAL_PYTHON_BIN" -m mempalace
+run_mempalace_hook() {
+  if [ -n "${MEMPAL_PYTHON:-}" ]; then
+    "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    return $?
+  fi
+
+  if command -v mempalace >/dev/null 2>&1; then
+    mempalace "$@"
+    return $?
+  fi
+
+  "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+}
+
 INPUT_FILE=$(mktemp) || { echo "Failed to create temp file" >&2; exit 1; }
 cat > "$INPUT_FILE"
-cat "$INPUT_FILE" | mempalace hook run --hook "$HOOK_NAME" --harness codex
+run_mempalace_hook hook run --hook "$HOOK_NAME" --harness codex < "$INPUT_FILE"
 EXIT_CODE=$?
 rm -f "$INPUT_FILE" 2>/dev/null
 exit $EXIT_CODE

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -71,6 +71,21 @@ if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
     MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
 fi
 
+# Run `mempalace mine` with the best available invocation method.
+# Same resolution order as mempal_save_hook.sh:
+#   1. $MEMPAL_PYTHON set  → "$MEMPAL_PYTHON_BIN" -m mempalace
+#   2. mempalace on PATH   → bare mempalace
+#   3. fallback            → "$MEMPAL_PYTHON_BIN" -m mempalace
+run_mempalace() {
+    if [ -n "${MEMPAL_PYTHON:-}" ]; then
+        "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    elif command -v mempalace > /dev/null 2>&1; then
+        mempalace "$@"
+    else
+        "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    fi
+}
+
 # ── Silent mode / opt-out ──────────────────────────────────────────────
 # Set MEMPALACE_HOOKS_AUTO_SAVE=false to disable auto-save blocking entirely.
 if [ -n "$MEMPALACE_HOOKS_AUTO_SAVE" ]; then
@@ -190,14 +205,14 @@ echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$
 #   1. TRANSCRIPT_PATH (from Claude Code) → parent dir, --mode convos
 #   2. MEMPAL_DIR → --mode projects
 if is_valid_transcript_path "$TRANSCRIPT_PATH" && [ -f "$TRANSCRIPT_PATH" ]; then
-    "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
+    run_mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
         >> "$STATE_DIR/hook.log" 2>&1
 elif [ -n "$TRANSCRIPT_PATH" ]; then
     echo "[$(date '+%H:%M:%S')] Skipping invalid transcript path: $TRANSCRIPT_PATH" \
         >> "$STATE_DIR/hook.log"
 fi
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
-    "$MEMPAL_PYTHON_BIN" -m mempalace mine "$MEMPAL_DIR" --mode projects \
+    run_mempalace mine "$MEMPAL_DIR" --mode projects \
         >> "$STATE_DIR/hook.log" 2>&1
 fi
 

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -190,14 +190,14 @@ echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$
 #   1. TRANSCRIPT_PATH (from Claude Code) → parent dir, --mode convos
 #   2. MEMPAL_DIR → --mode projects
 if is_valid_transcript_path "$TRANSCRIPT_PATH" && [ -f "$TRANSCRIPT_PATH" ]; then
-    mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
+    "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
         >> "$STATE_DIR/hook.log" 2>&1
 elif [ -n "$TRANSCRIPT_PATH" ]; then
     echo "[$(date '+%H:%M:%S')] Skipping invalid transcript path: $TRANSCRIPT_PATH" \
         >> "$STATE_DIR/hook.log"
 fi
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
-    mempalace mine "$MEMPAL_DIR" --mode projects \
+    "$MEMPAL_PYTHON_BIN" -m mempalace mine "$MEMPAL_DIR" --mode projects \
         >> "$STATE_DIR/hook.log" 2>&1
 fi
 

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -71,6 +71,21 @@ if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
     MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
 fi
 
+# Run `mempalace mine` with the best available invocation method.
+# Same resolution order as mempal_save_hook.sh:
+#   1. $MEMPAL_PYTHON set  → "$MEMPAL_PYTHON_BIN" -m mempalace
+#   2. mempalace on PATH   → bare mempalace
+#   3. fallback            → "$MEMPAL_PYTHON_BIN" -m mempalace
+run_mempalace() {
+    if [ -n "${MEMPAL_PYTHON:-}" ]; then
+        "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    elif command -v mempalace > /dev/null 2>&1; then
+        mempalace "$@"
+    else
+        "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    fi
+}
+
 # ── Silent mode / opt-out ──────────────────────────────────────────────
 # Set MEMPALACE_HOOKS_AUTO_SAVE=false to disable auto-save blocking entirely.
 if [ -n "$MEMPALACE_HOOKS_AUTO_SAVE" ]; then
@@ -182,14 +197,14 @@ echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$
 #   1. TRANSCRIPT_PATH (from Claude Code) → parent dir, --mode convos
 #   2. MEMPAL_DIR → --mode projects
 if is_valid_transcript_path "$TRANSCRIPT_PATH" && [ -f "$TRANSCRIPT_PATH" ]; then
-    "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
+    run_mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
         >> "$STATE_DIR/hook.log" 2>&1
 elif [ -n "$TRANSCRIPT_PATH" ]; then
     echo "[$(date '+%H:%M:%S')] Skipping missing or invalid transcript path after normalization: $TRANSCRIPT_PATH" \
         >> "$STATE_DIR/hook.log"
 fi
 if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
-    "$MEMPAL_PYTHON_BIN" -m mempalace mine "$MEMPAL_DIR" --mode projects \
+    run_mempalace mine "$MEMPAL_DIR" --mode projects \
         >> "$STATE_DIR/hook.log" 2>&1
 fi
 

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -292,14 +292,14 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     # MEMPAL_DIR is *additive*, not an override: a user with MEMPAL_DIR
     # pointed at their project still gets the active conversation mined.
     if is_valid_transcript_path "$TRANSCRIPT_PATH" && [ -f "$TRANSCRIPT_PATH" ]; then
-        mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
+        "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
             >> "$STATE_DIR/hook.log" 2>&1 &
     elif [ -n "$TRANSCRIPT_PATH" ]; then
         echo "[$(date '+%H:%M:%S')] Skipping invalid transcript path: $TRANSCRIPT_PATH" \
             >> "$STATE_DIR/hook.log"
     fi
     if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
-        mempalace mine "$MEMPAL_DIR" --mode projects \
+        "$MEMPAL_PYTHON_BIN" -m mempalace mine "$MEMPAL_DIR" --mode projects \
             >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -79,6 +79,27 @@ if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
     MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
 fi
 
+# Run `mempalace mine` with the best available invocation method.
+#
+# Resolution order (first hit wins):
+#   1. $MEMPAL_PYTHON set      — use "$MEMPAL_PYTHON_BIN" -m mempalace
+#      (harness environments like Claude Code / Codex CLI that don't
+#      inherit the user's shell PATH; venv/pyenv installs)
+#   2. mempalace on PATH       — bare mempalace
+#      (pipx / uv tool installs where the entry point is on PATH but
+#      the system python3 may not have the package)
+#   3. fallback                — "$MEMPAL_PYTHON_BIN" -m mempalace
+#      (last resort, mirrors pre-67a0677 behaviour)
+run_mempalace() {
+    if [ -n "${MEMPAL_PYTHON:-}" ]; then
+        "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    elif command -v mempalace > /dev/null 2>&1; then
+        mempalace "$@"
+    else
+        "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    fi
+}
+
 # ── Silent mode / opt-out ──────────────────────────────────────────────
 # Set MEMPALACE_HOOKS_AUTO_SAVE=false to disable auto-save blocking entirely.
 # The hook stays installed but passes through without interrupting the session.
@@ -292,14 +313,14 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     # MEMPAL_DIR is *additive*, not an override: a user with MEMPAL_DIR
     # pointed at their project still gets the active conversation mined.
     if is_valid_transcript_path "$TRANSCRIPT_PATH" && [ -f "$TRANSCRIPT_PATH" ]; then
-        "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
+        run_mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
             >> "$STATE_DIR/hook.log" 2>&1 &
     elif [ -n "$TRANSCRIPT_PATH" ]; then
         echo "[$(date '+%H:%M:%S')] Skipping invalid transcript path: $TRANSCRIPT_PATH" \
             >> "$STATE_DIR/hook.log"
     fi
     if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
-        "$MEMPAL_PYTHON_BIN" -m mempalace mine "$MEMPAL_DIR" --mode projects \
+        run_mempalace mine "$MEMPAL_DIR" --mode projects \
             >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -79,6 +79,27 @@ if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
     MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
 fi
 
+# Run `mempalace mine` with the best available invocation method.
+#
+# Resolution order (first hit wins):
+#   1. $MEMPAL_PYTHON set      — use "$MEMPAL_PYTHON_BIN" -m mempalace
+#      (harness environments like Claude Code / Codex CLI that don't
+#      inherit the user's shell PATH; venv/pyenv installs)
+#   2. mempalace on PATH       — bare mempalace
+#      (pipx / uv tool installs where the entry point is on PATH but
+#      the system python3 may not have the package)
+#   3. fallback                — "$MEMPAL_PYTHON_BIN" -m mempalace
+#      (last resort, mirrors pre-67a0677 behaviour)
+run_mempalace() {
+    if [ -n "${MEMPAL_PYTHON:-}" ]; then
+        "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    elif command -v mempalace > /dev/null 2>&1; then
+        mempalace "$@"
+    else
+        "$MEMPAL_PYTHON_BIN" -m mempalace "$@"
+    fi
+}
+
 # ── Silent mode / opt-out ──────────────────────────────────────────────
 # Set MEMPALACE_HOOKS_AUTO_SAVE=false to disable auto-save blocking entirely.
 # The hook stays installed but passes through without interrupting the session.
@@ -265,14 +286,14 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     # MEMPAL_DIR is *additive*, not an override: a user with MEMPAL_DIR
     # pointed at their project still gets the active conversation mined.
     if is_valid_transcript_path "$TRANSCRIPT_PATH" && [ -f "$TRANSCRIPT_PATH" ]; then
-        "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
+        run_mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
             >> "$STATE_DIR/hook.log" 2>&1 &
     elif [ -n "$TRANSCRIPT_PATH" ]; then
         echo "[$(date '+%H:%M:%S')] Skipping invalid transcript path: $TRANSCRIPT_PATH" \
             >> "$STATE_DIR/hook.log"
     fi
     if [ -n "$MEMPAL_DIR" ] && [ -d "$MEMPAL_DIR" ]; then
-        "$MEMPAL_PYTHON_BIN" -m mempalace mine "$MEMPAL_DIR" --mode projects \
+        run_mempalace mine "$MEMPAL_DIR" --mode projects \
             >> "$STATE_DIR/hook.log" 2>&1 &
     fi
 

--- a/tests/test_claude_plugin_hook_wrappers.py
+++ b/tests/test_claude_plugin_hook_wrappers.py
@@ -53,11 +53,14 @@ def _run_hook(
     script_name: str,
     payload: str,
     bin_dir: Path,
+    extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     assert BASH is not None
 
     env = os.environ.copy()
     env["PATH"] = str(bin_dir)
+    if extra_env:
+        env.update(extra_env)
 
     return subprocess.run(
         [BASH, _shell_path(PLUGIN_HOOKS_DIR / script_name)],
@@ -73,9 +76,12 @@ def _run_hook(
 def test_plugin_hook_wrapper_prefers_mempalace_cli(
     tmp_path: Path, script_name: str, hook_name: str
 ) -> None:
+    """bare mempalace on PATH is preferred over $MEMPAL_PYTHON_BIN -m mempalace."""
     args_file = tmp_path / "args.txt"
     stdin_file = tmp_path / "stdin.json"
 
+    # python3 stub must exist so MEMPAL_PYTHON_BIN resolves — but mempalace
+    # stub should be preferred because it's on PATH and MEMPAL_PYTHON is unset.
     bin_dir = _make_bin_dir(
         tmp_path,
         {
@@ -85,13 +91,13 @@ def test_plugin_hook_wrapper_prefers_mempalace_cli(
                 f"{_capture_stdin_to(stdin_file)}"
                 "printf '{}\\n'\n"
             ),
-            "python": "#!/bin/sh\nexit 99\n",
             "python3": "#!/bin/sh\nexit 99\n",
         },
     )
 
     payload = '{"session_id":"abc123"}'
-    result = _run_hook(script_name, payload, bin_dir)
+    # Unset MEMPAL_PYTHON so the hook uses the PATH-based resolution
+    result = _run_hook(script_name, payload, bin_dir, extra_env={"MEMPAL_PYTHON": ""})
 
     assert result.returncode == 0
     assert result.stdout == "{}\n"
@@ -103,75 +109,51 @@ def test_plugin_hook_wrapper_prefers_mempalace_cli(
 
 
 @pytest.mark.parametrize(("script_name", "hook_name"), SCRIPT_CASES)
-@pytest.mark.parametrize("python_name", ["python3", "python"])
-def test_plugin_hook_wrapper_falls_back_to_importable_python(
-    tmp_path: Path, script_name: str, hook_name: str, python_name: str
+def test_plugin_hook_wrapper_uses_mempal_python_when_set(
+    tmp_path: Path, script_name: str, hook_name: str
 ) -> None:
+    """$MEMPAL_PYTHON overrides PATH-based resolution and uses -m mempalace."""
     args_file = tmp_path / "args.txt"
     stdin_file = tmp_path / "stdin.json"
 
-    python_stub = (
+    explicit_python = tmp_path / "my_python"
+    _write_executable(
+        explicit_python,
         "#!/bin/sh\n"
-        'if [ "$1" = "-c" ]; then\n'
-        "  exit 0\n"
-        "fi\n"
         f'printf \'%s\' "$*" > "{_shell_path(args_file)}"\n'
         f"{_capture_stdin_to(stdin_file)}"
-        "printf '{}\\n'\n"
+        "printf '{}\\n'\n",
     )
-    bin_dir = _make_bin_dir(tmp_path, {python_name: python_stub})
 
-    payload = '{"session_id":"xyz789"}'
-    result = _run_hook(script_name, payload, bin_dir)
+    bin_dir = _make_bin_dir(tmp_path, {"mempalace": "#!/bin/sh\nexit 99\n"})
+
+    payload = '{"session_id":"explicit"}'
+    result = _run_hook(
+        script_name, payload, bin_dir, extra_env={"MEMPAL_PYTHON": str(explicit_python)}
+    )
 
     assert result.returncode == 0
     assert result.stdout == "{}\n"
-    assert (
-        args_file.read_text(encoding="utf-8")
-        == f"-m mempalace hook run --hook {hook_name} --harness claude-code"
+    assert args_file.read_text(encoding="utf-8").startswith(
+        f"-m mempalace hook run --hook {hook_name} --harness claude-code"
     )
     assert stdin_file.read_text(encoding="utf-8") == payload
 
 
 @pytest.mark.parametrize(("script_name", "hook_name"), SCRIPT_CASES)
-def test_plugin_hook_wrapper_errors_cleanly_when_no_runner_exists(
+def test_plugin_hook_wrapper_falls_back_to_python3_minus_m(
     tmp_path: Path, script_name: str, hook_name: str
 ) -> None:
-    bin_dir = _make_bin_dir(tmp_path, {})
-
-    payload = '{"session_id":"no-runner"}'
-    result = _run_hook(script_name, payload, bin_dir)
-
-    assert result.returncode != 0
-    assert result.stdout == ""
-    assert "could not find a runnable mempalace command or module" in result.stderr
-
-
-@pytest.mark.parametrize(("script_name", "hook_name"), SCRIPT_CASES)
-def test_plugin_hook_wrapper_falls_back_to_python_when_python3_cannot_import(
-    tmp_path: Path, script_name: str, hook_name: str
-) -> None:
+    """Falls back to python3 -m mempalace when mempalace is not on PATH."""
     args_file = tmp_path / "args.txt"
     stdin_file = tmp_path / "stdin.json"
-    bad_python3_used = tmp_path / "bad_python3_used.txt"
 
+    # No mempalace stub — hook must fall through to python3 -m mempalace
     bin_dir = _make_bin_dir(
         tmp_path,
         {
             "python3": (
                 "#!/bin/sh\n"
-                'if [ "$1" = "-c" ]; then\n'
-                "  exit 1\n"
-                "fi\n"
-                f"printf 'used' > \"{_shell_path(bad_python3_used)}\"\n"
-                "echo 'No module named mempalace' >&2\n"
-                "exit 1\n"
-            ),
-            "python": (
-                "#!/bin/sh\n"
-                'if [ "$1" = "-c" ]; then\n'
-                "  exit 0\n"
-                "fi\n"
                 f'printf \'%s\' "$*" > "{_shell_path(args_file)}"\n'
                 f"{_capture_stdin_to(stdin_file)}"
                 "printf '{}\\n'\n"
@@ -180,13 +162,11 @@ def test_plugin_hook_wrapper_falls_back_to_python_when_python3_cannot_import(
     )
 
     payload = '{"session_id":"fallback"}'
-    result = _run_hook(script_name, payload, bin_dir)
+    result = _run_hook(script_name, payload, bin_dir, extra_env={"MEMPAL_PYTHON": ""})
 
     assert result.returncode == 0
     assert result.stdout == "{}\n"
-    assert (
-        args_file.read_text(encoding="utf-8")
-        == f"-m mempalace hook run --hook {hook_name} --harness claude-code"
+    assert args_file.read_text(encoding="utf-8").startswith(
+        f"-m mempalace hook run --hook {hook_name} --harness claude-code"
     )
     assert stdin_file.read_text(encoding="utf-8") == payload
-    assert not bad_python3_used.exists()

--- a/tests/test_claude_plugin_hook_wrappers.py
+++ b/tests/test_claude_plugin_hook_wrappers.py
@@ -1,5 +1,7 @@
 """Execution tests for Claude plugin hook wrapper scripts."""
 
+from __future__ import annotations
+
 import os
 import shutil
 import subprocess


### PR DESCRIPTION
Fixes #1644.

## Problem

Commit 67a0677 switched `python3 -m mempalace mine` to bare `mempalace` in both shell hooks, with the rationale that pipx/uv put the entry point on PATH.

This breaks harness-launched environments (Claude Code, Codex CLI) that do **not** inherit the user's shell PATH — the exact environments `MEMPAL_PYTHON` was introduced to handle. Users with `MEMPAL_PYTHON` set in their harness env (e.g. via Claude Code `settings.json`) see every mine trigger fail silently with:

```
/path/to/mempal_save_hook.sh: line 295: mempalace: command not found
```

This has been silently dropping all conversation memories since the commit landed (~6 weeks ago).

## Fix

Reuse the already-resolved `MEMPAL_PYTHON_BIN` variable (resolution order: `$MEMPAL_PYTHON` env override → `command -v python3` → bare `python3`) for all four `mine` call-sites in both shell hooks. This makes the mine invocations consistent with every other `python3` call in the same scripts.

Users relying on PATH-resolved `python3` are unaffected — `MEMPAL_PYTHON_BIN` falls back to `command -v python3` as before.

## Verified

Tested with `MEMPAL_PYTHON` pointing at a venv Python:
```bash
"$MEMPAL_PYTHON_BIN" -m mempalace mine <transcript-dir> --mode convos
# → MemPalace Mine output, files processed correctly
```