### PR TITLE
feat(mining): preserve conversation timestamps from transcript in drawer metadata

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -14,7 +14,7 @@ import sys
 import hashlib
 import logging
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import defaultdict
 from typing import Optional
 
@@ -427,7 +427,7 @@ def _extract_conversation_timestamp(filepath: str) -> Optional[str]:
                         try:
                             if ts > 1e11:
                                 ts /= 1000.0
-                            return datetime.fromtimestamp(ts).isoformat()
+                            return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
                         except (ValueError, OSError, OverflowError):
                             return None
     except OSError:
@@ -435,7 +435,9 @@ def _extract_conversation_timestamp(filepath: str) -> Optional[str]:
     return None
 
 
-def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode, conversation_at=None):
+def _file_chunks_locked(
+    collection, source_file, chunks, wing, room, agent, extract_mode, conversation_at=None
+):
     """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
     Combines the per-file serialization that prevents concurrent agents from
@@ -484,17 +486,17 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                 batch_docs.append(chunk["content"])
                 batch_ids.append(drawer_id)
                 meta = {
-                        "wing": wing,
-                        "room": chunk_room,
-                        "hall": _detect_hall_cached(chunk["content"]),
-                        "source_file": source_file,
-                        "chunk_index": chunk["chunk_index"],
-                        "added_by": agent,
-                        "filed_at": filed_at,
-                        "ingest_mode": "convos",
-                        "extract_mode": extract_mode,
-                        "normalize_version": NORMALIZE_VERSION,
-                    }
+                    "wing": wing,
+                    "room": chunk_room,
+                    "hall": _detect_hall_cached(chunk["content"]),
+                    "source_file": source_file,
+                    "chunk_index": chunk["chunk_index"],
+                    "added_by": agent,
+                    "filed_at": filed_at,
+                    "ingest_mode": "convos",
+                    "extract_mode": extract_mode,
+                    "normalize_version": NORMALIZE_VERSION,
+                }
                 if conversation_at:
                     meta["conversation_at"] = conversation_at
                 batch_metas.append(meta)
@@ -746,7 +748,13 @@ def _mine_convos_impl(
         # agents; purge removes pre-v2 drawers so the schema bump applies.
         conversation_at = _extract_conversation_timestamp(source_file)
         drawers_added, room_delta, skipped = _file_chunks_locked(
-            collection, source_file, chunks, wing, room, agent, extract_mode,
+            collection,
+            source_file,
+            chunks,
+            wing,
+            room,
+            agent,
+            extract_mode,
             conversation_at=conversation_at,
         )
         if skipped:

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -379,8 +379,8 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
-def _extract_conversation_timestamp(filepath: str) -> Optional[str]:
-    """Return the ISO 8601 timestamp of the first user/assistant message in a JSONL transcript.
+def _extract_conversation_timestamp(filepath: str) -> Optional[tuple[str, int]]:
+    """Return (iso_str, epoch_int) for the first user/assistant message in a JSONL transcript.
 
     Reads the file directly to preserve the original conversation time
     regardless of when mining runs. Returns None for non-JSONL files or
@@ -392,8 +392,9 @@ def _extract_conversation_timestamp(filepath: str) -> Optional[str]:
     significant performance bottleneck.
 
     Handles both ISO 8601 strings and epoch timestamps (integer/float,
-    seconds or milliseconds) so timeline queries always receive a
-    lexicographically comparable ISO 8601 value.
+    seconds or milliseconds). Always returns both a human-readable ISO 8601
+    string and an integer Unix epoch so callers can store both for display
+    and numeric filtering without losing either representation.
     """
     if not filepath.endswith((".jsonl", ".json")):
         return None
@@ -418,7 +419,14 @@ def _extract_conversation_timestamp(filepath: str) -> Optional[str]:
                 if ts and msg_type in ("user", "human", "assistant"):
                     if isinstance(ts, str):
                         if "-" in ts or "T" in ts:
-                            return ts
+                            try:
+                                dt = datetime.fromisoformat(ts)
+                                if dt.tzinfo is None:
+                                    dt = dt.replace(tzinfo=timezone.utc)
+                                epoch = int(dt.timestamp())
+                                return ts, epoch
+                            except ValueError:
+                                return None
                         try:
                             ts = float(ts)
                         except ValueError:
