### PR TITLE
fix(backend): respect backend.persist_directory from palace mempalace.yaml

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import datetime as _dt
+import functools
 import json
 import logging
 import math
@@ -34,6 +35,41 @@ from .base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=64)
+def _resolve_persist_dir(palace_path: str, create: bool = False) -> str:
+    """Return the directory where ChromaDB files live for *palace_path*.
+
+    Reads ``backend.persist_directory`` from the palace's ``mempalace.yaml``.
+    Relative paths are resolved against ``palace_path``; absolute paths are
+    used as-is.  Falls back to ``palace_path`` itself when the key is absent
+    or the YAML is unreadable (fully backwards-compatible).
+
+    When *create* is ``True`` the resolved directory is created if it does not
+    already exist.  Read-only call sites (``detect``, ``_db_stat``, search)
+    should pass the default ``create=False`` so they never create directories
+    as a side-effect.
+    """
+    import yaml as _yaml
+
+    yaml_path = os.path.join(palace_path, "mempalace.yaml")
+    resolved = palace_path
+    try:
+        if os.path.isfile(yaml_path):
+            with open(yaml_path, encoding="utf-8") as _fh:
+                _cfg = _yaml.safe_load(_fh) or {}
+            persist_dir = (_cfg.get("backend") or {}).get("persist_directory")
+            if persist_dir:
+                if os.path.isabs(persist_dir):
+                    resolved = persist_dir
+                else:
+                    resolved = str(Path(palace_path).resolve() / persist_dir)
+    except Exception:  # noqa: BLE001
+        pass
+    if create:
+        os.makedirs(resolved, exist_ok=True)
+    return resolved
 
 
 _REQUIRED_OPERATORS = frozenset({"$eq", "$ne", "$in", "$nin", "$and", "$or", "$contains"})
@@ -366,7 +402,7 @@ def quarantine_stale_hnsw(palace_path: str, stale_seconds: float = 300.0) -> lis
     possible if the heuristic ever misfires.
     """
 
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return []
 
@@ -453,7 +489,7 @@ def _vector_segment_id(palace_path: str, collection_name: str) -> Optional[str]:
     Reads ``chroma.sqlite3`` directly so we never have to load a segment
     that may segfault on open (#1222 is exactly this case).
     """
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return None
     try:
@@ -622,7 +658,7 @@ def _read_sync_threshold(palace_path: str, collection_name: str) -> int:
     explicit setting — matches what older mempalace palaces were created
     with before PR #1191.
     """
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return 1000
     try:
@@ -742,7 +778,7 @@ def _sqlite_embedding_count(palace_path: str, collection_name: str) -> Optional[
     Mirrors :func:`mempalace.repair.sqlite_drawer_count` but kept in this
     module so the backend probe doesn't pull in the repair CLI module.
     """
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return None
     try:
@@ -803,7 +839,7 @@ def _sqlite_wing_room_counts(
       the ChromaDB path, which surfaces a numeric wing/room natively rather
       than dropping it to ``"?"``.
     """
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return None
     try:
@@ -1066,7 +1102,7 @@ def _fix_blob_seq_ids(palace_path: str) -> None:
     subsequent opens skip the sqlite connection entirely. Already-migrated
     palaces can touch the marker manually to opt into the fast path.
     """
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return
     marker = os.path.join(palace_path, _BLOB_FIX_MARKER)
@@ -1123,7 +1159,7 @@ def _fix_missing_collection_type(palace_path: str) -> None:
     Same lifecycle constraints as :func:`_fix_blob_seq_ids`: must run
     BEFORE ``PersistentClient`` is created.
     """
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return
     marker = os.path.join(palace_path, _COLLECTION_TYPE_MARKER)
@@ -1554,7 +1590,7 @@ class ChromaCollection(BaseCollection):
     ) -> Optional[list[LexicalHit]]:
         if not self._palace_path:
             return None
-        db_path = os.path.join(self._palace_path, "chroma.sqlite3")
+        db_path = os.path.join(_resolve_persist_dir(self._palace_path), "chroma.sqlite3")
         if not os.path.isfile(db_path):
             return []
         collection_name = self._collection_name()
@@ -1809,6 +1845,11 @@ class ChromaBackend(BaseBackend):
         self._closed = False
 
     @staticmethod
+    def _resolve_persist_dir(palace_path: str, create: bool = False) -> str:
+        """Delegate to the module-level :func:`_resolve_persist_dir`."""
+        return _resolve_persist_dir(palace_path, create)
+
+    @staticmethod
     def _resolve_embedding_function():
         """Return the EF for the user's ``embedding_device`` setting.
 
@@ -1864,7 +1905,7 @@ class ChromaBackend(BaseBackend):
     @staticmethod
     def _db_stat(palace_path: str) -> tuple[int, float]:
         """Return ``(inode, mtime)`` of ``chroma.sqlite3`` or ``(0, 0.0)`` if absent."""
-        db_path = os.path.join(palace_path, "chroma.sqlite3")
+        db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
         try:
             st = os.stat(db_path)
             return (st.st_ino, st.st_mtime)
@@ -1897,7 +1938,7 @@ class ChromaBackend(BaseBackend):
         cached_inode, cached_mtime = self._freshness.get(palace_path, (0, 0.0))
         current_inode, current_mtime = self._db_stat(palace_path)
 
-        db_path = os.path.join(palace_path, "chroma.sqlite3")
+        db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
         # DB was present when cache was built but is now missing → invalidate.
         if cached is not None and not os.path.isfile(db_path):
             _close_client(self._clients.pop(palace_path, None))
@@ -1929,7 +1970,7 @@ class ChromaBackend(BaseBackend):
             ):
                 ChromaBackend._quarantined_paths.discard(palace_path)
             ChromaBackend._prepare_palace_for_open(palace_path)
-            cached = chromadb.PersistentClient(path=palace_path)
+            cached = chromadb.PersistentClient(path=_resolve_persist_dir(palace_path, create=True))
             self._clients[palace_path] = cached
             # Re-stat after the client constructor runs: chromadb creates
             # chroma.sqlite3 lazily, so the stat captured before the call
@@ -2005,7 +2046,7 @@ class ChromaBackend(BaseBackend):
         disk change. See :attr:`_quarantined_paths` for the gate logic.
         """
         ChromaBackend._prepare_palace_for_open(palace_path)
-        return chromadb.PersistentClient(path=palace_path)
+        return chromadb.PersistentClient(path=_resolve_persist_dir(palace_path, create=True))
 
     @staticmethod
     def backend_version() -> str:
@@ -2113,7 +2154,7 @@ class ChromaBackend(BaseBackend):
 
     @classmethod
     def detect(cls, path: str) -> bool:
-        return os.path.isfile(os.path.join(path, "chroma.sqlite3"))
+        return os.path.isfile(os.path.join(_resolve_persist_dir(path), "chroma.sqlite3"))
 
     # ------------------------------------------------------------------
     # Legacy (pre-RFC 001) surface — retained while callers migrate.

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -977,7 +977,7 @@ def cmd_repair(args):
             sys.exit(1)
         return
 
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(ChromaBackend._resolve_persist_dir(palace_path), "chroma.sqlite3")
 
     if not os.path.isdir(palace_path):
         print(f"\n  No palace found at {palace_path}")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -534,7 +534,8 @@ def _get_client():
         _metadata_cache_time
     if not _is_chroma_backend():
         raise RuntimeError("_get_client is only available for the Chroma backend")
-    db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
+    persist_dir = ChromaBackend._resolve_persist_dir(_config.palace_path)
+    db_path = os.path.join(persist_dir, "chroma.sqlite3")
     try:
         st = os.stat(db_path)
         current_inode = st.st_ino
@@ -939,7 +940,8 @@ def _tool_status_via_sqlite() -> dict:
     """
     import sqlite3 as _sqlite3
 
