### PR TITLE
fix(mcp): exit orphaned stdio server when parent dies

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -3720,6 +3720,51 @@ def _maybe_eager_warmup_embedder() -> None:
         )
 
 
+_MCP_PARENT_WATCHDOG_ENV = "MEMPALACE_MCP_PARENT_WATCHDOG"
+
+
+def _start_parent_death_watchdog() -> None:
+    """Exit immediately if the parent (client) process dies.
+
+    The MCP stdio protocol carries no application-level liveness signal:
+    when a client crashes, force-quits, or restarts without closing stdio
+    cleanly, the child server can outlive its parent indefinitely — still
+    holding ChromaDB / HNSW / SQLite file handles. The idle watchdog only
+    catches this 8 h later; this thread catches it within seconds.
+
+    POSIX reparents an orphaned child to PID 1 (init / launchd). The
+    watchdog polls ``getppid()`` every 5 s and exits the process as soon
+    as it sees that signal.
+
+    Set ``MEMPALACE_MCP_PARENT_WATCHDOG=0`` to disable.
+    """
+    raw = os.environ.get(_MCP_PARENT_WATCHDOG_ENV, "").strip().lower()
+    if raw in {"0", "false", "no", "off"}:
+        return
+    initial_ppid = os.getppid()
+
+    def _watchdog() -> None:
+        while True:
+            time.sleep(5.0)
+            try:
+                current_ppid = os.getppid()
+            except OSError:
+                os._exit(0)
+            if current_ppid == 1:
+                if initial_ppid == 1:
+                    detail = "absent at startup"
+                else:
+                    detail = f"died (PPID was {initial_ppid})"
+                logger.info(
+                    "Parent process %s; exiting orphan to release file handles.",
+                    detail,
+                )
+                os._exit(0)
+
+    t = threading.Thread(target=_watchdog, name="mcp-parent-watchdog", daemon=True)
+    t.start()
+
+
 def _start_idle_exit_watchdog() -> None:
     """Start a daemon thread that exits the process after an idle period.
 
@@ -3786,6 +3831,9 @@ def main():
     # does not pay the ONNX/CoreML cold-load tax under the MCP client
     # timeout (#1495). Default off — preserves current startup latency.
     _maybe_eager_warmup_embedder()
+    # Parent-death watchdog: exit within ~5 s when the client process
+    # disappears (crash / force-quit / orphan). Catches what idle cannot.
+    _start_parent_death_watchdog()
     # Idle auto-exit: release ChromaDB file handles from stale servers
     # that outlived their Claude Code session (#1552).
     _start_idle_exit_watchdog()

--- a/tests/test_mcp_parent_watchdog.py
+++ b/tests/test_mcp_parent_watchdog.py
@@ -1,0 +1,144 @@
+"""Regression tests for the parent-death watchdog (MCP stdio orphan fix).
+
+The MCP stdio protocol carries no application-level liveness signal:
+when a client (Claude / Codex / etc.) crashes, force-quits, or restarts
+without closing stdio cleanly, the child ``mempalace-mcp`` server can
+outlive its parent indefinitely — still holding ChromaDB / HNSW /
+SQLite file handles. The 8 h idle watchdog (#1552) catches it
+eventually; the parent-death watchdog catches it within ~5 s by polling
+``os.getppid()`` and exiting as soon as the child is reparented to
+PID 1.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+
+WATCHDOG_THREAD_NAME = "mcp-parent-watchdog"
+
+
+def _run(code, env=None, timeout=60):
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        env=full_env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def test_parent_watchdog_starts_thread_by_default():
+    """No env override → ``_start_parent_death_watchdog()`` spawns a
+    daemon thread named ``mcp-parent-watchdog``."""
+    code = textwrap.dedent(
+        f"""
+        import sys, threading
+        from mempalace.mcp_server import _start_parent_death_watchdog
+        _start_parent_death_watchdog()
+        names = [t.name for t in threading.enumerate()]
+        sys.stderr.write("THREADS: " + ",".join(names) + "\\n")
+        assert {WATCHDOG_THREAD_NAME!r} in names, names
+        """
+    )
+    # Remove the override in case the harness sets one for development.
+    env = {"MEMPALACE_MCP_PARENT_WATCHDOG": ""}
+    result = _run(code, env=env)
+    assert result.returncode == 0, f"stderr={result.stderr!r}"
+
+
+@pytest.mark.parametrize("disable_value", ["0", "false", "False", "no", "off"])
+def test_parent_watchdog_respects_disable_env(disable_value):
+    """``MEMPALACE_MCP_PARENT_WATCHDOG=0/false/no/off`` skips the
+    thread — escape hatch for embedded / supervised contexts where the
+    host already provides liveness."""
+    code = textwrap.dedent(
+        f"""
+        import sys, threading
+        from mempalace.mcp_server import _start_parent_death_watchdog
+        _start_parent_death_watchdog()
+        names = [t.name for t in threading.enumerate()]
+        sys.stderr.write("THREADS: " + ",".join(names) + "\\n")
+        assert {WATCHDOG_THREAD_NAME!r} not in names, names
+        """
+    )
+    result = _run(code, env={"MEMPALACE_MCP_PARENT_WATCHDOG": disable_value})
+    assert result.returncode == 0, f"stderr={result.stderr!r}"
+
+
+@pytest.mark.skipif(
+    not os.path.exists("/dev/zero"),
+    reason="end-to-end orphan test relies on POSIX /dev/zero to keep stdin blocking",
+)
+def test_parent_watchdog_exits_orphaned_process(tmp_path):
+    """End-to-end live regression: spawn mempalace-mcp under a
+    short-lived driver, let the driver exit, assert the orphaned child
+    self-exits within 20 s and writes the expected log line to stderr.
+
+    The child's stdin is bound to ``/dev/zero`` so ``readline()`` blocks
+    forever — simulating an idle-but-connected client. Without the
+    watchdog this would hang until the 8 h idle timeout.
+    """
+    stderr_path = tmp_path / "child.err"
+    pid_path = tmp_path / "child.pid"
+
+    driver_code = textwrap.dedent(
+        f"""
+        import sys, subprocess
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "from mempalace.mcp_server import main; main()"],
+            stdin=open("/dev/zero"),
+            stdout=subprocess.DEVNULL,
+            stderr=open({str(stderr_path)!r}, "w"),
+        )
+        with open({str(pid_path)!r}, "w") as f:
+            f.write(str(proc.pid))
+        # driver exits → child reparented to PID 1
+        """
+    )
+    driver = subprocess.run(
+        [sys.executable, "-c", driver_code],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert driver.returncode == 0, f"driver failed: stderr={driver.stderr!r}"
+
+    child_pid = int(pid_path.read_text().strip())
+
+    # Give heavy imports (chromadb / hnsw) a moment to finish so the
+    # watchdog thread is actually running when we start polling.
+    time.sleep(2.0)
+
+    deadline = time.monotonic() + 20.0
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)  # existence check
+        except ProcessLookupError:
+            err = stderr_path.read_text()
+            # Watchdog log line covers both "died (PPID was N)" and
+            # "absent at startup" (driver may exit before child runs).
+            assert "exiting orphan to release file handles" in err, (
+                f"orphan exited but watchdog log line missing: stderr={err!r}"
+            )
+            return
+        time.sleep(0.5)
+
+    # Timeout — kill leaked child and fail.
+    try:
+        os.kill(child_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    pytest.fail(
+        f"orphan child {child_pid} did not exit within 20 s; stderr={stderr_path.read_text()!r}"
+    )


### PR DESCRIPTION
## Summary

Adds a parent-death watchdog for the existing MCP stdio server.

When a client process (Claude / Codex / etc.) crashes, force-quits, or restarts without closing stdio cleanly, `mempalace-mcp` can outlive its parent and keep ChromaDB / HNSW / SQLite file handles open. The existing 8 h idle watchdog catches this eventually; this watchdog catches the orphaned process within roughly 5 s.

The earlier `diary_write` schema fix is already present in `develop` via upstream commit `b1537be`, so this rebased PR now contains only the orphan watchdog slice.

### How the watchdog works

POSIX reparents an orphaned child to PID 1. A daemon thread polls `os.getppid()` every 5 s and exits the process on first PPID == 1 observation.

It handles both cases:
- **died (PPID was N)** — parent was alive at startup, then died later
- **absent at startup** — parent was already gone when child began executing

Escape hatch: `MEMPALACE_MCP_PARENT_WATCHDOG=0` for launchd / supervised contexts that supply their own liveness.

## Test plan

- [x] `uv run python -m py_compile mempalace/mcp_server.py`
- [x] `uv run pytest -q tests/test_mcp_parent_watchdog.py` — 7 passed
- [x] `uv run pytest -q tests/test_mcp_stdio_protection.py tests/test_mcp_server.py -k 'ColdStart or PYTHONPATH or idle or diary_write or schema or handle_request'` — 40 passed, 158 deselected
- [x] `uv run ruff check mempalace/mcp_server.py tests/test_mcp_parent_watchdog.py`
- [x] `uv run ruff format --check mempalace/mcp_server.py tests/test_mcp_parent_watchdog.py`
- [x] `uv run pytest tests/ -q --ignore=tests/benchmarks` — 2860 passed, 5 skipped, 1 warning

## Out of scope

HTTP/SSE / Streamable HTTP shared-server transport (one mempalace serving multiple clients) — separate slice. This PR only stabilizes the existing stdio surface.

Local client config changes (`MEMPALACE_MCP_IDLE_HOURS=1` in `~/.claude.json` and `~/.codex/config.toml`) are personal-env-only and not part of this PR.