### PR TITLE
docs: remove/contextualize external palace-daemon references

### DIFF
--- a/docs/recovery/index-metadata-recovery.md
+++ b/docs/recovery/index-metadata-recovery.md
@@ -40,15 +40,14 @@ The data is recoverable — the `data_level0.bin`, `link_lists.bin`,
 the quarantined dir. Only the `dimensionality` field is missing. We can
 supply it externally.
 
-### 1. Stop the mempalace MCP server / palace-daemon
+### 1. Stop the mempalace MCP server
 
 Two `PersistentClient` instances against the same palace deadlock on the
 sqlite filelock. The recovery script needs exclusive access.
 
 ```bash
 # If running mempalace MCP via Claude Code or similar, kill that process.
-# If running palace-daemon:
-sudo systemctl stop palace-daemon.service
+# If running any other service that holds the palace open, stop it too.
 ```
 
 ### 2. Snapshot sqlite as a rollback
@@ -137,7 +136,7 @@ PYEOF
 ### 6. Restart the service + verify
 
 ```bash
-sudo systemctl start palace-daemon.service       # or your equivalent
+# Restart your mempalace MCP server or equivalent service
 sleep 10  # warmup window
 
 # Confirm vector search is back (not BM25-only fallback):
@@ -191,12 +190,13 @@ rm "$PALACE/<UUID>/index_metadata.pickle.broken-backup"
   bad state during its temp-collection refile pass
 - MemPalace/mempalace#1493 — proposal to have the integrity gate auto-recover
   this exact corruption shape rather than just quarantining
-- jphein/palace-daemon `docs/recovery/chromadb-metadata-dict-patch.md` —
-  the same procedure written from a palace-daemon operator's perspective
-  (HTTP probes instead of CLI commands)
-- jphein/palace-daemon `tests/test_chromadb_metadata_recovery.py` —
-  regression test that builds a real palace, corrupts the metadata,
-  applies the patch, asserts chromadb fully loads + queries the result
+- [jphein/palace-daemon](https://github.com/jphein/palace-daemon) is an
+  external third-party service layer for mempalace (not shipped with this
+  project). Its `docs/recovery/chromadb-metadata-dict-patch.md` covers
+  the same procedure from an HTTP-service operator's perspective, and
+  `tests/test_chromadb_metadata_recovery.py` contains a regression test
+  that builds a real palace, corrupts the metadata, applies the patch,
+  and asserts chromadb fully loads + queries the result
 
 ## Tested on
 

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -127,9 +127,9 @@ def build_graph(col=None, config=None):
             # Skip these silently rather than crash the whole graph
             # build — a single None drawer shouldn't take down /stats
             # or any caller of build_graph for the entire palace. Caught
-            # 2026-04-25 by palace-daemon's verify-routes.sh smoke test
-            # against the canonical 151K palace. Closes the same gap as
-            # upstream #999 / fork PR #1094 in a different read path.
+            # 2026-04-25 during smoke testing against a canonical 151K
+            # palace. Closes the same gap as upstream #999 / fork
+            # PR #1094 in a different read path.
             if meta is None:
                 continue
             room = meta.get("room", "")

--- a/tests/test_palace_graph.py
+++ b/tests/test_palace_graph.py
@@ -58,11 +58,10 @@ class TestBuildGraph:
         """ChromaDB can return None for drawers without metadata (legacy
         data, partial writes — upstream #1020 territory). build_graph
         must skip None entries silently rather than crash the whole
-        graph build with AttributeError. Caught 2026-04-25 by
-        palace-daemon's verify-routes.sh smoke test against the
-        canonical 151K palace; /stats was 500-ing on a single None
-        drawer and taking out every consumer of build_graph for the
-        whole call path."""
+        graph build with AttributeError. Caught 2026-04-25 during
+        smoke testing against a canonical 151K palace; /stats was
+        500-ing on a single None drawer and taking out every consumer
+        of build_graph for the whole call path."""
         col = _make_fake_collection(
             [
                 {"room": "auth", "wing": "wing_code", "hall": "security", "date": "2026-01-01"},


### PR DESCRIPTION
## What does this PR do?

Addresses #1603 — removes or contextualizes confusing references to the external
`palace-daemon` project (not shipped with mempalace) across three files:

- `mempalace/palace_graph.py` — replaced provenance comment citing
  palace-daemon's verify-routes.sh with a self-contained description
- `tests/test_palace_graph.py` — same docstring update in the corresponding test
- `docs/recovery/index-metadata-recovery.md` — generalized systemctl commands,
  added context explaining what palace-daemon is in the Related section

The chroma.py reference (also listed in #1603) was already removed by #1602.

Closes #1603

## How to test

All 24 test_palace_graph.py tests pass. No code logic changed — comments/docs only.

## Checklist
- [x] Tests pass
- [x] No hardcoded paths
- [x] Linter passes (ruff check .)