-    db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
+    persist_dir = ChromaBackend._resolve_persist_dir(_config.palace_path)
+    db_path = os.path.join(persist_dir, "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return _no_palace()
     collection_name = _config.collection_name

--- a/mempalace/migrate.py
+++ b/mempalace/migrate.py
@@ -30,6 +30,7 @@ from contextlib import closing
 from datetime import datetime
 
 from .backups import prune_backups
+from .backends.chroma import _resolve_persist_dir
 from .config import MempalaceConfig
 
 
@@ -142,7 +143,7 @@ def detect_chromadb_version(db_path: str) -> str:
 
 def contains_palace_database(path: str) -> bool:
     """Return True when path looks like a MemPalace ChromaDB directory."""
-    return os.path.isfile(os.path.join(path, "chroma.sqlite3"))
+    return os.path.isfile(os.path.join(_resolve_persist_dir(path), "chroma.sqlite3"))
 
 
 def confirm_destructive_action(
@@ -220,7 +221,7 @@ def migrate(palace_path: str, dry_run: bool = False, confirm: bool = False):
     from .backends.chroma import ChromaBackend
 
     palace_path = os.path.abspath(os.path.expanduser(palace_path))
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
 
     if not os.path.isdir(palace_path) or not contains_palace_database(palace_path):
         print(f"\n  No palace database found at {db_path}")

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -42,7 +42,7 @@ from typing import Callable, Iterator, Optional
 
 from chromadb.errors import NotFoundError as ChromaNotFoundError
 
-from .backends.chroma import ChromaBackend, hnsw_capacity_status
+from .backends.chroma import ChromaBackend, _resolve_persist_dir, hnsw_capacity_status
 
 
 COLLECTION_NAME = "mempalace_drawers"
@@ -470,7 +470,7 @@ def sqlite_drawer_count(palace_path: str, collection_name: Optional[str] = None)
     "unknown" and fall back to the cap-detection check.
     """
     collection_name = collection_name or _drawers_collection_name()
-    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    sqlite_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.exists(sqlite_path):
         return None
     try:
@@ -511,7 +511,7 @@ def sqlite_integrity_errors(palace_path: str) -> list[str]:
     path.
     """
 
-    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    sqlite_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.exists(sqlite_path):
         return []
 
@@ -535,7 +535,7 @@ def sqlite_integrity_errors(palace_path: str) -> list[str]:
 def print_sqlite_integrity_abort(palace_path: str, errors: list[str]) -> None:
     """Print a clear repair abort message for SQLite-layer corruption."""
 
-    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    sqlite_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     preview = errors[:5]
 
     print("\n  ABORT: SQLite-layer corruption detected before repair rebuild.")
@@ -582,7 +582,7 @@ def maybe_repair_poisoned_max_seq_id_before_rebuild(
     extracts only already-visible embeddings and can discard queued writes.
     """
 
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return None
 
@@ -694,7 +694,7 @@ def _vacuum_and_rebuild_fts5(palace_path: str, progress=print) -> None:
     The repair itself succeeded at this point — VACUUM/FTS5 are best-effort
     cleanup, not correctness requirements.
     """
-    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    sqlite_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.exists(sqlite_path):
         return
     try:
@@ -809,7 +809,7 @@ def rebuild_index(
         return
 
     # Back up ONLY the SQLite database, not the bloated HNSW files
-    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    sqlite_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     backup_path = sqlite_path + ".backup"
     if os.path.exists(sqlite_path):
         progress(f"  Backing up chroma.sqlite3 ({os.path.getsize(sqlite_path) / 1e6:.0f} MB)...")
@@ -997,7 +997,7 @@ def extract_via_sqlite(palace_path: str, collection_name: str) -> Iterator[tuple
     "empty collection" from "collection not present" should query
     :func:`sqlite_drawer_count` first.
     """
-    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    sqlite_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(sqlite_path):
         return
 
@@ -1127,7 +1127,7 @@ def rebuild_from_sqlite(
     source_palace = os.path.abspath(os.path.expanduser(source_palace))
     dest_palace = os.path.abspath(os.path.expanduser(dest_palace))
 
-    src_db = os.path.join(source_palace, "chroma.sqlite3")
+    src_db = os.path.join(_resolve_persist_dir(source_palace), "chroma.sqlite3")
 
     in_place = source_palace == dest_palace
 
@@ -1174,7 +1174,7 @@ def rebuild_from_sqlite(
         print(f"  Archiving {dest_palace} → {archive_path}")
         shutil.move(dest_palace, archive_path)
         source_palace = archive_path
-        src_db = os.path.join(source_palace, "chroma.sqlite3")
+        src_db = os.path.join(_resolve_persist_dir(source_palace), "chroma.sqlite3")
 
         # In-place only: drop chromadb's process-wide System registry so
         # the new client at dest_palace builds a fresh System. Without
@@ -1260,7 +1260,7 @@ def status(palace_path=None, collection_name: Optional[str] = None) -> dict:
         print("  No palace found.\n")
         return {"status": "unknown", "message": "no palace at path"}
 
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(db_path):
         print(f"  Palace dir at {palace_path} exists but has no chroma.sqlite3 yet.\n")
         return {"status": "uninitialized", "message": "palace has no chroma.sqlite3 yet"}
@@ -1448,7 +1448,7 @@ def repair_max_seq_id(
     from .migrate import confirm_destructive_action, contains_palace_database
 
     palace_path = os.path.abspath(os.path.expanduser(palace_path))
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
 
     result: dict = {
         "palace_path": palace_path,
@@ -1535,7 +1535,10 @@ def repair_max_seq_id(
         from .config import MempalaceConfig
 
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        backup_path = os.path.join(palace_path, f"chroma.sqlite3.max-seq-id-backup-{timestamp}")
+        backup_path = os.path.join(
+            _resolve_persist_dir(palace_path),
+            f"chroma.sqlite3.max-seq-id-backup-{timestamp}",
+        )
         shutil.copy2(db_path, backup_path)
         result["backup"] = backup_path
         print(f"  Backup:  {backup_path}")
@@ -1544,7 +1547,10 @@ def repair_max_seq_id(
         # newest and is kept). Without this, every max-seq-id repair leaves a
         # full chroma.sqlite3 copy behind that is never cleaned up.
         prune_backups(
-            os.path.join(glob.escape(palace_path), "chroma.sqlite3.max-seq-id-backup-*"),
+            os.path.join(
+                glob.escape(_resolve_persist_dir(palace_path)),
+                "chroma.sqlite3.max-seq-id-backup-*",
+            ),
             MempalaceConfig().max_backups,
             log=print,
         )

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -280,7 +280,19 @@ def get_user_approval(rooms: list) -> list:
 
 
 def save_config(project_dir: str, project_name: str, rooms: list):
+    config_path = Path(project_dir).expanduser().resolve() / "mempalace.yaml"
+
+    # Preserve existing keys that init doesn't manage (e.g. backend, storage)
+    existing: dict = {}
+    if config_path.is_file():
+        try:
+            with open(config_path, encoding="utf-8") as fh:
+                existing = yaml.safe_load(fh) or {}
+        except Exception:
+            existing = {}
+
     config = {
+        **{k: v for k, v in existing.items() if k not in ("wing", "rooms")},
         "wing": project_name,
         "rooms": [
             {
@@ -291,8 +303,7 @@ def save_config(project_dir: str, project_name: str, rooms: list):
             for r in rooms
         ],
     }
-    config_path = Path(project_dir).expanduser().resolve() / "mempalace.yaml"
-    with open(config_path, "w") as f:
+    with open(config_path, "w", encoding="utf-8") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
 
     print(f"\n  Config saved: {config_path}")

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -23,6 +23,7 @@ from .backends import (
     PalaceNotFoundError,
     UnsupportedCapabilityError,
 )
+from .backends.chroma import _resolve_persist_dir
 from .palace import (
     _open_collection_or_explain,
     get_closets_collection,
@@ -460,7 +461,7 @@ def _bm25_only_via_sqlite(
     ``max_candidates`` rows so we still return *something* rather than
     nothing.
     """
-    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    db_path = os.path.join(_resolve_persist_dir(palace_path), "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return {
             "error": "No palace found",

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -253,6 +253,67 @@ def test_resolve_persist_dir_memoized(tmp_path):
     _resolve_persist_dir.cache_clear()
 
 
+# ---------------------------------------------------------------------------
+# Round-trip: persist_directory → mine → search/status find the DB
+# ---------------------------------------------------------------------------
+
+
+def test_persist_directory_round_trip(tmp_path):
+    """set persist_directory → mine → search and status all find the DB in the subdir.
+
+    Regression for the split-brain defect: the DB must land in the configured
+    subdir AND every reader (search, status) must look there — not in the
+    palace root.
+    """
+    import yaml
+    from mempalace.miner import mine
+    from mempalace.searcher import search_memories
+
+    _resolve_persist_dir.cache_clear()
+
+    # ── source project ───────────────────────────────────────────────────
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "mempalace.yaml").write_text(
+        "wing: test_wing\nrooms:\n  - name: general\n    description: General\n",
+        encoding="utf-8",
+    )
+    # Content must be long enough to produce at least one drawer after chunking.
+    (project_dir / "notes.txt").write_text(
+        "The authentication module uses JWT tokens for session management. "
+        "Tokens expire after 24 hours and refresh tokens are stored in HttpOnly cookies. "
+        "We use PostgreSQL 15 with connection pooling via pgbouncer for the database. "
+        "The React frontend uses TanStack Query for server state management. "
+        "Sprint planning: migrate auth to passkeys by Q3. " * 6,
+        encoding="utf-8",
+    )
+
+    # ── palace with persist_directory pointing at a subdir ───────────────
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    (palace_dir / "mempalace.yaml").write_text(
+        "backend:\n  persist_directory: .db\n",
+        encoding="utf-8",
+    )
+
+    mine(str(project_dir), str(palace_dir))
+
+    # DB must be in the configured subdir, not the palace root.
+    assert (palace_dir / ".db" / "chroma.sqlite3").is_file(), (
+        "chroma.sqlite3 not found in configured persist_directory (.db)"
+    )
+    assert not (palace_dir / "chroma.sqlite3").is_file(), (
+        "chroma.sqlite3 leaked into palace root despite persist_directory being set"
+    )
+
+    # search must find the DB and return results — not "no palace" error.
+    result = search_memories("JWT tokens authentication", str(palace_dir))
+    assert "error" not in result, f"search returned error: {result.get('error')}"
+    assert result.get("results"), "search returned no results after mining"
+
+    _resolve_persist_dir.cache_clear()
+
+
 def test_chroma_lexical_search_uses_sqlite_fts_not_full_collection_scan(tmp_path):
     db_path = tmp_path / "chroma.sqlite3"
     conn = sqlite3.connect(db_path)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -25,6 +25,7 @@ from mempalace.backends.chroma import (
     _fix_blob_seq_ids,
     _fix_missing_collection_type,
     _pin_hnsw_threads,
+    _resolve_persist_dir,
     _segment_appears_healthy,
     quarantine_invalid_hnsw_metadata,
     quarantine_stale_hnsw,
@@ -182,6 +183,74 @@ def test_chroma_detect_matches_palace_with_chroma_sqlite(tmp_path):
     (tmp_path / "chroma.sqlite3").write_bytes(b"")
     assert ChromaBackend.detect(str(tmp_path)) is True
     assert ChromaBackend.detect(str(tmp_path.parent)) is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_persist_dir
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_persist_dir_fallback_no_yaml(tmp_path):
+    """No mempalace.yaml → returns palace_path unchanged."""
+    _resolve_persist_dir.cache_clear()
+    result = _resolve_persist_dir(str(tmp_path))
+    assert result == str(tmp_path)
+
+
+def test_resolve_persist_dir_fallback_no_backend_key(tmp_path):
+    """mempalace.yaml without backend.persist_directory → returns palace_path."""
+    _resolve_persist_dir.cache_clear()
+    (tmp_path / "mempalace.yaml").write_text("wing: rachael\n")
+    result = _resolve_persist_dir(str(tmp_path))
+    assert result == str(tmp_path)
+
+
+def test_resolve_persist_dir_absolute_path(tmp_path):
+    """Absolute persist_directory is returned as-is; created only when create=True."""
+    _resolve_persist_dir.cache_clear()
+    db_dir = tmp_path / "external_db"
+    (tmp_path / "mempalace.yaml").write_text(f"backend:\n  persist_directory: {db_dir}\n")
+    result = _resolve_persist_dir(str(tmp_path))
+    assert result == str(db_dir)
+    assert not db_dir.exists()  # create=False (default) must not mkdir
+
+    _resolve_persist_dir.cache_clear()
+    result = _resolve_persist_dir(str(tmp_path), create=True)
+    assert result == str(db_dir)
+    assert db_dir.is_dir()  # create=True must mkdir
+
+
+def test_resolve_persist_dir_relative_path(tmp_path):
+    """Relative persist_directory is resolved against palace_path."""
+    _resolve_persist_dir.cache_clear()
+    (tmp_path / "mempalace.yaml").write_text("backend:\n  persist_directory: .db\n")
+    result = _resolve_persist_dir(str(tmp_path))
+    expected = str((tmp_path / ".db").resolve())
+    assert result == expected
+
+    _resolve_persist_dir.cache_clear()
+    _resolve_persist_dir(str(tmp_path), create=True)
+    assert (tmp_path / ".db").is_dir()
+
+
+def test_resolve_persist_dir_bad_yaml_fallback(tmp_path):
+    """Malformed YAML falls back to palace_path."""
+    _resolve_persist_dir.cache_clear()
+    (tmp_path / "mempalace.yaml").write_text(": bad: yaml: [\n")
+    result = _resolve_persist_dir(str(tmp_path))
+    assert result == str(tmp_path)
+
+
+def test_resolve_persist_dir_memoized(tmp_path):
+    """Same palace_path + create args return cached result without re-parsing."""
+    _resolve_persist_dir.cache_clear()
+    r1 = _resolve_persist_dir(str(tmp_path))
+    r2 = _resolve_persist_dir(str(tmp_path))
+    assert r1 == r2
+    info = _resolve_persist_dir.cache_info()
+    assert info.hits >= 1
+
+    _resolve_persist_dir.cache_clear()
 
 
 def test_chroma_lexical_search_uses_sqlite_fts_not_full_collection_scan(tmp_path):


### PR DESCRIPTION
## Problem

`backend.persist_directory` in a palace's `mempalace.yaml` was silently ignored. ChromaDB was **always** initialized at `palace_path` root because every call site hardcoded `path=palace_path` and no code ever read the palace-level YAML's backend section.

Users who configured:

```yaml
backend:
  type: chroma
  persist_directory: ".System_Data"
```

saw `chroma.sqlite3` and the HNSW segment directories keep reappearing in the palace root on every restart — making OneDrive, Dropbox, and other sync tools surface internal DB files alongside user content, and making it impossible to keep the palace directory organized.

## Root cause

`ChromaBackend._client()`, `make_client()`, `_db_stat()`, `_prepare_palace_for_open()`, and `detect()` all received `palace_path` and passed it straight to `chromadb.PersistentClient(path=palace_path)`. There was no code path that read `<palace_path>/mempalace.yaml` at all.

## Fix

Add `ChromaBackend._resolve_persist_dir(palace_path)` which:
1. Reads `<palace_path>/mempalace.yaml` for `backend.persist_directory`
2. Resolves relative paths against `palace_path`
3. Creates the directory if it does not exist
4. Falls back to `palace_path` for unconfigured palaces (fully backwards-compatible)

Wire it into every affected call site:
- `_db_stat` — inode/mtime freshness check
- `_client` — db_path existence check + `PersistentClient` init
- `_prepare_palace_for_open` — HNSW quarantine + blob seq_id fix
- `make_client` — legacy entry point
- `detect` — backend auto-detection
- `mcp_server._get_client` — stale-cache db_path probe (both occurrences)

## Testing

```python
from mempalace.backends.chroma import ChromaBackend
# With backend.persist_directory: ".System_Data" in palace yaml:
ChromaBackend._resolve_persist_dir("D:/OneDrive/palace")
# → "D:\OneDrive\palace\.System_Data"

# Without backend section (existing palaces):
ChromaBackend._resolve_persist_dir("/path/to/palace")
# → "/path/to/palace"  (unchanged)
```