### PR TITLE
feat: add append param to update_drawer

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1895,8 +1895,21 @@ def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offse
         return {"error": str(e)}
 
 
-def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, room: str = None):
-    """Update an existing drawer's content and/or metadata."""
+def tool_update_drawer(
+    drawer_id: str,
+    content: str = None,
+    wing: str = None,
+    room: str = None,
+    append: bool = False,
+):
+    """Update an existing drawer's content and/or metadata.
+
+    When ``append`` is True and ``content`` is given, the content is
+    concatenated onto the existing drawer body instead of replacing it, so a
+    caller updating a long drawer need only send the delta rather than
+    re-transmitting the whole body on every edit. ``append`` defaults to
+    False, preserving the prior replace-in-full behavior.
+    """
     global _metadata_cache
 
     if content is None and wing is None and room is None:
@@ -1916,9 +1929,10 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
         new_doc = old_doc
         if content is not None:
             try:
-                new_doc = sanitize_content(content)
+                sanitized = sanitize_content(content)
             except ValueError as e:
                 return {"success": False, "error": str(e)}
+            new_doc = old_doc + sanitized if append else sanitized
 
         new_meta = dict(old_meta)
         if wing is not None:
@@ -1949,6 +1963,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
                 "new_wing": new_meta.get("wing", ""),
                 "new_room": new_meta.get("room", ""),
                 "content_changed": content is not None,
+                "append": append,
                 "content_preview": new_doc[:200] if content is not None else None,
             },
         )
