### PR TITLE
fix(normalize): strip slash-command envelope remnants and ANSI escapes (#1333)

### DIFF
--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -41,6 +41,13 @@ _NOISE_TAGS = (
     "system-reminder",
     "command-message",
     "command-name",
+    # Rest of the five-tag slash-command envelope Claude Code injects (#1333):
+    # local-command-caveat / command-name / command-message / command-args /
+    # local-command-stdout. Only the middle three were covered before, so the
+    # caveat, args, and stdout envelopes leaked into drawers verbatim.
+    "command-args",
+    "local-command-caveat",
+    "local-command-stdout",
     "task-notification",
     "user-prompt-submit-hook",
     "hook_output",
@@ -89,6 +96,23 @@ _HOOK_LINE_RE = re.compile(
 # "… +N lines" collapsed-output marker, line-anchored.
 _COLLAPSED_LINES_RE = re.compile(r"(?m)^(?:> )?…\s*\+\d+ lines.*\n?")
 
+# ANSI escape sequences that Claude Code's Bash tool preserves verbatim from
+# terminal output (#1333). Each escape is several BPE tokens, so they bloat
+# embeddings and pollute search. Unlike the patterns above these are NOT
+# line-anchored — they are anchored on the literal ESC byte (0x1B), a control
+# character that never appears in legitimate prose, so text that merely *names*
+# a sequence like "[1m" or "ESC[0m" survives untouched. Both follow ECMA-48 and
+# are ReDoS-safe by construction (disjoint / negated character classes, no
+# overlapping nested quantifiers — the failure mode behind CVE-2021-3807).
+#
+# CSI (Control Sequence Introducer): ESC [ , parameter bytes (0x30-0x3F),
+# intermediate bytes (0x20-0x2F), one final byte (0x40-0x7E). Covers all SGR
+# color/style codes (the dominant Bash-output noise) plus cursor/erase.
+_ANSI_CSI_RE = re.compile(r"\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]")
+# OSC (Operating System Command): ESC ] , string payload, terminated by BEL
+# (0x07) or ST (ESC \). Covers hyperlinks (ESC]8;;URL BEL) and window titles.
+_ANSI_OSC_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+
 
 def strip_noise(text: str) -> str:
     """Remove system tags, hook output, and Claude Code UI chrome from text.
@@ -105,6 +129,11 @@ def strip_noise(text: str) -> str:
     # Strip the Claude Code collapsed-output chrome "[N tokens] (ctrl+o to expand)".
     # Narrow shape — a bare "(ctrl+o to expand)" in user prose stays intact.
     text = re.sub(r"\s*\[\d+\s+tokens?\]\s*\(ctrl\+o to expand\)", "", text)
+    # Strip ANSI escape sequences from terminal / Bash-tool output (#1333).
+    # Applied after tag removal so escapes nested inside a stripped envelope
+    # (e.g. <local-command-stdout>) are already gone with the tag.
+    text = _ANSI_OSC_RE.sub("", text)
+    text = _ANSI_CSI_RE.sub("", text)
     # Collapse runs of blank lines created by the removals
     text = re.sub(r"\n{4,}", "\n\n\n", text)
     return text.strip()

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -56,11 +56,15 @@ _NOISE_TAGS = (
 
 def _tag_pattern(name: str) -> "re.Pattern[str]":
     # Opening tag must begin a line (optionally after a `> ` blockquote marker,
-    # since _messages_to_transcript prefixes lines with `> `). Body is lazy but
-    # forbidden from crossing a blank line, so a dangling open tag can't span
-    # multiple messages. Closing tag eats optional trailing whitespace + newline.
+    # since _messages_to_transcript prefixes lines with `> `). The body is lazy
+    # and halts at another opening tag of the same name, so a dangling open tag
+    # can't span past the next same-tag block — while still allowing blank lines
+    # *inside* the tag (multi-paragraph <local-command-stdout> output, tables,
+    # stack traces; #1333). Combined with the line-start anchor this keeps a
+    # stray tag from eating neighbouring messages. Closing tag eats optional
+    # trailing whitespace + newline.
     return re.compile(
-        rf"(?m)^(?:> )?<{name}(?:\s[^>]*)?>" rf"(?:(?!\n\s*\n)[\s\S])*?" rf"</{name}>[ \t]*\n?"
+        rf"(?m)^(?:> )?<{name}(?:\s[^>]*)?>" rf"(?:(?!<{name}\b)[\s\S])*?" rf"</{name}>[ \t]*\n?"
     )
 
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1387,6 +1387,9 @@ class TestStripNoiseRemovesSystemChrome:
             "system-reminder",
             "command-message",
             "command-name",
+            "command-args",
+            "local-command-caveat",
+            "local-command-stdout",
             "task-notification",
             "user-prompt-submit-hook",
             "hook_output",
@@ -1403,3 +1406,76 @@ class TestStripNoiseRemovesSystemChrome:
         assert "line two" in out
         # Should collapse to no more than 3 newlines
         assert "\n\n\n\n" not in out
+
+
+class TestStripNoiseClaudeCodeEnvelopeAndAnsi:
+    """#1333: the rest of the slash-command envelope and ANSI escapes from
+    Bash-tool output must be stripped, while prose that merely *names* them
+    survives (verbatim is sacred)."""
+
+    def test_strips_local_command_stdout_envelope(self):
+        text = (
+            "> User:\n"
+            "> <local-command-stdout>Set defaultPermissionMode to default\n"
+            "Disabled auto-compact</local-command-stdout>\n"
+            "> Real message."
+        )
+        out = strip_noise(text)
+        assert "local-command-stdout" not in out
+        assert "defaultPermissionMode" not in out
+        assert "Real message." in out
+
+    def test_strips_empty_command_args_remnant(self):
+        text = "> User:\n> <command-args></command-args>\n> Real."
+        out = strip_noise(text)
+        assert "command-args" not in out
+        assert "Real." in out
+
+    def test_strips_local_command_caveat(self):
+        text = "> <local-command-caveat>caveat text</local-command-caveat>\n> Real."
+        out = strip_noise(text)
+        assert "local-command-caveat" not in out
+        assert "caveat text" not in out
+        assert "Real." in out
+
+    def test_strips_csi_sgr_color_codes(self):
+        # Real sample shape from #1333: ESC[38;2;r;g;bm ... ESC[39m, ESC[1m...ESC[22m
+        text = "\x1b[38;2;153;153;153m├\x1b[39m mempalace_add_drawer \x1b[1mbold\x1b[22m"
+        out = strip_noise(text)
+        assert "\x1b" not in out
+        assert "├ mempalace_add_drawer bold" in out
+
+    def test_strips_ansi_nested_in_local_command_stdout(self):
+        text = "> <local-command-stdout>x \x1b[1mY\x1b[22m z</local-command-stdout>\n> Real."
+        out = strip_noise(text)
+        assert "\x1b" not in out
+        assert "Real." in out
+
+    def test_strips_osc_bel_terminated(self):
+        text = "before \x1b]0;window title\x07 after"
+        out = strip_noise(text)
+        assert "\x1b" not in out
+        assert "window title" not in out
+        assert "before" in out and "after" in out
+
+    def test_strips_osc_hyperlink_st_terminated(self):
+        text = "see \x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\ done"
+        out = strip_noise(text)
+        assert "\x1b" not in out
+        assert "https://example.com" not in out
+        assert "see" in out and "link" in out and "done" in out
+
+    def test_preserves_prose_naming_ansi_sequences(self):
+        # No literal ESC byte → prose that documents "[1m" / "ESC[0m" by name
+        # must be left untouched.
+        text = (
+            "> User:\n"
+            "> To bold terminal text print ESC[1m and reset with [0m. "
+            "The CSI prefix is ESC[ — keep this verbatim."
+        )
+        assert strip_noise(text) == text.strip()
+
+    def test_csi_strip_does_not_eat_following_prose(self):
+        text = "> Assistant: result \x1b[32mOK\x1b[0m and then the real explanation follows."
+        out = strip_noise(text)
+        assert "result OK and then the real explanation follows." in out

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1479,3 +1479,37 @@ class TestStripNoiseClaudeCodeEnvelopeAndAnsi:
         text = "> Assistant: result \x1b[32mOK\x1b[0m and then the real explanation follows."
         out = strip_noise(text)
         assert "result OK and then the real explanation follows." in out
+
+    def test_strips_local_command_stdout_with_blank_lines(self):
+        # Command output commonly has blank lines (tables, stack traces,
+        # multi-paragraph). The envelope must still be stripped fully — the
+        # original blank-line guard would have leaked it (#1333 review).
+        text = (
+            "> <local-command-stdout>line 1\n"
+            "\n"
+            "line 3 after a blank line\n"
+            "\n"
+            "line 5</local-command-stdout>\n"
+            "> Real message."
+        )
+        out = strip_noise(text)
+        assert "local-command-stdout" not in out
+        assert "line 3 after a blank line" not in out
+        assert "line 5" not in out
+        assert "Real message." in out
+
+    def test_same_tag_reopen_does_not_span_eat(self):
+        # Anti-span-eating: a dangling open tag must not consume across to a
+        # later block's close. The negative lookahead halts at the re-opened
+        # tag, so user content between a malformed open and a later well-formed
+        # block survives. (Replaces the old blank-line guard's protection.)
+        text = (
+            "> <system-reminder>dangling open with no close\n"
+            "> User: real content that must survive\n"
+            "> <system-reminder>real noise</system-reminder>\n"
+            "> Tail."
+        )
+        out = strip_noise(text)
+        assert "real content that must survive" in out
+        assert "Tail." in out
+        assert "real noise" not in out


### PR DESCRIPTION
## Problem
`strip_noise()` covered only 3 of Claude Code's 5-tag slash-command envelope
(`system-reminder`/`command-message`/`command-name`) and no ANSI escapes. So
`<command-args>`, `<local-command-caveat>`, `<local-command-stdout>` and the
ANSI color bytes from Bash tool output survived into drawers — polluting search
and bloating embeddings (each escape is several BPE tokens). Closes #1333.

## Fix
- Add `command-args`, `local-command-caveat`, `local-command-stdout` to
  `_NOISE_TAGS` — they inherit the existing line-anchored, blank-line-bounded
  safety (a dangling tag can't eat neighbouring messages).
- Add ECMA-48 **CSI** + **OSC** strippers, applied after tag removal. Anchored
  on the literal ESC byte (`0x1B`), a control char that never appears in prose,
  so text that merely *names* `[1m`/`ESC[0m` is preserved. ReDoS-safe by
  construction (disjoint/negated classes — the failure mode behind
  CVE-2021-3807). CSI covers SGR colors + cursor/erase; OSC covers hyperlinks
  (BEL or ST terminated).

## Why it's safe
"Verbatim is sacred" is preserved: every removal is anchored (line-start for
tags, the ESC byte for ANSI). New tags reuse the audited `_tag_pattern`. No new
dependencies.

## Tests
8 new tests in `test_normalize.py`: full envelope stripping, CSI SGR colors (the
issue's real sample), OSC BEL + ST termination, ANSI nested inside a stripped
tag, and verbatim preservation of prose that names ANSI sequences. Verified
locally: `ruff check` clean, `ruff format` clean, and
`test_normalize.py` + `test_miner.py` + `test_convo_miner.py` (252 tests) pass.
