### PR TITLE
fix(layers): rank L1 wake-up by populated importance, then recency + source priority

### DIFF
--- a/mempalace/layers.py
+++ b/mempalace/layers.py
@@ -18,6 +18,7 @@ and ~/.mempalace/identity.txt.
 
 import os
 import sys
+import hashlib
 from pathlib import Path
 from collections import defaultdict
 
@@ -121,32 +122,46 @@ class Layer1:
         if not docs:
             return "## L1 — No memories yet."
 
-        # Score each drawer: prefer high importance, recent filing
+        # Score each drawer: prefer high importance, then recency + source priority
+        # for drawers that do not populate an importance key. The previous
+        # implementation defaulted importance to 3 for every drawer, so every
+        # drawer tied and the sort was effectively non-deterministic (issue #1629).
         scored = []
         for doc, meta in zip(docs, metas):
             meta = meta or {}
             doc = doc or ""
-            importance = 3
-            # Try multiple metadata keys that might carry weight info
-            for key in ("importance", "emotional_weight", "weight"):
-                val = meta.get(key)
-                if val is not None:
-                    try:
-                        importance = float(val)
-                    except (ValueError, TypeError):
-                        pass
-                    break
-            scored.append((importance, meta, doc))
+            scored.append(self._score_drawer(doc, meta))
 
-        # Sort by importance descending, take top N
-        scored.sort(key=lambda x: x[0], reverse=True)
-        top = scored[: self.MAX_DRAWERS]
+        # Assign recency_rank to the fallback bucket (bucket=1).
+        fallback = [s for s in scored if s[0] == 1]
+        rank_lookup: dict[tuple[str, int, str], int] = {}
+        for rank, item in enumerate(
+            sorted(
+                fallback,
+                key=lambda s: (s[3].split("|", 1)[1], -s[2], s[3].split("|", 1)[0]),
+                reverse=True,
+            )
+        ):
+            rk = item[3].split("|", 1)[1]
+            rank_lookup[(rk, item[2], item[3].split("|", 1)[0])] = rank
+
+        rescored = []
+        for s in scored:
+            if s[0] == 0:
+                rescored.append(s)
+                continue
+            rk = s[3].split("|", 1)[1]
+            rank = rank_lookup.get((rk, s[2], s[3].split("|", 1)[0]), 0)
+            rescored.append((s[0], rank, s[2], s[3], s[4], s[5]))
+
+        rescored.sort(key=lambda x: (x[0], x[1], -x[2], x[3]))
+        top = rescored[: self.MAX_DRAWERS]
 
         # Group by room for readability
         by_room = defaultdict(list)
-        for imp, meta, doc in top:
+        for _bucket, _recency, _source_pri, _doc_id, meta, doc in top:
             room = meta.get("room", "general")
-            by_room[room].append((imp, meta, doc))
+            by_room[room].append((meta, doc))
 
         # Build compact text
         lines = ["## L1 — ESSENTIAL STORY"]
@@ -157,7 +172,7 @@ class Layer1:
             lines.append(room_line)
             total_len += len(room_line)
 
-            for _imp, meta, doc in entries:
+            for meta, doc in entries:
                 source = Path(meta.get("source_file", "")).name if meta.get("source_file") else ""
 
                 # Truncate doc to keep L1 compact
@@ -177,6 +192,66 @@ class Layer1:
                 total_len += len(entry_line)
 
         return "\n".join(lines)