@@ -2932,7 +2947,7 @@ TOOLS = {
         "handler": tool_list_drawers,
     },
     "mempalace_update_drawer": {
-        "description": "Update an existing drawer's content and/or metadata (wing, room). Fetches existing drawer first; returns error if not found.",
+        "description": "Update an existing drawer's content and/or metadata (wing, room). Fetches existing drawer first; returns error if not found. Set append=true to concatenate content onto the existing body (send only the delta) instead of replacing it.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -2948,6 +2963,10 @@ TOOLS = {
                 "room": {
                     "type": "string",
                     "description": "New room (optional — omit to keep existing)",
+                },
+                "append": {
+                    "type": "boolean",
+                    "description": "If true, append content to the existing drawer body instead of replacing it (send only the delta). Default false (replace).",
                 },
             },
             "required": ["drawer_id"],

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1932,7 +1932,10 @@ def tool_update_drawer(
                 sanitized = sanitize_content(content)
             except ValueError as e:
                 return {"success": False, "error": str(e)}
-            new_doc = old_doc + sanitized if append else sanitized
+            # ``old_doc`` can be None when the stored drawer has no document
+            # body (Chroma returns None for such rows); guard the append path
+            # so concatenation never raises TypeError.
+            new_doc = (old_doc or "") + sanitized if append else sanitized
 
         new_meta = dict(old_meta)
         if wing is not None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1766,6 +1766,42 @@ class TestWriteTools:
         assert deleted_logical["success"] is False
         assert "not found" in deleted_logical["error"].lower()
 
+    def test_update_drawer_append(self, monkeypatch, config, palace_path, seeded_collection, kg):
+        # append=True concatenates the delta onto the existing body instead of
+        # replacing it, so a caller updating a long drawer need only send the
+        # delta rather than re-transmitting the whole body on every edit.
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import (
+            tool_update_drawer,
+            tool_get_drawer,
+            sanitize_content,
+        )
+
+        before = tool_get_drawer("drawer_proj_backend_aaa")["content"]
+        assert before, "fixture drawer should have an existing body to append onto"
+        delta = "\n\nAppended delta line — only this was sent, not the whole body."
+
+        result = tool_update_drawer(
+            "drawer_proj_backend_aaa", content=delta, append=True
+        )
+        assert result["success"] is True
+
+        fetched = tool_get_drawer("drawer_proj_backend_aaa")["content"]
+        # the original body survives (no full rewrite) and the delta is appended
+        assert fetched == before + sanitize_content(delta)
+        assert before in fetched
+
+    def test_update_drawer_replace_is_default(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        # append defaults to False → content REPLACES, preserving prior behavior.
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_update_drawer, tool_get_drawer
+
+        tool_update_drawer("drawer_proj_backend_aaa", content="Wholly new body.")
+        fetched = tool_get_drawer("drawer_proj_backend_aaa")["content"]
+        assert fetched == "Wholly new body."
+
 
 # ── KG Tools ────────────────────────────────────────────────────────────
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1802,6 +1802,32 @@ class TestWriteTools:
         fetched = tool_get_drawer("drawer_proj_backend_aaa")["content"]
         assert fetched == "Wholly new body."
 
+    def test_update_drawer_append_tolerates_none_existing_body(self, monkeypatch, config, kg):
+        # Regression for the PR #1762 review: Chroma can return ``None`` for a
+        # stored drawer's document body. The append path must treat a missing
+        # body as empty rather than raising TypeError on ``None + str``.
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        captured = {}
+
+        class _FakeCol:
+            def get(self, ids, include=None):
+                return {"ids": list(ids), "documents": [None], "metadatas": [{}]}
+
+            def update(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr(mcp_server, "_get_collection", lambda *a, **kw: _FakeCol())
+        monkeypatch.setattr(mcp_server, "_wal_log", lambda *a, **kw: None)
+
+        result = mcp_server.tool_update_drawer(
+            "drawer_none_body", content="fresh delta", append=True
+        )
+        # None body coerced to "" → no crash, stored doc is just the delta.
+        assert result["success"] is True
+        assert captured["documents"] == [mcp_server.sanitize_content("fresh delta")]
+
 
 # ── KG Tools ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds an `append: bool = False` parameter to `tool_update_drawer` (and its MCP
schema entry). When `append=True` and `content` is provided, the content is
**concatenated onto the existing drawer body** instead of replacing it, so a
caller updating a long drawer can send only the delta rather than
re-transmitting the whole body on every edit.

`append` defaults to `False` — existing callers and the replace-in-full
behavior are unchanged. The handler already fetches the existing document, so
this is a minimal read-modify-write with no extra round-trip:

```python
new_doc = old_doc + sanitized if append else sanitized
```

Motivation and the alternatives considered (a separate `append_to_drawer`
tool, or a richer section-patch) are in the linked issue — this PR implements
the smallest form and is happy to follow a different surface if preferred.

Closes https://github.com/MemPalace/mempalace/issues/1761

## Changes

- `mempalace/mcp_server.py`
  - `tool_update_drawer(...)` gains `append: bool = False`; content path now
    appends-or-replaces based on the flag.
  - WAL log records the `append` flag.
  - `mempalace_update_drawer` MCP schema gains an `append` boolean property;
    tool description notes the delta-append behavior.
- `tests/test_mcp_server.py`
  - `test_update_drawer_append` — appends a delta and asserts the original body
    survives and the delta is concatenated (`old_doc + sanitize_content(delta)`).
  - `test_update_drawer_replace_is_default` — pins that the default
    (`append=False`) still replaces, guarding the back-compat path.

## Verification

Test-first (RED → GREEN; visible in the commit order on this branch):

- RED commit adds `test_update_drawer_append`, which fails against the current
  code with `TypeError: tool_update_drawer() got an unexpected keyword argument
  'append'`.
- GREEN commit adds the parameter; the test passes.

```
$ pytest tests/ -q
889 passed, 106 deselected, 1 warning in ~56s     # 1 warning is a pre-existing,
                                                   # unrelated fact_checker runpy warning
$ ruff check mempalace/mcp_server.py
All checks passed!
```

## CONTRIBUTING.md adherence

- Conventional commits (`test:` for the failing test, `feat:` for the param).
- `ruff` clean on the changed file (100-char limit).
- Branched from and targeted at `develop`; pushed to a personal fork.
- Tests run without API keys or network access.
