### PR TITLE
fix(embedding): download embeddinggemma external-data sibling (.onnx_data)

### DIFF
--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -191,6 +191,21 @@ class EmbeddinggemmaONNX:
         model_path = hf_hub_download(
             _EMBEDDINGGEMMA_REPO, subfolder="onnx", filename=_EMBEDDINGGEMMA_ONNX
         )
+        # The q8 export stores weights in a sibling external-data file
+        # (``model_quantized.onnx_data``) that the .onnx references by relative
+        # path. hf_hub_download fetches one file at a time, so without this the
+        # weights are absent and onnxruntime fails on first use with
+        # "External data path does not exist: …model_quantized.onnx_data".
+        # Co-locate it in the same snapshot dir so the relative path resolves.
+        try:
+            hf_hub_download(
+                _EMBEDDINGGEMMA_REPO,
+                subfolder="onnx",
+                filename=_EMBEDDINGGEMMA_ONNX + "_data",
+            )
+        except Exception:
+            # Some exports inline their weights — a missing sibling is non-fatal.
+            logger.debug("No external-data sibling for %s", _EMBEDDINGGEMMA_ONNX)
         tok_path = hf_hub_download(_EMBEDDINGGEMMA_REPO, filename="tokenizer.json")
 
         self._session = ort.InferenceSession(model_path, providers=self._providers)


### PR DESCRIPTION
## Problem

`MEMPALACE_EMBEDDING_MODEL=embeddinggemma` crashes on first use on a clean cache:

```
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL :
External data path validation failed for initializer: model.embed_tokens.weight_quantized.
External data path does not exist: .../onnx/model_quantized.onnx_data
```

The q8 export (`onnx-community/embeddinggemma-300m-ONNX`) keeps its weights in a sibling `model_quantized.onnx_data` file that the `.onnx` references by relative path. `EmbeddinggemmaONNX._lazy_load()` only `hf_hub_download`s `model_quantized.onnx`, so the weights file is never fetched and onnxruntime can't resolve it.

## Fix

Also fetch the `.onnx_data` sibling into the same snapshot dir (one extra `hf_hub_download`), wrapped in try/except so inlined-weight exports without a sibling stay non-fatal.

## Repro / verification

- **Before:** clean HF cache → embeddinggemma → crash above (only `model_quantized.onnx` present in the snapshot `onnx/` dir).
- **After:** the `.onnx_data` lands next to the `.onnx`; embeddinggemma loads and embeds. Verified the model works once both files are co-located — cross-lingual FR/EN cosine 0.89 (parallel) vs 0.40 (unrelated) on a 6-pair probe, matching the model card's multilingual claim.

No behavior change for `minilm`. Single-file additive fetch; honors the local-first principle (still HF-hosted weights, same as before — just the missing half).