@@ -427,7 +435,9 @@ def _extract_conversation_timestamp(filepath: str) -> Optional[str]:
                         try:
                             if ts > 1e11:
                                 ts /= 1000.0
-                            return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+                            epoch = int(ts)
+                            iso = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+                            return iso, epoch
                         except (ValueError, OSError, OverflowError):
                             return None
     except OSError:
@@ -436,7 +446,15 @@ def _extract_conversation_timestamp(filepath: str) -> Optional[str]:
 
 
 def _file_chunks_locked(
-    collection, source_file, chunks, wing, room, agent, extract_mode, conversation_at=None
+    collection,
+    source_file,
+    chunks,
+    wing,
+    room,
+    agent,
+    extract_mode,
+    conversation_at=None,
+    conversation_at_epoch=None,
 ):
     """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
@@ -499,6 +517,8 @@ def _file_chunks_locked(
                 }
                 if conversation_at:
                     meta["conversation_at"] = conversation_at
+                if conversation_at_epoch is not None:
+                    meta["conversation_at_epoch"] = conversation_at_epoch
                 batch_metas.append(meta)
             try:
                 collection.upsert(
@@ -746,7 +766,8 @@ def _mine_convos_impl(
 
         # Lock + purge stale + file fresh chunks. Lock serializes concurrent
         # agents; purge removes pre-v2 drawers so the schema bump applies.
-        conversation_at = _extract_conversation_timestamp(source_file)
+        ts_result = _extract_conversation_timestamp(source_file)
+        conversation_at, conversation_at_epoch = ts_result if ts_result else (None, None)
         drawers_added, room_delta, skipped = _file_chunks_locked(
             collection,
             source_file,
@@ -756,6 +777,7 @@ def _mine_convos_impl(
             agent,
             extract_mode,
             conversation_at=conversation_at,
+            conversation_at_epoch=conversation_at_epoch,
         )
         if skipped:
             files_skipped += 1

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -8,6 +8,7 @@ Normalizes format, chunks by exchange pair (Q+A = one unit), files to palace.
 Same palace as project mining. Different ingest strategy.
 """
 
+import json
 import os
 import sys
 import hashlib
@@ -378,7 +379,37 @@ def scan_convos(convo_dir: str) -> list:
 # =============================================================================
 
 
-def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode):
+def _extract_conversation_timestamp(filepath: str) -> Optional[str]:
+    """Return the ISO 8601 timestamp of the first user/assistant message in a JSONL transcript.
+
+    Reads the file directly to preserve the original conversation time
+    regardless of when mining runs. Returns None for non-JSONL files or
+    when no timestamped message entry is found.
+    """
+    if not filepath.endswith((".jsonl", ".json")):
+        return None
+    try:
+        with open(filepath, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                ts = entry.get("timestamp")
+                msg_type = entry.get("type", "")
+                if ts and msg_type in ("user", "human", "assistant"):
+                    return str(ts)
+    except OSError:
+        pass
+    return None
+
+
+def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extract_mode, conversation_at=None):
     """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
     Combines the per-file serialization that prevents concurrent agents from
@@ -426,8 +457,7 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                 )
                 batch_docs.append(chunk["content"])
                 batch_ids.append(drawer_id)
-                batch_metas.append(
-                    {
+                meta = {
                         "wing": wing,
                         "room": chunk_room,
                         "hall": _detect_hall_cached(chunk["content"]),
@@ -439,7 +469,9 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                         "extract_mode": extract_mode,
                         "normalize_version": NORMALIZE_VERSION,
                     }
-                )
+                if conversation_at:
+                    meta["conversation_at"] = conversation_at
+                batch_metas.append(meta)
             try:
                 collection.upsert(
                     documents=batch_docs,
@@ -686,8 +718,10 @@ def _mine_convos_impl(
 
         # Lock + purge stale + file fresh chunks. Lock serializes concurrent
         # agents; purge removes pre-v2 drawers so the schema bump applies.
+        conversation_at = _extract_conversation_timestamp(source_file)
         drawers_added, room_delta, skipped = _file_chunks_locked(
-            collection, source_file, chunks, wing, room, agent, extract_mode
+            collection, source_file, chunks, wing, room, agent, extract_mode,
+            conversation_at=conversation_at,
         )
         if skipped:
             files_skipped += 1

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -385,10 +385,20 @@ def _extract_conversation_timestamp(filepath: str) -> Optional[str]:
     Reads the file directly to preserve the original conversation time
     regardless of when mining runs. Returns None for non-JSONL files or
     when no timestamped message entry is found.
+
+    Aborts immediately if the first non-empty line is not valid JSON —
+    pretty-printed JSON files (ChatGPT exports, Slack exports) would
+    otherwise raise JSONDecodeError on almost every line, causing a
+    significant performance bottleneck.
+
+    Handles both ISO 8601 strings and epoch timestamps (integer/float,
+    seconds or milliseconds) so timeline queries always receive a
+    lexicographically comparable ISO 8601 value.
     """
     if not filepath.endswith((".jsonl", ".json")):
         return None
     try:
+        first_line = True
         with open(filepath, encoding="utf-8", errors="replace") as fh:
             for line in fh:
                 line = line.strip()
@@ -397,13 +407,29 @@ def _extract_conversation_timestamp(filepath: str) -> Optional[str]:
                 try:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
+                    if first_line:
+                        return None
                     continue
+                first_line = False
                 if not isinstance(entry, dict):
                     continue
                 ts = entry.get("timestamp")
                 msg_type = entry.get("type", "")
                 if ts and msg_type in ("user", "human", "assistant"):
-                    return str(ts)
+                    if isinstance(ts, str):
+                        if "-" in ts or "T" in ts:
+                            return ts
+                        try:
+                            ts = float(ts)
+                        except ValueError:
+                            return None
+                    if isinstance(ts, (int, float)):
+                        try:
+                            if ts > 1e11:
+                                ts /= 1000.0
+                            return datetime.fromtimestamp(ts).isoformat()
+                        except (ValueError, OSError, OverflowError):
+                            return None
     except OSError:
         pass
     return None

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -430,23 +430,35 @@ def _write_jsonl(tmp_path, lines, name="convo.jsonl"):
 
 
 def test_extract_timestamp_iso_string_passthrough(tmp_path):
-    """An ISO 8601 string on the first message entry is returned verbatim."""
+    """An ISO 8601 string on the first message entry is returned as (iso, epoch) tuple."""
     path = _write_jsonl(tmp_path, [{"type": "user", "timestamp": "2024-03-01T09:30:00+00:00"}])
-    assert _extract_conversation_timestamp(path) == "2024-03-01T09:30:00+00:00"
+    result = _extract_conversation_timestamp(path)
+    assert result is not None
+    iso, epoch = result
+    assert iso == "2024-03-01T09:30:00+00:00"
+    assert epoch == 1709285400
 
 
 def test_extract_timestamp_epoch_seconds_is_utc(tmp_path):
