### PR TITLE
perf(status): aggregate wing/room counts in the backend instead of client-side fetch

### DIFF
--- a/mempalace/backends/pgvector.py
+++ b/mempalace/backends/pgvector.py
@@ -1058,6 +1058,21 @@ class PgVectorCollection(BaseCollection):
             return 0
         return self._client.count_rows(self._table)
 
+    def count_by_metadata_field(self, field: str) -> dict[str, int]:
+        """Return ``{value: count}`` for a top-level metadata key, aggregated in
+        SQL. Lets callers (e.g. the status overview) tally by ``wing`` / ``room``
+        without streaming every drawer's metadata to the client — O(1) memory and
+        a single query instead of O(n). ``NULL`` values bucket under ``"unknown"``."""
+        self._ensure_open()
+        if not self._table_exists():
+            return {}
+        sql = (
+            f"SELECT metadata->>%s AS k, count(*) AS c "
+            f"FROM {_quote_identifier(self._table)} GROUP BY 1"
+        )
+        rows = self._client._execute(sql, [field], fetch=True)
+        return {(r[0] if r[0] is not None else "unknown"): int(r[1]) for r in rows}
+
     def lexical_search(self, *, query: str, n_results: int = 10, where: Optional[dict] = None):
         _validate_where(where)
         pushdown = None if _requires_local_filter(where) else where

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1073,13 +1073,23 @@ def tool_status():
         "backend": _selected_backend_name(),
     }
     try:
-        all_meta = _get_cached_metadata(col)
-        for m in all_meta:
-            m = m or {}
-            w = m.get("wing", "unknown")
-            r = m.get("room", "unknown")
-            wings[w] = wings.get(w, 0) + 1
-            rooms[r] = rooms.get(r, 0) + 1
+        grouper = getattr(col, "count_by_metadata_field", None)
+        if callable(grouper):
+            # Efficient path: backends that can aggregate server-side (e.g.
+            # pgvector via SQL GROUP BY) tally wing/room counts without
+            # streaming every drawer's metadata to the client. On a large
+            # palace the client-side fetch below is O(n) memory and can take
+            # minutes (or OOM); this is a single query.
+            wings.update(grouper("wing"))
+            rooms.update(grouper("room"))
+        else:
+            all_meta = _get_cached_metadata(col)
+            for m in all_meta:
+                m = m or {}
+                w = m.get("wing", "unknown")
+                r = m.get("room", "unknown")
+                wings[w] = wings.get(w, 0) + 1
+                rooms[r] = rooms.get(r, 0) + 1
     except Exception as e:
         logger.exception("tool_status metadata fetch failed")
         result["error"] = str(e)


### PR DESCRIPTION
## Problem
`mempalace_status` builds its wing/room breakdown by pulling **every** drawer's metadata to the client (`_get_cached_metadata`) and counting in Python. That's O(n) memory and time.

On a **418,997-drawer** pgvector palace this took **~344s** and OOM-killed a 2Gi pod. Since the MCP wake-up protocol calls `status` first, large palaces effectively can't wake up.

## Change
- Add an optional collection hook `count_by_metadata_field(field) -> {value: count}`.
- Implement it on the pgvector backend as a single `SELECT metadata->>field, count(*) ... GROUP BY 1`.
- `tool_status` uses it when the collection provides it; backends without it keep the existing client-side path unchanged (duck-typed, fully backward compatible).

## Result
Same 418k palace: `status` drops from **~344s → ~0.4s**, flat memory. Counts verified identical to the client-side tally (7 wings / 50 rooms; e.g. `my_other_repos`=169,587).

## Notes
- Backward compatible — chroma/qdrant/sqlite paths are untouched.
- `list_wings` / `list_rooms` have the same client-side pattern and could adopt this hook in a follow-up; kept this PR focused on the wake-up path.