### PR TITLE
fix: detect Java project manifests

### DIFF
--- a/mempalace/project_scanner.py
+++ b/mempalace/project_scanner.py
@@ -175,7 +175,7 @@ def _parse_pom(path: Path) -> Optional[str]:
     except (ET.ParseError, OSError):
         return None
     for child in root:
-        if _xml_local_name(child.tag) == "artifactId":
+        if isinstance(child.tag, str) and _xml_local_name(child.tag) == "artifactId":
             name = (child.text or "").strip()
             return name or None
     return None
@@ -526,10 +526,12 @@ def scan(root: str | os.PathLike) -> tuple[list[ProjectInfo], list[PersonInfo]]:
 
     for repo in repos:
         manifests = _collect_manifest_names(repo)
-        if manifests:
-            manifest_file, proj_name, _ = manifests[0]
+        root_manifest = next((entry for entry in manifests if entry[2] == repo), None)
+        if root_manifest:
+            manifest_file, proj_name, _ = root_manifest
         else:
             manifest_file, proj_name = None, repo.name
+        extra_manifests = [entry for entry in manifests if entry != root_manifest]
 
         authors = _git_authors(repo)
         non_bot_authors = [(name, email) for name, email in authors if not _is_bot(name, email)]
@@ -566,8 +568,13 @@ def scan(root: str | os.PathLike) -> tuple[list[ProjectInfo], list[PersonInfo]]:
         if existing is None or proj.user_commits > existing.user_commits:
             projects[proj_name] = proj
 
