### PR TITLE
fix(hooks): guard Claude plugin hook wrappers against stale mempalace binaries

### DIFF
--- a/.claude-plugin/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin/hooks/mempal-precompact-hook.sh
@@ -1,19 +1,115 @@
 #!/bin/bash
 # MemPalace PreCompact Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
+#
+# Dispatch guard: a stale `mempalace` binary on PATH (e.g. an old uv/pipx
+# tool install) must not shadow the plugin's bundled package. If the PATH
+# binary reports a version older than the plugin's pyproject.toml, prefer
+# `python -m mempalace` with the plugin root prepended to PYTHONPATH, and
+# only fall back to the stale binary (with a warning) when no python
+# runner is available. Uses bash builtins only — hook environments may
+# carry a minimal PATH.
+
+_plugin_root() {
+  # builtins only — no dirname on a minimal hook PATH.
+  local src="${BASH_SOURCE[0]}" dir
+  case "$src" in
+    */*) dir="${src%/*}" ;;
+    *) dir="." ;;
+  esac
+  dir="$(cd "$dir/../.." 2>/dev/null && pwd)" || return 1
+  printf '%s' "$dir"
+}
+
+_plugin_version() {
+  # First `version = "X.Y.Z"` line in pyproject.toml, builtins only.
+  local root="$1" line
+  [ -f "$root/pyproject.toml" ] || return 1
+  while IFS= read -r line; do
+    if [[ $line =~ ^[[:space:]]*version[[:space:]]*=[[:space:]]*\"([0-9]+(\.[0-9]+)*)\" ]]; then
+      printf '%s' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done < "$root/pyproject.toml"
+  return 1
+}
+
+_binary_version() {
+  # Parse "MemPalace X.Y.Z"; fall back to the first dotted-numeric run so
+  # an unparsable banner fails open (binary treated as current).
+  local out
+  out="$(mempalace --version </dev/null 2>/dev/null)" || return 1
+  if [[ $out =~ [Mm]em[Pp]alace[[:space:]]+v?([0-9]+(\.[0-9]+)+) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  if [[ $out =~ ([0-9]+(\.[0-9]+)+) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+_version_lt() {
+  # _version_lt A B → exit 0 (true) when dotted version A < B.
+  local IFS=.
+  local -a av bv
+  local i a b
+  read -r -a av <<< "$1"
+  read -r -a bv <<< "$2"
+  for ((i = 0; i < ${#av[@]} || i < ${#bv[@]}; i++)); do
+    a=$((10#${av[i]:-0}))
+    b=$((10#${bv[i]:-0}))
+    ((a < b)) && return 0
+    ((a > b)) && return 1
+  done
+  return 1
+}
+
 run_mempalace_hook() {
+  local plugin_root expected="" bin_ver="" stale_binary=""
+  plugin_root="$(_plugin_root)" || plugin_root=""
+  if [ -n "$plugin_root" ]; then
+    expected="$(_plugin_version "$plugin_root")" || expected=""
+  fi
+
   if command -v mempalace >/dev/null 2>&1; then
+    bin_ver="$(_binary_version)" || bin_ver=""
+    if [ -z "$expected" ] || [ -z "$bin_ver" ] || ! _version_lt "$bin_ver" "$expected"; then
+      mempalace hook run "$@"
+      return $?
+    fi
+    stale_binary="$bin_ver"
+    echo "MemPalace hook warning: PATH mempalace v$bin_ver is older than plugin v$expected; preferring bundled module (fix: uv tool upgrade mempalace)" >&2
+  fi
+
+  # Prepend the plugin root so the bundled package wins over any stale
+  # site-packages copy.
+  local pp="${PYTHONPATH:-}"
+  if [ -n "$plugin_root" ] && [ -d "$plugin_root/mempalace" ]; then
+    pp="$plugin_root${pp:+:$pp}"
+  fi
+
+  # Probe the modules the -m entry actually loads: cli.main() imports
+  # miner unconditionally while building its arg parser, so `python -m
+  # mempalace hook run` needs the heavy backends importable in-process.
+  # A bare `import mempalace` succeeds even when they are missing and the
+  # hook run would crash.
+  local probe="import mempalace.cli, mempalace.hooks_cli, mempalace.miner"
+
+  if command -v python3 >/dev/null 2>&1 && PYTHONPATH="$pp" python3 -c "$probe" >/dev/null 2>&1; then
+    PYTHONPATH="$pp" python3 -m mempalace hook run "$@"
+    return $?
+  fi
+
+  if command -v python >/dev/null 2>&1 && PYTHONPATH="$pp" python -c "$probe" >/dev/null 2>&1; then
+    PYTHONPATH="$pp" python -m mempalace hook run "$@"
+    return $?
+  fi
+
+  if [ -n "$stale_binary" ]; then
+    echo "MemPalace hook warning: no python runner with mempalace available; falling back to stale mempalace v$stale_binary" >&2
     mempalace hook run "$@"
-    return $?
-  fi
-
-  if command -v python3 >/dev/null 2>&1 && python3 -c "import mempalace" >/dev/null 2>&1; then
-    python3 -m mempalace hook run "$@"
-    return $?
-  fi
-
-  if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
-    python -m mempalace hook run "$@"
     return $?
   fi
 

--- a/.claude-plugin/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin/hooks/mempal-stop-hook.sh
@@ -1,19 +1,115 @@
 #!/bin/bash
 # MemPalace Stop Hook — thin wrapper calling Python CLI
 # All logic lives in mempalace.hooks_cli for cross-harness extensibility
+#
+# Dispatch guard: a stale `mempalace` binary on PATH (e.g. an old uv/pipx
+# tool install) must not shadow the plugin's bundled package. If the PATH
+# binary reports a version older than the plugin's pyproject.toml, prefer
+# `python -m mempalace` with the plugin root prepended to PYTHONPATH, and
+# only fall back to the stale binary (with a warning) when no python
+# runner is available. Uses bash builtins only — hook environments may
+# carry a minimal PATH.
+
+_plugin_root() {
+  # builtins only — no dirname on a minimal hook PATH.
+  local src="${BASH_SOURCE[0]}" dir
+  case "$src" in
+    */*) dir="${src%/*}" ;;
+    *) dir="." ;;
+  esac
+  dir="$(cd "$dir/../.." 2>/dev/null && pwd)" || return 1
+  printf '%s' "$dir"
+}
+
+_plugin_version() {
+  # First `version = "X.Y.Z"` line in pyproject.toml, builtins only.
+  local root="$1" line
+  [ -f "$root/pyproject.toml" ] || return 1
+  while IFS= read -r line; do
+    if [[ $line =~ ^[[:space:]]*version[[:space:]]*=[[:space:]]*\"([0-9]+(\.[0-9]+)*)\" ]]; then
+      printf '%s' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done < "$root/pyproject.toml"
+  return 1
+}
+
+_binary_version() {
+  # Parse "MemPalace X.Y.Z"; fall back to the first dotted-numeric run so
+  # an unparsable banner fails open (binary treated as current).
+  local out
+  out="$(mempalace --version </dev/null 2>/dev/null)" || return 1
+  if [[ $out =~ [Mm]em[Pp]alace[[:space:]]+v?([0-9]+(\.[0-9]+)+) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  if [[ $out =~ ([0-9]+(\.[0-9]+)+) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+_version_lt() {
+  # _version_lt A B → exit 0 (true) when dotted version A < B.
+  local IFS=.
+  local -a av bv
+  local i a b
+  read -r -a av <<< "$1"
+  read -r -a bv <<< "$2"
+  for ((i = 0; i < ${#av[@]} || i < ${#bv[@]}; i++)); do
+    a=$((10#${av[i]:-0}))
+    b=$((10#${bv[i]:-0}))
+    ((a < b)) && return 0
+    ((a > b)) && return 1
+  done
+  return 1
+}
+
 run_mempalace_hook() {
+  local plugin_root expected="" bin_ver="" stale_binary=""
+  plugin_root="$(_plugin_root)" || plugin_root=""
+  if [ -n "$plugin_root" ]; then
+    expected="$(_plugin_version "$plugin_root")" || expected=""
+  fi
+
   if command -v mempalace >/dev/null 2>&1; then
+    bin_ver="$(_binary_version)" || bin_ver=""
+    if [ -z "$expected" ] || [ -z "$bin_ver" ] || ! _version_lt "$bin_ver" "$expected"; then
+      mempalace hook run "$@"
+      return $?
+    fi
+    stale_binary="$bin_ver"
+    echo "MemPalace hook warning: PATH mempalace v$bin_ver is older than plugin v$expected; preferring bundled module (fix: uv tool upgrade mempalace)" >&2
+  fi
+
+  # Prepend the plugin root so the bundled package wins over any stale
+  # site-packages copy.
+  local pp="${PYTHONPATH:-}"
+  if [ -n "$plugin_root" ] && [ -d "$plugin_root/mempalace" ]; then
+    pp="$plugin_root${pp:+:$pp}"
+  fi
+
+  # Probe the modules the -m entry actually loads: cli.main() imports
+  # miner unconditionally while building its arg parser, so `python -m
+  # mempalace hook run` needs the heavy backends importable in-process.
+  # A bare `import mempalace` succeeds even when they are missing and the
+  # hook run would crash.
+  local probe="import mempalace.cli, mempalace.hooks_cli, mempalace.miner"
+
+  if command -v python3 >/dev/null 2>&1 && PYTHONPATH="$pp" python3 -c "$probe" >/dev/null 2>&1; then
+    PYTHONPATH="$pp" python3 -m mempalace hook run "$@"
+    return $?
+  fi
+
+  if command -v python >/dev/null 2>&1 && PYTHONPATH="$pp" python -c "$probe" >/dev/null 2>&1; then
+    PYTHONPATH="$pp" python -m mempalace hook run "$@"
+    return $?
+  fi
+
+  if [ -n "$stale_binary" ]; then
+    echo "MemPalace hook warning: no python runner with mempalace available; falling back to stale mempalace v$stale_binary" >&2
     mempalace hook run "$@"
-    return $?
-  fi
-
-  if command -v python3 >/dev/null 2>&1 && python3 -c "import mempalace" >/dev/null 2>&1; then
-    python3 -m mempalace hook run "$@"
-    return $?
-  fi
-
-  if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
-    python -m mempalace hook run "$@"
     return $?
   fi
 

--- a/tests/test_claude_plugin_hook_wrappers.py
+++ b/tests/test_claude_plugin_hook_wrappers.py
@@ -190,3 +190,137 @@ def test_plugin_hook_wrapper_falls_back_to_python_when_python3_cannot_import(
     )
     assert stdin_file.read_text(encoding="utf-8") == payload
     assert not bad_python3_used.exists()
+
+
+def _versioned_mempalace_stub(
+    version: str, args_file: Path, stdin_file: Path
+) -> str:
+    return (
+        "#!/bin/sh\n"
+        'if [ "$1" = "--version" ]; then\n'
+        f"  printf 'MemPalace {version}\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        f'printf \'%s\' "$*" > "{_shell_path(args_file)}"\n'
+        f"{_capture_stdin_to(stdin_file)}"
+        "printf '{}\\n'\n"
+    )
+
+
+@pytest.mark.parametrize(("script_name", "hook_name"), SCRIPT_CASES)
+def test_plugin_hook_wrapper_skips_stale_mempalace_binary(
+    tmp_path: Path, script_name: str, hook_name: str
+) -> None:
+    """A PATH binary older than the plugin must not handle the hook."""
+    stale_args_file = tmp_path / "stale_args.txt"
+    stale_stdin_file = tmp_path / "stale_stdin.json"
+    args_file = tmp_path / "args.txt"
+    stdin_file = tmp_path / "stdin.json"
+    pythonpath_file = tmp_path / "pythonpath.txt"
+    probe_file = tmp_path / "probe.txt"
+
+    python3_stub = (
+        "#!/bin/sh\n"
+        'if [ "$1" = "-c" ]; then\n'
+        f'  printf \'%s\' "$2" > "{_shell_path(probe_file)}"\n'
+        "  exit 0\n"
+        "fi\n"
+        f'printf \'%s\' "$PYTHONPATH" > "{_shell_path(pythonpath_file)}"\n'
+        f'printf \'%s\' "$*" > "{_shell_path(args_file)}"\n'
+        f"{_capture_stdin_to(stdin_file)}"
+        "printf '{}\\n'\n"
+    )
+    bin_dir = _make_bin_dir(
+        tmp_path,
+        {
+            "mempalace": _versioned_mempalace_stub(
+                "0.0.1", stale_args_file, stale_stdin_file
+            ),
+            "python3": python3_stub,
+        },
+    )
+
+    payload = '{"session_id":"stale-binary"}'
+    result = _run_hook(script_name, payload, bin_dir)
+
+    assert result.returncode == 0
+    assert result.stdout == "{}\n"
+    assert "older than plugin" in result.stderr
+    assert (
+        args_file.read_text(encoding="utf-8")
+        == f"-m mempalace hook run --hook {hook_name} --harness claude-code"
+    )
+    assert stdin_file.read_text(encoding="utf-8") == payload
+    # The stale binary answered --version only — never the hook itself
+    # (the stub records args only for non-version invocations).
+    assert not stale_args_file.exists()
+    # The bundled package must win over any stale site-packages copy.
+    pythonpath = pythonpath_file.read_text(encoding="utf-8")
+    assert pythonpath.split(":")[0] == REPO_ROOT.as_posix()
+    # The probe must exercise the modules `-m mempalace` loads at startup
+    # (cli.main() imports miner unconditionally), not just the package root.
+    probe = probe_file.read_text(encoding="utf-8")
+    for module in ("mempalace.cli", "mempalace.hooks_cli", "mempalace.miner"):
+        assert module in probe
+
+
+@pytest.mark.parametrize(("script_name", "hook_name"), SCRIPT_CASES)
+def test_plugin_hook_wrapper_uses_stale_binary_when_no_python(
+    tmp_path: Path, script_name: str, hook_name: str
+) -> None:
+    """With no python runner, a stale binary still beats a hard failure."""
+    args_file = tmp_path / "args.txt"
+    stdin_file = tmp_path / "stdin.json"
+
+    bin_dir = _make_bin_dir(
+        tmp_path,
+        {
+            "mempalace": _versioned_mempalace_stub(
+                "0.0.1", args_file, stdin_file
+            ),
+        },
+    )
+
+    payload = '{"session_id":"stale-last-resort"}'
+    result = _run_hook(script_name, payload, bin_dir)
+
+    assert result.returncode == 0
+    assert result.stdout == "{}\n"
+    assert "older than plugin" in result.stderr
+    assert "falling back to stale mempalace" in result.stderr
+    assert (
+        args_file.read_text(encoding="utf-8")
+        == f"hook run --hook {hook_name} --harness claude-code"
+    )
+    assert stdin_file.read_text(encoding="utf-8") == payload
+
+
+@pytest.mark.parametrize(("script_name", "hook_name"), SCRIPT_CASES)
+def test_plugin_hook_wrapper_uses_current_mempalace_binary(
+    tmp_path: Path, script_name: str, hook_name: str
+) -> None:
+    """A binary at or above the plugin version handles the hook directly."""
+    args_file = tmp_path / "args.txt"
+    stdin_file = tmp_path / "stdin.json"
+
+    bin_dir = _make_bin_dir(
+        tmp_path,
+        {
+            "mempalace": _versioned_mempalace_stub(
+                "999.0.0", args_file, stdin_file
+            ),
+            "python3": "#!/bin/sh\nexit 99\n",
+        },
+    )
+
+    payload = '{"session_id":"current-binary"}'
+    result = _run_hook(script_name, payload, bin_dir)
+
+    assert result.returncode == 0
+    assert result.stdout == "{}\n"
+    assert "older than plugin" not in result.stderr
+    assert (
+        args_file.read_text(encoding="utf-8")
+        == f"hook run --hook {hook_name} --harness claude-code"
+    )
+    assert stdin_file.read_text(encoding="utf-8") == payload


### PR DESCRIPTION
## Problem

The Claude plugin hook wrappers dispatch to the first `mempalace` on PATH, so a stale uv/pipx tool install silently shadows the plugin's bundled (newer) package. Observed in the field: a v3.1.0 binary — whose precompact handler still had the *always block* design — shadowed a v3.3.5 plugin (precompact = mine-then-allow), leaving `/compact` permanently blocked with no hint at the cause. Any user who installed the `mempalace` CLI once and later updates only the plugin is exposed.

## Fix

`run_mempalace_hook` in both wrappers now compares the PATH binary's `--version` against the plugin's `pyproject.toml` version (bash builtins only — hook PATHs can be minimal, no `dirname`/`grep`/`sort`):

- **binary current or version undeterminable** → use it; behavior unchanged (fail-open).
- **binary stale** → warn with the exact remedy (`uv tool upgrade mempalace`) and prefer `python -m mempalace` with the plugin root prepended to `PYTHONPATH`, so the bundled package wins over stale site-packages.
- **bundled module not runnable** → fall back to the stale binary with a second warning rather than failing the hook (a failed PreCompact is worse than a stale one).

The python probe imports `mempalace.cli, mempalace.hooks_cli, mempalace.miner` — not just the package root — because `cli.main()` imports `miner` unconditionally while building its arg parser (the `mine` subparser's `--max-chunks-per-file` help text reads `miner.MAX_CHUNKS_PER_FILE`), so any `-m mempalace` invocation needs the heavy backends importable in-process. Verified empirically: with `chromadb` absent, `python -m mempalace hook run` crashes at `cli.py` argparse construction while `import mempalace` alone succeeds.

> Side observation for maintainers: making that help-text import lazy (or precomputing the default) would let `hook run` work without the heavy backends in-process — happy to file separately.

## Tests

Six new wrapper execution tests alongside the existing ten (all sixteen pass, stub-only PATH):

- stale binary is skipped: warning emitted, `python3 -m` used, `PYTHONPATH` leads with the plugin root, probe content pinned (mutation-covers the module list), stale binary never receives the hook
- stale binary as last resort when no python runner exists: both warnings, hook still completes
- current/newer binary: fast path unchanged, no warning

```
uv run --no-project --with pytest pytest --noconftest tests/test_claude_plugin_hook_wrappers.py
16 passed
```

Also live-verified on a real stale environment (binary 3.3.5 vs plugin 3.3.6): warns, falls back cleanly, hook returns `{}` / rc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)