### PR TITLE
feat(miner): add PHP ecosystem file extensions

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -47,6 +47,34 @@ from .ids import ID_RECIPE, make_drawer_id_from_chunk
 
 logger = logging.getLogger("mempalace_mcp")
 
+PHP_EXTENSIONS = {
+    # Compound Blade templates such as ``view.blade.php`` are covered by the
+    # final ``.php`` suffix.
+    ".php",
+    ".php3",
+    ".php4",
+    ".php5",
+    ".php7",
+    ".php8",
+    ".phtml",
+    ".phps",
+    ".phpt",
+    ".inc",
+    ".aw",
+    ".fcgi",
+    ".ctp",
+    ".module",
+    ".install",
+    ".profile",
+    ".theme",
+    ".engine",
+    ".twig",
+    ".blade",
+    ".tpl",
+    ".latte",
+    ".volt",
+}
+
 READABLE_EXTENSIONS = {
     ".txt",
     ".md",
@@ -69,7 +97,7 @@ READABLE_EXTENSIONS = {
     ".csv",
     ".sql",
     ".toml",
-}
+} | PHP_EXTENSIONS
 
 SKIP_FILENAMES = {
     "entities.json",

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -10,7 +10,15 @@ import pytest
 import yaml
 
 from mempalace.config import normalize_wing_name
-from mempalace.miner import detect_room, load_config, mine, scan_project, status
+from mempalace.miner import (
+    PHP_EXTENSIONS,
+    READABLE_EXTENSIONS,
+    detect_room,
+    load_config,
+    mine,
+    scan_project,
+    status,
+)
 from mempalace.palace import NORMALIZE_VERSION, file_already_mined, prefetch_mined_set
 
 
@@ -22,6 +30,24 @@ def write_file(path: Path, content: str):
 def scanned_files(project_root: Path, **kwargs):
     files = scan_project(str(project_root), **kwargs)
     return sorted(path.relative_to(project_root).as_posix() for path in files)
+
+
+def test_php_ecosystem_extensions_are_readable():
+    assert PHP_EXTENSIONS <= READABLE_EXTENSIONS
+
+
+def test_scan_project_includes_php_ecosystem_files(tmp_path):
+    expected = []
+    for index, extension in enumerate(sorted(PHP_EXTENSIONS)):
+        filename = f"example_{index}{extension}"
+        write_file(tmp_path / filename, "<?php echo 'verbatim';\n")
+        expected.append(filename)
+
+    # Extension matching is deliberately case-insensitive.
+    write_file(tmp_path / "uppercase.PHP", "<?php echo 'uppercase';\n")
+    expected.append("uppercase.PHP")
+
+    assert scanned_files(tmp_path) == sorted(expected)
 
 
 def test_project_mining():


### PR DESCRIPTION
## What does this PR do?

  - Add support for 23 common PHP ecosystem file extensions.
  - Cover PHP source files, versioned PHP files, framework-specific files, and templates such as Twig, Blade, Smarty, Latte, and Volt.
  - Add tests verifying every extension is discovered by the project scanner.
  - Verify extension matching remains case-insensitive.

  Binary PHP archives such as .phar are intentionally excluded.

## How to test

There is a unit test. Or just use mempalace in a php project.

## Checklist
- [X] Tests pass (`python -m pytest tests/ -v`)
- [X] No hardcoded paths
- [X] Linter passes (`ruff check .`)
