### PR TITLE
fix(cli): add repair rebuild-index alias

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -8,6 +8,7 @@ import math
 import os
 import pickle
 import re
+import shlex
 import sqlite3
 from collections import defaultdict
 from numbers import Integral
@@ -1800,6 +1801,7 @@ class ChromaBackend(BaseBackend):
             current_model = MempalaceConfig().embedding_model
         except Exception:
             current_model = "unknown"
+        rebuild_cmd = f"mempalace --palace {shlex.quote(palace_path)} repair rebuild-index"
         return (
             f"Embedding model mismatch reading palace at {palace_path!r}.\n"
             f"  Underlying ChromaDB error: {msg}\n"
@@ -1807,8 +1809,8 @@ class ChromaBackend(BaseBackend):
             f"  The palace was built with a different embedding model. Either:\n"
             f"    (a) revert the model: unset MEMPALACE_EMBEDDING_MODEL (or set "
             f"the previous value), or\n"
-            f"    (b) re-embed in place: `mempalace repair rebuild-index "
-            f"--palace {palace_path}` (writes new vectors with the current model)."
+            f"    (b) re-embed in place: `{rebuild_cmd}` "
+            f"(writes new vectors with the current model)."
         )
 
     # ------------------------------------------------------------------

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -866,6 +866,10 @@ def cmd_repair(args):
         sqlite_integrity_errors,
     )
 
+    if getattr(args, "repair_action", None) == "rebuild-index":
+        args.mode = "from-sqlite"
+        args.archive_existing = True
+
     if getattr(args, "mode", "legacy") == "max-seq-id":
         from .repair import repair_max_seq_id
 
@@ -1577,6 +1581,15 @@ def main():
     )
     p_repair.add_argument(
         "--yes", action="store_true", help="Skip confirmation for destructive changes"
+    )
+    p_repair.add_argument(
+        "repair_action",
+        nargs="?",
+        choices=["rebuild-index"],
+        help=(
+            "Re-embed the palace from SQLite using the current embedding model "
+            "(alias for --mode from-sqlite --archive-existing)."
+        ),
     )
     p_repair.add_argument(
         "--confirm-truncation-ok",

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1754,7 +1754,7 @@ def test_explain_ef_mismatch_recognizes_chromadb_conflict():
     assert msg is not None
     assert "/tmp/palace.db" in msg
     assert "MEMPALACE_EMBEDDING_MODEL" in msg
-    assert "rebuild-index" in msg
+    assert "mempalace --palace /tmp/palace.db repair rebuild-index" in msg
 
 
 def test_explain_ef_mismatch_returns_none_for_unrelated_errors():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -896,6 +896,16 @@ def test_main_repair_dispatches():
         mock_cmd.assert_called_once()
 
 
+def test_main_repair_rebuild_index_dispatches():
+    with (
+        patch("sys.argv", ["mempalace", "repair", "rebuild-index"]),
+        patch("mempalace.cli.cmd_repair") as mock_cmd,
+    ):
+        main()
+        args = mock_cmd.call_args.args[0]
+        assert args.repair_action == "rebuild-index"
+
+
 def test_main_compress_dispatches():
     with (
         patch("sys.argv", ["mempalace", "compress"]),
@@ -1446,3 +1456,29 @@ def test_cmd_repair_from_sqlite_success_does_not_exit(mock_config_cls, tmp_path)
     with patch("mempalace.repair.rebuild_from_sqlite", return_value=fake_counts):
         # Should return cleanly; no SystemExit raised.
         cmd_repair(args)
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_rebuild_index_alias_uses_sqlite_archive(mock_config_cls, tmp_path):
+    """``repair rebuild-index`` must bypass Chroma reads and rebuild from SQLite."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+
+    args = argparse.Namespace(
+        palace=str(palace_dir),
+        repair_action="rebuild-index",
+        mode="legacy",
+        source=None,
+        archive_existing=False,
+        yes=True,
+    )
+    fake_counts = {"mempalace_drawers": 1, "mempalace_closets": 0}
+    with patch("mempalace.repair.rebuild_from_sqlite", return_value=fake_counts) as rebuild:
+        cmd_repair(args)
+
+    rebuild.assert_called_once_with(
+        source_palace=str(palace_dir),
+        dest_palace=str(palace_dir),
+        archive_existing_dest=True,
+    )


### PR DESCRIPTION
## What does this PR do?

Adds `mempalace repair rebuild-index` as a CLI alias for rebuilding a palace index after changing `MEMPALACE_EMBEDDING_MODEL`.

The alias routes to the existing SQLite rebuild path with archive enabled, so the repair command avoids opening the old Chroma collection with the new embedding function. The embedding mismatch hint now points to the working command and quotes the palace path safely.

Related to #1663.

## How to test

- `.venv/bin/python -m pytest tests/test_cli.py -q`
- `.venv/bin/python -m pytest tests/test_backends.py::test_get_collection_translates_ef_mismatch_to_helpful_error -q`
- `.venv/bin/ruff check mempalace/cli.py mempalace/backends/chroma.py tests/test_cli.py tests/test_backends.py`

## Checklist

- [x] Targeted tests pass
- [x] No hardcoded paths
- [x] Linter passes for changed files
