### PR TITLE
feat(mcp): track editor identity on drawer updates

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1443,8 +1443,9 @@ def tool_update_drawer(
             except ValueError as e:
                 return {"success": False, "error": str(e)}
        if updated_by is not None:
-    updated_by = strip_lone_surrogates(updated_by)
-    new_meta["updated_by"] = updated_by
+           updated_by = strip_lone_surrogates(updated_by)
+           new_meta["updated_by"] = updated_by
+        
         wal_params = {
             "drawer_id": drawer_id,
             "old_wing": old_meta.get("wing", ""),

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1400,11 +1400,17 @@ def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offse
         return {"error": str(e)}
 
 
-def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, room: str = None):
+def tool_update_drawer(
+    drawer_id: str,
+    content: str = None,
+    wing: str = None,
+    room: str = None,
+    updated_by: str = None,
+):
     """Update an existing drawer's content and/or metadata."""
     global _metadata_cache
 
-    if content is None and wing is None and room is None:
+    if content is None and wing is None and room is None and updated_by is None:
         return {"success": True, "drawer_id": drawer_id, "noop": True}
 
     col = _get_collection()
@@ -1436,19 +1442,26 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
                 new_meta["room"] = sanitize_name(room, "room")
             except ValueError as e:
                 return {"success": False, "error": str(e)}
+        if updated_by is not None:
+            try:
+                updated_by = sanitize_name(updated_by, "updated_by")
+            except ValueError as e:
+                return {"success": False, "error": str(e)}
+            new_meta["updated_by"] = updated_by
 
-        _wal_log(
-            "update_drawer",
-            {
-                "drawer_id": drawer_id,
-                "old_wing": old_meta.get("wing", ""),
-                "old_room": old_meta.get("room", ""),
-                "new_wing": new_meta.get("wing", ""),
-                "new_room": new_meta.get("room", ""),
-                "content_changed": content is not None,
-                "content_preview": new_doc[:200] if content is not None else None,
-            },
-        )
+        wal_params = {
+            "drawer_id": drawer_id,
+            "old_wing": old_meta.get("wing", ""),
+            "old_room": old_meta.get("room", ""),
+            "new_wing": new_meta.get("wing", ""),
+            "new_room": new_meta.get("room", ""),
+            "content_changed": content is not None,
+            "content_preview": new_doc[:200] if content is not None else None,
+        }
+        if updated_by is not None:
+            wal_params["updated_by"] = updated_by
+
+        _wal_log("update_drawer", wal_params)
 
         update_kwargs = {"ids": [drawer_id]}
         if content is not None:
@@ -2327,6 +2340,10 @@ TOOLS = {
                 "room": {
                     "type": "string",
                     "description": "New room (optional — omit to keep existing)",
+                },
+                "updated_by": {
+                    "type": "string",
+                    "description": "Who is editing this drawer (optional)",
                 },
             },
             "required": ["drawer_id"],

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1442,13 +1442,9 @@ def tool_update_drawer(
                 new_meta["room"] = sanitize_name(room, "room")
             except ValueError as e:
                 return {"success": False, "error": str(e)}
-        if updated_by is not None:
-            try:
-                updated_by = sanitize_name(updated_by, "updated_by")
-            except ValueError as e:
-                return {"success": False, "error": str(e)}
-            new_meta["updated_by"] = updated_by
-
+       if updated_by is not None:
+    updated_by = strip_lone_surrogates(updated_by)
+    new_meta["updated_by"] = updated_by
         wal_params = {
             "drawer_id": drawer_id,
             "old_wing": old_meta.get("wing", ""),

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1443,8 +1443,8 @@ def tool_update_drawer(
             except ValueError as e:
                 return {"success": False, "error": str(e)}
         if updated_by is not None:
-           updated_by = strip_lone_surrogates(updated_by)
-           new_meta["updated_by"] = updated_by
+            updated_by = strip_lone_surrogates(updated_by)
+            new_meta["updated_by"] = updated_by
         
         wal_params = {
             "drawer_id": drawer_id,

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1446,7 +1446,7 @@ def tool_update_drawer(
            updated_by = strip_lone_surrogates(updated_by)
            new_meta["updated_by"] = updated_by
         
-        wal_params = {
+       wal_params = {
             "drawer_id": drawer_id,
             "old_wing": old_meta.get("wing", ""),
             "old_room": old_meta.get("room", ""),

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1442,11 +1442,11 @@ def tool_update_drawer(
                 new_meta["room"] = sanitize_name(room, "room")
             except ValueError as e:
                 return {"success": False, "error": str(e)}
-       if updated_by is not None:
+        if updated_by is not None:
            updated_by = strip_lone_surrogates(updated_by)
            new_meta["updated_by"] = updated_by
         
-       wal_params = {
+        wal_params = {
             "drawer_id": drawer_id,
             "old_wing": old_meta.get("wing", ""),
             "old_room": old_meta.get("room", ""),

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -3619,11 +3619,17 @@ def tool_list_drawers(
         return {"error": str(e)}
 
 
-def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, room: str = None):
+def tool_update_drawer(
+    drawer_id: str,
+    content: str = None,
+    wing: str = None,
+    room: str = None,
+    updated_by: str = None,
+):
     """Update an existing logical drawer's content and/or metadata."""
     global _metadata_cache
 
-    if content is None and wing is None and room is None:
+    if content is None and wing is None and room is None and updated_by is None:
         return {"success": True, "drawer_id": drawer_id, "noop": True}
 
     col = _get_collection()
@@ -3663,18 +3669,23 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
             if room.lower() != str(old_meta.get("room") or "").lower():
                 new_meta["room"] = room
 
-        _wal_log(
-            "update_drawer",
-            {
-                "drawer_id": drawer_id,
-                "old_wing": old_meta.get("wing", ""),
-                "old_room": old_meta.get("room", ""),
-                "new_wing": new_meta.get("wing", ""),
-                "new_room": new_meta.get("room", ""),
-                "content_changed": content is not None,
-                "content_preview": new_doc[:200] if content is not None else None,
-            },
-        )
+        if updated_by is not None:
+            updated_by = strip_lone_surrogates(updated_by)
+            new_meta["updated_by"] = updated_by
+
+        wal_params = {
+            "drawer_id": drawer_id,
+            "old_wing": old_meta.get("wing", ""),
+            "old_room": old_meta.get("room", ""),
+            "new_wing": new_meta.get("wing", ""),
+            "new_room": new_meta.get("room", ""),
+            "content_changed": content is not None,
+            "content_preview": new_doc[:200] if content is not None else None,
+        }
+        if updated_by is not None:
+            wal_params["updated_by"] = updated_by
+
+        _wal_log("update_drawer", wal_params)
 
         chunk_size = max(1, int(getattr(_config, "chunk_size", 800) or 800))
         should_chunk = bool(record.get("chunked")) or len(new_doc) > chunk_size
@@ -5222,7 +5233,7 @@ TOOLS = {
         "handler": tool_list_drawers,
     },
     "mempalace_update_drawer": {
-        "description": "Update an existing drawer's content and/or metadata (wing, room). Fetches existing drawer first; returns error if not found.",
+        "description": "Update an existing drawer's content and/or metadata (wing, room, editor identity). Fetches existing drawer first; returns error if not found.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -5238,6 +5249,10 @@ TOOLS = {
                 "room": {
                     "type": "string",
                     "description": "New room (optional — omit to keep existing)",
+                },
+                "updated_by": {
+                    "type": "string",
+                    "description": "Who is editing this drawer (optional)",
                 },
             },
             "required": ["drawer_id"],

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2748,6 +2748,68 @@ class TestWriteTools:
         assert result["success"] is True
         assert result.get("noop") is True
 
+    def test_update_drawer_with_updated_by_stores_editor_metadata(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_update_drawer
+
+        result = tool_update_drawer("drawer_proj_backend_aaa", updated_by="user@example.com")
+        assert result["success"] is True
+
+        fetched = seeded_collection.get(ids=["drawer_proj_backend_aaa"], include=["metadatas"])
+        metadata = fetched["metadatas"][0]
+        assert metadata["updated_by"] == "user@example.com"
+        assert metadata["added_by"] == "miner"
+
+    def test_update_drawer_with_updated_by_includes_editor_in_wal_params(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        wal_calls = []
+        monkeypatch.setattr(
+            mcp_server,
+            "_wal_log",
+            lambda operation, params, result=None: wal_calls.append((operation, params, result)),
+        )
+        result = mcp_server.tool_update_drawer(
+            "drawer_proj_backend_aaa", updated_by="user@example.com"
+        )
+        assert result["success"] is True
+        assert wal_calls[0][0] == "update_drawer"
+        assert wal_calls[0][1]["updated_by"] == "user@example.com"
+
+    def test_update_drawer_without_updated_by_preserves_existing_behavior(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        wal_calls = []
+        monkeypatch.setattr(
+            mcp_server,
+            "_wal_log",
+            lambda operation, params, result=None: wal_calls.append((operation, params, result)),
+        )
+        result = mcp_server.tool_update_drawer(
+            "drawer_proj_backend_aaa", content="Updated content about auth."
+        )
+        assert result["success"] is True
+
+        fetched = seeded_collection.get(ids=["drawer_proj_backend_aaa"], include=["metadatas"])
+        metadata = fetched["metadatas"][0]
+        assert "updated_by" not in metadata
+        assert metadata["added_by"] == "miner"
+        assert "updated_by" not in wal_calls[0][1]
+
+    def test_update_drawer_schema_exposes_updated_by(self):
+        from mempalace import mcp_server
+
+        properties = mcp_server.TOOLS["mempalace_update_drawer"]["input_schema"]["properties"]
+        assert properties["updated_by"]["type"] == "string"
+
     def test_tool_create_tunnel_preserves_hyphenated_wings(self, monkeypatch, tmp_path):
         """Regression for #1504: ``tool_create_tunnel`` stores the wing slug
         verbatim, and both hyphen and underscore queries find the result."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1366,6 +1366,81 @@ class TestWriteTools:
         assert result["success"] is True
         assert result.get("noop") is True
 
+    def test_update_drawer_with_updated_by_stores_editor_metadata(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_update_drawer
+
+        result = tool_update_drawer("drawer_proj_backend_aaa", updated_by="claude")
+        assert result["success"] is True
+
+        fetched = seeded_collection.get(
+            ids=["drawer_proj_backend_aaa"], include=["metadatas"]
+        )
+        metadata = fetched["metadatas"][0]
+        assert metadata["updated_by"] == "claude"
+        assert metadata["added_by"] == "miner"
+
+    def test_update_drawer_with_updated_by_includes_editor_in_wal_params(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        wal_calls = []
+        monkeypatch.setattr(
+            mcp_server,
+            "_wal_log",
+            lambda operation, params, result=None: wal_calls.append((operation, params, result)),
+        )
+
+        result = mcp_server.tool_update_drawer("drawer_proj_backend_aaa", updated_by="claude")
+        assert result["success"] is True
+
+        assert wal_calls == [
+            (
+                "update_drawer",
+                {
+                    "drawer_id": "drawer_proj_backend_aaa",
+                    "old_wing": "project",
+                    "old_room": "backend",
+                    "new_wing": "project",
+                    "new_room": "backend",
+                    "content_changed": False,
+                    "content_preview": None,
+                    "updated_by": "claude",
+                },
+                None,
+            )
+        ]
+
+    def test_update_drawer_without_updated_by_does_not_add_editor_metadata_or_wal_param(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        wal_calls = []
+        monkeypatch.setattr(
+            mcp_server,
+            "_wal_log",
+            lambda operation, params, result=None: wal_calls.append((operation, params, result)),
+        )
+
+        result = mcp_server.tool_update_drawer(
+            "drawer_proj_backend_aaa", content="Updated content about auth."
+        )
+        assert result["success"] is True
+
+        fetched = seeded_collection.get(
+            ids=["drawer_proj_backend_aaa"], include=["metadatas"]
+        )
+        metadata = fetched["metadatas"][0]
+        assert "updated_by" not in metadata
+        assert metadata["added_by"] == "miner"
+        assert "updated_by" not in wal_calls[0][1]
+
     def test_tool_create_tunnel_preserves_hyphenated_wings(self, monkeypatch, tmp_path):
         """Regression for #1504: ``tool_create_tunnel`` stores the wing slug
         verbatim, and both hyphen and underscore queries find the result."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1372,14 +1372,14 @@ class TestWriteTools:
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_update_drawer
 
-        result = tool_update_drawer("drawer_proj_backend_aaa", updated_by="claude")
+        result = tool_update_drawer("drawer_proj_backend_aaa", updated_by="user@example.com")
         assert result["success"] is True
 
         fetched = seeded_collection.get(
             ids=["drawer_proj_backend_aaa"], include=["metadatas"]
         )
         metadata = fetched["metadatas"][0]
-        assert metadata["updated_by"] == "claude"
+        assert metadata["updated_by"] == "user@example.com"
         assert metadata["added_by"] == "miner"
 
     def test_update_drawer_with_updated_by_includes_editor_in_wal_params(
@@ -1395,7 +1395,7 @@ class TestWriteTools:
             lambda operation, params, result=None: wal_calls.append((operation, params, result)),
         )
 
-        result = mcp_server.tool_update_drawer("drawer_proj_backend_aaa", updated_by="claude")
+        result = mcp_server.tool_update_drawer("drawer_proj_backend_aaa", updated_by="user@example.com")
         assert result["success"] is True
 
         assert wal_calls == [
@@ -1409,7 +1409,7 @@ class TestWriteTools:
                     "new_room": "backend",
                     "content_changed": False,
                     "content_preview": None,
-                    "updated_by": "claude",
+                    "updated_by": "user@example.com",
                 },
                 None,
             )


### PR DESCRIPTION
Fixes #1637.

Adds an optional `updated_by` parameter to `mempalace_update_drawer` / `tool_update_drawer` so callers can record who performed an edit without overwriting `added_by`.

Behavior:
- `updated_by` is optional and backwards-compatible.
- when provided, it is stored in drawer metadata as `updated_by`.
- when provided, it is included in `update_drawer` WAL params for audit tooling.
- when omitted, existing behavior is unchanged.
- `added_by` remains preserved across edits.
- editor identities use `strip_lone_surrogates`, matching `added_by`, so email-style identifiers remain valid.

Validation against current `develop`:
- targeted `update_drawer` tests: 10 passed.
- `ruff check mempalace/mcp_server.py tests/test_mcp_server.py`
- `ruff format --check mempalace/mcp_server.py tests/test_mcp_server.py`
- `python -m compileall -q mempalace/mcp_server.py tests/test_mcp_server.py`

Rebased onto current `develop` (`639c69a`) and adapted to the current logical/chunked drawer update path.