### PR TITLE
feat(sqlite): bound read-path statement timeout + connection lifecycle via _connect_ro

### DIFF
--- a/mempalace/_sqlite_ro.py
+++ b/mempalace/_sqlite_ro.py
@@ -1,0 +1,210 @@
+"""Centralized read-only SQLite connection helper for MemPalace.
+
+SQLite has no ``SET statement_timeout`` (that is Postgres-only). The correct
+analogs are:
+
+- ``PRAGMA busy_timeout`` -- a *lock-wait* ceiling (how long to wait for a
+  writer's lock before giving up). Bounds contention with the miner/repair.
+- ``set_progress_handler`` + an abort return -- a *runaway-statement* ceiling
+  (wall-clock deadline for a single statement). Bounds a pathological
+  BM25/IN/metadata scan that would otherwise run unbounded against the
+  multi-GB ``chroma.sqlite3`` and block the MCP event loop.
+
+This helper centralizes both ceilings, guarantees the connection is closed on
+every exit path (success or exception), enforces ``query_only`` as defense in
+depth, and applies read-tuning PRAGMAs (``mmap_size`` / ``cache_size`` /
+``temp_store``) sized for the large store.
+
+Behaviour-preserving: callers run exactly the same SQL and get exactly the same
+rows in the same order. The only new behaviour is that a statement exceeding its
+wall-clock deadline now raises :class:`StatementTimeout` instead of running
+unbounded. Normal queries (well under the deadline) see no behavioural change.
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+# --- Defaults -----------------------------------------------------------------
+
+# Lock-wait ceiling. Matches SQLite's historical 5 s default; explicit so the
+# value is visible and tunable rather than implicit.
+DEFAULT_BUSY_TIMEOUT_MS = 5_000
+
+# Runaway-statement wall-clock ceiling for interactive read surfaces
+# (search, status, vector-segment lookup). Batch/repair callers pass a
+# larger value explicitly.
+DEFAULT_DEADLINE_S = 15.0
+
+# Progress handler fires every N virtual-machine opcodes and calls
+# time.monotonic(). Lower = finer deadline granularity but more per-opcode
+# overhead -- and FTS5/union scans burn opcodes fast, so an aggressive value
+# measurably slowed the union path (p50 +8%, p95 +63%) in the first AFTER run.
+# For a 15-120 s wall-clock deadline, checking the clock every ~1M opcodes is
+# more than frequent enough; it cuts the callback rate ~20x and erases the
+# union regression while still aborting a true runaway well inside the ceiling.
+_PROGRESS_OPS = 1_000_000
+
+# Read-tuning PRAGMAs (mmap_size / cache_size / temp_store) are DISABLED by
+# default (0 = "don't set"). Two measured reasons, from the paired benchmark in
+# projects/active/mempalace-ab/bench/harden-sqlite/:
+#   1. No latency benefit. The warm read path is served from the OS page cache
+#      and is Python/chromadb-bound, not SQLite-I/O-bound; 5 alternating rounds
+#      showed the tuning delta inside the run-to-run noise band (+/-~40 ms p50).
+#   2. They perturb results. The upstream FTS5 candidate query has no
+#      deterministic ORDER BY before its LIMIT; mmap/cache/temp_store change the
+#      b-tree traversal order, which changes which candidates survive the LIMIT
+#      -> different (and run-to-run unstable) recall on high-fanout queries.
+#      A read-safety change must be recall-neutral, so we do not pay an ordering
+#      risk for a benefit that does not exist.
+# Callers that benchmark a STATIC snapshot may still opt in by passing explicit
+# mmap_size / cache_size_kib. The live read path uses 0/0.
+DEFAULT_MMAP_SIZE = 0  # bytes; 0 = leave SQLite default (no PRAGMA mmap_size)
+DEFAULT_CACHE_SIZE_KIB = 0  # 0 = leave SQLite default (no PRAGMA cache_size)
+DEFAULT_TEMP_STORE_MEMORY = False  # leave PRAGMA temp_store at its default
+
+
+class StatementTimeout(sqlite3.OperationalError):
+    """A read statement exceeded its wall-clock deadline and was aborted."""
+
+
+def _install_deadline(conn: sqlite3.Connection, deadline_s: Optional[float]) -> None:
+    """Arm a wall-clock deadline via the progress handler.
+
+    The handler returns non-zero once the deadline passes, which makes SQLite
+    abort the running statement and raise ``sqlite3.OperationalError``.
+    """
+    if not deadline_s or deadline_s <= 0:
+        return
+    deadline = time.monotonic() + deadline_s
+
+    def _handler() -> int:  # pragma: no cover - exercised via integration
+        return 1 if time.monotonic() > deadline else 0
+
+    conn.set_progress_handler(_handler, _PROGRESS_OPS)
+
+
+def _apply_read_pragmas(
+    conn: sqlite3.Connection,
+    *,
+    busy_timeout_ms: int,
+    mmap_size: int,
+    cache_size_kib: int,
+    temp_store_memory: bool,
+) -> None:
+    # Safety floor -- always applied, never changes query RESULTS or ordering:
+    conn.execute(f"PRAGMA busy_timeout = {int(busy_timeout_ms)}")
+    conn.execute("PRAGMA query_only = ON")
+    # Read-tuning -- opt-in only (default off); see the DEFAULT_* notes above on
+    # why these are not applied to the live read path (no measured speedup +
+    # they perturb FTS5 candidate traversal order).
+    if temp_store_memory:
+        conn.execute("PRAGMA temp_store = MEMORY")
+    if cache_size_kib:
+        conn.execute(f"PRAGMA cache_size = {int(cache_size_kib)}")
+    if mmap_size:
+        # mmap_size is best-effort; ignored if the build caps it lower.
+        conn.execute(f"PRAGMA mmap_size = {int(mmap_size)}")
+
+
+def _build_uri(db_path: str, *, immutable: bool) -> str:
+    uri = f"file:{db_path}?mode=ro"
+    if immutable:
+        # immutable=1 promises SQLite the file will not change while open, so
+        # it can skip locking and shared-memory work for a read speedup. Valid
+        # ONLY for a static snapshot -- NEVER for the live, actively-mined
+        # palace (the miner/repair write it concurrently).
+        uri += "&immutable=1"
+    return uri
+
+
+def open_ro(
+    db_path: str,
+    *,
+    deadline_s: Optional[float] = DEFAULT_DEADLINE_S,
+    busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
+    immutable: bool = False,
+    mmap_size: int = DEFAULT_MMAP_SIZE,
+    cache_size_kib: int = DEFAULT_CACHE_SIZE_KIB,
+    temp_store_memory: bool = DEFAULT_TEMP_STORE_MEMORY,
+) -> sqlite3.Connection:
+    """Open and configure a read-only connection (caller owns ``.close()``).
+
+    Use this at call sites that already manage the connection with their own
+    ``try/finally`` -- it is a drop-in replacement for
+    ``sqlite3.connect(f"file:{path}?mode=ro", uri=True)`` that additionally
+    applies the read PRAGMAs and arms the statement deadline. For new code,
+    prefer the :func:`connect_ro` context manager, which also guarantees the
+    close.
+
+    The read-tuning args (``mmap_size`` / ``cache_size_kib`` /
+    ``temp_store_memory``) default to off; see the module-level notes for why.
+
+    Raises:
+        sqlite3.OperationalError: on open failure or PRAGMA failure (the
+            half-open connection is closed before the exception propagates).
+    """
+    conn = sqlite3.connect(_build_uri(db_path, immutable=immutable), uri=True)
+    try:
+        _apply_read_pragmas(
+            conn,
+            busy_timeout_ms=busy_timeout_ms,
+            mmap_size=mmap_size,
+            cache_size_kib=cache_size_kib,
+            temp_store_memory=temp_store_memory,
+        )
+        _install_deadline(conn, deadline_s)
+    except Exception:
+        conn.close()
+        raise
+    return conn
+
+
+@contextmanager
+def connect_ro(
+    db_path: str,
+    *,
+    deadline_s: Optional[float] = DEFAULT_DEADLINE_S,
+    busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
+    immutable: bool = False,
+    mmap_size: int = DEFAULT_MMAP_SIZE,
+    cache_size_kib: int = DEFAULT_CACHE_SIZE_KIB,
+    temp_store_memory: bool = DEFAULT_TEMP_STORE_MEMORY,
+) -> Iterator[sqlite3.Connection]:
+    """Open a read-only SQLite connection with timeout + lifecycle guarantees.
+
+    Args:
+        db_path: filesystem path to the SQLite database.
+        deadline_s: wall-clock ceiling for any single statement; ``None``/``0``
+            disables. Exceeding it aborts the statement (OperationalError).
+        busy_timeout_ms: lock-wait ceiling in milliseconds.
+        immutable: snapshot-only fast path; must stay ``False`` for the live
+            palace.
+        mmap_size: memory-map ceiling in bytes (best-effort).
+        cache_size_kib: page cache size; negative value is KiB per SQLite.
+
+    Yields:
+        An open ``sqlite3.Connection`` in read-only mode. Always closed on exit.
+
+    Raises:
+        sqlite3.OperationalError: on open failure or deadline overrun.
+    """
+    conn = open_ro(
+        db_path,
+        deadline_s=deadline_s,
+        busy_timeout_ms=busy_timeout_ms,
+        immutable=immutable,
+        mmap_size=mmap_size,
+        cache_size_kib=cache_size_kib,
+        temp_store_memory=temp_store_memory,
+    )
+    try:
+        yield conn
+    finally:
+        try:
+            conn.set_progress_handler(None, 0)
+        except Exception:  # pragma: no cover - best effort teardown
+            pass
+        conn.close()

--- a/mempalace/_sqlite_ro.py
+++ b/mempalace/_sqlite_ro.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import sqlite3
 import time
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Iterator, Optional
 
 # --- Defaults -----------------------------------------------------------------
@@ -67,18 +68,95 @@ DEFAULT_TEMP_STORE_MEMORY = False  # leave PRAGMA temp_store at its default
 
 
 class StatementTimeout(sqlite3.OperationalError):
-    """A read statement exceeded its wall-clock deadline and was aborted."""
+    """A read statement exceeded its wall-clock deadline and was aborted.
+
+    When the progress handler trips, the sqlite3 driver surfaces the abort as a
+    generic :class:`sqlite3.OperationalError` ("interrupted"). The connection
+    returned by :func:`open_ro` / :func:`connect_ro` translates that specific
+    abort -- recognised by the connection's wall-clock deadline having already
+    passed -- into this subclass, so a runaway-statement timeout is catchable
+    distinctly. Every other ``OperationalError`` (locked, malformed, read-only
+    violation, …) propagates unchanged. Because it subclasses
+    ``OperationalError``, existing broad ``except sqlite3.OperationalError``
+    handlers keep working.
+    """
 
 
-def _install_deadline(conn: sqlite3.Connection, deadline_s: Optional[float]) -> None:
+def _timeout_or_original(
+    exc: sqlite3.OperationalError, deadline: Optional[float]
+) -> sqlite3.OperationalError:
+    """Map a statement abort to StatementTimeout iff the deadline has passed.
+
+    The progress-handler abort is the only OperationalError whose timing
+    coincides with the deadline; any other OperationalError raised before the
+    deadline (locked, read-only violation, malformed schema) is returned as-is.
+    """
+    if deadline is not None and time.monotonic() > deadline:
+        return StatementTimeout(
+            str(exc) or "statement exceeded its wall-clock deadline"
+        )
+    return exc
+
+
+class _RODeadlineCursor(sqlite3.Cursor):
+    """Cursor that translates a deadline-abort into :class:`StatementTimeout`."""
+
+    def execute(self, *args, **kwargs):  # type: ignore[override]
+        try:
+            return super().execute(*args, **kwargs)
+        except sqlite3.OperationalError as exc:
+            deadline = getattr(self.connection, "_ro_deadline", None)
+            raise _timeout_or_original(exc, deadline) from exc
+
+    def executemany(self, *args, **kwargs):  # type: ignore[override]
+        try:
+            return super().executemany(*args, **kwargs)
+        except sqlite3.OperationalError as exc:
+            deadline = getattr(self.connection, "_ro_deadline", None)
+            raise _timeout_or_original(exc, deadline) from exc
+
+
+class _RODeadlineConnection(sqlite3.Connection):
+    """Connection that maps a deadline-abort into :class:`StatementTimeout`.
+
+    Covers both the direct ``connection.execute(...)`` shortcut and the
+    ``connection.cursor().execute(...)`` surface (callers use both).
+    """
+
+    # Armed by _install_deadline; None when no deadline is set. Declared at
+    # class level so getattr is safe before the connection is configured.
+    _ro_deadline: Optional[float] = None
+
+    def execute(self, *args, **kwargs):  # type: ignore[override]
+        try:
+            return super().execute(*args, **kwargs)
+        except sqlite3.OperationalError as exc:
+            raise _timeout_or_original(exc, self._ro_deadline) from exc
+
+    def executemany(self, *args, **kwargs):  # type: ignore[override]
+        try:
+            return super().executemany(*args, **kwargs)
+        except sqlite3.OperationalError as exc:
+            raise _timeout_or_original(exc, self._ro_deadline) from exc
+
+    def cursor(self, factory=_RODeadlineCursor):  # type: ignore[override]
+        return super().cursor(factory)
+
+
+def _install_deadline(conn: "_RODeadlineConnection", deadline_s: Optional[float]) -> None:
     """Arm a wall-clock deadline via the progress handler.
 
     The handler returns non-zero once the deadline passes, which makes SQLite
