### PR TITLE
fix: replace bash wrapper hooks with direct mempalace commands (Windows path fix)

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/mempal-stop-hook.sh\"",
+            "command": "mempalace hook run --hook stop --harness claude-code",
             "timeout": 30
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/mempal-precompact-hook.sh\"",
+            "command": "mempalace hook run --hook precompact --harness claude-code",
             "timeout": 90
           }
         ]


### PR DESCRIPTION
## Problem

On Windows, the Stop and PreCompact hooks fail with:
```
Stop hook error: /bin/bash: C:UsersRachael.claudepluginscachemempalacemempalace3.3.6/hooks/mempal-stop-hook.sh: No such file or directory
```

`CLAUDE_PLUGIN_ROOT` on Windows expands to a backslash path (`C:\Users\...`). When passed to `bash`, the backslashes are treated as escape sequences and stripped, producing a non-existent path.

## Fix

The `.sh` wrappers are single-line pass-throughs to `mempalace hook run`. Replace the bash wrapper calls with the direct command, which works cross-platform since `mempalace` is on PATH after installation.

**Before:**
```json
"command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/mempal-stop-hook.sh\""
```

**After:**
```json
"command": "mempalace hook run --hook stop --harness claude-code"
```

Same for PreCompact.

## Testing

Verified on Windows 11 with Claude Code v2.1.157 — Stop and PreCompact hooks run cleanly after this change.

Closes #1660