-        for extra_manifest, extra_name, extra_dir in manifests[1:]:
-            if extra_manifest not in JAVA_MANIFESTS or extra_name in projects:
+        for extra_manifest, extra_name, extra_dir in extra_manifests:
+            if extra_manifest not in JAVA_MANIFESTS:
+                continue
+            existing = projects.get(extra_name)
+            if existing is not None and (
+                existing.manifest is not None or existing.repo_root != repo
+            ):
                 continue
             projects[extra_name] = ProjectInfo(
                 name=extra_name,

--- a/mempalace/project_scanner.py
+++ b/mempalace/project_scanner.py
@@ -3,8 +3,8 @@ project_scanner.py — Detect projects and people from real signal.
 
 For a codebase with build manifests or git history, this beats regex-based
 entity detection by a wide margin: the project's own name is already written
-down in package.json / pyproject.toml / Cargo.toml / go.mod, and the people
-who worked on it are in `git log`.
+down in package.json / pyproject.toml / Cargo.toml / go.mod / pom.xml /
+Gradle manifests, and the people who worked on it are in `git log`.
 
 This module is used as the primary signal in `mempalace init`. The regex
 detector in entity_detector.py stays as a fallback for prose-only folders
@@ -21,6 +21,7 @@ import json
 import os
 import re
 import subprocess
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -164,11 +165,63 @@ def _parse_gomod(path: Path) -> Optional[str]:
     return None
 
 
+def _xml_local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def _parse_pom(path: Path) -> Optional[str]:
+    try:
+        root = ET.parse(path).getroot()
+    except (ET.ParseError, OSError):
+        return None
+    for child in root:
+        if _xml_local_name(child.tag) == "artifactId":
+            name = (child.text or "").strip()
+            return name or None
+    return None
+
+
+_GRADLE_ROOT_PROJECT_NAME_PATTERNS = [
+    re.compile(r"""(?m)^\s*rootProject\.name\s*=\s*(["'])(?P<name>[^"']+)\1"""),
+    re.compile(r"""(?m)^\s*rootProject\.name\.set\(\s*(["'])(?P<name>[^"']+)\1\s*\)"""),
+]
+
+
+def _parse_gradle_root_project_name(path: Path) -> Optional[str]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    for pattern in _GRADLE_ROOT_PROJECT_NAME_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            name = match.group("name").strip()
+            return name or None
+    return None
+
+
+def _parse_gradle(path: Path) -> Optional[str]:
+    if path.name.startswith("build.gradle"):
+        for settings_name in ("settings.gradle.kts", "settings.gradle"):
+            name = _parse_gradle_root_project_name(path.with_name(settings_name))
+            if name:
+                return name
+    name = _parse_gradle_root_project_name(path)
+    if name:
+        return name
+    return path.parent.name or None
+
+
 MANIFEST_PRIORITY = {
     "pyproject.toml": 0,
     "package.json": 1,
     "Cargo.toml": 2,
     "go.mod": 3,
+    "pom.xml": 4,
+    "settings.gradle": 5,
+    "settings.gradle.kts": 6,
+    "build.gradle": 7,
+    "build.gradle.kts": 8,
 }
 # Sentinel so unknown manifests always sort after the known manifest types above.
 UNKNOWN_MANIFEST_PRIORITY = max(MANIFEST_PRIORITY.values()) + 1
@@ -177,6 +230,18 @@ MANIFEST_PARSERS = {
     "pyproject.toml": _parse_pyproject,
     "Cargo.toml": _parse_cargo,
     "go.mod": _parse_gomod,
+    "pom.xml": _parse_pom,
+    "settings.gradle": _parse_gradle,
+    "settings.gradle.kts": _parse_gradle,
+    "build.gradle": _parse_gradle,
+    "build.gradle.kts": _parse_gradle,
+}
+JAVA_MANIFESTS = {
+    "pom.xml",
+    "settings.gradle",
+    "settings.gradle.kts",
+    "build.gradle",
+    "build.gradle.kts",
 }
 
 
@@ -501,17 +566,30 @@ def scan(root: str | os.PathLike) -> tuple[list[ProjectInfo], list[PersonInfo]]:
         if existing is None or proj.user_commits > existing.user_commits:
             projects[proj_name] = proj
 
+        for extra_manifest, extra_name, extra_dir in manifests[1:]:
+            if extra_manifest not in JAVA_MANIFESTS or extra_name in projects:
+                continue
+            projects[extra_name] = ProjectInfo(
+                name=extra_name,
+                repo_root=extra_dir,
+                manifest=extra_manifest,
+                has_git=True,
+                total_commits=total_commits,
+                user_commits=user_commits,
+                is_mine=is_mine,
+            )
+
     people = _dedupe_people(all_commits)
 
     # Handle case: root has manifests but no git repo anywhere
     if not repos:
         manifests = _collect_manifest_names(root_path)
-        for manifest_file, proj_name, _dirpath in manifests:
+        for manifest_file, proj_name, dirpath in manifests:
             if proj_name in projects:
                 continue
             projects[proj_name] = ProjectInfo(
                 name=proj_name,
-                repo_root=root_path,
+                repo_root=dirpath,
                 manifest=manifest_file,
                 has_git=False,
             )
@@ -605,8 +683,8 @@ def discover_entities(
     plugs into ``confirm_entities`` unchanged.
 
     Order of signal preference:
-      1. Package manifests (package.json, pyproject.toml, Cargo.toml, go.mod)
-         → canonical project names
+      1. Package manifests (package.json, pyproject.toml, Cargo.toml, go.mod,
+         pom.xml, Gradle manifests) → canonical project names
       2. Git commit authors → real people with real commit counts
       3. Claude Code conversation dirs (~/.claude/projects/) → per-session
          project names (pulled from each session's ``cwd`` metadata)

--- a/tests/test_project_scanner.py
+++ b/tests/test_project_scanner.py
@@ -112,6 +112,24 @@ def test_parse_pom_missing_or_malformed_artifact_id(tmp_path):
     assert _parse_pom(malformed) is None
 
 
+def test_parse_pom_ignores_non_string_child_tags(tmp_path, monkeypatch):
+    class FakeChild:
+        tag = object()
+        text = "ignored"
+
+    class ArtifactChild:
+        tag = "artifactId"
+        text = "safe-artifact"
+
+    class FakeTree:
+        def getroot(self):
+            return [FakeChild(), ArtifactChild()]
+
+    monkeypatch.setattr("mempalace.project_scanner.ET.parse", lambda _path: FakeTree())
+
+    assert _parse_pom(tmp_path / "pom.xml") == "safe-artifact"
+
+
 def test_parse_gradle_build_reads_sibling_settings(tmp_path):
     (tmp_path / "settings.gradle").write_text('rootProject.name = "settings-name"\n')
     f = tmp_path / "build.gradle"
@@ -406,6 +424,27 @@ def test_scan_includes_java_subprojects_inside_mixed_git_repo(tmp_path):
     assert by_name["java-service"].repo_root == service
     assert by_name["worker"].manifest == "build.gradle.kts"
     assert by_name["worker"].repo_root == worker
+
+
+def test_scan_git_repo_without_root_manifest_keeps_java_subproject_dir(tmp_path):
+    service = tmp_path / "service"
+    service.mkdir()
+    (service / "pom.xml").write_text(
+        """<project>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>java-service</artifactId>
+</project>
+"""
+    )
+    _init_git_repo(tmp_path)
+
+    projects, _ = scan(tmp_path)
+    by_name = {p.name: p for p in projects}
+
+    assert by_name[tmp_path.name].manifest is None
+    assert by_name[tmp_path.name].repo_root == tmp_path
+    assert by_name["java-service"].manifest == "pom.xml"
+    assert by_name["java-service"].repo_root == service
 
 
 def test_scan_prefers_root_manifest_with_explicit_priority(tmp_path):

--- a/tests/test_project_scanner.py
+++ b/tests/test_project_scanner.py
@@ -18,8 +18,10 @@ from mempalace.project_scanner import (
     _collect_manifest_names,
     _merge_detected,
     _parse_cargo,
+    _parse_gradle,
     _parse_gomod,
     _parse_package_json,
+    _parse_pom,
     _parse_pyproject,
     _UnionFind,
     discover_entities,
@@ -80,6 +82,58 @@ def test_parse_gomod(tmp_path):
     f = tmp_path / "go.mod"
     f.write_text("module github.com/user/my-go-mod\n\ngo 1.21\n")
     assert _parse_gomod(f) == "my-go-mod"
+
+
+def test_parse_pom_direct_artifact_id_with_namespace(tmp_path):
+    f = tmp_path / "pom.xml"
+    f.write_text(
+        """<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent-artifact</artifactId>
+    <version>1.0.0</version>
+  </parent>
+  <groupId>com.example</groupId>
+  <artifactId>child-artifact</artifactId>
+</project>
+"""
+    )
+    assert _parse_pom(f) == "child-artifact"
+
+
+def test_parse_pom_missing_or_malformed_artifact_id(tmp_path):
+    missing = tmp_path / "missing-pom.xml"
+    missing.write_text("<project><modelVersion>4.0.0</modelVersion></project>")
+    malformed = tmp_path / "bad-pom.xml"
+    malformed.write_text("<project><artifactId>broken")
+
+    assert _parse_pom(missing) is None
+    assert _parse_pom(malformed) is None
+
+
+def test_parse_gradle_build_reads_sibling_settings(tmp_path):
+    (tmp_path / "settings.gradle").write_text('rootProject.name = "settings-name"\n')
+    f = tmp_path / "build.gradle"
+    f.write_text("plugins { id 'java' }\n")
+
+    assert _parse_gradle(f) == "settings-name"
+
+
+def test_parse_gradle_kotlin_set_syntax(tmp_path):
+    f = tmp_path / "settings.gradle.kts"
+    f.write_text('rootProject.name.set("kotlin-settings-name")\n')
+
+    assert _parse_gradle(f) == "kotlin-settings-name"
+
+
+def test_parse_gradle_falls_back_to_directory_name(tmp_path):
+    project = tmp_path / "gradle-dir-name"
+    project.mkdir()
+    f = project / "build.gradle.kts"
+    f.write_text("plugins { java }\n")
+
+    assert _parse_gradle(f) == "gradle-dir-name"
 
 
 # ── bot filtering ───────────────────────────────────────────────────────
@@ -284,6 +338,74 @@ def test_scan_project_from_pyproject(tmp_path):
     _init_git_repo(tmp_path)
     projects, _ = scan(tmp_path)
     assert any(p.name == "pyproj" for p in projects)
+
+
+def test_scan_project_from_maven_pom(tmp_path):
+    (tmp_path / "pom.xml").write_text(
+        """<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>maven-app</artifactId>
+</project>
+"""
+    )
+    _init_git_repo(tmp_path)
+    projects, _ = scan(tmp_path)
+
+    assert projects[0].name == "maven-app"
+    assert projects[0].manifest == "pom.xml"
+
+
+def test_scan_project_from_gradle_settings_without_git(tmp_path):
+    (tmp_path / "settings.gradle.kts").write_text('rootProject.name = "gradle-root"\n')
+    (tmp_path / "build.gradle.kts").write_text("plugins { java }\n")
+    projects, people = scan(tmp_path)
+
+    assert len(projects) == 1
+    assert projects[0].name == "gradle-root"
+    assert projects[0].manifest == "settings.gradle.kts"
+    assert projects[0].has_git is False
+    assert people == []
+
+
+def test_scan_gradle_subproject_without_git_keeps_manifest_dir(tmp_path):
+    (tmp_path / "settings.gradle").write_text('rootProject.name = "gradle-root"\n')
+    app = tmp_path / "app"
+    app.mkdir()
+    (app / "build.gradle").write_text("plugins { id 'java' }\n")
+
+    projects, _ = scan(tmp_path)
+    by_name = {p.name: p for p in projects}
+
+    assert by_name["gradle-root"].repo_root == tmp_path
+    assert by_name["app"].manifest == "build.gradle"
+    assert by_name["app"].repo_root == app
+
+
+def test_scan_includes_java_subprojects_inside_mixed_git_repo(tmp_path):
+    (tmp_path / "package.json").write_text(json.dumps({"name": "web-root"}))
+    service = tmp_path / "service"
+    service.mkdir()
+    (service / "pom.xml").write_text(
+        """<project>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>java-service</artifactId>
+</project>
+"""
+    )
+    worker = tmp_path / "worker"
+    worker.mkdir()
+    (worker / "build.gradle.kts").write_text("plugins { java }\n")
+    _init_git_repo(tmp_path)
+
+    projects, _ = scan(tmp_path)
+    by_name = {p.name: p for p in projects}
+
+    assert by_name["web-root"].manifest == "package.json"
+    assert by_name["java-service"].manifest == "pom.xml"
+    assert by_name["java-service"].repo_root == service
+    assert by_name["worker"].manifest == "build.gradle.kts"
+    assert by_name["worker"].repo_root == worker
 
 
 def test_scan_prefers_root_manifest_with_explicit_priority(tmp_path):


### PR DESCRIPTION
## Summary
- add Maven pom.xml parsing via direct artifactId
- add Gradle build/settings parsing for rootProject.name with directory fallback
- include Java subprojects discovered inside mixed git repositories

Fixes #1571

## Tests
- uv run pytest tests/test_project_scanner.py -q
- uv run ruff check mempalace/project_scanner.py tests/test_project_scanner.py
- uv run ruff format --check mempalace/project_scanner.py tests/test_project_scanner.py
- uv run pytest tests/ -q --ignore=tests/benchmarks