-    abort the running statement and raise ``sqlite3.OperationalError``.
+    abort the running statement; :class:`_RODeadlineConnection` then translates
+    that abort into :class:`StatementTimeout`. The deadline is also stored on the
+    connection so the translation can tell a timeout abort from any other
+    OperationalError.
     """
     if not deadline_s or deadline_s <= 0:
+        conn._ro_deadline = None
         return
     deadline = time.monotonic() + deadline_s
+    conn._ro_deadline = deadline
 
     def _handler() -> int:  # pragma: no cover - exercised via integration
         return 1 if time.monotonic() > deadline else 0
@@ -110,7 +188,11 @@ def _apply_read_pragmas(
 
 
 def _build_uri(db_path: str, *, immutable: bool) -> str:
-    uri = f"file:{db_path}?mode=ro"
+    # Build the file: URI via Path.as_uri() rather than f-string interpolation:
+    # it produces an absolute, properly percent-encoded URI and handles Windows
+    # drive letters / backslashes and POSIX paths containing '?' or '#' (both
+    # valid in filenames) that would otherwise confuse SQLite's URI parser.
+    uri = f"{Path(db_path).absolute().as_uri()}?mode=ro"
     if immutable:
         # immutable=1 promises SQLite the file will not change while open, so
         # it can skip locking and shared-memory work for a read speedup. Valid
@@ -145,8 +227,14 @@ def open_ro(
     Raises:
         sqlite3.OperationalError: on open failure or PRAGMA failure (the
             half-open connection is closed before the exception propagates).
+        StatementTimeout: (subclass of OperationalError) when a later statement
+            on the returned connection exceeds ``deadline_s``.
     """
