### PR TITLE
feat(hooks): add a budget-safe SessionEnd save hook for clean exits (#1341)

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -41,9 +41,10 @@ After installing the plugin, run the init command to complete setup (installs th
 
 ## Hooks
 
-MemPalace registers two hooks that run automatically:
+MemPalace registers three hooks that run automatically:
 
 - **Stop** -- Saves conversation context every 15 messages.
+- **SessionEnd** -- Runs one final save in the background on a clean exit, so short sessions that never hit the Stop interval or a compaction are still captured.
 - **PreCompact** -- Preserves important memories before context compaction.
 
 Set the `MEMPAL_DIR` environment variable to a directory path to automatically run `mempalace mine` on that directory during each save trigger.

--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -12,6 +12,17 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/mempal-session-end-hook.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "hooks": [

--- a/.claude-plugin/hooks/mempal-session-end-hook.sh
+++ b/.claude-plugin/hooks/mempal-session-end-hook.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# MemPalace SessionEnd Hook — thin wrapper calling the Python CLI.
+#
+# Claude Code documents a default SessionEnd hook timeout of 1.5s, and
+# "timeouts set on plugin-provided hooks do not raise the budget"
+# (https://code.claude.com/docs/en/hooks). A cold `mempalace` start alone
+# exceeds 1.5s, so the final mine must NOT run in the foreground — it would be
+# killed before it saved anything. Unlike the foreground Stop/PreCompact plugin
+# wrappers, this one backgrounds the hook and returns immediately; the detached
+# child finishes the save after the session has exited. All logic lives in
+# mempalace.hooks_cli for cross-harness extensibility.
+run_mempalace_hook() {
+  if command -v mempalace >/dev/null 2>&1; then
+    exec mempalace hook run "$@"
+  fi
+
+  MEMPAL_PYTHON_BIN="${MEMPAL_PYTHON:-}"
+  if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
+    MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
+  fi
+  if "$MEMPAL_PYTHON_BIN" -c "import mempalace" >/dev/null 2>&1; then
+    exec "$MEMPAL_PYTHON_BIN" -m mempalace hook run "$@"
+  fi
+
+  if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
+    exec python -m mempalace hook run "$@"
+  fi
+
+  echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
+  exit 1
+}
+
+# Capture stdin (the SessionEnd JSON) before backgrounding — the parent's
+# stdin is gone once we return. Forward it to the detached worker, which runs
+# the final mine on its own time and outlives this process.
+payload="$(cat)"
+(
+  printf '%s' "$payload" | run_mempalace_hook --hook session-end --harness "${MEMPALACE_HOOK_HARNESS:-claude-code}"
+) >/dev/null 2>&1 </dev/null &
+disown 2>/dev/null || true
+
+# Return immediately so the harness never blocks on session exit.
+printf '{}'

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -18,6 +18,7 @@ It covers hook wiring, JSONL backup, and one-time backfill.
 | Hook | When It Fires | What Happens |
 |------|--------------|-------------|
 | **Save Hook** | Every 15 human messages | Auto-mines transcript (tool output included), then blocks the AI to save topics/decisions/quotes |
+| **SessionEnd Hook** | Clean session exit | Backgrounds a final transcript mine (when a transcript exists) so short sessions aren't lost; returns immediately so teardown is never delayed. A lightweight diary checkpoint is written in the detached child. |
 | **PreCompact Hook** | Right before context compaction | Auto-mines transcript, then emergency save — forces the AI to save EVERYTHING before losing context |
 
 **Two-layer capture:** Hooks auto-mine the JSONL transcript directly into the palace (capturing raw tool output — Bash results, search findings, build errors). They also block the AI with a reason message telling it to save verbatim tool output and key context. Belt and suspenders — tool output gets stored even if the AI summarizes instead of quoting.
@@ -37,6 +38,13 @@ Add to `.claude/settings.local.json`:
         "timeout": 30
       }]
     }],