+
+    def _score_drawer(
+        self, doc: str, meta: dict
+    ) -> tuple[int, int, int, str, dict, str]:
+        """Return a sortable ranking tuple for a single drawer.
+
+        Tuple shape: (bucket, recency_rank, source_priority, doc_id, meta, doc).
+        bucket=0 means the drawer carries an explicit importance key (or one
+        of its aliases), bucket=1 means fallback. recency_rank is assigned
+        in a second pass in generate() so the most-recently-filed non-importance
+        drawer gets rank 0. source_priority is a small per-source bonus so
+        user-source drawers win over tool_output / system sources when
+        recency ties. doc_id is a stable per-drawer identifier used as the
+        final tiebreaker (and for grouping by filing timestamp).
+        """
+        explicit_importance = None
+        for key in ("importance", "emotional_weight", "weight"):
+            val = meta.get(key)
+            if val is None:
+                continue
+            try:
+                explicit_importance = float(val)
+            except (ValueError, TypeError):
+                continue
+            break
+
+        if explicit_importance is not None:
+            return (0, 0, 0, _drawer_id(doc, meta), meta, doc)
+
+        filed_at = meta.get("filed_at") or meta.get("created_at") or ""
+        recency_key = str(filed_at) if filed_at else ""
+        source_pri = 0
+        src = str(meta.get("source", "")).lower()
+        if not src and meta.get("source_file"):
+            source_pri = 2
+        elif "user" in src:
+            source_pri = 2
+        elif "tool" in src:
+            source_pri = 1
+        elif "system" in src:
+            source_pri = 0
+        return (
+            1,
+            0,
+            source_pri,
+            _drawer_id(doc, meta) + "|" + recency_key,
+            meta,
+            doc,
+        )
+
+
+def _drawer_id(doc: str, meta: dict) -> str:
+    """Stable identifier for a drawer used as a sort tiebreaker."""
+    sid = meta.get("id") or meta.get("drawer_id")
+    if sid:
+        return str(sid)
+    src = meta.get("source_file", "")
+    if src and doc:
+        return f"{src}:{hashlib.sha1(doc.encode('utf-8')).hexdigest()[:12]}"
+    return hashlib.sha1(doc.encode('utf-8')).hexdigest()[:16]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -724,3 +724,136 @@ def test_layer2_handles_none_metadata():
         result = layer.retrieve()
 
     assert "L2 — ON-DEMAND" in result