-    """Epoch seconds become a UTC, offset-aware ISO value (not naive local time)
+    """Epoch seconds return a UTC ISO string and the integer epoch unchanged.
     so timeline ordering is machine- and DST-independent."""
     # 2024-03-01T09:30:00Z
     path = _write_jsonl(tmp_path, [{"type": "assistant", "timestamp": 1709285400}])
-    assert _extract_conversation_timestamp(path) == "2024-03-01T09:30:00+00:00"
+    result = _extract_conversation_timestamp(path)
+    assert result is not None
+    iso, epoch = result
+    assert iso == "2024-03-01T09:30:00+00:00"
+    assert epoch == 1709285400
 
 
 def test_extract_timestamp_epoch_millis_scaled(tmp_path):
     """Millisecond epochs (> 1e11) are scaled to seconds before conversion."""
     path = _write_jsonl(tmp_path, [{"type": "user", "timestamp": 1709285400000}])
-    assert _extract_conversation_timestamp(path) == "2024-03-01T09:30:00+00:00"
+    result = _extract_conversation_timestamp(path)
+    assert result is not None
+    iso, epoch = result
+    assert iso == "2024-03-01T09:30:00+00:00"
+    assert epoch == 1709285400
 
 
 def test_extract_timestamp_aborts_on_pretty_printed_json(tmp_path):

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import shutil
@@ -7,6 +8,7 @@ import chromadb
 import pytest
 
 from mempalace.convo_miner import (
+    _extract_conversation_timestamp,
     _is_ai_tool_path,
     _resolve_wing,
     mine_convos,
@@ -416,3 +418,53 @@ def test_resolve_wing_empty_string_treated_as_no_wing(tmp_path):
     target = tmp_path / ".gemini" / "tmp"
     target.mkdir(parents=True)
     assert _resolve_wing(target, wing="") == "wing_api"
+
+
+# --- _extract_conversation_timestamp: preserve the original conversation time ---
+
+
+def _write_jsonl(tmp_path, lines, name="convo.jsonl"):
+    path = tmp_path / name
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def test_extract_timestamp_iso_string_passthrough(tmp_path):
+    """An ISO 8601 string on the first message entry is returned verbatim."""
+    path = _write_jsonl(tmp_path, [{"type": "user", "timestamp": "2024-03-01T09:30:00+00:00"}])
+    assert _extract_conversation_timestamp(path) == "2024-03-01T09:30:00+00:00"
+
+
+def test_extract_timestamp_epoch_seconds_is_utc(tmp_path):
+    """Epoch seconds become a UTC, offset-aware ISO value (not naive local time)
+    so timeline ordering is machine- and DST-independent."""
+    # 2024-03-01T09:30:00Z
+    path = _write_jsonl(tmp_path, [{"type": "assistant", "timestamp": 1709285400}])
+    assert _extract_conversation_timestamp(path) == "2024-03-01T09:30:00+00:00"
+
+
+def test_extract_timestamp_epoch_millis_scaled(tmp_path):
+    """Millisecond epochs (> 1e11) are scaled to seconds before conversion."""
+    path = _write_jsonl(tmp_path, [{"type": "user", "timestamp": 1709285400000}])
+    assert _extract_conversation_timestamp(path) == "2024-03-01T09:30:00+00:00"
+
+
+def test_extract_timestamp_aborts_on_pretty_printed_json(tmp_path):
+    """A first line that isn't valid JSON (pretty-printed export) returns None
+    immediately rather than scanning every line."""
+    path = tmp_path / "pretty.json"
+    path.write_text('{\n  "type": "user",\n  "timestamp": 1709285400\n}\n', encoding="utf-8")
+    assert _extract_conversation_timestamp(str(path)) is None
+
+
+def test_extract_timestamp_none_when_no_timestamped_message(tmp_path):
+    """Entries without a timestamp on a user/assistant message yield None."""
+    path = _write_jsonl(tmp_path, [{"type": "system", "timestamp": 1709285400}, {"type": "user"}])
+    assert _extract_conversation_timestamp(path) is None
+
+
+def test_extract_timestamp_none_for_non_jsonl_extension(tmp_path):
+    """Non-JSONL/JSON files are skipped without reading."""
+    path = tmp_path / "transcript.txt"
+    path.write_text("> hi\nhello\n", encoding="utf-8")
+    assert _extract_conversation_timestamp(str(path)) is None


### PR DESCRIPTION
## Summary

Fixes #1649.

The conversation miner wrote `filed_at` (ingest time) to every drawer's metadata — but this reflects *when mining ran*, not *when the conversation happened*. A transcript from three weeks ago mined today got `filed_at = today`, losing the original temporal context.

Every message entry in Claude Code's JSONL transcript format already carries a `timestamp` field — this PR extracts it and writes it as `conversation_at` alongside the existing `filed_at`.

## Changes

- New `_extract_conversation_timestamp(filepath)` helper reads the JSONL directly and returns the ISO 8601 timestamp of the first user/assistant message
- `conversation_at` is written into drawer metadata when available (optional, backwards-compatible — non-JSONL files and transcripts without timestamps simply omit the field)
- `filed_at` is kept unchanged for backwards compatibility

## Impact

- Time-based search ("what did we discuss last week?") becomes possible
- Knowledge graph facts can be anchored to real conversation dates
- `mempalace_kg_timeline` and `as_of` queries reflect reality instead of ingest time
- Already-mined drawers need a re-mine to pick up the new field (acceptable)

## Test plan

- [ ] All existing `test_convo_miner.py` tests pass (22/22)
- [ ] Verify `conversation_at` appears in drawer metadata after mining a Claude Code JSONL transcript
- [ ] Verify non-JSONL files mine without error (field simply absent)
- [ ] Verify `filed_at` is unchanged