-    conn = sqlite3.connect(_build_uri(db_path, immutable=immutable), uri=True)
+    conn = sqlite3.connect(
+        _build_uri(db_path, immutable=immutable),
+        uri=True,
+        factory=_RODeadlineConnection,
+    )
     try:
         _apply_read_pragmas(
             conn,
@@ -189,7 +277,8 @@ def connect_ro(
         An open ``sqlite3.Connection`` in read-only mode. Always closed on exit.
 
     Raises:
-        sqlite3.OperationalError: on open failure or deadline overrun.
+        sqlite3.OperationalError: on open failure.
+        StatementTimeout: (subclass of OperationalError) on deadline overrun.
     """
     conn = open_ro(
         db_path,

--- a/mempalace/_sqlite_ro.py
+++ b/mempalace/_sqlite_ro.py
@@ -20,6 +20,7 @@ rows in the same order. The only new behaviour is that a statement exceeding its
 wall-clock deadline now raises :class:`StatementTimeout` instead of running
 unbounded. Normal queries (well under the deadline) see no behavioural change.
 """
+
 from __future__ import annotations
 
 import sqlite3
@@ -92,9 +93,7 @@ def _timeout_or_original(
     deadline (locked, read-only violation, malformed schema) is returned as-is.
     """
     if deadline is not None and time.monotonic() > deadline:
-        return StatementTimeout(
-            str(exc) or "statement exceeded its wall-clock deadline"
-        )
+        return StatementTimeout(str(exc) or "statement exceeded its wall-clock deadline")
     return exc
 
 

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -25,6 +25,7 @@ from .base import (
     UnsupportedFilterError,
     _IncludeSpec,
 )
+from .._sqlite_ro import open_ro
 
 logger = logging.getLogger(__name__)
 
@@ -328,7 +329,7 @@ def _vector_segment_id(palace_path: str, collection_name: str) -> Optional[str]:
     if not os.path.isfile(db_path):
         return None
     try:
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn = open_ro(db_path)
         try:
             row = conn.execute(
                 """
@@ -496,7 +497,7 @@ def _read_sync_threshold(palace_path: str, collection_name: str) -> int:
     if not os.path.isfile(db_path):
         return 1000
     try:
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn = open_ro(db_path)
         try:
             cur = conn.cursor()
             cur.execute(
@@ -616,7 +617,7 @@ def _sqlite_embedding_count(palace_path: str, collection_name: str) -> Optional[
     if not os.path.isfile(db_path):
         return None
     try:
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn = open_ro(db_path)
         try:
             row = conn.execute(
                 """

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -673,6 +673,8 @@ def _tool_status_via_sqlite() -> dict:
     """
     import sqlite3 as _sqlite3
 
+    from ._sqlite_ro import open_ro
+
     db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return _no_palace()
@@ -682,7 +684,7 @@ def _tool_status_via_sqlite() -> dict:
     rooms: dict = {}
     total = 0
     try:
-        conn = _sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn = open_ro(db_path)
         try:
             row = conn.execute(
                 """

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -42,6 +42,7 @@ from typing import Callable, Iterator, Optional
 
 from chromadb.errors import NotFoundError as ChromaNotFoundError
 
+from ._sqlite_ro import connect_ro, open_ro
 from .backends.chroma import ChromaBackend, hnsw_capacity_status
 
 
@@ -474,9 +475,7 @@ def sqlite_drawer_count(palace_path: str, collection_name: Optional[str] = None)
     if not os.path.exists(sqlite_path):
         return None
     try:
-        import sqlite3
-
-        conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
+        conn = open_ro(sqlite_path, deadline_s=120.0)
         try:
             row = conn.execute(
                 """
@@ -516,7 +515,11 @@ def sqlite_integrity_errors(palace_path: str) -> list[str]:
         return []
 
     try:
-        with sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True) as conn:
+        # Full-DB integrity scan run as an explicit maintenance op (not on the
+        # MCP event loop), so no wall-clock deadline -- it legitimately scans
+        # the whole multi-GB file. connect_ro still guarantees close (the bare
+        # `with sqlite3.connect(...)` form commits but never closes).
+        with connect_ro(sqlite_path, deadline_s=None) as conn:
             rows = conn.execute("PRAGMA quick_check").fetchall()
     except sqlite3.Error as e:
         return [f"PRAGMA quick_check failed: {e}"]
@@ -1001,7 +1004,7 @@ def extract_via_sqlite(palace_path: str, collection_name: str) -> Iterator[tuple
     if not os.path.isfile(sqlite_path):
         return
 
-    conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
+    conn = open_ro(sqlite_path, deadline_s=120.0)
     try:
         seg_row = conn.execute(
             """

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -16,6 +16,7 @@ import re
 import sqlite3
 from pathlib import Path
 
+from ._sqlite_ro import open_ro
 from .backends import CollectionNotInitializedError, PalaceNotFoundError
 from .palace import get_closets_collection, get_collection
 
@@ -458,7 +459,11 @@ def _bm25_only_via_sqlite(
         return "".join(clauses), params
 
     try:
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        # Interactive search surface: bounded busy_timeout + statement deadline
+        # + read PRAGMAs (see mempalace._sqlite_ro). Behaviour-preserving --
+        # same SQL, same rows; only the connection setup and the runaway ceiling
+        # change. The existing finally: conn.close() below stays the owner.
+        conn = open_ro(db_path)
     except sqlite3.Error as e:
         return {"error": f"sqlite open failed: {e}"}
 

--- a/tests/test_sqlite_ro.py
+++ b/tests/test_sqlite_ro.py
@@ -1,0 +1,183 @@
+"""Tests for the read-only SQLite connection helper and the read-path
+parameterization regression guard (change: harden-mempalace-sqlite-timeouts)."""
+from __future__ import annotations
+
+import ast
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from mempalace._sqlite_ro import StatementTimeout, connect_ro, open_ro
+
+import mempalace.searcher as _searcher_mod
+import mempalace.repair as _repair_mod
+import mempalace.backends.chroma as _chroma_mod
+import mempalace.mcp_server as _mcp_mod
+
+
+@pytest.fixture()
+def tiny_db(tmp_path: Path) -> str:
+    """A real on-disk SQLite file (open_ro requires mode=ro on a file)."""
+    p = tmp_path / "tiny.sqlite3"
+    conn = sqlite3.connect(str(p))
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+    conn.executemany("INSERT INTO t (v) VALUES (?)", [("a",), ("b",), ("c",)])
+    conn.commit()
+    conn.close()
+    return str(p)
+
+
+# --- P3.3 deadline -----------------------------------------------------------
+
+def test_deadline_aborts_runaway_statement(tiny_db: str) -> None:
+    """A deliberately infinite recursive CTE must be aborted near the deadline,
+    not run unbounded."""
+    deadline_s = 0.4
+    start = time.monotonic()
+    with pytest.raises(sqlite3.OperationalError):
+        with connect_ro(tiny_db, deadline_s=deadline_s) as conn:
+            # Infinite generator — only the progress-handler deadline stops it.
+            conn.execute(
+                "WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c)"
+                " SELECT count(*) FROM c"
+            ).fetchall()
+    elapsed = time.monotonic() - start
+    # Aborts promptly after the deadline (generous upper bound for CI jitter).
+    assert deadline_s - 0.1 <= elapsed <= deadline_s + 5.0
+
+
+def test_statement_timeout_is_operationalerror() -> None:
+    """The exported StatementTimeout is a sqlite3.OperationalError subclass so
+    callers can catch it via the broad sqlite3.Error/OperationalError they
+    already handle on read paths."""
+    assert issubclass(StatementTimeout, sqlite3.OperationalError)
+
+
+def test_no_deadline_allows_normal_query(tiny_db: str) -> None:
+    """deadline_s=None disables the ceiling; a normal query returns rows."""
+    with connect_ro(tiny_db, deadline_s=None) as conn:
+        rows = conn.execute("SELECT v FROM t ORDER BY id").fetchall()
+    assert [r[0] for r in rows] == ["a", "b", "c"]
+
+
+# --- P3.4 lifecycle ----------------------------------------------------------
+
+def test_context_manager_closes_on_success(tiny_db: str) -> None:
+    with connect_ro(tiny_db) as conn:
+        conn.execute("SELECT 1").fetchone()
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")  # closed connection
+
+
+def test_context_manager_closes_on_exception(tiny_db: str) -> None:
+    captured = {}
+
+    class Boom(RuntimeError):
+        pass
+
+    with pytest.raises(Boom):
+        with connect_ro(tiny_db) as conn:
+            captured["conn"] = conn
+            raise Boom()
+    with pytest.raises(sqlite3.ProgrammingError):
+        captured["conn"].execute("SELECT 1")
+
+
+def test_open_ro_caller_owns_close(tiny_db: str) -> None:
+    conn = open_ro(tiny_db)
+    try:
+        assert conn.execute("SELECT count(*) FROM t").fetchone()[0] == 3
+    finally:
+        conn.close()
+
+
+# --- read PRAGMAs applied ----------------------------------------------------
+
+def test_safety_floor_pragmas_always_applied(tiny_db: str) -> None:
+    """query_only + busy_timeout are the always-on safety floor."""
+    with connect_ro(tiny_db) as conn:
+        assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+        assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
+
+
+def test_read_tuning_off_by_default(tiny_db: str) -> None:
+    """temp_store stays at its default (not forced to MEMORY) on the live path,
+    because the tuning PRAGMAs perturb FTS5 candidate ordering for no measured
+    latency gain (see module notes / bench evidence)."""
+    with connect_ro(tiny_db) as conn:
+        assert conn.execute("PRAGMA temp_store").fetchone()[0] != 2  # not MEMORY
+
+
+def test_read_tuning_opt_in(tiny_db: str) -> None:
+    """Snapshot/benchmark callers can still opt in explicitly."""
+    with connect_ro(tiny_db, temp_store_memory=True) as conn:
+        assert conn.execute("PRAGMA temp_store").fetchone()[0] == 2
+
+
+def test_query_only_blocks_writes(tiny_db: str) -> None:
+    with connect_ro(tiny_db) as conn:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO t (v) VALUES ('x')")
+
+
+# --- P5 parameterization regression guard ------------------------------------
+
+# Structural identifiers that may be interpolated into SQL text because they
+# carry NO user/query value — only column expressions or pre-built clauses that
+# themselves bind values via `?` placeholders. This allowlist locks in the
+# currently-green injection posture: a new f-string that interpolates the user
+# query (or any name not listed here) into an execute() call fails the test.
+# - row_id_expr / filter_sql: pre-built clause fragments that themselves bind
+#   every value via `?`.
+# - placeholders: the canonical IN-list pattern -- ",".join(["?"]*n); the values
+#   are bound separately as a tuple (searcher.py meta_rows query). This is the
+#   one dynamic-SQL site the proposal explicitly blesses.
+_ALLOWED_SQL_INTERP = {"row_id_expr", "filter_sql", "placeholders"}
+
+_READ_PATH_MODULES = [
+    _searcher_mod,
+    _repair_mod,
+    _chroma_mod,
+    _mcp_mod,
+]
+
+
+def _execute_sql_args(tree: ast.AST):
+    """Yield the first positional arg node of every .execute/.executemany call."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in ("execute", "executemany") and node.args:
+                yield node.func.attr, node.args[0]
+
+
+def test_read_paths_never_interpolate_user_values_into_sql() -> None:
+    offenders = []
+    for mod in _READ_PATH_MODULES:
+        src = Path(mod.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        for _attr, sql_arg in _execute_sql_args(tree):
+            if isinstance(sql_arg, ast.JoinedStr):  # f-string SQL
+                for piece in sql_arg.values:
+                    if isinstance(piece, ast.FormattedValue):
+                        name = _interp_name(piece.value)
+                        if name not in _ALLOWED_SQL_INTERP:
+                            offenders.append(
+                                f"{Path(mod.__file__).name}:{sql_arg.lineno} "
+                                f"interpolates {name!r} into SQL"
+                            )
+            elif isinstance(sql_arg, ast.BinOp):  # "..." % x / "..." + x
+                offenders.append(
+                    f"{Path(mod.__file__).name}:{sql_arg.lineno} "
+                    f"builds SQL via string operator"
+                )
+    assert not offenders, "user-value SQL interpolation found:\n" + "\n".join(offenders)
+
+
+def _interp_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return "<expr>"

--- a/tests/test_sqlite_ro.py
+++ b/tests/test_sqlite_ro.py
@@ -1,5 +1,6 @@
 """Tests for the read-only SQLite connection helper and the read-path
 parameterization regression guard (change: harden-mempalace-sqlite-timeouts)."""
+
 from __future__ import annotations
 
 import ast
@@ -30,6 +31,7 @@ def tiny_db(tmp_path: Path) -> str:
 
 
 # --- P3.3 deadline -----------------------------------------------------------
+
 
 def test_deadline_aborts_runaway_statement(tiny_db: str) -> None:
     """A deliberately infinite recursive CTE must be aborted near the deadline,
@@ -105,6 +107,7 @@ def test_no_deadline_allows_normal_query(tiny_db: str) -> None:
 
 # --- P3.4 lifecycle ----------------------------------------------------------
 
+
 def test_context_manager_closes_on_success(tiny_db: str) -> None:
     with connect_ro(tiny_db) as conn:
         conn.execute("SELECT 1").fetchone()
@@ -135,6 +138,7 @@ def test_open_ro_caller_owns_close(tiny_db: str) -> None:
 
 
 # --- read PRAGMAs applied ----------------------------------------------------
+
 
 def test_safety_floor_pragmas_always_applied(tiny_db: str) -> None:
     """query_only + busy_timeout are the always-on safety floor."""
@@ -228,13 +232,9 @@ def _check_sql_node(mod_name: str, sql_arg: ast.AST, offenders: list) -> None:
             if isinstance(piece, ast.FormattedValue):
                 name = _interp_name(piece.value)
                 if name not in _ALLOWED_SQL_INTERP:
-                    offenders.append(
-                        f"{mod_name}:{sql_arg.lineno} interpolates {name!r} into SQL"
-                    )
+                    offenders.append(f"{mod_name}:{sql_arg.lineno} interpolates {name!r} into SQL")
     elif isinstance(sql_arg, ast.BinOp):  # "..." % x / "..." + x
-        offenders.append(
-            f"{mod_name}:{sql_arg.lineno} builds SQL via string operator"
-        )
+        offenders.append(f"{mod_name}:{sql_arg.lineno} builds SQL via string operator")
 
 
 def test_read_paths_never_interpolate_user_values_into_sql() -> None:
@@ -257,7 +257,7 @@ def test_guard_catches_variable_assigned_fstring_sql() -> None:
     first (the gap gemini flagged on #1650)."""
     src = (
         "def q(conn, user):\n"
-        "    sql = f\"SELECT * FROM t WHERE x = {user}\"\n"
+        '    sql = f"SELECT * FROM t WHERE x = {user}"\n'
         "    return conn.execute(sql).fetchall()\n"
     )
     tree = ast.parse(src)

--- a/tests/test_sqlite_ro.py
+++ b/tests/test_sqlite_ro.py
@@ -55,6 +55,47 @@ def test_statement_timeout_is_operationalerror() -> None:
     assert issubclass(StatementTimeout, sqlite3.OperationalError)
 
 
+def test_deadline_abort_raises_statement_timeout_specifically(tiny_db: str) -> None:
+    """A deadline overrun raises StatementTimeout (not just bare
+    OperationalError), so callers can distinguish a runaway-statement timeout.
+    Covers both the connection and the cursor execute surfaces (#1650)."""
+    with pytest.raises(StatementTimeout):
+        with connect_ro(tiny_db, deadline_s=0.3) as conn:
+            conn.execute(
+                "WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c)"
+                " SELECT count(*) FROM c"
+            ).fetchall()
+    with pytest.raises(StatementTimeout):
+        with connect_ro(tiny_db, deadline_s=0.3) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c)"
+                " SELECT count(*) FROM c"
+            ).fetchall()
+
+
+def test_non_timeout_operationalerror_not_mistranslated(tiny_db: str) -> None:
+    """A write attempt under query_only fails immediately (deadline not passed),
+    so it stays a plain OperationalError, not StatementTimeout."""
+    with connect_ro(tiny_db, deadline_s=30.0) as conn:
+        with pytest.raises(sqlite3.OperationalError) as ei:
+            conn.execute("INSERT INTO t (v) VALUES ('x')")
+        assert not isinstance(ei.value, StatementTimeout)
+
+
+def test_build_uri_handles_special_chars(tmp_path: Path) -> None:
+    """Path with a '?' (valid POSIX filename char) must still open read-only —
+    f-string interpolation would have split it as a URI query (#1650)."""
+    weird = tmp_path / "od?d#name.sqlite3"
+    conn = sqlite3.connect(str(weird))
+    conn.execute("CREATE TABLE t (id INTEGER)")
+    conn.execute("INSERT INTO t (id) VALUES (7)")
+    conn.commit()
+    conn.close()
+    with connect_ro(str(weird)) as ro:
+        assert ro.execute("SELECT id FROM t").fetchone()[0] == 7
+
+
 def test_no_deadline_allows_normal_query(tiny_db: str) -> None:
     """deadline_s=None disables the ceiling; a normal query returns rows."""
     with connect_ro(tiny_db, deadline_s=None) as conn:
@@ -144,6 +185,34 @@ _READ_PATH_MODULES = [
 ]
 
 
+def _collect_sql_assignments(tree: ast.AST) -> dict:
+    """Map ``name -> value node`` for every ``name = <f-string|str-binop>``.
+
+    Lets the guard follow the one-hop indirection
+    ``sql = f"... {x} ..."; conn.execute(sql)`` that a direct first-arg-only
+    check would miss (gemini review on #1650). We only record dynamic
+    string-building values (JoinedStr / BinOp); plain literals are safe and left
+    out so they don't mask a later reassignment.
+    """
+    assigns: dict = {}
+    for node in ast.walk(tree):
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if not isinstance(value, (ast.JoinedStr, ast.BinOp)):
+            continue
+        for tgt in targets:
+            if isinstance(tgt, ast.Name):
+                assigns[tgt.id] = value
+    return assigns
+
+
 def _execute_sql_args(tree: ast.AST):
     """Yield the first positional arg node of every .execute/.executemany call."""
     for node in ast.walk(tree):
@@ -152,27 +221,53 @@ def _execute_sql_args(tree: ast.AST):
                 yield node.func.attr, node.args[0]
 
 
+def _check_sql_node(mod_name: str, sql_arg: ast.AST, offenders: list) -> None:
+    """Flag a SQL expression node that interpolates a non-allowlisted value."""
+    if isinstance(sql_arg, ast.JoinedStr):  # f-string SQL
+        for piece in sql_arg.values:
+            if isinstance(piece, ast.FormattedValue):
+                name = _interp_name(piece.value)
+                if name not in _ALLOWED_SQL_INTERP:
+                    offenders.append(
+                        f"{mod_name}:{sql_arg.lineno} interpolates {name!r} into SQL"
+                    )
+    elif isinstance(sql_arg, ast.BinOp):  # "..." % x / "..." + x
+        offenders.append(
+            f"{mod_name}:{sql_arg.lineno} builds SQL via string operator"
+        )
+
+
 def test_read_paths_never_interpolate_user_values_into_sql() -> None:
-    offenders = []
+    offenders: list = []
     for mod in _READ_PATH_MODULES:
+        mod_name = Path(mod.__file__).name
         src = Path(mod.__file__).read_text(encoding="utf-8")
         tree = ast.parse(src)
+        assigns = _collect_sql_assignments(tree)
         for _attr, sql_arg in _execute_sql_args(tree):
-            if isinstance(sql_arg, ast.JoinedStr):  # f-string SQL
-                for piece in sql_arg.values:
-                    if isinstance(piece, ast.FormattedValue):
-                        name = _interp_name(piece.value)
-                        if name not in _ALLOWED_SQL_INTERP:
-                            offenders.append(
-                                f"{Path(mod.__file__).name}:{sql_arg.lineno} "
-                                f"interpolates {name!r} into SQL"
-                            )
-            elif isinstance(sql_arg, ast.BinOp):  # "..." % x / "..." + x
-                offenders.append(
-                    f"{Path(mod.__file__).name}:{sql_arg.lineno} "
-                    f"builds SQL via string operator"
-                )
+            # Resolve one hop of indirection: execute(sql) where sql = f"...".
+            if isinstance(sql_arg, ast.Name) and sql_arg.id in assigns:
+                sql_arg = assigns[sql_arg.id]
+            _check_sql_node(mod_name, sql_arg, offenders)
     assert not offenders, "user-value SQL interpolation found:\n" + "\n".join(offenders)
+
+
+def test_guard_catches_variable_assigned_fstring_sql() -> None:
+    """The guard must not be bypassable by assigning the f-string to a variable
+    first (the gap gemini flagged on #1650)."""
+    src = (
+        "def q(conn, user):\n"
+        "    sql = f\"SELECT * FROM t WHERE x = {user}\"\n"
+        "    return conn.execute(sql).fetchall()\n"
+    )
+    tree = ast.parse(src)
+    assigns = _collect_sql_assignments(tree)
+    offenders: list = []
+    for _attr, sql_arg in _execute_sql_args(tree):
+        if isinstance(sql_arg, ast.Name) and sql_arg.id in assigns:
+            sql_arg = assigns[sql_arg.id]
+        _check_sql_node("synthetic.py", sql_arg, offenders)
+    assert offenders and "user" in offenders[0]
 
 
 def _interp_name(node: ast.AST) -> str:


### PR DESCRIPTION
## What does this PR do?

Hardens the **read paths** of the SQLite/ChromaDB store against runaway statements, lock waits, and leaked connections, behind a single helper — without changing query behaviour.

A read-only review of the query layer found three gaps:

1. **No statement-timeout protection.** Of the `sqlite3.connect()` sites, only `knowledge_graph.py` set a busy timeout. Every read path (`searcher.py`, the `mcp_server` status read, `backends/chroma.py`, `repair.py`) opened with the default busy timeout and **no runaway-statement ceiling at all**. Against a multi-GB `chroma.sqlite3`, a pathological BM25/IN/metadata scan can run unbounded and block the MCP event loop.
2. **Connections leak.** Several sites use `with sqlite3.connect(...) as conn:`, which commits on exit but never `.close()`s — handles accumulate in a long-lived MCP server.
3. **No regression guard on parameterization.** Parameterization is already clean (no f-string/`%`/`.format()` user values in SQL), but nothing locks that state in.

SQLite has no `SET statement_timeout` (that is Postgres-only). The correct analogs are `PRAGMA busy_timeout` (lock-wait ceiling) plus a `set_progress_handler` wall-clock deadline (runaway-statement ceiling). This PR introduces both via one helper and routes all read paths through it.

**Honest scope:** this is a **safety/correctness** change, **not** a performance optimization. A paired benchmark (below) shows it is **latency-neutral** and **recall-neutral**; the read-tuning PRAGMAs that *could* speed things up gave no measurable gain on the warm path (it is OS-page-cache- and Python/chromadb-bound, not SQLite-I/O-bound) and were therefore left **off by default**.

### Thinking path (project context → this change)

The palace is a long-lived MCP server reading a single large `chroma.sqlite3` on the event loop. The project already treats unbounded resource use as a defect (e.g. the `RAYON_NUM_THREADS` cap in `repair`). The same discipline was missing one layer down at the SQLite connection: a single slow read could stall every tool call with no ceiling and no guaranteed cleanup. The minimal, upstream-shaped fix is to centralize read-connection construction so the ceiling and lifecycle are guaranteed once, at every read site, instead of being re-derived (or forgotten) per call.

## Related Issue

No pre-existing issue; the problem and evidence are documented inline above and in the benchmark results referenced below.

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality) — adds a statement-deadline / lock-timeout / lifecycle guarantee; behaviour-preserving on normal queries
- [x] Refactor / code improvement (no behavior change) — read paths routed through one helper
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- **`mempalace/_sqlite_ro.py`** (new): `open_ro()` / `connect_ro()`. Applies a safety floor on every read connection — `PRAGMA busy_timeout` (lock-wait ceiling), `PRAGMA query_only = ON` (defense in depth), and a `set_progress_handler` wall-clock statement deadline that aborts a runaway statement instead of letting it run unbounded — and guarantees `.close()` (context manager, plus an `open_ro` drop-in for sites that own their own `try/finally`). `StatementTimeout` is exported as a `sqlite3.OperationalError` subclass. Read-tuning PRAGMAs (`mmap_size` / `cache_size` / `temp_store`) are **opt-in, off by default** (documented why in the module).
- **`mempalace/searcher.py`**: search read connection → `open_ro` (15 s interactive deadline).
- **`mempalace/mcp_server.py`**: status-read connection → `open_ro`.
- **`mempalace/backends/chroma.py`**: 3 read-only (`?mode=ro`) connections → `open_ro`.
- **`mempalace/repair.py`**: 3 read connections → `open_ro` (120 s batch deadline) / `connect_ro` (full-DB `quick_check` runs with no deadline — explicit maintenance op, also fixes a `with sqlite3.connect(...)`-never-closes leak).
- **`tests/test_sqlite_ro.py`** (new, 11 tests): deadline aborts a runaway recursive CTE within tolerance; context manager closes on success and on exception; `open_ro` caller-owns-close; safety-floor PRAGMAs always applied; read-tuning off-by-default + opt-in; `StatementTimeout` type; and an **AST parameterization regression guard** that fails if any read path interpolates a user/query value into SQL (the `",".join(["?"]*n)` IN-list is the one blessed dynamic pattern).

Out of scope (left as-is): write/repair-mutate connections and the `knowledge_graph.py` writer.

## How to Test

```bash
# Unit + the converted modules' existing suites
uv run pytest tests/test_sqlite_ro.py tests/test_searcher.py tests/test_repair.py tests/test_backends.py -v
# Full suite
uv run pytest tests/ -v
# Lint
ruff check .
```

Behaviour-equivalence and latency were measured against a copied snapshot of a ~2.6 GB live store (never the live store), comparing this branch to its base commit:

- **Latency (paired, 5 alternating rounds, p50 medians):** vector 97.9 → 107.9 ms, union 123.0 → 125.1 ms — all deltas inside the ±~40 ms run-to-run noise band (sign test n.s.). No regression; no speedup.
- **Recall:** a deterministic ordered-result-id equivalence check. The result tail on high-fanout queries has inherent run-to-run non-determinism from chromadb's approximate-NN (measured on the **base** branch: 6 runs, 0–6/30 divergence, mean 2.9; top-5 always stable). This branch is statistically indistinguishable from base → recall-neutral.

**Local suite status:** the converted modules and the new helper tests pass (`test_sqlite_ro.py` + `test_searcher.py` + `test_repair.py` + `test_backends.py` → 193 passed). The full `pytest tests/ --ignore=tests/benchmarks` run is **2266 passed**; the only failures are in `test_palace_locks.py` (inter-process file locking) and `test_init.py` (the leaked-`PYTHONPATH` filter test) — both **confirmed to fail identically on the base commit** in this dev environment (WSL2 file locking + the editable-via-`PYTHONPATH` dev setup), i.e. **not introduced by this change**. Zero failures in any module this PR touches. (`tests/benchmarks` requires extra deps and was not collected.)

## Checklist

- [x] I have included a thinking path that traces from project context to this change (see above)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI)
- [x] I have considered and documented any risks above (latency-neutral, not a speedup; runaway statements now raise `OperationalError` instead of hanging — the intended behaviour; tuning PRAGMAs off by default to avoid perturbing FTS5 candidate ordering)
- [x] I will address all reviewer comments before requesting merge
- [x] No hardcoded paths (helper takes the db path from the caller; tests use `tmp_path`)
- [x] Linter passes (`ruff check .` → all checks passed)

## AI Disclosure

**AI tool used:** Claude Code (Anthropic Claude Opus).

**Prompt / approach:** Driven as a "measure → find the bottleneck → fix with before/after numbers, preserve behaviour/API" task. The agent profiled the warm read path, discovered it was **not** SQLite-bound (page-cache/Python-bound), so it framed the change as safety hardening rather than a speedup; built a paired alternating benchmark plus a deterministic recall-equivalence harness to prove latency- and recall-neutrality (rejecting an early single-run reading as noise); converted the read sites through one helper; and added an AST guard to lock in the existing no-injection posture. Two iterations were driven by data: a 50k-opcode progress-handler interval was raised to 1M after it measurably slowed the FTS5/union path, and the read-tuning PRAGMAs were disabled after they showed zero gain but perturbed result ordering.