+    "SessionEnd": [{
+      "hooks": [{
+        "type": "command",
+        "command": "/absolute/path/to/hooks/mempal_session_end_hook.sh",
+        "timeout": 10
+      }]
+    }],
     "PreCompact": [{
       "hooks": [{
         "type": "command",
@@ -48,9 +56,15 @@ Add to `.claude/settings.local.json`:
 }
 ```
 
+`SessionEnd` runs once on a clean exit and backgrounds its work, so it
+returns instantly and stays within Claude Code's SessionEnd budget. Wired
+through `settings.local.json` (above) the `timeout` can raise that budget;
+the bundled plugin cannot, which is why the hook backgrounds rather than
+mining in the foreground.
+
 Make them executable:
 ```bash
-chmod +x hooks/mempal_save_hook.sh hooks/mempal_precompact_hook.sh
+chmod +x hooks/mempal_save_hook.sh hooks/mempal_session_end_hook.sh hooks/mempal_precompact_hook.sh
 ```
 
 ## Install — Antigravity (Google)
@@ -89,6 +103,13 @@ Add to `.codex/hooks.json`:
   }]
 }
 ```
+
+**Other harnesses:** the clean-exit save runs through the harness-agnostic
+`mempalace hook run --hook session-end` entry point. This release wires it
+for Claude Code. Antigravity exposes no dedicated session-end event (its
+lifecycle hooks are PreToolUse/PostToolUse/PreInvocation/PostInvocation/Stop,
+and MemPalace already saves there via `Stop`); Cursor and Codex can adopt the
+same entry point as a follow-up wherever their own session-end event is available.
 
 ## Configuration
 

--- a/hooks/mempal_session_end_hook.sh
+++ b/hooks/mempal_session_end_hook.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# MemPalace SessionEnd Hook — final save on clean exit.
+#
+# Claude Code documents a default SessionEnd hook timeout of 1.5s; a per-hook
+# "timeout" in settings.local.json can raise it (up to 60s), but a
+# plugin-provided timeout cannot (https://code.claude.com/docs/en/hooks). A cold
+# `mempalace` start alone can exceed 1.5s, so we background the hook and return
+# immediately; the detached child finishes the save after the session has
+# exited. All logic lives in mempalace.hooks_cli for cross-harness extensibility.
+run_mempalace_hook() {
+  if command -v mempalace >/dev/null 2>&1; then
+    exec mempalace hook run "$@"
+  fi
+
+  MEMPAL_PYTHON_BIN="${MEMPAL_PYTHON:-}"
+  if [ -z "$MEMPAL_PYTHON_BIN" ] || [ ! -x "$MEMPAL_PYTHON_BIN" ]; then
+    MEMPAL_PYTHON_BIN="$(command -v python3 2>/dev/null || echo python3)"
+  fi
+  if "$MEMPAL_PYTHON_BIN" -c "import mempalace" >/dev/null 2>&1; then
+    exec "$MEMPAL_PYTHON_BIN" -m mempalace hook run "$@"
+  fi
+
+  if command -v python >/dev/null 2>&1 && python -c "import mempalace" >/dev/null 2>&1; then
+    exec python -m mempalace hook run "$@"
+  fi
+
+  echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
+  exit 1
+}
+
+# Capture stdin (the SessionEnd JSON) before backgrounding — the parent's
+# stdin is gone once we return. Forward it to the detached worker, which runs
+# the final mine on its own time and outlives this process.
+payload="$(cat)"
+(
+  printf '%s' "$payload" | run_mempalace_hook --hook session-end --harness "${MEMPALACE_HOOK_HARNESS:-claude-code}"
+) >/dev/null 2>&1 </dev/null &
+disown 2>/dev/null || true
+
+# Return immediately so the harness never blocks on session exit.
+printf '{}'

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1605,7 +1605,7 @@ def main():
     p_hook_run.add_argument(
         "--hook",
         required=True,
-        choices=["session-start", "stop", "precompact"],
+        choices=["session-start", "stop", "session-end", "precompact"],
         help="Hook name to run",
     )
     p_hook_run.add_argument(

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -1,8 +1,8 @@
 """
-Hook logic for MemPalace — Python implementation of session-start, stop, and precompact hooks.
+Hook logic for MemPalace — Python implementation of session-start, stop, session-end, and precompact hooks.
 
 Reads JSON from stdin, outputs JSON to stdout.
-Supported hooks: session-start, stop, precompact
+Supported hooks: session-start, stop, session-end, precompact
 Supported harnesses: claude-code, codex (extensible to cursor, gemini, etc.)
 """
 
@@ -1021,6 +1021,113 @@ def hook_session_start(data: dict, harness: str):
     _output({})
 
 
+def _clear_session_last_save(session_id: str) -> None:
+    """Drop the per-session save marker once a session has ended.
+
+    ``hook_stop`` writes ``{session_id}_last_save`` but never had a clean-exit
+    cleanup path, so the marker lingered. The session is over by the time
+    ``hook_session_end`` runs, so removing it here keeps ``hook_state/`` from
+    accumulating dead markers. OS errors (including a missing marker, since
+    ``FileNotFoundError`` is an ``OSError``) are swallowed — this is best-effort
+    cleanup, never a reason to fail the hook.
+    """
+    try:
+        (STATE_DIR / f"{session_id}_last_save").unlink()
+    except OSError:
+        pass
+
+
+def hook_session_end(data: dict, harness: str):
+    """Session end hook: one final flush when a session exits cleanly.
+
+    Closes the gap (#1341) where a session that never crosses ``SAVE_INTERVAL``
+    on ``Stop`` and never triggers ``PreCompact`` exits with nothing saved —
+    the common case for short, useful sessions.
+
+    Why background instead of mine inline: Claude Code's hooks reference
+    documents a default SessionEnd timeout of 1.5 seconds, and "timeouts set on
+    plugin-provided hooks do not raise the budget"
+    (https://code.claude.com/docs/en/hooks). A cold ``mempalace`` start alone
+    exceeds 1.5s, so this handler must never mine in the hook foreground. The
+    shell wrapper backgrounds it and returns immediately; the heavy capture is
+    spawned *detached* via ``_ingest_transcript`` / ``_maybe_auto_ingest`` (both
+    route through ``_spawn_mine`` / ``_detached_popen_kwargs``). On POSIX that
+    detached child reliably outlives the session (verified). On Windows only the
+    mine grandchild (spawned with detached-process flags) is designed to break
+    away from the session; the backgrounded hook process and the in-process
+    diary write are best-effort there (no Windows CI coverage yet). This
+    honors the "background everything / hooks under 500ms" budget. SessionEnd
+    has no decision control, so this only ever saves; it never emits a block
+    payload.
+    """
+    if not _palace_root_exists():
+        _output({})
+        return
+
+    # Parse inside the try so a malformed payload (e.g. non-dict stdin that
+    # makes _parse_harness_input raise) still runs the finally cleanup below.
+    session_id = "unknown"
+    try:
+        parsed = _parse_harness_input(data, harness)
+        session_id = parsed["session_id"]
+        transcript_path = parsed["transcript_path"]
+
+        # Read config defensively (mirror hook_stop): a corrupt or unreadable
+        # config must not lose the final save, so default to auto-save on and
+        # toasts off rather than crashing the hook.
+        try:
+            config = MempalaceConfig()
+            auto_save = config.hooks_auto_save
+            toast = config.hook_desktop_toast
+        except Exception:
+            auto_save = True
+            toast = False
+
+        # Respect auto_save config toggle (clean opt-out)
+        if not auto_save:
+            _output({})
+            return
+
+        _log(f"SESSION END for session {session_id}")
+
+        # Validate the harness-provided transcript path before touching it
+        # (extension + ".." traversal check), mirroring the read path that
+        # already runs through _validate_transcript_path. A rejected path skips
+        # the transcript captures but still lets the independent MEMPAL_DIR mine
+        # run.
+        valid_transcript = ""
+        if transcript_path:
+            validated = _validate_transcript_path(transcript_path)
+            if validated is None:
+                _log(f"WARNING: transcript_path rejected by validator: {transcript_path!r}")
+            else:
+                valid_transcript = str(validated)
+
+        # Flush. The diary checkpoint (in-process ChromaDB write) runs FIRST,
+        # before any detached mine is spawned, so it never contends for the
+        # palace lock; this handler is already backgrounded by the wrapper, so it
+        # is not under the SessionEnd budget and has time to finish. The detached
+        # transcript ingest follows; re-mining a transcript ``Stop`` already
+        # captured is a near no-op (deterministic convo IDs + ``file_already_mined``
+        # short-circuit + upsert). ``reason`` is intentionally not branched on:
+        # every clean-exit reason (incl. ``/clear`` / ``resume``) warrants the
+        # flush. Order matches ``hook_stop``.
+        if valid_transcript:
+            _save_diary_direct(
+                valid_transcript,
+                session_id,
+                wing=_wing_from_transcript_path(valid_transcript),
+                toast=toast,
+                agent_name=_diary_agent_for_harness(harness),
+            )
+            _ingest_transcript(valid_transcript)
+        _maybe_auto_ingest()
+
+        _output({})
+    finally:
+        _clear_session_last_save(session_id)
+
+
 def hook_precompact(data: dict, harness: str):
     """Precompact hook: mine transcript synchronously, then allow compaction.
 
@@ -1064,6 +1171,7 @@ def run_hook(hook_name: str, harness: str):
     hooks = {
         "session-start": hook_session_start,
         "stop": hook_stop,
+        "session-end": hook_session_end,
         "precompact": hook_precompact,
     }
 

--- a/tests/test_claude_plugin_hook_config.py
+++ b/tests/test_claude_plugin_hook_config.py
@@ -19,8 +19,14 @@ HOOK_CONFIG = REPO_ROOT / ".claude-plugin" / "hooks" / "hooks.json"
 # timeout of 60s in mempalace/hooks_cli.py. The hook-level floor of 60
 # keeps the inner bound from being truncated, and the ceiling of 90
 # bounds the worst case at ~30s above that.
+# SessionEnd backgrounds all of its work in the shell wrapper — the foreground
+# only forks the detached child and returns in milliseconds — so its timeout is
+# a generous backstop on a near-instant operation, not a synchronous-work bound
+# like Stop/PreCompact. A bound is still required (#1465) so a wedged fork can
+# never fall back to the 600s command default.
 EVENT_TIMEOUT_BOUNDS: dict[str, tuple[int, int]] = {
     "Stop": (10, 30),
+    "SessionEnd": (5, 30),
     "PreCompact": (60, 90),
 }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,6 +166,13 @@ def test_cmd_hook_calls_run_hook():
         mock_run.assert_called_once_with(hook_name="session-start", harness="claude-code")
 
 
+def test_cmd_hook_session_end_calls_run_hook():
+    args = argparse.Namespace(hook="session-end", harness="claude-code")
+    with patch("mempalace.hooks_cli.run_hook") as mock_run:
+        cmd_hook(args)
+        mock_run.assert_called_once_with(hook_name="session-end", harness="claude-code")
+
+
 # ── cmd_init ───────────────────────────────────────────────────────────
 
 
@@ -865,6 +872,18 @@ def test_main_hook_run_dispatches():
         patch(
             "sys.argv",
             ["mempalace", "hook", "run", "--hook", "session-start", "--harness", "claude-code"],
+        ),
+        patch("mempalace.cli.cmd_hook") as mock_cmd,
+    ):
+        main()
+        mock_cmd.assert_called_once()
+
+
+def test_main_hook_run_dispatches_session_end():
+    with (
+        patch(
+            "sys.argv",
+            ["mempalace", "hook", "run", "--hook", "session-end", "--harness", "claude-code"],
         ),
         patch("mempalace.cli.cmd_hook") as mock_cmd,
     ):

--- a/tests/test_hooks_bash_compat.py
+++ b/tests/test_hooks_bash_compat.py
@@ -27,6 +27,14 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SAVE_HOOK = REPO_ROOT / "hooks" / "mempal_save_hook.sh"
 PRECOMPACT_HOOK = REPO_ROOT / "hooks" / "mempal_precompact_hook.sh"
+SESSION_END_HOOK = REPO_ROOT / "hooks" / "mempal_session_end_hook.sh"
+PLUGIN_SESSION_END_HOOK = REPO_ROOT / ".claude-plugin" / "hooks" / "mempal-session-end-hook.sh"
+
+_SESSION_END_HOOKS = pytest.mark.parametrize(
+    "hook",
+    [SESSION_END_HOOK, PLUGIN_SESSION_END_HOOK],
+    ids=["user_hook", "plugin_hook"],
+)
 
 # Re-used by every parametrize decorator that runs the same test against
 # both hooks. ``ids=`` keeps pytest output readable (`...[save_hook]`
@@ -322,3 +330,40 @@ class TestFailLoudGuard:
         err_log = tmp_path / ".mempalace" / "hook_state" / "last_python_err.log"
         mode = stat.S_IMODE(err_log.stat().st_mode)
         assert mode == 0o600, f"last_python_err.log mode should be 0600 on failure, got {oct(mode)}"
+
+
+class TestSessionEndWrappers:
+    """The SessionEnd wrappers must background their work — so the foreground
+    beats Claude Code's ~1.5s SessionEnd budget (a plugin-provided per-hook
+    timeout cannot raise it) — and stay bash 3.2-safe like the other hooks."""
+
+    @_SESSION_END_HOOKS
+    def test_bash_syntax_clean(self, hook):
+        p = subprocess.run(["bash", "-n", str(hook)], capture_output=True, text=True)
+        assert p.returncode == 0, f"{hook.name} syntax error: {p.stderr}"
+
+    @_SESSION_END_HOOKS
+    def test_dispatches_session_end_through_cli(self, hook):
+        src = _hook_src_no_comments(hook)
+        # The dispatcher runs ``mempalace hook run "$@"`` in run_mempalace_hook,
+        # and the bottom call supplies the ``--hook session-end --harness`` args
+        # — so the two halves are asserted separately, not as one contiguous string.
+        assert "hook run" in src
+        assert "--hook session-end --harness" in src
+        assert "MEMPALACE_HOOK_HARNESS" in src
+        assert "MEMPAL_PYTHON" in src
+
+    @_SESSION_END_HOOKS
+    def test_backgrounds_then_returns_empty(self, hook):
+        src = _hook_src_no_comments(hook)
+        assert "</dev/null &" in src, f"{hook.name} does not background the worker"
+        assert "disown" in src, f"{hook.name} does not disown the backgrounded worker"
+        assert src.rstrip().endswith("printf '{}'"), (
+            f"{hook.name} must return the empty payload immediately"
+        )
+
+    @_SESSION_END_HOOKS
+    def test_no_bash4_only_builtins(self, hook):
+        src = _hook_src_no_comments(hook)
+        assert "mapfile" not in src, f"{hook.name} uses mapfile (bash 4 only)"
+        assert "readarray" not in src, f"{hook.name} uses readarray (bash 4 only)"

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -28,6 +28,7 @@ from mempalace.hooks_cli import (
     _wing_from_transcript_path,
     hook_stop,
     hook_session_start,
+    hook_session_end,
     hook_precompact,
     run_hook,
     _claim_mine_slot,
@@ -1779,6 +1780,284 @@ def test_hook_stop_does_not_create_palace_dir_when_absent(tmp_path, monkeypatch)
         )
     assert json.loads(buf.getvalue() or "{}") == {}
     assert not fake_root.exists()
+
+
+# ── session-end hook (#1341) ──────────────────────────────────────────────
+
+
+def test_run_hook_dispatches_session_end():
+    stdin_data = json.dumps({"session_id": "run-test"})
+    with patch("sys.stdin", io.StringIO(stdin_data)):
+        with patch("mempalace.hooks_cli.hook_session_end") as mock_hook:
+            run_hook("session-end", "claude-code")
+    mock_hook.assert_called_once_with({"session_id": "run-test"}, "claude-code")
+
+
+def test_session_end_uses_detached_paths_not_sync_mine(tmp_path):
+    """SessionEnd must spawn the detached ingest/auto-ingest and NEVER call the
+    synchronous ``_mine_sync``: the foreground SessionEnd budget (~1.5s, which a
+    plugin-provided per-hook timeout cannot raise) would kill a synchronous mine
+    before it saved anything.
+    """
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(3)],
+    )
+    last_save_file = tmp_path / "sess_last_save"
+    last_save_file.write_text("2", encoding="utf-8")
+    with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
+        mock_cfg_cls.return_value.hooks_auto_save = True
+        mock_cfg_cls.return_value.hook_desktop_toast = False
+        with (
+            patch(
+                "mempalace.hooks_cli._save_diary_direct",
+                return_value={"count": 3, "themes": ["exit"]},
+            ) as mock_save,
+            patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+            patch("mempalace.hooks_cli._maybe_auto_ingest") as mock_auto,
+            patch("mempalace.hooks_cli._mine_sync") as mock_sync,
+        ):
+            result = _capture_hook_output(
+                hook_session_end,
+                {"session_id": "sess", "transcript_path": str(transcript)},
+                state_dir=tmp_path,
+            )
+    assert result == {}
+    expected_path = str(transcript.resolve())
+    mock_ingest.assert_called_once_with(expected_path)
+    mock_auto.assert_called_once()
+    mock_sync.assert_not_called()
+    mock_save.assert_called_once_with(
+        expected_path, "sess", wing="wing_sessions", toast=False, agent_name="claude"
+    )
+    # The session is over; its per-session save marker is cleared.
+    assert not last_save_file.exists()
+
+
+def test_session_end_disabled_by_config_clears_marker(tmp_path):
+    last_save_file = tmp_path / "sess_last_save"
+    last_save_file.write_text("15", encoding="utf-8")
+    with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
+        mock_cfg_cls.return_value.hooks_auto_save = False
+        with (
+            patch("mempalace.hooks_cli._save_diary_direct") as mock_save,
+            patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+            patch("mempalace.hooks_cli._maybe_auto_ingest") as mock_auto,
+        ):
+            result = _capture_hook_output(
+                hook_session_end,
+                {"session_id": "sess", "transcript_path": ""},
+                state_dir=tmp_path,
+            )
+    assert result == {}
+    mock_save.assert_not_called()
+    mock_ingest.assert_not_called()
+    mock_auto.assert_not_called()
+    assert not last_save_file.exists()
+
+
+def test_session_end_defaults_to_saving_when_config_unreadable(tmp_path):
+    """A corrupt/unreadable config must not lose the final save: the handler
+    defaults to auto-save on (toasts off) instead of crashing the hook."""
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(transcript, [{"message": {"role": "user", "content": "hi"}}])
+    with patch("mempalace.hooks_cli.MempalaceConfig", side_effect=RuntimeError("corrupt config")):
+        with (
+            patch(
+                "mempalace.hooks_cli._save_diary_direct",
+                return_value={"count": 1, "themes": []},
+            ) as mock_save,
+            patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+            patch("mempalace.hooks_cli._maybe_auto_ingest") as mock_auto,
+        ):
+            result = _capture_hook_output(
+                hook_session_end,
+                {"session_id": "cfg", "transcript_path": str(transcript)},
+                state_dir=tmp_path,
+            )
+    assert result == {}
+    mock_save.assert_called_once()
+    mock_ingest.assert_called_once()
+    mock_auto.assert_called_once()
+
+
+def test_session_end_clears_marker_even_if_capture_raises(tmp_path):
+    """Marker cleanup runs in a ``finally`` so a failing ingest still cleans up
+    and never wedges the per-session marker on."""
+    last_save_file = tmp_path / "boom_last_save"
+    last_save_file.write_text("5", encoding="utf-8")
+    with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
+        mock_cfg_cls.return_value.hooks_auto_save = True
+        mock_cfg_cls.return_value.hook_desktop_toast = False
+        with (
+            patch("mempalace.hooks_cli.STATE_DIR", tmp_path),
+            patch(
+                "mempalace.hooks_cli._ingest_transcript",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("mempalace.hooks_cli._output"),
+        ):
+            with pytest.raises(RuntimeError):
+                hook_session_end(
+                    {"session_id": "boom", "transcript_path": str(tmp_path / "x.jsonl")},
+                    "claude-code",
+                )
+    assert not last_save_file.exists()
+
+
+def test_session_end_clears_marker_on_parse_failure(tmp_path):
+    """A non-dict payload makes _parse_harness_input raise, but parsing now runs
+    inside the try, so the finally still clears the default-session marker
+    instead of skipping cleanup entirely."""
+    last_save_file = tmp_path / "unknown_last_save"
+    last_save_file.write_text("5", encoding="utf-8")
+    with (
+        patch("mempalace.hooks_cli.STATE_DIR", tmp_path),
+        patch("mempalace.hooks_cli._output"),
+    ):
+        with pytest.raises(AttributeError):
+            hook_session_end(["not", "a", "dict"], "claude-code")
+    assert not last_save_file.exists()
+
+
+def test_hook_session_end_does_not_create_palace_dir_when_absent(tmp_path, monkeypatch):
+    fake_root = _redirect_palace_root(monkeypatch, tmp_path)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        hook_session_end({"session_id": "absent", "transcript_path": ""}, "claude-code")
+    assert json.loads(buf.getvalue() or "{}") == {}
+    assert not fake_root.exists()
+
+
+def test_session_end_auto_ingest_only_when_no_transcript(tmp_path):
+    """auto_save on but no transcript: project mine still fires, transcript-only
+    paths are skipped, and the marker is still cleared. Guards against wrapping
+    ``_maybe_auto_ingest`` inside the ``if transcript_path`` block by mistake."""
+    last_save_file = tmp_path / "sess_last_save"
+    last_save_file.write_text("3", encoding="utf-8")
+    with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
+        mock_cfg_cls.return_value.hooks_auto_save = True
+        mock_cfg_cls.return_value.hook_desktop_toast = False
+        with (
+            patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+            patch("mempalace.hooks_cli._maybe_auto_ingest") as mock_auto,
+            patch("mempalace.hooks_cli._save_diary_direct") as mock_save,
+            patch("mempalace.hooks_cli._mine_sync") as mock_sync,
+        ):
+            result = _capture_hook_output(
+                hook_session_end,
+                {"session_id": "sess", "transcript_path": ""},
+                state_dir=tmp_path,
+            )
+    assert result == {}
+    mock_auto.assert_called_once()
+    mock_ingest.assert_not_called()
+    mock_save.assert_not_called()
+    mock_sync.assert_not_called()
+    assert not last_save_file.exists()
+
+
+def test_session_end_rejects_invalid_transcript_path(tmp_path):
+    """A traversal / wrong-suffix transcript_path is rejected by the validator:
+    no transcript ingest or diary write fires (the independent project mine
+    still runs), and the per-session marker is still cleared."""
+    last_save_file = tmp_path / "bad_last_save"
+    last_save_file.write_text("5", encoding="utf-8")
+    with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
+        mock_cfg_cls.return_value.hooks_auto_save = True
+        mock_cfg_cls.return_value.hook_desktop_toast = False
+        with (
+            patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+            patch("mempalace.hooks_cli._save_diary_direct") as mock_save,
+            patch("mempalace.hooks_cli._maybe_auto_ingest") as mock_auto,
+        ):
+            result = _capture_hook_output(
+                hook_session_end,
+                {"session_id": "bad", "transcript_path": "../../etc/passwd"},
+                state_dir=tmp_path,
+            )
+    assert result == {}
+    mock_ingest.assert_not_called()
+    mock_save.assert_not_called()
+    mock_auto.assert_called_once()  # project mine is independent of the transcript
+    assert not last_save_file.exists()
+
+
+def test_session_end_accepts_full_sessionend_payload(tmp_path):
+    """The handler tolerates the real Claude Code SessionEnd stdin (reason,
+    hook_event_name, cwd) — extra keys ignored, behavior unchanged. Pins the
+    contract so a future strict-parse or reason-branching regression is caught."""
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(transcript, [{"message": {"role": "user", "content": "hi"}}])
+    with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
+        mock_cfg_cls.return_value.hooks_auto_save = True
+        mock_cfg_cls.return_value.hook_desktop_toast = False
+        with (
+            patch(
+                "mempalace.hooks_cli._save_diary_direct",
+                return_value={"count": 1, "themes": []},
+            ),
+            patch("mempalace.hooks_cli._ingest_transcript") as mock_ingest,
+            patch("mempalace.hooks_cli._maybe_auto_ingest") as mock_auto,
+            patch("mempalace.hooks_cli._mine_sync") as mock_sync,
+        ):
+            result = _capture_hook_output(
+                hook_session_end,
+                {
+                    "session_id": "sess",
+                    "transcript_path": str(transcript),
+                    "hook_event_name": "SessionEnd",
+                    "reason": "logout",
+                    "cwd": str(tmp_path),
+                },
+                state_dir=tmp_path,
+            )
+    assert result == {}
+    mock_ingest.assert_called_once_with(str(transcript.resolve()))
+    mock_auto.assert_called_once()
+    mock_sync.assert_not_called()
+
+
+def test_session_end_checkpoint_visible_to_diary_read(
+    monkeypatch, config, palace_path, kg, tmp_path
+):
+    """The SessionEnd in-process diary checkpoint is real and discoverable via
+    diary_read (not mocked) — the diary half of #1341's clean-exit capture,
+    mirroring test_stop_hook_checkpoint_visible_to_diary_read."""
+    import chromadb
+
+    from mempalace import mcp_server
+    from mempalace.mcp_server import tool_diary_read
+
+    monkeypatch.setattr(mcp_server, "_config", config)
+    monkeypatch.setattr(mcp_server, "_get_kg", lambda *a, **kw: kg)
+    client = chromadb.PersistentClient(path=palace_path)
+    client.get_or_create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
+    del client
+
+    transcript = tmp_path / "session.jsonl"
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"msg {i}"}} for i in range(5)],
+    )
+
+    with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
+        mock_cfg_cls.return_value.hooks_auto_save = True
+        mock_cfg_cls.return_value.hook_desktop_toast = False
+        # Mock only the detached subprocess mines; run the REAL diary write.
+        with (
+            patch("mempalace.hooks_cli._ingest_transcript"),
+            patch("mempalace.hooks_cli._maybe_auto_ingest"),
+        ):
+            hook_session_end(
+                {"session_id": "sessX", "transcript_path": str(transcript)},
+                "claude-code",
+            )
+
+    visible = tool_diary_read(agent_name="claude")
+    assert visible.get("total", 0) >= 1
+    assert "CHECKPOINT" in visible["entries"][0]["content"]
 
 
 def test_hook_precompact_does_not_create_palace_dir_when_absent(tmp_path, monkeypatch):

--- a/tests/test_hooks_shell.py
+++ b/tests/test_hooks_shell.py
@@ -24,6 +24,7 @@ import os
 import stat
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -31,6 +32,8 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SAVE_HOOK = REPO_ROOT / "hooks" / "mempal_save_hook.sh"
 PRECOMPACT_HOOK = REPO_ROOT / "hooks" / "mempal_precompact_hook.sh"
+SESSION_END_HOOK = REPO_ROOT / "hooks" / "mempal_session_end_hook.sh"
+PLUGIN_SESSION_END_HOOK = REPO_ROOT / ".claude-plugin" / "hooks" / "mempal-session-end-hook.sh"
 
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="bash hook scripts are POSIX-only")
@@ -168,3 +171,131 @@ class TestMempalPythonOverride:
         assert "python3" in invocations, (
             f"fallback-to-PATH did not use the shimmed python3. Marker log: {invocations!r}"
         )
+
+
+# ── session-end wrapper: must background so the foreground beats the budget ──
+
+
+def _write_recording_mempalace(
+    path: Path, args_file: Path, *, sleep_secs: float = 0.0, done_file: Path | None = None
+) -> Path:
+    """A fake ``mempalace`` that consumes stdin, optionally sleeps, then records
+    its argv to ``args_file`` (and touches ``done_file``). Lets a test observe a
+    *backgrounded* dispatch after the wrapper's foreground has already returned.
+    """
+    done_line = f'printf done > "{done_file}"' if done_file is not None else ":"
+    src = f"""#!/bin/bash
+cat >/dev/null
+sleep {sleep_secs}
+printf '%s' "$*" > "{args_file}"
+{done_line}
+printf '{{}}'
+"""
+    path.write_text(src)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _wait_for(path: Path, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists() and path.read_text():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+class TestSessionEndWrapper:
+    def test_foreground_returns_before_worker_finishes(self, tmp_path):
+        """Budget contract: the foreground must return well before the (slow)
+        worker completes, otherwise SessionEnd's ~1.5s budget would kill the
+        mine. Proven with a worker that sleeps 2s before recording."""
+        args_file = tmp_path / "args.log"
+        done_file = tmp_path / "worker.done"
+        fake = _write_recording_mempalace(
+            tmp_path / "mempalace", args_file, sleep_secs=2.0, done_file=done_file
+        )
+        t0 = time.monotonic()
+        result = _run_hook(
+            SESSION_END_HOOK,
+            {"session_id": "abc", "transcript_path": ""},
+            env_overrides={"HOME": str(tmp_path)},
+            path_prefix=[fake.parent],
+        )
+        elapsed = time.monotonic() - t0
+        assert result.returncode == 0, f"stderr={result.stderr!r}"
+        assert result.stdout == "{}"
+        assert elapsed < 1.5, f"foreground blocked {elapsed:.2f}s; the budget would kill it"
+        assert not done_file.exists(), (
+            "worker finished before the foreground returned — wrapper is not backgrounding"
+        )
+        assert _wait_for(done_file), "detached worker never completed"
+        assert args_file.read_text() == "hook run --hook session-end --harness claude-code"
+
+    def test_dispatches_via_mempal_python_override(self, tmp_path):
+        args_file = tmp_path / "args.log"
+        shim = tmp_path / "python3"
+        shim.write_text(
+            f"""#!/bin/bash
+if [ "$1" = "-c" ]; then exit 0; fi
+if [ "$1" = "-m" ] && [ "$2" = "mempalace" ]; then
+  shift 2
+  cat >/dev/null
+  printf '%s' "$*" > "{args_file}"
+  printf '{{}}'
+  exit 0
+fi
+exit 1
+""",
+            encoding="utf-8",
+        )
+        shim.chmod(shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        result = _run_hook(
+            SESSION_END_HOOK,
+            {"session_id": "abc", "transcript_path": ""},
+            env_overrides={
+                "HOME": str(tmp_path),
+                "PATH": "/usr/bin:/bin",
+                "MEMPAL_PYTHON": str(shim),
+            },
+        )
+        assert result.returncode == 0, f"stderr={result.stderr!r}"
+        assert result.stdout == "{}"
+        assert _wait_for(args_file), "backgrounded worker never ran"
+        assert args_file.read_text() == "hook run --hook session-end --harness claude-code"
+
+    def test_harness_override_is_forwarded(self, tmp_path):
+        args_file = tmp_path / "args.log"
+        fake = _write_recording_mempalace(tmp_path / "mempalace", args_file)
+        result = _run_hook(
+            SESSION_END_HOOK,
+            {"session_id": "abc", "transcript_path": ""},
+            env_overrides={"HOME": str(tmp_path), "MEMPALACE_HOOK_HARNESS": "codex"},
+            path_prefix=[fake.parent],
+        )
+        assert result.returncode == 0
+        assert _wait_for(args_file)
+        assert args_file.read_text() == "hook run --hook session-end --harness codex"
+
+
+class TestPluginSessionEndWrapper:
+    def test_foreground_returns_before_worker_finishes(self, tmp_path):
+        args_file = tmp_path / "args.log"
+        done_file = tmp_path / "worker.done"
+        fake = _write_recording_mempalace(
+            tmp_path / "mempalace", args_file, sleep_secs=2.0, done_file=done_file
+        )
+        t0 = time.monotonic()
+        result = _run_hook(
+            PLUGIN_SESSION_END_HOOK,
+            {"session_id": "abc", "transcript_path": ""},
+            env_overrides={"HOME": str(tmp_path)},
+            path_prefix=[fake.parent],
+        )
+        elapsed = time.monotonic() - t0
+        assert result.returncode == 0, f"stderr={result.stderr!r}"
+        assert result.stdout == "{}"
+        assert elapsed < 1.5, f"plugin foreground blocked {elapsed:.2f}s"
+        assert not done_file.exists()
+        assert _wait_for(done_file), "detached plugin worker never completed"
+        assert args_file.read_text() == "hook run --hook session-end --harness claude-code"


### PR DESCRIPTION
## What does this PR do?

Closes #1341. Closes #1814 (a duplicate of #1341).

Short sessions that exit cleanly can still lose memories: MemPalace saves only
when the `Stop` hook crosses `SAVE_INTERVAL` (15 human messages) or when
`PreCompact` fires, so a short session that ends without ever compacting is
dropped from the palace.

A `SessionEnd` hook that mines synchronously gets killed before it can save.
From the Claude Code hooks reference:

> SessionEnd hooks have a default timeout of 1.5 seconds. [...] Timeouts set on
> plugin-provided hooks do not raise the budget.

(https://code.claude.com/docs/en/hooks)

A `mempalace` start measures ~8s cold and ~1.7s warm, both past that 1.5s
window, and a plugin-shipped `timeout` cannot widen it. So the hook backgrounds
its work and returns immediately (foreground ~0.01s, measured), and the handler
spawns the capture as a detached child that outlives the exiting session:

- `.claude-plugin/hooks/hooks.json`: register `SessionEnd`.
- New wrappers `hooks/mempal_session_end_hook.sh` and the plugin
  `.claude-plugin/hooks/mempal-session-end-hook.sh` background the dispatch.
- `mempalace/hooks_cli.py`: `hook_session_end()` validates `transcript_path`,
  then flushes regardless of `SAVE_INTERVAL` (an in-process diary checkpoint,
  then a detached transcript ingest and project mine), then clears the
  per-session marker.
- `mempalace/cli.py`: add `session-end` to the `hook run` choices.

This stays inside both the 1.5s budget and the project's "hooks under 500ms /
background everything" principle. `SessionEnd` has no decision control, so the
hook only ever saves.

**Scope:** Claude Code only. The handler is harness-agnostic
(`mempalace hook run --hook session-end --harness <name>`). Cursor has a
`sessionEnd` event that is not wired yet (follow-up); Codex has none today;
Antigravity has none and saves via `Stop`.

**Windows:** verified on POSIX. On Windows only the mine grandchild (spawned
with detached-process flags) is designed to break away from the session; the
backgrounded hook process and the in-process diary checkpoint are best-effort,
and the teardown path has no Windows CI coverage yet.

Builds on the request and design sketch in #1341 and the first implementation
attempt in #1738; the new piece is the budget-safe backgrounding, since that
earlier attempt mined synchronously and the 1.5s plugin budget reaps it before
it can save.

## How to test

```
uv run pytest tests/test_hooks_cli.py tests/test_cli.py tests/test_hooks_shell.py tests/test_hooks_bash_compat.py tests/test_claude_plugin_hook_config.py -v
uv run ruff check .
uv run ruff format --check .
```

246 passed, 1 skipped locally. The shell tests prove backgrounding: the
foreground returns before a 2s worker finishes, and the detached worker still
completes. End to end, a 5-message sub-threshold session was captured and found
via `mempalace search`, and a unit test confirms the diary checkpoint is visible
via `diary_read`.

## Checklist

- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