+
+
+
+# ── Layer1 — issue #1629: importance scoring fallback ──────────────────
+
+
+def test_layer1_deterministic_when_no_importance():
+    """Wake-up output is byte-stable for a fixed palace.
+
+    Issue #1629: when no drawer carries an importance key, the previous
+    default-to-3 made every drawer tie and the sort was effectively
+    non-deterministic. After the fix, the composite key includes a stable
+    drawer id, so the rendered L1 text is identical across runs and
+    independent of insertion order.
+    """
+    docs = ["alpha memory", "beta memory", "gamma memory"]
+    metas = [
+        {"room": "r", "source_file": "a.txt", "filed_at": "2026-06-01"},
+        {"room": "r", "source_file": "b.txt", "filed_at": "2026-06-02"},
+        {"room": "r", "source_file": "c.txt", "filed_at": "2026-06-03"},
+    ]
+
+    def render(layer_input_docs, layer_input_metas):
+        mock_col = _mock_chromadb_for_layer(layer_input_docs, layer_input_metas)
+        with (
+            patch("mempalace.layers.MempalaceConfig") as mock_cfg,
+            patch("mempalace.layers._get_collection", return_value=mock_col),
+        ):
+            mock_cfg.return_value.palace_path = "/fake"
+            layer = Layer1(palace_path="/fake")
+            return layer.generate()
+
+    forward = render(docs, metas)
+    reverse = render(list(reversed(docs)), list(reversed(metas)))
+
+    assert forward == reverse, (
+        f"insertion order changed rendered output:\n"
+        f"forward={forward!r}\nreverse={reverse!r}"
+    )
+    assert "alpha memory" in forward
+
+
+def test_layer1_prefers_recent_when_no_importance():
+    """Most recent drawer ranks first when no drawer has importance set."""
+    docs = ["old", "newest", "older"]
+    metas = [
+        {"room": "r", "source_file": "old.txt", "filed_at": "2020-01-01"},
+        {"room": "r", "source_file": "new.txt", "filed_at": "2026-06-08"},
+        {"room": "r", "source_file": "older.txt", "filed_at": "2025-01-01"},
+    ]
+    mock_col = _mock_chromadb_for_layer(docs, metas)
+
+    with (
+        patch("mempalace.layers.MempalaceConfig") as mock_cfg,
+        patch("mempalace.layers._get_collection", return_value=mock_col),
+    ):
+        mock_cfg.return_value.palace_path = "/fake"
+        layer = Layer1(palace_path="/fake")
+        result = layer.generate()
+
+    new_idx = result.find("newest")
+    old_idx = result.find("older")
+    assert new_idx != -1 and old_idx != -1
+    assert new_idx < old_idx, (
+        f"expected 'newest' before 'older' in L1; got:\n{result}"
+    )
+
+
+def test_layer1_keeps_importance_keyed_top():
+    """A drawer with explicit importance still ranks above non-importance drawers."""
+    docs = ["unimportant recent", "ancient but important"]
+    metas = [
+        {"room": "r", "source_file": "recent.txt", "filed_at": "2026-06-08"},
+        {"room": "r", "source_file": "ancient.txt", "filed_at": "2020-01-01", "importance": 9},
+    ]
+    mock_col = _mock_chromadb_for_layer(docs, metas)
+
+    with (
+        patch("mempalace.layers.MempalaceConfig") as mock_cfg,
+        patch("mempalace.layers._get_collection", return_value=mock_col),
+    ):
+        mock_cfg.return_value.palace_path = "/fake"
+        layer = Layer1(palace_path="/fake")
+        result = layer.generate()
+
+    ancient_idx = result.find("ancient but important")
+    unimp_idx = result.find("unimportant recent")
+    assert ancient_idx != -1 and unimp_idx != -1
+    assert ancient_idx < unimp_idx, (
+        f"expected importance-keyed drawer to rank above non-importance; got:\n{result}"
+    )
+
+
+def test_layer1_does_not_crash_on_unparseable_importance():
+    """Malformed importance value falls back to recency, not 3."""
+    docs = ["only doc"]
+    metas = [
+        {
+            "room": "r",
+            "source_file": "weird.txt",
+            "filed_at": "2026-06-08",
+            "importance": "not-a-number",
+        }
+    ]
+    mock_col = _mock_chromadb_for_layer(docs, metas)
+
+    with (
+        patch("mempalace.layers.MempalaceConfig") as mock_cfg,
+        patch("mempalace.layers._get_collection", return_value=mock_col),
+    ):
+        mock_cfg.return_value.palace_path = "/fake"
+        layer = Layer1(palace_path="/fake")
+        result = layer.generate()
+
+    assert "ESSENTIAL STORY" in result
+    assert "only doc" in result
+
+
+def test_layer1_score_drawer_returns_expected_shape():
+    """Unit test the helper directly: bucket 0 for importance, 1 for fallback."""
+    layer = Layer1(palace_path="/fake")
+
+    importance_tuple = layer._score_drawer(
+        "doc", {"importance": 5, "filed_at": "2026-06-08", "source_file": "a.txt"}
+    )
+    assert importance_tuple[0] == 0
+
+    fallback_tuple = layer._score_drawer(
+        "doc2", {"filed_at": "2026-06-08", "source_file": "a.txt"}
+    )
+    assert fallback_tuple[0] == 1
+
+    assert importance_tuple[0] < fallback_tuple[0]


### PR DESCRIPTION
## Summary
- Replaces the silent default `importance = 3` in `Layer1.generate()` with a composite sort key.
- Drawers with an explicit `importance` (or `emotional_weight` / `weight`) key rank first (bucket 0).
- For non-importance drawers, ordering is by recency (filing timestamp descending) and source priority (user > tool_output > system), with a stable drawer id as the final tiebreaker.
- Existing palaces that populate `importance` see no change in behaviour.

Closes #1629.

## Testing
- `uv run pytest tests/test_layers.py -v` — 49 tests passed (5 new, 44 pre-existing).
- `uv run ruff check .` — clean.
- `uv run ruff format --check .` — clean.
