### PR TITLE
feat: opt-in local daemon for queued MemPalace writes

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -534,6 +534,27 @@ def cmd_mine(args):
     for raw in args.include_ignored or []:
         include_ignored.extend(part.strip() for part in raw.split(",") if part.strip())
 
+    if getattr(args, "background", False) and not getattr(args, "daemon", False):
+        print("mempalace: --background requires --daemon", file=sys.stderr)
+        sys.exit(2)
+
+    if getattr(args, "daemon", False):
+        payload = {
+            "source": args.dir,
+            "mode": args.mode,
+            "wing": args.wing,
+            "agent": args.agent,
+            "limit": args.limit,
+            "dry_run": args.dry_run,
+            "extract": args.extract,
+            "no_gitignore": args.no_gitignore,
+            "include_ignored": include_ignored,
+            "max_chunks_per_file": getattr(args, "max_chunks_per_file", None),
+            "redetect_origin": getattr(args, "redetect_origin", False),
+        }
+        _submit_daemon_cli_job("mine", payload, args, background=getattr(args, "background", False))
+        return
+
     # --redetect-origin re-runs corpus_origin on the current corpus state
     # and overwrites <palace>/.mempalace/origin.json before mining proceeds.
     # Heuristic-only by design — full LLM detection lives on `mempalace init`.
@@ -655,13 +676,27 @@ def cmd_sweep(args):
 
 def cmd_sync(args):
     """Prune drawers whose source files are gitignored, deleted, or moved (#1252)."""
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+
+    if getattr(args, "background", False) and not getattr(args, "daemon", False):
+        print("mempalace: --background requires --daemon", file=sys.stderr)
+        sys.exit(2)
+
+    if getattr(args, "daemon", False):
+        payload = {
+            "dir": args.dir,
+            "root": list(args.root or []),
+            "wing": args.wing,
+            "dry_run": args.dry_run,
+        }
+        _submit_daemon_cli_job("sync", payload, args, background=getattr(args, "background", False))
+        return
+
     from .mcp_server import _wal_log
     from .palace import MineAlreadyRunning
     from .backends import detect_backend_for_path
     from .palace import _backend_artifact_label, resolve_backend_name
     from .sync import sync_palace
-
-    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
 
     if not os.path.isdir(palace_path):
         print(f"\n  No palace found at {palace_path}")
@@ -743,6 +778,133 @@ def cmd_sync(args):
         )
 
     print(f"\n{'=' * 55}\n")
+
+
+def _submit_daemon_cli_job(kind: str, payload: dict, args, *, background: bool) -> None:
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    backend = _backend_arg(args)
+    from .daemon import DaemonError, submit_job
+
+    try:
+        job = submit_job(
+            kind,
+            payload,
+            palace_path=palace_path,
+            backend=backend,
+            wait=not background,
+            auto_start=True,
+        )
+    except DaemonError as exc:
+        print(f"mempalace: daemon submission failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if background:
+        print(f"Submitted daemon job {job['id']} ({kind})")
+        return
+
+    result = job.get("result") or {}
+    from .service import print_job_result
+
+    exit_code = print_job_result(result)
+    if job.get("state") != "succeeded" and exit_code == 0:
+        error = job.get("error") or {}
+        print(
+            f"mempalace: daemon job failed: {error.get('message', 'unknown error')}",
+            file=sys.stderr,
+        )
+        exit_code = 1
+    if exit_code:
+        sys.exit(exit_code)
+
+
+def cmd_daemon(args):
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    backend = _backend_arg(args)
+    from .daemon import (
+        TERMINAL_STATES,
+        DaemonError,
+        QueueStore,
+        get_client_if_running,
+        job_to_dict,
+        queue_path,
+        start_daemon,
+        stop_daemon,
+    )
+
+    action = getattr(args, "daemon_action", None)
+    try:
+        if action == "start":
+            if args.foreground:
+                start_daemon(palace_path, backend=backend, foreground=True)
+                return
+            client = start_daemon(palace_path, backend=backend, foreground=False)
+            health = client.health()
+            print(f"MemPalace daemon running on 127.0.0.1:{client.port}")
+            print(f"  Palace: {health.get('palace_path')}")
+            print(f"  PID:    {health.get('pid')}")
+            return
+
+        if action == "stop":
+            if stop_daemon(palace_path):
+                print("MemPalace daemon stopping")
+            else:
+                print("MemPalace daemon is not running")
+            return
+
+        if action == "status":
+            client = get_client_if_running(palace_path)
+            if client is None:
+                print("MemPalace daemon is not running")
+                sys.exit(1)
+            health = client.health()
+            print("MemPalace daemon is running")
+            print(f"  Palace: {health.get('palace_path')}")
+            print(f"  PID:    {health.get('pid')}")
+            print(f"  Active: {health.get('active_job_id') or '-'}")
+            print(f"  Jobs:   {health.get('counts') or {}}")
+            return
+
+        if action == "jobs":
+            client = get_client_if_running(palace_path)
+            if client is not None:
+                jobs = client.list_jobs(limit=args.limit)
+            else:
+                qpath = queue_path(palace_path)
+                if not qpath.exists():
+                    jobs = []
+                else:
+                    jobs = [
+                        job_to_dict(job, include_payload=False)
+                        for job in QueueStore(qpath).list(args.limit)
+                    ]
+            for job in jobs:
+                print(f"{job['id']}  {job['state']:<9}  {job['kind']:<10}  {job['created_at']}")
+            return
+
+        if action == "wait":
+            client = get_client_if_running(palace_path)
+            if client is not None:
+                job = client.wait(args.job_id)
+            else:
+                qpath = queue_path(palace_path)
+                if not qpath.exists():
+                    raise DaemonError("daemon is not running")
+                job = job_to_dict(QueueStore(qpath).get(args.job_id))
+                if job.get("state") not in TERMINAL_STATES:
+                    raise DaemonError(f"daemon is not running; job {args.job_id} is {job['state']}")
+            result = job.get("result") or {}
+            from .service import print_job_result
+
+            exit_code = print_job_result(result)
+            if job.get("state") != "succeeded" and exit_code == 0:
+                print(f"mempalace: daemon job failed: {job.get('error')}", file=sys.stderr)
+                exit_code = 1
+            if exit_code:
+                sys.exit(exit_code)
+            return
+    except DaemonError as exc:
+        print(f"mempalace: daemon error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 def cmd_search(args):
@@ -1481,6 +1643,16 @@ def main():
         "--dry-run", action="store_true", help="Show what would be filed without filing"
     )
     p_mine.add_argument(
+        "--daemon",
+        action="store_true",
+        help="Submit this mine to the opt-in local daemon queue",
+    )
+    p_mine.add_argument(
+        "--background",
+        action="store_true",
+        help="With --daemon, return a job id immediately instead of waiting",
+    )
+    p_mine.add_argument(
         "--extract",
         choices=["exchange", "general"],
         default="exchange",
@@ -1542,6 +1714,16 @@ def main():
         dest="dry_run",
         action="store_false",
         help="Actually delete drawers (overrides --dry-run; requires --wing or a project root)",
+    )
+    p_sync.add_argument(
+        "--daemon",
+        action="store_true",
+        help="Submit this sync to the opt-in local daemon queue",
+    )
+    p_sync.add_argument(
+        "--background",
+        action="store_true",
+        help="With --daemon, return a job id immediately instead of waiting",
     )
 
     # search
@@ -1705,6 +1887,27 @@ def main():
         help="Compare sqlite vs HNSW element counts (read-only; never opens a chromadb client)",
     )
 
+    # daemon
+    p_daemon = sub.add_parser("daemon", help="Manage the opt-in long-lived daemon")
+    daemon_sub = p_daemon.add_subparsers(dest="daemon_action")
+    p_daemon_start = daemon_sub.add_parser("start", help="Start the daemon")
+    p_daemon_start.add_argument(
+        "--foreground",
+        action="store_true",
+        help="Run in the foreground for debugging or process supervisors",
+    )
+    p_daemon_start.add_argument(
+        "--backend",
+        default=None,
+        help="Storage backend for this daemon (default: config/env/detected/chroma)",
+    )
+    daemon_sub.add_parser("stop", help="Stop the daemon")
+    daemon_sub.add_parser("status", help="Show daemon status")
+    p_daemon_jobs = daemon_sub.add_parser("jobs", help="List recent daemon jobs")
+    p_daemon_jobs.add_argument("--limit", type=int, default=20, help="Max jobs to show")
+    p_daemon_wait = daemon_sub.add_parser("wait", help="Wait for a daemon job")
+    p_daemon_wait.add_argument("job_id", help="Job id returned by --background")
+
     # mcp
     p_mcp = sub.add_parser(
         "mcp",
@@ -1804,6 +2007,13 @@ def main():
             cmd_palace_set_embedder(args)
         else:
             p_palace.print_help()
+        return
+
+    if args.command == "daemon":
+        if not getattr(args, "daemon_action", None):
+            p_daemon.print_help()
+            return
+        cmd_daemon(args)
         return
 
     dispatch = {

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -749,6 +749,19 @@ class MempalaceConfig:
         """Whether the stop hook shows a desktop notification via notify-send."""
         return self._file_config.get("hooks", {}).get("desktop_toast", False)
 
+    @property
+    def hook_use_daemon(self):
+        """Whether hooks should submit save/mine work to the opt-in daemon."""
+        env_val = os.environ.get("MEMPALACE_HOOKS_DAEMON")
+        if env_val is not None:
+            return env_val.lower() in ("true", "1", "yes", "on")
+        value = self._file_config.get("hooks", {}).get("daemon", False)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ("true", "1", "yes", "on")
+        return value == 1
+
     def set_hook_setting(self, key: str, value: bool):
         """Update a hook setting and write config to disk."""
         if "hooks" not in self._file_config:

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -775,6 +775,15 @@ class DaemonClient:
         self.token = read_token(self.palace_path)
         self.host = endpoint.get("host") or HOST
         self.port = int(port)
+        # The daemon is always on 127.0.0.1, so a request must never go through
+        # an HTTP proxy. Building an opener with an empty ProxyHandler bypasses
+        # urllib's proxy discovery entirely. On macOS that discovery
+        # (urllib.request._scproxy, via the SystemConfiguration framework) runs
+        # on the first request to any host and is NOT bounded by the per-request
+        # timeout — on a CI runner with no network it can hang for tens of
+        # seconds, which looks exactly like the daemon never came up. A no-proxy
+        # opener is the correct production choice here and also removes that hang.
+        self._opener = urlrequest.build_opener(urlrequest.ProxyHandler({}))
 
     @property
     def base_url(self) -> str:
@@ -799,7 +808,7 @@ class DaemonClient:
             },
         )
         try:
-            with urlrequest.urlopen(req, timeout=timeout) as resp:
+            with self._opener.open(req, timeout=timeout) as resp:
                 raw = resp.read().decode("utf-8")
         except urlerror.HTTPError as exc:
             raw = exc.read().decode("utf-8", errors="replace")

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -137,9 +137,55 @@ def _read_endpoint(palace_path: str) -> dict[str, Any]:
         raise DaemonError("daemon endpoint not found") from exc
 
 
+def _pid_alive_windows(pid: int) -> bool:
+    """Liveness probe for Windows that never sends a console control event.
+
+    ``os.kill(pid, 0)`` is NOT a harmless existence check on Windows: signal 0
+    is ``signal.CTRL_C_EVENT``, so Python routes it to
+    ``GenerateConsoleCtrlEvent`` and sends a Ctrl-C to the target's process
+    group instead of probing the pid. On a process with an attached console
+    (e.g. a CI runner) that Ctrl-C is delivered back to *this* interpreter and
+    surfaces as a spurious ``KeyboardInterrupt`` — exactly the hang seen when
+    ``DaemonClient`` polled a same-process endpoint. Probe via the Win32 process
+    handle API instead, which has no signalling side effects.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    SYNCHRONIZE = 0x00100000
+    WAIT_TIMEOUT = 0x00000102
+    ERROR_ACCESS_DENIED = 5
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+
+    handle = kernel32.OpenProcess(SYNCHRONIZE, False, int(pid))
+    if not handle:
+        # No handle: access-denied means the process exists but isn't ours to
+        # open; any other error (invalid parameter / not found) means it's gone.
+        return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+    try:
+        # A live process is not signalled, so the zero-timeout wait returns
+        # WAIT_TIMEOUT; an exited process is signalled and returns WAIT_OBJECT_0.
+        return kernel32.WaitForSingleObject(handle, 0) == WAIT_TIMEOUT
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def _pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
+    if os.name == "nt":
+        try:
+            return _pid_alive_windows(pid)
+        except OSError:
+            # If the Win32 probe itself fails, assume alive rather than risk
+            # discarding a healthy endpoint — and never fall back to os.kill.
+            return True
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -741,6 +741,20 @@ def run_server(palace_path: str, *, backend: str | None = None, port: int = 0) -
         daemon_threads = True
         allow_reuse_address = True
 
+        def server_bind(self):
+            # http.server's HTTPServer.server_bind() calls socket.getfqdn(host)
+            # to set server_name — a reverse-DNS lookup. For our 127.0.0.1 bind
+            # that lookup is useless, and on a host with slow or absent reverse
+            # DNS it blocks daemon startup for ~30s (until the resolver times
+            # out), which looks exactly like the daemon never coming up. Bind via
+            # TCPServer directly and set the name from the literal host instead.
+            import socketserver
+
+            socketserver.TCPServer.server_bind(self)
+            host, port = self.server_address[:2]
+            self.server_name = host
+            self.server_port = port
+
     # Privacy by architecture: the queue DB holds verbatim user content (diary
     # entries, source paths). Force owner-only perms on every file this process
     # creates — queue.sqlite3, its WAL/SHM sidecars, and any future artifact.

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -8,6 +8,7 @@ execution.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import secrets
@@ -173,10 +174,26 @@ class QueueStore:
         self._lock = threading.RLock()
         self._init_db()
 
+    @contextlib.contextmanager
     def _connect(self):
+        """Open a short-lived sqlite3 connection and close it on exit.
+
+        The bare ``with sqlite3.connect(...)`` context manager only manages the
+        transaction (commit/rollback) — it does NOT close the connection, so every
+        QueueStore call in this long-lived daemon process leaked a connection FD.
+        In a daemon that runs thousands of jobs that is an unbounded FD leak. This
+        wrapper closes the connection on exit so each call is self-contained.
+        """
         conn = sqlite3.connect(str(self.path), timeout=30)
-        conn.row_factory = sqlite3.Row
-        return conn
+        try:
+            conn.row_factory = sqlite3.Row
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
     def _init_db(self) -> None:
         with self._connect() as conn:
@@ -375,13 +392,21 @@ class QueueStore:
         state: str,
         result: dict[str, Any] | None = None,
         error: dict[str, Any] | None = None,
+        only_if_running: bool = False,
     ) -> Job:
+        # ``only_if_running`` guards the worker's finish against a lost race with
+        # shutdown's cancel: if the active job was already flipped to 'cancelled'
+        # by _drain_and_cleanup, a late worker finish must NOT overwrite it back to
+        # 'succeeded'/'failed' (which would un-cancel a job recover_running must
+        # not re-run). The conditional UPDATE makes the worker's finish a no-op in
+        # that window instead of relying on process-exit timing.
+        where = "WHERE id = ?" + (" AND state = 'running'" if only_if_running else "")
         with self._lock, self._connect() as conn:
             conn.execute(
-                """
+                f"""
                 UPDATE jobs
                 SET state = ?, finished_at = ?, result_json = ?, error_json = ?
-                WHERE id = ?
+                {where}
                 """,
                 (
                     state,
@@ -490,7 +515,9 @@ class DaemonRuntime:
 
     def _safe_finish(self, job_id: str, *, state: str, result: dict, error: dict | None) -> None:
         try:
-            self.store.finish(job_id, state=state, result=result, error=error)
+            # only_if_running: if shutdown already cancelled this job, don't
+            # resurrect it. A finish failure must not kill the worker regardless.
+            self.store.finish(job_id, state=state, result=result, error=error, only_if_running=True)
         except Exception:  # noqa: BLE001 - a finish failure must not kill the worker
             pass
 
@@ -783,7 +810,15 @@ class DaemonClient:
             raise DaemonError(str(payload.get("error", exc))) from exc
         except OSError as exc:
             raise DaemonError(str(exc)) from exc
-        return json.loads(raw) if raw else {}
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            # A 2xx response with a non-JSON body (empty 200, truncated write,
+            # proxy HTML) shouldn't surface as a bare JSONDecodeError to callers
+            # that only know how to handle DaemonError.
+            raise DaemonError(f"daemon returned non-JSON response: {raw[:200]!r}") from exc
 
     def health(self) -> dict[str, Any]:
         return self.request("GET", "/health")

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -1,0 +1,1018 @@
+"""Long-lived local daemon for queued MemPalace writes.
+
+Daemon mode is strictly opt-in. The default CLI, hooks, and MCP paths still use
+their direct execution behavior unless callers explicitly request daemon-backed
+execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib import error as urlerror
+from urllib import request as urlrequest
+from urllib.parse import parse_qs, urlparse
+
+from .config import MempalaceConfig
+
+HOST = "127.0.0.1"
+STATE_ROOT_ENV = "MEMPALACE_DAEMON_STATE_ROOT"
+DEFAULT_WAIT_TIMEOUT = 60.0 * 60.0
+TERMINAL_STATES = {"succeeded", "failed", "cancelled"}
+MAX_ATTEMPTS = 3
+MAX_BODY_BYTES = 1 << 20  # 1 MiB cap on request bodies (auth-gated DoS guard)
+SHUTDOWN_DRAIN_SECONDS = 10.0
+# Terminal jobs are kept for diagnostics then pruned so the queue DB (which
+# holds verbatim payloads) doesn't grow without bound across a long-lived
+# daemon. Override via env for operators who want a longer/shorter window.
+JOB_RETENTION_DAYS = int(os.environ.get("MEMPALACE_DAEMON_RETENTION_DAYS", "7") or "7")
+try:
+    import fcntl as _fcntl  # POSIX only; absent on Windows
+except ImportError:  # pragma: no cover - Windows fallback
+    _fcntl = None
+
+
+def _chmod_private(path: Path) -> None:
+    try:
+        os.chmod(str(path), 0o600)
+    except OSError:
+        pass
+
+
+def _chmod_dir_private(path: Path) -> None:
+    try:
+        os.chmod(str(path), 0o700)
+    except OSError:
+        pass
+
+
+class DaemonError(RuntimeError):
+    """Raised when daemon client operations fail."""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def canonical_palace_path(path: str | None = None) -> str:
+    value = path or MempalaceConfig().palace_path
+    return os.path.abspath(os.path.realpath(os.path.expanduser(value)))
+
+
+def palace_key(palace_path: str) -> str:
+    import hashlib
+
+    normalized = os.path.normcase(canonical_palace_path(palace_path))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:24]
+
+
+def state_root() -> Path:
+    raw = os.environ.get(STATE_ROOT_ENV)
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".mempalace" / "daemon"
+
+
+def state_dir(palace_path: str) -> Path:
+    return state_root() / palace_key(palace_path)
+
+
+def _write_private(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+def ensure_token(palace_path: str) -> str:
+    token_path = state_dir(palace_path) / "token"
+    if token_path.exists():
+        token = token_path.read_text(encoding="utf-8").strip()
+        if token:
+            return token
+    token = secrets.token_urlsafe(32)
+    _write_private(token_path, token + "\n")
+    return token
+
+
+def read_token(palace_path: str) -> str:
+    token_path = state_dir(palace_path) / "token"
+    try:
+        return token_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise DaemonError(f"daemon token not found for {palace_path}") from exc
+
+
+def endpoint_path(palace_path: str) -> Path:
+    return state_dir(palace_path) / "endpoint.json"
+
+
+def pid_path(palace_path: str) -> Path:
+    return state_dir(palace_path) / "pid"
+
+
+def queue_path(palace_path: str) -> Path:
+    return state_dir(palace_path) / "queue.sqlite3"
+
+
+def _read_endpoint(palace_path: str) -> dict[str, Any]:
+    try:
+        with open(endpoint_path(palace_path), encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DaemonError("daemon endpoint not found") from exc
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+@dataclass
+class Job:
+    id: str
+    kind: str
+    payload: dict[str, Any]
+    state: str
+    priority: int
+    dedupe_key: str | None
+    created_at: str
+    started_at: str | None
+    finished_at: str | None
+    result: dict[str, Any] | None
+    error: dict[str, Any] | None
+    attempts: int
+
+
+class QueueStore:
+    def __init__(self, path: Path):
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._init_db()
+
+    def _connect(self):
+        conn = sqlite3.connect(str(self.path), timeout=30)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS jobs (
+                    id TEXT PRIMARY KEY,
+                    kind TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    priority INTEGER NOT NULL DEFAULT 0,
+                    dedupe_key TEXT,
+                    created_at TEXT NOT NULL,
+                    started_at TEXT,
+                    finished_at TEXT,
+                    result_json TEXT,
+                    error_json TEXT,
+                    attempts INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_state ON jobs(state, priority)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_dedupe ON jobs(dedupe_key, state)")
+            # Unique partial index: at most one queued/running job per dedupe_key.
+            # Enforces the dedupe invariant across processes (TOCTOU-safe); finished
+            # jobs drop out of the index so a later identical enqueue is allowed.
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_dedupe_active "
+                "ON jobs(dedupe_key) WHERE state IN ('queued', 'running')"
+            )
+        # The queue DB holds verbatim payloads (diary text, source paths) — lock it
+        # down to owner-only regardless of the invoking user's umask.
+        _chmod_private(self.path)
+
+    def prune_terminal(self, older_than_days: int = JOB_RETENTION_DAYS) -> int:
+        """Delete terminal (succeeded/failed/cancelled) jobs older than the
+        retention window.
+
+        Bounded growth for the queue DB, which holds verbatim payloads. Only
+        terminal jobs are eligible — queued/running jobs are never touched, so
+        a crash mid-prune cannot drop in-flight work (incremental-only). The
+        cutoff uses ``finished_at``; a terminal job is never re-examined by
+        recover_running, so deleting it is safe.
+        """
+        if older_than_days <= 0:
+            return 0
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=older_than_days)).isoformat()
+        with self._lock, self._connect() as conn:
+            cur = conn.execute(
+                """
+                DELETE FROM jobs
+                WHERE state IN ('succeeded', 'failed', 'cancelled')
+                  AND finished_at IS NOT NULL
+                  AND finished_at < ?
+                """,
+                (cutoff,),
+            )
+            return int(cur.rowcount or 0)
+
+    def recover_running(self) -> int:
+        """Re-queue jobs left ``running`` by a crashed/killed daemon.
+
+        Jobs that have already exhausted ``MAX_ATTEMPTS`` claims are dead-lettered
+        to ``failed`` instead of being retried — non-idempotent kinds (diary_write
+        derives its entry_id from wall-clock time) would otherwise duplicate
+        verbatim palace content on every restart, violating the incremental-only
+        principle. The last error_json is preserved for diagnostics.
+        """
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE jobs
+                SET state = 'failed', finished_at = ?,
+                    error_json = COALESCE(error_json, ?)
+                WHERE state = 'running' AND attempts >= ?
+                """,
+                (
+                    _now(),
+                    json.dumps(
+                        {"error_class": "MaxAttemptsExceeded", "message": "max attempts exceeded"},
+                        ensure_ascii=False,
+                    ),
+                    MAX_ATTEMPTS,
+                ),
+            )
+            cur = conn.execute(
+                """
+                UPDATE jobs
+                SET state = 'queued', started_at = NULL
+                WHERE state = 'running' AND attempts < ?
+                """,
+                (MAX_ATTEMPTS,),
+            )
+            return int(cur.rowcount or 0)
+
+    def enqueue(
+        self,
+        kind: str,
+        payload: dict[str, Any],
+        *,
+        dedupe_key: str | None = None,
+        priority: int = 0,
+    ) -> Job:
+        payload_json = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        with self._lock, self._connect() as conn:
+            if dedupe_key:
+                row = conn.execute(
+                    """
+                    SELECT * FROM jobs
+                    WHERE dedupe_key = ? AND state IN ('queued', 'running')
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """,
+                    (dedupe_key,),
+                ).fetchone()
+                if row is not None:
+                    return self._row_to_job(row)
+
+            job_id = uuid.uuid4().hex
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO jobs (
+                        id, kind, payload_json, state, priority, dedupe_key, created_at, attempts
+                    ) VALUES (?, ?, ?, 'queued', ?, ?, ?, 0)
+                    """,
+                    (job_id, kind, payload_json, int(priority), dedupe_key, _now()),
+                )
+            except sqlite3.IntegrityError:
+                # Unique partial index beat us in a cross-process race — return the
+                # job that won. SELECT-then-INSERT is not atomic across processes; the
+                # index is the source of truth.
+                if not dedupe_key:
+                    raise
+                row = conn.execute(
+                    """
+                    SELECT * FROM jobs
+                    WHERE dedupe_key = ? AND state IN ('queued', 'running')
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """,
+                    (dedupe_key,),
+                ).fetchone()
+                if row is None:
+                    # Index guard fired but the row is already gone — retry the INSERT.
+                    conn.execute(
+                        """
+                        INSERT INTO jobs (
+                            id, kind, payload_json, state, priority, dedupe_key, created_at, attempts
+                        ) VALUES (?, ?, ?, 'queued', ?, ?, ?, 0)
+                        """,
+                        (job_id, kind, payload_json, int(priority), dedupe_key, _now()),
+                    )
+                    row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+                return self._row_to_job(row)
+            row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+            return self._row_to_job(row)
+
+    def claim_next(self) -> Job | None:
+        # Atomic across processes: the UPDATE only fires if the row is still
+        # 'queued'. If two daemon processes SELECT the same row, the first to
+        # UPDATE it flips state to 'running' (rowcount=1); the second's UPDATE
+        # matches 0 rows (WHERE state='queued' is now false) and we re-loop
+        # instead of double-executing the job. The in-process RLock does not
+        # protect against a second OS process — this guard does.
+        with self._lock, self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT * FROM jobs
+                WHERE state = 'queued'
+                ORDER BY priority DESC, created_at ASC
+                LIMIT 1
+                """
+            ).fetchone()
+            if row is None:
+                return None
+            cur = conn.execute(
+                """
+                UPDATE jobs
+                SET state = 'running', started_at = ?, attempts = attempts + 1
+                WHERE id = ? AND state = 'queued'
+                """,
+                (_now(), row["id"]),
+            )
+            if cur.rowcount != 1:
+                # Lost the race to another process — nothing to run this iteration.
+                return None
+            claimed = conn.execute("SELECT * FROM jobs WHERE id = ?", (row["id"],)).fetchone()
+            return self._row_to_job(claimed)
+
+    def finish(
+        self,
+        job_id: str,
+        *,
+        state: str,
+        result: dict[str, Any] | None = None,
+        error: dict[str, Any] | None = None,
+    ) -> Job:
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE jobs
+                SET state = ?, finished_at = ?, result_json = ?, error_json = ?
+                WHERE id = ?
+                """,
+                (
+                    state,
+                    _now(),
+                    json.dumps(result or {}, ensure_ascii=False),
+                    json.dumps(error or {}, ensure_ascii=False) if error else None,
+                    job_id,
+                ),
+            )
+            row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+            return self._row_to_job(row)
+
+    def get(self, job_id: str) -> Job:
+        with self._lock, self._connect() as conn:
+            row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+            if row is None:
+                raise DaemonError(f"unknown job id: {job_id}")
+            return self._row_to_job(row)
+
+    def list(self, limit: int = 20) -> list[Job]:
+        with self._lock, self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM jobs ORDER BY created_at DESC LIMIT ?",
+                (max(1, int(limit)),),
+            ).fetchall()
+            return [self._row_to_job(row) for row in rows]
+
+    def counts(self) -> dict[str, int]:
+        with self._lock, self._connect() as conn:
+            rows = conn.execute("SELECT state, COUNT(*) AS n FROM jobs GROUP BY state").fetchall()
+            return {str(row["state"]): int(row["n"]) for row in rows}
+
+    @staticmethod
+    def _row_to_job(row: sqlite3.Row) -> Job:
+        def _loads(value):
+            if not value:
+                return None
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return None
+
+        return Job(
+            id=str(row["id"]),
+            kind=str(row["kind"]),
+            payload=_loads(row["payload_json"]) or {},
+            state=str(row["state"]),
+            priority=int(row["priority"]),
+            dedupe_key=row["dedupe_key"],
+            created_at=str(row["created_at"]),
+            started_at=row["started_at"],
+            finished_at=row["finished_at"],
+            result=_loads(row["result_json"]),
+            error=_loads(row["error_json"]),
+            attempts=int(row["attempts"]),
+        )
+
+
+def job_to_dict(job: Job, *, include_payload: bool = True) -> dict[str, Any]:
+    out = {
+        "id": job.id,
+        "kind": job.kind,
+        "state": job.state,
+        "priority": job.priority,
+        "dedupe_key": job.dedupe_key,
+        "created_at": job.created_at,
+        "started_at": job.started_at,
+        "finished_at": job.finished_at,
+        "result": job.result,
+        "error": job.error,
+        "attempts": job.attempts,
+    }
+    if include_payload:
+        out["payload"] = job.payload
+    return out
+
+
+class DaemonRuntime:
+    def __init__(self, palace_path: str, backend: str | None = None):
+        self.palace_path = canonical_palace_path(palace_path)
+        self.backend = backend
+        self.store = QueueStore(queue_path(self.palace_path))
+        self.shutdown_event = threading.Event()
+        self.worker_wake = threading.Event()
+        self.active_job_id: str | None = None
+        self.worker_thread: threading.Thread | None = None
+
+    def start_worker(self) -> threading.Thread:
+        self.store.recover_running()
+        # Bounded growth: drop terminal jobs older than the retention window
+        # before bringing the worker up. Best-effort — a prune failure must not
+        # block startup.
+        try:
+            self.store.prune_terminal()
+        except Exception:  # noqa: BLE001 - retention is best-effort, never fatal
+            pass
+        thread = threading.Thread(
+            target=self._worker_loop, name="mempalace-daemon-worker", daemon=True
+        )
+        self.worker_thread = thread
+        thread.start()
+        return thread
+
+    def worker_alive(self) -> bool:
+        return self.worker_thread is not None and self.worker_thread.is_alive()
+
+    def _safe_finish(self, job_id: str, *, state: str, result: dict, error: dict | None) -> None:
+        try:
+            self.store.finish(job_id, state=state, result=result, error=error)
+        except Exception:  # noqa: BLE001 - a finish failure must not kill the worker
+            pass
+
+    def _worker_loop(self) -> None:
+        from .service import execute_job
+
+        while not self.shutdown_event.is_set():
+            try:
+                job = self.store.claim_next()
+            except Exception:  # noqa: BLE001 - sqlite/disk errors must not kill the worker
+                self.shutdown_event.wait(1.0)
+                continue
+            if job is None:
+                self.worker_wake.wait(0.5)
+                self.worker_wake.clear()
+                continue
+            self.active_job_id = job.id
+            try:
+                payload = dict(job.payload)
+                # Override, never trust the client: an authenticated request for
+                # palace A must not be able to retarget the daemon at palace B.
+                payload["palace_path"] = self.palace_path
+                if self.backend:
+                    payload["backend"] = self.backend
+                result = execute_job(job.kind, payload)
+                ok = bool(result.get("success", True))
+                state = "succeeded" if ok else "failed"
+                error = None if ok else {"message": result.get("error", "job failed")}
+                self._safe_finish(job.id, state=state, result=result, error=error)
+            except (Exception, SystemExit) as exc:
+                # SystemExit is BaseException, not Exception — catching it here is
+                # deliberate. Without it, a sys.exit() in a dependency would slip
+                # past `except Exception`, kill this worker thread, leave the job
+                # stuck in 'running' forever, and stall every later job while
+                # /health keeps reporting ok. (See mcp_server.py tool_mine for the
+                # same BaseException-slip-past semantics, documented in comments.)
+                self._safe_finish(
+                    job.id,
+                    state="failed",
+                    result={"success": False, "exit_code": 1},
+                    error={"error_class": type(exc).__name__, "message": str(exc)},
+                )
+            finally:
+                self.active_job_id = None
+
+
+def _json_response(handler: BaseHTTPRequestHandler, status: int, payload: dict[str, Any]) -> None:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json; charset=utf-8")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.send_header("Connection", "close")
+    handler.end_headers()
+    handler.wfile.write(body)
+    handler.close_connection = True
+
+
+def run_server(palace_path: str, *, backend: str | None = None, port: int = 0) -> None:
+    palace_path = canonical_palace_path(palace_path)
+    previous_env = {
+        "MEMPALACE_PALACE_PATH": os.environ.get("MEMPALACE_PALACE_PATH"),
+        "MEMPALACE_BACKEND_EXPLICIT": os.environ.get("MEMPALACE_BACKEND_EXPLICIT"),
+        "MEMPALACE_BACKEND": os.environ.get("MEMPALACE_BACKEND"),
+    }
+    os.environ["MEMPALACE_PALACE_PATH"] = palace_path
+    if backend:
+        os.environ["MEMPALACE_BACKEND_EXPLICIT"] = backend
+        os.environ["MEMPALACE_BACKEND"] = backend
+    token = ensure_token(palace_path)
+    runtime = DaemonRuntime(palace_path, backend=backend)
+
+    class _Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        timeout = 10
+
+        def log_message(self, fmt, *args):  # pragma: no cover - stdlib access logging noise
+            return
+
+        def _authorized(self) -> bool:
+            auth = self.headers.get("Authorization")
+            if auth and secrets.compare_digest(auth, f"Bearer {token}"):
+                return True
+            _json_response(self, 401, {"error": "unauthorized"})
+            return False
+
+        def _read_json(self) -> dict[str, Any]:
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            if length > MAX_BODY_BYTES:
+                raise ValueError("request body too large")
+            raw = self.rfile.read(length)
+            return json.loads(raw.decode("utf-8")) if raw else {}
+
+        def do_GET(self):
+            if not self._authorized():
+                return
+            try:
+                self._handle_get()
+            except Exception as exc:  # noqa: BLE001 - malformed query/DB error → 400
+                _json_response(self, 400, {"error": str(exc)})
+
+        def _handle_get(self):
+            parsed = urlparse(self.path)
+            if parsed.path == "/health":
+                _json_response(
+                    self,
+                    200,
+                    {
+                        "ok": True,
+                        "worker_alive": runtime.worker_alive(),
+                        "pid": os.getpid(),
+                        "palace_path": runtime.palace_path,
+                        "backend": runtime.backend,
+                        "active_job_id": runtime.active_job_id,
+                        "counts": runtime.store.counts(),
+                    },
+                )
+                return
+            if parsed.path == "/jobs":
+                qs = parse_qs(parsed.query)
+                limit = int((qs.get("limit") or ["20"])[0])
+                jobs = [
+                    job_to_dict(job, include_payload=False) for job in runtime.store.list(limit)
+                ]
+                _json_response(self, 200, {"jobs": jobs})
+                return
+            if parsed.path.startswith("/jobs/"):
+                job_id = parsed.path.rsplit("/", 1)[-1]
+                try:
+                    job = runtime.store.get(job_id)
+                except DaemonError as exc:
+                    _json_response(self, 404, {"error": str(exc)})
+                    return
+                # Payloads carry verbatim user content (diary text) — do not return
+                # them over HTTP unless the caller explicitly opts in.
+                qs = parse_qs(parsed.query)
+                include_payload = qs.get("include_payload", ["false"])[0].lower() in (
+                    "1",
+                    "true",
+                    "yes",
+                    "on",
+                )
+                _json_response(
+                    self, 200, {"job": job_to_dict(job, include_payload=include_payload)}
+                )
+                return
+            _json_response(self, 404, {"error": "not found"})
+
+        def do_POST(self):
+            if not self._authorized():
+                return
+            parsed = urlparse(self.path)
+            if parsed.path == "/jobs":
+                try:
+                    body = self._read_json()
+                    job = runtime.store.enqueue(
+                        str(body.get("kind") or ""),
+                        body.get("payload") or {},
+                        dedupe_key=body.get("dedupe_key"),
+                        priority=int(body.get("priority") or 0),
+                    )
+                    runtime.worker_wake.set()
+                except Exception as exc:  # noqa: BLE001 - client gets structured failure
+                    _json_response(self, 400, {"error": str(exc)})
+                    return
+                _json_response(self, 202, {"job": job_to_dict(job)})
+                return
+            if parsed.path == "/shutdown":
+                _json_response(self, 200, {"ok": True})
+                runtime.shutdown_event.set()
+                threading.Thread(target=httpd.shutdown, daemon=True).start()
+                return
+            _json_response(self, 404, {"error": "not found"})
+
+    class _Server(ThreadingHTTPServer):
+        daemon_threads = True
+        allow_reuse_address = True
+
+    # Privacy by architecture: the queue DB holds verbatim user content (diary
+    # entries, source paths). Force owner-only perms on every file this process
+    # creates — queue.sqlite3, its WAL/SHM sidecars, and any future artifact.
+    prev_umask = os.umask(0o077)
+    try:
+        with _Server((HOST, port), _Handler) as httpd:
+            actual_port = int(httpd.server_address[1])
+            sd = state_dir(palace_path)
+            sd.mkdir(parents=True, exist_ok=True)
+            _chmod_dir_private(sd)
+            endpoint = {
+                "host": HOST,
+                "port": actual_port,
+                "pid": os.getpid(),
+                "palace_path": palace_path,
+                "started_at": _now(),
+            }
+            _write_private(endpoint_path(palace_path), json.dumps(endpoint, indent=2) + "\n")
+            _write_private(pid_path(palace_path), f"{os.getpid()}\n")
+            runtime.start_worker()
+            try:
+                httpd.serve_forever(poll_interval=0.5)
+            finally:
+                _drain_and_cleanup(runtime, palace_path, previous_env)
+    finally:
+        os.umask(prev_umask)
+
+
+def _drain_and_cleanup(
+    runtime: "DaemonRuntime", palace_path: str, previous_env: dict[str, str | None]
+) -> None:
+    """Drain the active job, then tear down server-side state.
+
+    Killing a daemon thread mid-write (mid mine upsert, mid irreversible sync
+    DELETE) violates incremental-only. Give the worker a bounded window to
+    finish, then mark whatever is still running as cancelled so recover_running
+    won't blindly re-run it on the next start (which would duplicate verbatim
+    content). Finally restore the env vars run_server mutated.
+    """
+    runtime.shutdown_event.set()
+    worker = runtime.worker_thread
+    if worker is not None:
+        worker.join(timeout=SHUTDOWN_DRAIN_SECONDS)
+    active = runtime.active_job_id
+    if active:
+        runtime._safe_finish(
+            active,
+            state="cancelled",
+            result={"success": False, "exit_code": 1},
+            error={"message": "cancelled by daemon shutdown"},
+        )
+    for stale in (endpoint_path(palace_path), pid_path(palace_path)):
+        try:
+            stale.unlink()
+        except OSError:
+            pass
+    for key, value in previous_env.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+class DaemonClient:
+    def __init__(self, palace_path: str):
+        self.palace_path = canonical_palace_path(palace_path)
+        endpoint = _read_endpoint(self.palace_path)
+        port = endpoint.get("port")
+        if port is None:
+            raise DaemonError("daemon endpoint missing port")
+        # Don't read the token until we trust the endpoint points at a live
+        # process we started: a stale endpoint whose pid is dead may have its
+        # port reused by an unrelated process, and we must not send our bearer
+        # token there.
+        pid = endpoint.get("pid")
+        if pid is not None and not _pid_alive(int(pid)):
+            raise DaemonError("daemon endpoint pid is not alive")
+        self.token = read_token(self.palace_path)
+        self.host = endpoint.get("host") or HOST
+        self.port = int(port)
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+        *,
+        timeout: float = 5.0,
+    ) -> dict[str, Any]:
+        data = None if body is None else json.dumps(body, ensure_ascii=False).encode("utf-8")
+        req = urlrequest.Request(
+            self.base_url + path,
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urlrequest.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read().decode("utf-8")
+        except urlerror.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                payload = {"error": raw or str(exc)}
+            raise DaemonError(str(payload.get("error", exc))) from exc
+        except OSError as exc:
+            raise DaemonError(str(exc)) from exc
+        return json.loads(raw) if raw else {}
+
+    def health(self) -> dict[str, Any]:
+        return self.request("GET", "/health")
+
+    def submit(
+        self,
+        kind: str,
+        payload: dict[str, Any],
+        *,
+        dedupe_key: str | None = None,
+        priority: int = 0,
+    ) -> dict[str, Any]:
+        return self.request(
+            "POST",
+            "/jobs",
+            {"kind": kind, "payload": payload, "dedupe_key": dedupe_key, "priority": priority},
+        )["job"]
+
+    def get_job(self, job_id: str) -> dict[str, Any]:
+        return self.request("GET", f"/jobs/{job_id}")["job"]
+
+    def list_jobs(self, limit: int = 20) -> list[dict[str, Any]]:
+        return self.request("GET", f"/jobs?limit={int(limit)}")["jobs"]
+
+    def wait(self, job_id: str, *, timeout: float = DEFAULT_WAIT_TIMEOUT) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        while True:
+            job = self.get_job(job_id)
+            if job["state"] in TERMINAL_STATES:
+                return job
+            if time.monotonic() >= deadline:
+                raise DaemonError(f"timed out waiting for job {job_id}")
+            time.sleep(0.2)
+
+    def shutdown(self) -> dict[str, Any]:
+        return self.request("POST", "/shutdown", {})
+
+
+def get_client_if_running(palace_path: str) -> DaemonClient | None:
+    try:
+        client = DaemonClient(palace_path)
+        client.health()
+        return client
+    except DaemonError:
+        return None
+
+
+def _detached_kwargs(log_path: Path) -> dict[str, Any]:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_fh = open(log_path, "a", encoding="utf-8")
+    # The daemon log may capture verbatim content in tracebacks — owner-only.
+    _chmod_private(log_path)
+    kwargs: dict[str, Any] = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": log_fh,
+        "stderr": log_fh,
+        "close_fds": True,
+    }
+    if os.name == "nt":
+        flags = 0
+        for name in ("DETACHED_PROCESS", "CREATE_NEW_PROCESS_GROUP", "CREATE_BREAKAWAY_FROM_JOB"):
+            flags |= getattr(subprocess, name, 0)
+        if flags:
+            kwargs["creationflags"] = flags
+    else:
+        kwargs["start_new_session"] = True
+    return kwargs
+
+
+def start_daemon(
+    palace_path: str,
+    *,
+    backend: str | None = None,
+    foreground: bool = False,
+    timeout: float = 15.0,
+) -> DaemonClient:
+    palace_path = canonical_palace_path(palace_path)
+    ensure_token(palace_path)
+    existing = get_client_if_running(palace_path)
+    if existing is not None:
+        return existing
+    if foreground:
+        # Blocks until the daemon stops. A clean stop is a normal exit, not an
+        # error — return None so the caller (cmd_daemon) exits 0.
+        run_server(palace_path, backend=backend, port=0)
+        return None  # type: ignore[return-value]
+
+    sd = state_dir(palace_path)
+    sd.mkdir(parents=True, exist_ok=True)
+    _chmod_dir_private(sd)
+
+    # Spawn mutual exclusion: two concurrent `daemon start` callers would both
+    # observe no running daemon and both spawn a child, double-claiming jobs.
+    # A non-blocking flock serializes the check-then-spawn; the loser waits for
+    # the winner to finish coming up, then re-checks and reuses that daemon.
+    lock_fh = open(sd / "start.lock", "w") if _fcntl is not None else None
+    if _fcntl is not None and lock_fh is not None:
+        _chmod_private(sd / "start.lock")
+        try:
+            _fcntl.flock(lock_fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+        except OSError:
+            # Another start is in flight — wait for it, then reuse its daemon.
+            _fcntl.flock(lock_fh.fileno(), _fcntl.LOCK_EX)
+            existing = get_client_if_running(palace_path)
+            if existing is not None:
+                return existing
+            # The other starter failed without bringing the daemon up; fall
+            # through and spawn ourselves (we now hold the lock).
+
+    for stale in (endpoint_path(palace_path), pid_path(palace_path)):
+        try:
+            stale.unlink()
+        except OSError:
+            pass
+    cmd = [
+        sys.executable,
+        "-m",
+        "mempalace.daemon",
+        "serve",
+        "--palace",
+        palace_path,
+    ]
+    if backend:
+        cmd.extend(["--backend", backend])
+    env = os.environ.copy()
+    if STATE_ROOT_ENV in os.environ:
+        env[STATE_ROOT_ENV] = os.environ[STATE_ROOT_ENV]
+    kwargs = _detached_kwargs(sd / "daemon.log")
+    proc = None
+    try:
+        proc = subprocess.Popen(cmd, env=env, **kwargs)
+    finally:
+        log_fh = kwargs.get("stdout")
+        if hasattr(log_fh, "close"):
+            log_fh.close()
+    try:
+        deadline = time.monotonic() + timeout
+        last_error = None
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                raise DaemonError(f"daemon exited during startup with code {proc.returncode}")
+            try:
+                client = DaemonClient(palace_path)
+                client.health()
+                return client
+            except DaemonError as exc:
+                last_error = exc
+                time.sleep(0.1)
+        raise DaemonError(f"daemon did not become ready: {last_error}")
+    except BaseException:
+        # Readiness failed — don't leak an orphaned detached child holding the
+        # port, token, queue, and log handle. Kill and reap it before raising.
+        if proc is not None and proc.poll() is None:
+            try:
+                proc.kill()
+                proc.wait()
+            except Exception:  # noqa: BLE001 - cleanup best-effort
+                pass
+        raise
+    finally:
+        if lock_fh is not None:
+            try:
+                lock_fh.close()
+            except Exception:  # noqa: BLE001 - cleanup best-effort
+                pass
+
+
+def ensure_client(
+    palace_path: str, *, backend: str | None = None, auto_start: bool = True
+) -> DaemonClient:
+    palace_path = canonical_palace_path(palace_path)
+    client = get_client_if_running(palace_path)
+    if client is not None:
+        return client
+    if not auto_start:
+        raise DaemonError("daemon is not running")
+    return start_daemon(palace_path, backend=backend)
+
+
+def submit_job(
+    kind: str,
+    payload: dict[str, Any],
+    *,
+    palace_path: str | None = None,
+    backend: str | None = None,
+    dedupe_key: str | None = None,
+    priority: int = 0,
+    wait: bool = True,
+    auto_start: bool = False,
+    timeout: float = DEFAULT_WAIT_TIMEOUT,
+) -> dict[str, Any]:
+    # Strictly opt-in: callers that want the daemon auto-started must say so
+    # explicitly (the CLI --daemon path passes auto_start=True). The default
+    # refuses to spawn a long-lived process on a background code path.
+    resolved_palace = canonical_palace_path(palace_path or payload.get("palace_path"))
+    payload = dict(payload)
+    payload["palace_path"] = resolved_palace  # override, never trust client input
+    if backend:
+        payload["backend"] = backend
+    client = ensure_client(resolved_palace, backend=backend, auto_start=auto_start)
+    job = client.submit(kind, payload, dedupe_key=dedupe_key, priority=priority)
+    if not wait:
+        return job
+    return client.wait(job["id"], timeout=timeout)
+
+
+def stop_daemon(palace_path: str) -> bool:
+    client = get_client_if_running(palace_path)
+    if client is None:
+        return False
+    client.shutdown()
+    return True
+
+
+def _cmd_serve(args) -> None:
+    run_server(args.palace, backend=args.backend, port=args.port)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="MemPalace daemon internals")
+    sub = parser.add_subparsers(dest="command", required=True)
+    serve = sub.add_parser("serve")
+    serve.add_argument("--palace", required=True)
+    serve.add_argument("--backend", default=None)
+    serve.add_argument("--port", type=int, default=0)
+    args = parser.parse_args(argv)
+    if args.command == "serve":
+        _cmd_serve(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -545,7 +545,7 @@ def _submit_daemon_job(
     kind: str,
     payload: dict,
     *,
-    dedupe_key: str | None = None,
+    dedupe_key: str = None,
     priority: int = 0,
     wait: bool = False,
     timeout: float = 60.0,

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -509,6 +509,70 @@ def _spawn_mine(cmd: list) -> None:
         pass
 
 
+def _hooks_daemon_enabled() -> bool:
+    try:
+        return MempalaceConfig().hook_use_daemon is True
+    except Exception:
+        return False
+
+
+def _daemon_mine_dedupe_key(source: str, mode: str) -> str:
+    try:
+        source_key = str(Path(source).expanduser().resolve())
+    except OSError:
+        source_key = str(Path(source).expanduser())
+    return f"hook:mine:{mode}:{source_key}"
+
+
+def _daemon_available() -> bool:
+    """True iff a daemon is already running for the configured palace.
+
+    This is a fast localhost health check, not a spawn: the 500ms hook budget
+    forbids auto-starting a python subprocess from a hook (cold start is
+    ~15s). Daemon mode for hooks requires the user to have started the daemon
+    explicitly via `mempalace daemon start`; when it isn't up, hooks fall back
+    to the existing direct (in-process / spawn) path instead of blocking.
+    """
+    from .daemon import get_client_if_running
+
+    try:
+        return get_client_if_running(MempalaceConfig().palace_path) is not None
+    except Exception:
+        return False
+
+
+def _submit_daemon_job(
+    kind: str,
+    payload: dict,
+    *,
+    dedupe_key: str | None = None,
+    priority: int = 0,
+    wait: bool = False,
+    timeout: float = 60.0,
+):
+    """Submit to an already-running daemon. Never auto-starts (see _daemon_available).
+
+    Raises DaemonError on a real failure (job rejected, timeout, daemon died
+    mid-submit). Callers must NOT fall back to the direct path on such errors —
+    the daemon may already have accepted the job, and re-running it would
+    duplicate verbatim content. Only an absent daemon (handled by the caller's
+    _daemon_available() precheck) should fall back.
+    """
+    from .daemon import submit_job
+
+    palace_path = MempalaceConfig().palace_path
+    return submit_job(
+        kind,
+        payload,
+        palace_path=palace_path,
+        dedupe_key=dedupe_key,
+        priority=priority,
+        wait=wait,
+        auto_start=False,
+        timeout=timeout,
+    )
+
+
 def _maybe_auto_ingest():
     """Background-mine MEMPAL_DIR (project files) if set.
 
@@ -527,9 +591,26 @@ def _maybe_auto_ingest():
         return
     for mine_dir, mode in targets:
         try:
+            if _hooks_daemon_enabled() and _daemon_available():
+                try:
+                    _submit_daemon_job(
+                        "mine",
+                        {"source": mine_dir, "mode": mode, "agent": "mempalace"},
+                        dedupe_key=_daemon_mine_dedupe_key(mine_dir, mode),
+                        wait=False,
+                    )
+                except Exception as exc:
+                    # Daemon accepted context — don't fall back (would double-mine).
+                    _log(f"Daemon mine submission failed: {exc}")
+                continue
             _spawn_mine([_mempalace_python(), "-m", "mempalace", "mine", mine_dir, "--mode", mode])
         except OSError:
             pass
+        except Exception as exc:
+            # Non-daemon spawn path failed. Hooks must never crash the user's
+            # shell — log and continue. Do not label this a daemon failure: the
+            # daemon block above handles its own errors with its own message.
+            _log(f"mine hook failed: {exc}")
 
 
 def _mine_sync():
@@ -546,6 +627,22 @@ def _mine_sync():
     log_path = STATE_DIR / "hook.log"
     for mine_dir, mode in targets:
         try:
+            if _hooks_daemon_enabled() and _daemon_available():
+                try:
+                    job = _submit_daemon_job(
+                        "mine",
+                        {"source": mine_dir, "mode": mode, "agent": "mempalace"},
+                        dedupe_key=_daemon_mine_dedupe_key(mine_dir, mode),
+                        wait=True,
+                        timeout=60,
+                    )
+                    result = job.get("result") or {}
+                    if job.get("state") != "succeeded" or not result.get("success", True):
+                        _log(f"Daemon sync mine failed: {result.get('error', job.get('error'))}")
+                except Exception as exc:
+                    # Daemon accepted context — don't fall back (would double-mine).
+                    _log(f"Daemon sync mine submission failed: {exc}")
+                continue
             with open(log_path, "a") as log_f:
                 subprocess.run(
                     [
@@ -563,6 +660,11 @@ def _mine_sync():
                 )
         except (OSError, subprocess.TimeoutExpired):
             pass
+        except Exception as exc:
+            # Non-daemon sync spawn path failed. Hooks must never crash the
+            # user's shell — log and continue (not a daemon failure; the daemon
+            # block above handles its own errors).
+            _log(f"mine hook failed: {exc}")
 
 
 def _desktop_toast(body: str, title: str = "MemPalace"):
@@ -680,6 +782,41 @@ def _save_diary_direct(
     )
 
     try:
+        if _hooks_daemon_enabled() and _daemon_available():
+            try:
+                job = _submit_daemon_job(
+                    "diary_write",
+                    {
+                        "agent_name": agent_name,
+                        "entry": entry,
+                        "topic": "checkpoint",
+                        "wing": wing,
+                    },
+                    priority=10,
+                    wait=True,
+                    timeout=30,
+                )
+            except Exception as exc:
+                # Daemon accepted context — don't fall back (would double-write).
+                _log(f"Daemon diary checkpoint failed: {exc}")
+                return {"count": 0}
+            result = job.get("result") or {}
+            if job.get("state") == "succeeded" and result.get("success"):
+                _log(f"Diary checkpoint saved: {result.get('entry_id', '?')}")
+                try:
+                    ack_file = STATE_DIR / "last_checkpoint"
+                    ack_file.write_text(
+                        json.dumps({"msgs": len(messages), "ts": now.isoformat()}),
+                        encoding="utf-8",
+                    )
+                except OSError:
+                    pass
+                if toast:
+                    _desktop_toast(f"Checkpoint saved - {len(messages)} messages archived")
+                return {"count": len(messages), "themes": themes}
+            _log(f"Daemon diary checkpoint failed: {result.get('error', job.get('error'))}")
+            return {"count": 0}
+
         from .mcp_server import tool_diary_write
 
         result = tool_diary_write(
@@ -721,6 +858,25 @@ def _ingest_transcript(transcript_path: str):
         return
 
     try:
+        if _hooks_daemon_enabled() and _daemon_available():
+            try:
+                _submit_daemon_job(
+                    "mine",
+                    {
+                        "source": str(path.parent),
+                        "mode": "convos",
+                        "wing": "sessions",
+                        "agent": "mempalace",
+                    },
+                    dedupe_key=_daemon_mine_dedupe_key(str(path.parent), "convos"),
+                    wait=False,
+                )
+                _log(f"Transcript ingest submitted to daemon: {path.name}")
+            except Exception as exc:
+                # Daemon accepted context — don't fall back (would double-mine).
+                _log(f"Daemon transcript ingest failed: {exc}")
+            return
+
         # Route through ``_spawn_mine`` so the per-target PID guard kicks
         # in here too — repeated Stop/PreCompact fires for the same
         # transcript should not stack up parallel ingest mines.
@@ -740,6 +896,11 @@ def _ingest_transcript(transcript_path: str):
         _log(f"Transcript ingest started: {path.name}")
     except OSError:
         pass
+    except Exception as exc:
+        # Non-daemon ingest spawn path failed. Hooks must never crash the
+        # user's shell — log and continue (not a daemon failure; the daemon
+        # block above handles its own errors).
+        _log(f"transcript ingest hook failed: {exc}")
 
 
 SUPPORTED_HARNESSES = {"claude-code", "codex"}

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -1,0 +1,398 @@
+"""Shared service operations used by daemon-backed entry points.
+
+The MCP server remains the owner of MCP transport details. This module owns the
+small, transport-neutral execution surface the daemon needs: classify known
+tools and execute durable background jobs without printing directly to the
+caller's terminal.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+from typing import Any
+
+from .config import MempalaceConfig
+
+_EXPLICIT_BACKEND_ENV = "MEMPALACE_BACKEND_EXPLICIT"
+_PALACE_PATH_ENV = "MEMPALACE_PALACE_PATH"
+_BACKEND_ENV = "MEMPALACE_BACKEND"
+# Env vars a job may mutate via _apply_backend / palace_path injection. They are
+# snapshotted per job and restored afterward so a job that switches the backend
+# (e.g. qdrant) cannot poison every later job in the same daemon process —
+# including mcp_tool jobs, which read MempalaceConfig (and thus the leaked env).
+_PER_JOB_ENV = (_PALACE_PATH_ENV, _BACKEND_ENV, _EXPLICIT_BACKEND_ENV)
+
+
+READ_TOOLS = frozenset(
+    {
+        "mempalace_status",
+        "mempalace_list_wings",
+        "mempalace_list_rooms",
+        "mempalace_get_taxonomy",
+        "mempalace_get_aaak_spec",
+        "mempalace_traverse",
+        "mempalace_find_tunnels",
+        "mempalace_graph_stats",
+        "mempalace_list_tunnels",
+        "mempalace_list_hallways",
+        "mempalace_follow_tunnels",
+        "mempalace_search",
+        "mempalace_check_duplicate",
+        "mempalace_get_drawer",
+        "mempalace_list_drawers",
+        "mempalace_diary_read",
+        "mempalace_memories_filed_away",
+        "mempalace_kg_query",
+        "mempalace_kg_stats",
+        "mempalace_kg_timeline",
+    }
+)
+
+WRITE_TOOLS = frozenset(
+    {
+        "mempalace_add_drawer",
+        "mempalace_delete_drawer",
+        "mempalace_update_drawer",
+        "mempalace_diary_write",
+        "mempalace_kg_add",
+        "mempalace_kg_invalidate",
+        "mempalace_create_tunnel",
+        "mempalace_delete_tunnel",
+        "mempalace_delete_hallway",
+        "mempalace_hook_settings",
+    }
+)
+
+MAINTENANCE_TOOLS = frozenset({"mempalace_mine", "mempalace_sync", "mempalace_reconnect"})
+
+
+def classify_tool(name: str) -> str:
+    """Return ``read``, ``write``, ``maintenance``, or ``unknown`` for an MCP tool."""
+    if name in READ_TOOLS:
+        return "read"
+    if name in WRITE_TOOLS:
+        return "write"
+    if name in MAINTENANCE_TOOLS:
+        return "maintenance"
+    return "unknown"
+
+
+def _apply_backend(backend: str | None) -> None:
+    if not backend:
+        return
+    backend_name = str(backend).strip().lower()
+    from .backends import get_backend_class
+
+    get_backend_class(backend_name)
+    os.environ[_EXPLICIT_BACKEND_ENV] = backend_name
+    os.environ[_BACKEND_ENV] = backend_name
+
+
+def _capture(fn):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        result = fn()
+    return result, stdout.getvalue(), stderr.getvalue()
+
+
+def execute_job(kind: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Execute one daemon job and return a JSON-serializable result."""
+
+    def _run():
+        if kind == "mine":
+            return run_mine(payload)
+        if kind == "sync":
+            return run_sync(payload)
+        if kind == "diary_write":
+            return run_diary_write(payload)
+        if kind == "mcp_tool":
+            return run_mcp_tool(payload)
+        return {"success": False, "error": f"unknown daemon job kind: {kind}", "exit_code": 2}
+
+    # Per-job env isolation: snapshot the backend/palace env vars and restore
+    # them after the job so one job's _apply_backend / palace_path injection
+    # can't leak into the next job in the same long-lived process.
+    saved_env = {key: os.environ.get(key) for key in _PER_JOB_ENV}
+    try:
+        result, stdout, stderr = _capture(_run)
+    finally:
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    if result is None:
+        result = {}
+    if not isinstance(result, dict):
+        result = {"success": True, "value": result}
+    result.setdefault("success", True)
+    result.setdefault("exit_code", 0 if result.get("success") else 1)
+    if stdout:
+        result["stdout"] = stdout
+    if stderr:
+        result["stderr"] = stderr
+    return result
+
+
+def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
+    """Run the same mine operation as the CLI, without daemon transport concerns."""
+    palace_path = os.path.abspath(
+        os.path.expanduser(payload.get("palace_path") or MempalaceConfig().palace_path)
+    )
+    os.environ["MEMPALACE_PALACE_PATH"] = palace_path
+    _apply_backend(payload.get("backend"))
+
+    source = payload.get("source") or payload.get("dir")
+    mode = payload.get("mode") or "projects"
+    wing = payload.get("wing")
+    agent = payload.get("agent") or "mempalace"
+    limit = int(payload.get("limit") or 0)
+    dry_run = bool(payload.get("dry_run"))
+
+    if payload.get("redetect_origin"):
+        from .cli import _run_pass_zero
+
+        _run_pass_zero(project_dir=source, palace_dir=palace_path, llm_provider=None)
+
+    from .palace import MineAlreadyRunning, MineValidationError
+
+    try:
+        if mode == "convos":
+            from .convo_miner import mine_convos
+
+            mine_convos(
+                convo_dir=source,
+                palace_path=palace_path,
+                wing=wing,
+                agent=agent,
+                limit=limit,
+                dry_run=dry_run,
+                extract_mode=payload.get("extract") or "exchange",
+            )
+        elif mode == "extract":
+            from .format_miner import mine_formats
+
+            mine_formats(
+                format_dir=source,
+                palace_path=palace_path,
+                wing=wing,
+                agent=agent,
+                limit=limit,
+                dry_run=dry_run,
+            )
+        elif mode == "projects":
+            include_ignored = payload.get("include_ignored") or []
+            from .miner import mine
+
+            mine(
+                project_dir=source,
+                palace_path=palace_path,
+                wing_override=wing,
+                agent=agent,
+                limit=limit,
+                dry_run=dry_run,
+                respect_gitignore=not bool(payload.get("no_gitignore")),
+                include_ignored=include_ignored,
+                max_chunks_per_file=payload.get("max_chunks_per_file"),
+            )
+        else:
+            return {"success": False, "error": f"invalid mine mode: {mode}", "exit_code": 2}
+    except MineAlreadyRunning as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_class": "LockHeldByOtherProcess",
+            "exit_code": 1,
+        }
+    except MineValidationError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_class": "MineValidationError",
+            "exit_code": 1,
+        }
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+        return {
+            "success": code == 0,
+            "error": str(exc),
+            "error_class": "SystemExit",
+            "exit_code": code,
+        }
+    except Exception as exc:
+        return {"success": False, "error": f"mine failed: {exc}", "exit_code": 1}
+
+    return {"success": True, "kind": "mine", "mode": mode, "dry_run": dry_run, "exit_code": 0}
+
+
+def run_sync(payload: dict[str, Any]) -> dict[str, Any]:
+    """Run sync and render the same operator-facing summary shape as the CLI."""
+    palace_path = os.path.abspath(
+        os.path.expanduser(payload.get("palace_path") or MempalaceConfig().palace_path)
+    )
+    os.environ["MEMPALACE_PALACE_PATH"] = palace_path
+    _apply_backend(payload.get("backend"))
+
+    from .backends import detect_backend_for_path
+    from .palace import MineAlreadyRunning, _backend_artifact_label, resolve_backend_name
+
+    if not os.path.isdir(palace_path):
+        print(f"\n  No palace found at {palace_path}")
+        return {"success": True, "exit_code": 0}
+
+    try:
+        backend_name = resolve_backend_name(palace_path)
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": f"Could not resolve palace backend: {exc}",
+            "exit_code": 1,
+        }
+
+    if detect_backend_for_path(palace_path) is None:
+        print(
+            f"\n  Palace dir at {palace_path} exists but has no "
+            f"{_backend_artifact_label(backend_name)} yet."
+        )
+        print("  Run: mempalace mine <dir>")
+        return {"success": True, "exit_code": 0}
+
+    project_dirs = []
+    if payload.get("dir"):
+        project_dirs.append(os.path.expanduser(str(payload["dir"])))
+    project_dirs.extend(os.path.expanduser(str(root)) for root in payload.get("root") or [])
+    project_dirs = project_dirs or None
+    dry_run = bool(payload.get("dry_run", True))
+
+    print(f"\n{'=' * 55}")
+    print("  MemPalace Sync — Gitignore-aware drawer prune")
+    print(f"{'=' * 55}")
+    print(f"  Palace:   {palace_path}")
+    if payload.get("wing"):
+        print(f"  Wing:     {payload['wing']}")
+    if project_dirs:
+        for project_dir in project_dirs:
+            print(f"  Project:  {project_dir}")
+    print(
+        "  Mode:     DRY RUN (no deletions)" if dry_run else "  Mode:     APPLY (deleting drawers)"
+    )
+    print(f"{'-' * 55}\n")
+
+    try:
+        from .mcp_server import _wal_log
+        from .sync import sync_palace
+
+        report = sync_palace(
+            palace_path=palace_path,
+            project_dirs=project_dirs,
+            wing=payload.get("wing"),
+            dry_run=dry_run,
+            wal_log=_wal_log,
+        )
+    except MineAlreadyRunning as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_class": "LockHeldByOtherProcess",
+            "exit_code": 1,
+        }
+    except ValueError as exc:
+        return {"success": False, "error": str(exc), "exit_code": 2}
+    except Exception as exc:
+        return {"success": False, "error": f"sync failed: {exc}", "exit_code": 1}
+
+    removed_suffix = "(would remove)" if dry_run else "(removed)"
+    print(f"  Scanned:        {report['scanned']}")
+    print(f"  Kept:           {report['kept']}")
+    print(f"  Gitignored:     {report['gitignored']}  {removed_suffix}")
+    print(f"  Missing:        {report['missing']}  {removed_suffix}")
+    print(f"  No source:      {report['no_source']}  (kept)")
+    print(f"  Out of scope:   {report['out_of_scope']}  (kept)")
+
+    by_source = report.get("by_source") or {}
+    if by_source:
+        top = sorted(by_source.items(), key=lambda kv: -kv[1])[:5]
+        label = "Top sources to remove" if dry_run else "Top sources removed"
+        print(f"\n  {label}:")
+        for src, n in top:
+            print(f"    {src}  ({n})")
+
+    if dry_run:
+        if report["gitignored"] + report["missing"] > 0:
+            print("\n  Re-run with --apply to commit these deletions.")
+    else:
+        print(
+            f"\n  Removed {report['removed_drawers']} drawers, {report['removed_closets']} closets."
+        )
+
+    print(f"\n{'=' * 55}\n")
+    return {"success": True, "report": report, "exit_code": 0}
+
+
+def run_diary_write(payload: dict[str, Any]) -> dict[str, Any]:
+    palace_path = payload.get("palace_path")
+    if palace_path:
+        os.environ["MEMPALACE_PALACE_PATH"] = os.path.abspath(os.path.expanduser(palace_path))
+    _apply_backend(payload.get("backend"))
+
+    from .mcp_server import tool_diary_write
+
+    result = tool_diary_write(
+        agent_name=payload.get("agent_name") or "mempalace",
+        entry=payload.get("entry") or "",
+        topic=payload.get("topic") or "general",
+        wing=payload.get("wing") or "",
+    )
+    result.setdefault("exit_code", 0 if result.get("success") else 1)
+    return result
+
+
+def run_mcp_tool(payload: dict[str, Any]) -> dict[str, Any]:
+    """Execute an MCP tool by name over the daemon queue.
+
+    The daemon is a durable, retried write surface — not a general MCP transport.
+    Restrict ``mcp_tool`` to write-classified tools only: read tools would
+    exfiltrate verbatim palace content into the queue DB and the job result
+    (stored world-readable-by-default without the perms fix, and returned over
+    /jobs), and maintenance tools already have their own dedicated kinds
+    (mine/sync). No internal caller currently uses ``mcp_tool``; this allowlist
+    bounds the blast radius of the generic escape hatch.
+    """
+    name = payload.get("name")
+    arguments = payload.get("arguments") or {}
+    if not isinstance(arguments, dict):
+        return {"success": False, "error": "arguments must be an object", "exit_code": 2}
+    classification = classify_tool(name) if name else "unknown"
+    if classification != "write":
+        return {
+            "success": False,
+            "error": f"daemon mcp_tool only accepts write tools; {name!r} is {classification}",
+            "exit_code": 2,
+        }
+    from .mcp_server import TOOLS
+
+    if name not in TOOLS:
+        return {"success": False, "error": f"unknown MCP tool: {name}", "exit_code": 2}
+    result = TOOLS[name]["handler"](**arguments)
+    if isinstance(result, dict):
+        result.setdefault("success", True)
+        result.setdefault("exit_code", 0 if result.get("success") else 1)
+        return result
+    return {"success": True, "value": result, "exit_code": 0}
+
+
+def print_job_result(result: dict[str, Any]) -> int:
+    """Replay captured daemon job output and return the intended process exit code."""
+    stdout = result.get("stdout")
+    stderr = result.get("stderr")
+    if stdout:
+        print(stdout, end="")
+    if stderr:
+        print(stderr, end="", file=sys.stderr)
+    if not result.get("success", True) and result.get("error") and not stderr:
+        print(f"mempalace: {result['error']}", file=sys.stderr)
+    return int(result.get("exit_code", 0 if result.get("success", True) else 1) or 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ instead of the real user profile.
 
 import os
 import shutil
-import sys
 import tempfile
 
 # ── Isolate HOME before any mempalace imports ──────────────────────────
@@ -118,33 +117,6 @@ def _isolate_home():
         else:
             os.environ[var] = orig
     shutil.rmtree(_session_tmp, ignore_errors=True)
-
-
-# Windows-only diagnostic for the process-exit hang (a non-daemon thread
-# blocked on a socket outlives the test session). Tests pass (666) then the
-# interpreter blocks at shutdown until CI sends SIGINT. dump_traceback_later
-# fires a watchdog that prints every thread's stack to stderr once the hang
-# has run a while, so the culprit thread is visible in the log. Gated to
-# win32 so green platforms see no extra output. Remove once the hang is fixed.
-if sys.platform == "win32":
-    import faulthandler as _faulthandler
-    import threading as _threading
-
-    @pytest.fixture(scope="session", autouse=True)
-    def _diag_win_exit_hang():
-        _faulthandler.dump_traceback_later(130, exit=False, file=sys.stderr)
-
-        yield
-
-        # Snapshot every live thread right after the tests finish. A non-daemon
-        # thread present here is what blocks interpreter shutdown.
-        print("--- alive threads at session teardown ---", file=sys.stderr, flush=True)
-        for t in _threading.enumerate():
-            print(
-                f"thread name={t.name!r} daemon={t.daemon} alive={t.is_alive()} ident={t.ident}",
-                file=sys.stderr,
-                flush=True,
-            )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ instead of the real user profile.
 
 import os
 import shutil
+import sys
 import tempfile
 
 # ── Isolate HOME before any mempalace imports ──────────────────────────
@@ -117,6 +118,33 @@ def _isolate_home():
         else:
             os.environ[var] = orig
     shutil.rmtree(_session_tmp, ignore_errors=True)
+
+
+# Windows-only diagnostic for the process-exit hang (a non-daemon thread
+# blocked on a socket outlives the test session). Tests pass (666) then the
+# interpreter blocks at shutdown until CI sends SIGINT. dump_traceback_later
+# fires a watchdog that prints every thread's stack to stderr once the hang
+# has run a while, so the culprit thread is visible in the log. Gated to
+# win32 so green platforms see no extra output. Remove once the hang is fixed.
+if sys.platform == "win32":
+    import faulthandler as _faulthandler
+    import threading as _threading
+
+    @pytest.fixture(scope="session", autouse=True)
+    def _diag_win_exit_hang():
+        _faulthandler.dump_traceback_later(130, exit=False, file=sys.stderr)
+
+        yield
+
+        # Snapshot every live thread right after the tests finish. A non-daemon
+        # thread present here is what blocks interpreter shutdown.
+        print("--- alive threads at session teardown ---", file=sys.stderr, flush=True)
+        for t in _threading.enumerate():
+            print(
+                f"thread name={t.name!r} daemon={t.daemon} alive={t.is_alive()} ident={t.ident}",
+                file=sys.stderr,
+                flush=True,
+            )
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from mempalace.cli import (
     cmd_hook,
     cmd_init,
     cmd_instructions,
+    cmd_daemon,
     cmd_mine,
     cmd_repair,
     cmd_search,
@@ -619,6 +620,64 @@ def test_cmd_mine_include_ignored_comma_split(mock_config_cls):
         mock_mine.assert_called_once()
         call_kwargs = mock_mine.call_args[1]
         assert call_kwargs["include_ignored"] == ["a.txt", "b.txt", "c.txt"]
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_mine_daemon_background_submits_job(mock_config_cls, capsys):
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = argparse.Namespace(
+        dir="/src",
+        palace=None,
+        mode="projects",
+        wing=None,
+        agent="mempalace",
+        limit=0,
+        dry_run=False,
+        no_gitignore=False,
+        include_ignored=["a.txt,b.txt"],
+        extract="exchange",
+        daemon=True,
+        background=True,
+        backend=None,
+        global_backend=None,
+        max_chunks_per_file=None,
+        redetect_origin=False,
+    )
+    with patch("mempalace.daemon.submit_job", return_value={"id": "job-1"}) as mock_submit:
+        with patch("mempalace.miner.mine") as mock_mine:
+            cmd_mine(args)
+
+    mock_mine.assert_not_called()
+    mock_submit.assert_called_once()
+    call_kwargs = mock_submit.call_args.kwargs
+    assert call_kwargs["palace_path"] == "/fake/palace"
+    assert call_kwargs["wait"] is False
+    payload = mock_submit.call_args.args[1]
+    assert payload["include_ignored"] == ["a.txt", "b.txt"]
+    assert "job-1" in capsys.readouterr().out
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_mine_background_requires_daemon(mock_config_cls, capsys):
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = argparse.Namespace(
+        dir="/src",
+        palace=None,
+        mode="projects",
+        wing=None,
+        agent="mempalace",
+        limit=0,
+        dry_run=False,
+        no_gitignore=False,
+        include_ignored=[],
+        extract="exchange",
+        daemon=False,
+        background=True,
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        cmd_mine(args)
+    assert excinfo.value.code == 2
+    assert "--background requires --daemon" in capsys.readouterr().err
 
 
 @patch("mempalace.cli.MempalaceConfig")
@@ -1258,6 +1317,94 @@ def test_cmd_sync_palace_dir_no_db(mock_config_cls, tmp_path, capsys):
     assert "has no chroma.sqlite3 yet" in captured.out + captured.err
     # Side-effect-free: backend not invoked.
     assert list(tmp_path.iterdir()) == []
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_sync_daemon_background_submits_job(mock_config_cls, capsys):
+    from mempalace.cli import cmd_sync
+
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    args = argparse.Namespace(
+        palace=None,
+        dir="/project",
+        root=["/extra"],
+        wing="wing_a",
+        dry_run=False,
+        daemon=True,
+        background=True,
+        backend=None,
+        global_backend=None,
+    )
+    with patch("mempalace.daemon.submit_job", return_value={"id": "sync-job"}) as mock_submit:
+        cmd_sync(args)
+
+    mock_submit.assert_called_once()
+    assert mock_submit.call_args.args[0] == "sync"
+    payload = mock_submit.call_args.args[1]
+    assert payload == {"dir": "/project", "root": ["/extra"], "wing": "wing_a", "dry_run": False}
+    assert mock_submit.call_args.kwargs["wait"] is False
+    assert "sync-job" in capsys.readouterr().out
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_daemon_jobs_reads_durable_queue_when_stopped(
+    mock_config_cls, tmp_path, monkeypatch, capsys
+):
+    from mempalace.daemon import QueueStore, queue_path
+
+    palace_dir = tmp_path / "palace"
+    state_root = tmp_path / "state"
+    palace_dir.mkdir()
+    monkeypatch.setenv("MEMPALACE_DAEMON_STATE_ROOT", str(state_root))
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    job = QueueStore(queue_path(str(palace_dir))).enqueue("mine", {"source": "/src"})
+
+    args = argparse.Namespace(
+        palace=None,
+        backend=None,
+        global_backend=None,
+        daemon_action="jobs",
+        limit=20,
+    )
+    with patch("mempalace.daemon.get_client_if_running", return_value=None):
+        cmd_daemon(args)
+
+    out = capsys.readouterr().out
+    assert job.id in out
+    assert "queued" in out
+    assert "mine" in out
+
+
+@patch("mempalace.cli.MempalaceConfig")
+def test_cmd_daemon_wait_reads_finished_job_when_stopped(
+    mock_config_cls, tmp_path, monkeypatch, capsys
+):
+    from mempalace.daemon import QueueStore, queue_path
+
+    palace_dir = tmp_path / "palace"
+    state_root = tmp_path / "state"
+    palace_dir.mkdir()
+    monkeypatch.setenv("MEMPALACE_DAEMON_STATE_ROOT", str(state_root))
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    store = QueueStore(queue_path(str(palace_dir)))
+    queued = store.enqueue("mine", {"source": "/src"})
+    store.finish(
+        queued.id,
+        state="succeeded",
+        result={"success": True, "stdout": "done\n", "exit_code": 0},
+    )
+
+    args = argparse.Namespace(
+        palace=None,
+        backend=None,
+        global_backend=None,
+        daemon_action="wait",
+        job_id=queued.id,
+    )
+    with patch("mempalace.daemon.get_client_if_running", return_value=None):
+        cmd_daemon(args)
+
+    assert "done" in capsys.readouterr().out
 
 
 @patch("mempalace.cli.MempalaceConfig")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -690,6 +690,36 @@ def test_hooks_auto_save_env_override_true():
         del os.environ["MEMPALACE_HOOKS_AUTO_SAVE"]
 
 
+def test_hook_use_daemon_default_false(monkeypatch):
+    monkeypatch.delenv("MEMPALACE_HOOKS_DAEMON", raising=False)
+    cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+    assert cfg.hook_use_daemon is False
+
+
+def test_hook_use_daemon_from_config(monkeypatch, tmp_path):
+    monkeypatch.delenv("MEMPALACE_HOOKS_DAEMON", raising=False)
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump({"hooks": {"daemon": True}}, f)
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.hook_use_daemon is True
+
+
+def test_hook_use_daemon_string_config(monkeypatch, tmp_path):
+    monkeypatch.delenv("MEMPALACE_HOOKS_DAEMON", raising=False)
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump({"hooks": {"daemon": "yes"}}, f)
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.hook_use_daemon is True
+
+
+def test_hook_use_daemon_env_override(monkeypatch, tmp_path):
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump({"hooks": {"daemon": False}}, f)
+    monkeypatch.setenv("MEMPALACE_HOOKS_DAEMON", "yes")
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.hook_use_daemon is True
+
+
 # --- max_backups (backup retention) ---
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -98,38 +98,14 @@ def test_queue_dedupes_and_recovers_running_jobs(tmp_path, monkeypatch):
 
 
 def test_daemon_http_lifecycle_executes_job(tmp_path, monkeypatch):
-    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
-    palace = tmp_path / "palace"
-    palace.mkdir()
     calls = []
 
     def fake_execute(kind, payload):
         calls.append((kind, payload))
         return {"success": True, "exit_code": 0, "stdout": "done\n"}
 
-    monkeypatch.setattr(service, "execute_job", fake_execute)
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
 
-    thread = threading.Thread(
-        target=daemon.run_server,
-        kwargs={"palace_path": str(palace), "port": 0},
-        daemon=True,
-    )
-    thread.start()
-
-    client = None
-    # 30s: localhost bind is sub-second locally, but contended CI runners (notably
-    # the macOS GitHub Actions fleet) can take several seconds to bring the server
-    # up. A too-tight deadline here makes the test flake AND, because the server
-    # thread never shuts down on timeout, leaks env/umask into the rest of the
-    # suite (guarded by the _isolate_process_global_state fixture above).
-    deadline = time.monotonic() + 30
-    while time.monotonic() < deadline:
-        client = daemon.get_client_if_running(str(palace))
-        if client is not None:
-            break
-        time.sleep(0.05)
-
-    assert client is not None
     health = client.health()
     assert health["ok"] is True
     assert health["palace_path"] == daemon.canonical_palace_path(str(palace))
@@ -141,9 +117,7 @@ def test_daemon_http_lifecycle_executes_job(tmp_path, monkeypatch):
     assert finished["result"]["stdout"] == "done\n"
     assert calls == [("mine", {"source": "src", "palace_path": str(palace.resolve())})]
 
-    client.shutdown()
-    thread.join(timeout=5)
-    assert not thread.is_alive()
+    _stop_server(client, thread, holders)
 
 
 def test_submit_job_uses_client_and_waits(monkeypatch, tmp_path):
@@ -194,11 +168,64 @@ def test_service_tool_classification():
 # --- helpers for HTTP-lifecycle tests ---
 
 
+def _capture_httpd(monkeypatch):
+    """Capture the httpd instance run_server creates.
+
+    run_server defines a local ``class _Server(ThreadingHTTPServer)``; by
+    monkeypatching ``daemon.ThreadingHTTPServer`` before run_server runs, that
+    subclass inherits from a capturing base that records each instance. The
+    httpd can then be force-stopped from the test thread (see _stop_server) so a
+    slow/failed ``client.shutdown()`` POST can never leave the server thread
+    alive — which on Windows hangs the interpreter at process exit on an open
+    listening socket.
+    """
+    holders: list = []
+    base = daemon.ThreadingHTTPServer
+
+    class _CapturingServer(base):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            holders.append(self)
+
+    monkeypatch.setattr(daemon, "ThreadingHTTPServer", _CapturingServer)
+    return holders
+
+
+def _stop_server(client, thread, holders, *, join_timeout=5.0):
+    """Shut the daemon down deterministically and assert the thread died.
+
+    First try the normal path (POST /shutdown). If the server thread is still
+    alive afterwards — the POST was slow, lost, or the drain overran the join —
+    call httpd.shutdown() directly from this thread (stdlib-safe: it is a
+    different thread than serve_forever) to force serve_forever to return, then
+    re-join. The assert turns a leak into a visible failure instead of a silent
+    interpreter-exit hang.
+    """
+    try:
+        client.shutdown()
+    except Exception:  # noqa: BLE001 - best-effort; we force-shutdown below
+        pass
+    thread.join(timeout=join_timeout)
+    if thread.is_alive() and holders:
+        httpd = holders[-1]
+        try:
+            httpd.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            httpd.server_close()
+        except Exception:  # noqa: BLE001
+            pass
+        thread.join(timeout=join_timeout)
+    assert not thread.is_alive(), "daemon server thread did not shut down"
+
+
 def _start_server(tmp_path, monkeypatch, execute_fn):
     monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
     palace = tmp_path / "palace"
     palace.mkdir()
     monkeypatch.setattr(service, "execute_job", execute_fn)
+    holders = _capture_httpd(monkeypatch)
     thread = threading.Thread(
         target=daemon.run_server,
         kwargs={"palace_path": str(palace), "port": 0},
@@ -213,7 +240,7 @@ def _start_server(tmp_path, monkeypatch, execute_fn):
             break
         time.sleep(0.05)
     assert client is not None
-    return client, thread, palace
+    return client, thread, palace, holders
 
 
 # --- ship-blocker regressions ---
@@ -231,7 +258,7 @@ def test_systemexit_in_job_does_not_kill_worker(tmp_path, monkeypatch):
             raise SystemExit("boom")
         return {"success": True, "exit_code": 0}
 
-    client, thread, palace = _start_server(tmp_path, monkeypatch, fake_execute)
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
     try:
         first = client.submit("mine", {"source": "src"})
         finished_first = client.wait(first["id"], timeout=5)
@@ -244,9 +271,7 @@ def test_systemexit_in_job_does_not_kill_worker(tmp_path, monkeypatch):
         finished_second = client.wait(second["id"], timeout=5)
         assert finished_second["state"] == "succeeded"
     finally:
-        client.shutdown()
-        thread.join(timeout=5)
-    assert not thread.is_alive()
+        _stop_server(client, thread, holders)
 
 
 def test_shutdown_cancels_active_job(tmp_path, monkeypatch):
@@ -267,7 +292,7 @@ def test_shutdown_cancels_active_job(tmp_path, monkeypatch):
         return {"success": True, "exit_code": 0}
 
     monkeypatch.setattr(daemon, "SHUTDOWN_DRAIN_SECONDS", 0.2)
-    client, thread, palace = _start_server(tmp_path, monkeypatch, fake_execute)
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
     job = client.submit("mine", {"source": "src"}, dedupe_key="x")
     # Wait until the worker has claimed it (state flips to running).
     deadline = time.monotonic() + 5
@@ -277,9 +302,7 @@ def test_shutdown_cancels_active_job(tmp_path, monkeypatch):
         time.sleep(0.02)
     assert client.get_job(job["id"])["state"] == "running"
 
-    client.shutdown()
-    thread.join(timeout=5)
-    assert not thread.is_alive()
+    _stop_server(client, thread, holders)
 
     # The interrupted job must be cancelled (terminal), not left running.
     store = daemon.QueueStore(daemon.queue_path(str(palace)))
@@ -362,7 +385,9 @@ def test_health_rejects_missing_and_wrong_token(tmp_path, monkeypatch):
     from urllib import error as urlerror
     from urllib import request as urlrequest
 
-    client, thread, palace = _start_server(tmp_path, monkeypatch, lambda k, p: {"success": True})
+    client, thread, palace, holders = _start_server(
+        tmp_path, monkeypatch, lambda k, p: {"success": True}
+    )
     try:
         base = f"http://127.0.0.1:{client.port}"
         # No Authorization header → 401.
@@ -375,8 +400,7 @@ def test_health_rejects_missing_and_wrong_token(tmp_path, monkeypatch):
                 timeout=3,
             )
     finally:
-        client.shutdown()
-        thread.join(timeout=5)
+        _stop_server(client, thread, holders)
 
 
 def test_worker_overrides_client_palace_path(tmp_path, monkeypatch):
@@ -388,15 +412,14 @@ def test_worker_overrides_client_palace_path(tmp_path, monkeypatch):
         seen["palace_path"] = payload.get("palace_path")
         return {"success": True, "exit_code": 0}
 
-    client, thread, palace = _start_server(tmp_path, monkeypatch, fake_execute)
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
     try:
         job = client.submit(
             "mine", {"source": "src", "palace_path": "/tmp/other-palace"}, dedupe_key="p"
         )
         client.wait(job["id"], timeout=5)
     finally:
-        client.shutdown()
-        thread.join(timeout=5)
+        _stop_server(client, thread, holders)
     assert seen["palace_path"] == daemon.canonical_palace_path(str(palace))
     assert seen["palace_path"] != "/tmp/other-palace"
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -7,6 +7,15 @@ import pytest
 from mempalace import daemon
 from mempalace import service
 
+# POSIX file-mode bits (0600/0700) are not representable on Windows: os.chmod
+# can only toggle the read-only attribute, so a "private" file still reports
+# 0o666. The daemon relies on the user-profile directory ACLs for privacy
+# there, so the owner-only assertions only make sense on POSIX.
+_posix_only_perms = pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX 0600/0700 file-mode bits are not representable on Windows (ACL-based privacy)",
+)
+
 # Env keys run_server mutates from its background thread, plus umask. If a
 # lifecycle test times out before the server comes up, run_server's finally
 # never runs and those mutations leak into the rest of the suite — every later
@@ -226,20 +235,35 @@ def _start_server(tmp_path, monkeypatch, execute_fn):
     palace.mkdir()
     monkeypatch.setattr(service, "execute_job", execute_fn)
     holders = _capture_httpd(monkeypatch)
-    thread = threading.Thread(
-        target=daemon.run_server,
-        kwargs={"palace_path": str(palace), "port": 0},
-        daemon=True,
-    )
+
+    # Capture any exception run_server raises in its thread. Without this a
+    # startup crash is invisible: the poll below would just spin for 30s and
+    # fail with a bare ``assert client is not None`` giving no cause.
+    server_error: list = []
+
+    def _serve():
+        try:
+            daemon.run_server(palace_path=str(palace), port=0)
+        except BaseException as exc:  # noqa: BLE001 - re-surfaced to the test thread
+            server_error.append(exc)
+
+    thread = threading.Thread(target=_serve, name="test-daemon-server", daemon=True)
     thread.start()
     client = None
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
+        if server_error:
+            raise AssertionError(f"run_server crashed during startup: {server_error[0]!r}")
         client = daemon.get_client_if_running(str(palace))
         if client is not None:
             break
         time.sleep(0.05)
-    assert client is not None
+    if client is None:
+        raise AssertionError(
+            "daemon did not become ready within 30s "
+            f"(thread_alive={thread.is_alive()}, httpd_bound={bool(holders)}, "
+            f"endpoint_exists={daemon.endpoint_path(str(palace)).exists()})"
+        )
     return client, thread, palace, holders
 
 
@@ -356,6 +380,7 @@ def test_claim_next_does_not_reclaim_running_job(tmp_path, monkeypatch):
     assert store.claim_next() is None
 
 
+@_posix_only_perms
 def test_queue_db_file_is_owner_only(tmp_path, monkeypatch):
     """The queue DB holds verbatim payloads — it must be 0600, not the sqlite
     default 0644. Regression for the privacy-principle violation."""
@@ -370,6 +395,7 @@ def test_queue_db_file_is_owner_only(tmp_path, monkeypatch):
     assert mode == 0o600, f"queue.sqlite3 is {oct(mode)}, expected 0600"
 
 
+@_posix_only_perms
 def test_token_file_is_owner_only(tmp_path, monkeypatch):
     import os as _os
 
@@ -476,6 +502,40 @@ def test_daemon_client_raises_on_endpoint_missing_port(tmp_path, monkeypatch):
 
     with pytest.raises(daemon.DaemonError):
         daemon.DaemonClient(str(palace))
+
+
+def test_pid_alive_probe_is_signal_free_and_correct():
+    """``_pid_alive`` must be a pure liveness probe.
+
+    On Windows ``os.kill(pid, 0)`` is NOT harmless — signal 0 is
+    ``CTRL_C_EVENT``, so it emits a console Ctrl-C to the target's process
+    group. The daemon client polls a same-process endpoint, so that Ctrl-C was
+    delivered back to the interpreter and surfaced as a spurious
+    ``KeyboardInterrupt`` that hung the whole test session on CI runners (which,
+    unlike a detached dev shell, have an attached console). Assert the probe is
+    both correct and emits no SIGINT even when hammered like the poll loop.
+    """
+    import signal
+
+    assert daemon._pid_alive(os.getpid()) is True
+    assert daemon._pid_alive(0) is False
+    assert daemon._pid_alive(-1) is False
+    # A pid that is almost certainly not running.
+    assert daemon._pid_alive(2_000_000_000) is False
+
+    # pytest runs tests on the main thread, so installing a SIGINT handler is
+    # allowed. If the probe regresses to os.kill(pid, 0) on Windows, the repeated
+    # calls below deliver CTRL_C_EVENT and this handler fires.
+    fired = []
+    previous = signal.getsignal(signal.SIGINT)
+    signal.signal(signal.SIGINT, lambda *_: fired.append(1))
+    try:
+        for _ in range(25):
+            daemon._pid_alive(os.getpid())
+        time.sleep(0.25)
+    finally:
+        signal.signal(signal.SIGINT, previous)
+    assert fired == [], "_pid_alive delivered a console control event (CTRL_C_EVENT)"
 
 
 def test_start_daemon_kills_orphan_on_readiness_timeout(tmp_path, monkeypatch):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,3 +1,4 @@
+import os
 import threading
 import time
 
@@ -5,6 +6,37 @@ import pytest
 
 from mempalace import daemon
 from mempalace import service
+
+# Env keys run_server mutates from its background thread, plus umask. If a
+# lifecycle test times out before the server comes up, run_server's finally
+# never runs and those mutations leak into the rest of the suite — every later
+# test that reads MempalaceConfig().palace_path sees a stale deleted tmp path and
+# fails (the 60+ test cascade seen on slow CI runners). The fixtures below force a
+# clean baseline around every daemon test so a leaked thread can't poison the
+# process for tests/test_mcp_server.py and friends (which have no such guard).
+_LEAK_ENV_KEYS = ("MEMPALACE_PALACE_PATH", "MEMPALACE_BACKEND", "MEMPALACE_BACKEND_EXPLICIT")
+
+
+@pytest.fixture(scope="module")
+def _clean_env_snapshot():
+    """Capture the true pre-suite values once, before any daemon test runs."""
+    return {key: os.environ.get(key) for key in _LEAK_ENV_KEYS}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_process_global_state(_clean_env_snapshot):
+    """Restore the process-global env + umask to the pre-suite baseline after every
+    daemon test, even if a leaked run_server thread is still holding them mutated.
+    """
+    prev_umask = os.umask(0o022)
+    os.umask(prev_umask)  # read current umask without changing it
+    yield
+    for key, value in _clean_env_snapshot.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    os.umask(prev_umask)
 
 
 def _raise_not_ready(*a, **kw):
@@ -85,7 +117,12 @@ def test_daemon_http_lifecycle_executes_job(tmp_path, monkeypatch):
     thread.start()
 
     client = None
-    deadline = time.monotonic() + 10
+    # 30s: localhost bind is sub-second locally, but contended CI runners (notably
+    # the macOS GitHub Actions fleet) can take several seconds to bring the server
+    # up. A too-tight deadline here makes the test flake AND, because the server
+    # thread never shuts down on timeout, leaks env/umask into the rest of the
+    # suite (guarded by the _isolate_process_global_state fixture above).
+    deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         client = daemon.get_client_if_running(str(palace))
         if client is not None:
@@ -169,7 +206,7 @@ def _start_server(tmp_path, monkeypatch, execute_fn):
     )
     thread.start()
     client = None
-    deadline = time.monotonic() + 10
+    deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         client = daemon.get_client_if_running(str(palace))
         if client is not None:
@@ -455,3 +492,176 @@ def test_start_daemon_kills_orphan_on_readiness_timeout(tmp_path, monkeypatch):
     with pytest.raises(daemon.DaemonError):
         daemon.start_daemon(str(palace), timeout=0.05)
     assert fake.killed is True
+
+
+# --- service.run_* happy-path coverage ---
+# These close the draft PR's follow-up ("Add focused happy-path tests for
+# service.run_mine / run_diary_write / run_mcp_tool") and, now that the daemon
+# tests complete reliably, keep service.py's coverage above the CI gate. The
+# capsys-using tests come first; the two that import mempalace.mcp_server (which
+# rebinds sys.stdout) come last and do not use capsys, so the rebind can't break
+# capture in this file or later files (capsys activates after the rebind).
+
+
+def test_print_job_result_replays_stdout_stderr_and_returns_exit_code(capsys):
+    from mempalace import service
+
+    code = service.print_job_result(
+        {"success": False, "error": "boom", "stdout": "out\n", "stderr": "err\n", "exit_code": 3}
+    )
+    assert code == 3
+    captured = capsys.readouterr()
+    assert "out" in captured.out
+    assert "err" in captured.err
+
+
+def test_print_job_result_prints_error_to_stderr_when_no_stderr(capsys):
+    from mempalace import service
+
+    code = service.print_job_result({"success": False, "error": "boom", "exit_code": 1})
+    assert code == 1
+    captured = capsys.readouterr()
+    assert "mempalace: boom" in captured.err
+
+
+def test_run_sync_returns_success_when_palace_dir_missing(tmp_path):
+    from mempalace import service
+
+    result = service.run_sync({"palace_path": str(tmp_path / "nope"), "dry_run": True})
+    assert result["success"] is True
+    assert result["exit_code"] == 0
+
+
+def test_run_sync_returns_success_when_palace_has_no_backend_artifact(tmp_path):
+    from mempalace import service
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    result = service.run_sync({"palace_path": str(palace), "dry_run": True})
+    assert result["success"] is True
+    assert result["exit_code"] == 0
+
+
+def test_run_mine_invalid_mode_returns_structured_error(tmp_path):
+    from mempalace import service
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    out = service.run_mine({"palace_path": str(palace), "mode": "bogus"})
+    assert out["success"] is False
+    assert "invalid mine mode" in out["error"]
+    assert out["exit_code"] == 2
+
+
+def test_run_mcp_tool_rejects_non_dict_arguments():
+    from mempalace import service
+
+    out = service.run_mcp_tool({"name": "mempalace_add_drawer", "arguments": "nope"})
+    assert out["success"] is False
+    assert "must be an object" in out["error"]
+    assert out["exit_code"] == 2
+
+
+def test_run_mcp_tool_dispatches_write_tool(monkeypatch):
+    import mempalace.mcp_server as mcp
+    from mempalace import service
+
+    captured = {}
+
+    def fake_handler(**arguments):
+        captured["arguments"] = arguments
+        return {"success": True, "written": True}
+
+    monkeypatch.setattr(mcp, "TOOLS", {"mempalace_add_drawer": {"handler": fake_handler}})
+    out = service.run_mcp_tool({"name": "mempalace_add_drawer", "arguments": {"x": 1}})
+    assert out["success"] is True
+    assert out["written"] is True
+    assert out["exit_code"] == 0
+    assert captured["arguments"] == {"x": 1}
+
+
+def test_run_diary_write_forwards_args_and_sets_exit_code(monkeypatch):
+    import mempalace.mcp_server as mcp
+    from mempalace import service
+
+    captured = {}
+
+    def fake_diary(agent_name, entry, topic, wing):
+        captured.update(agent_name=agent_name, entry=entry, topic=topic, wing=wing)
+        return {"success": True}
+
+    monkeypatch.setattr(mcp, "tool_diary_write", fake_diary)
+    out = service.run_diary_write(
+        {"agent_name": "alice", "entry": "hello", "topic": "t", "wing": "w"}
+    )
+    assert out["success"] is True
+    assert out["exit_code"] == 0
+    assert captured == {"agent_name": "alice", "entry": "hello", "topic": "t", "wing": "w"}
+
+
+def test_run_mine_applies_backend_before_mode_validation(tmp_path):
+    """Covers _apply_backend (env set + get_backend_class validation) on the daemon
+    path; the invalid mode short-circuits before any mining runs."""
+    from mempalace import service
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    out = service.run_mine({"palace_path": str(palace), "mode": "bogus", "backend": "chroma"})
+    assert out["success"] is False
+    assert out["exit_code"] == 2
+
+
+def test_execute_job_dispatches_diary_write_mcp_tool_and_unknown(monkeypatch):
+    """Covers execute_job's kind dispatch for diary_write, mcp_tool, and the
+    unknown-kind fallback."""
+    import mempalace.mcp_server as mcp
+    from mempalace import service
+
+    monkeypatch.setattr(mcp, "tool_diary_write", lambda **kw: {"success": True})
+    monkeypatch.setattr(
+        mcp, "TOOLS", {"mempalace_add_drawer": {"handler": lambda **kw: {"success": True}}}
+    )
+    assert service.execute_job("diary_write", {"entry": "x"})["success"] is True
+    assert (
+        service.execute_job("mcp_tool", {"name": "mempalace_add_drawer", "arguments": {}})[
+            "success"
+        ]
+        is True
+    )
+    unknown = service.execute_job("bogus_kind", {})
+    assert unknown["success"] is False
+    assert unknown["exit_code"] == 2
+
+
+def test_run_sync_structured_errors_on_sync_failures(tmp_path, monkeypatch):
+    """Covers run_sync's three exception handlers (MineAlreadyRunning, ValueError,
+    generic Exception) so a failing sync_palace returns a structured error instead
+    of propagating."""
+    import mempalace.sync as sync_module
+    from mempalace import service
+    from mempalace.palace import MineAlreadyRunning
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    (palace / "chroma.sqlite3").touch()
+
+    def _raise(exc):
+        def fn(**kw):
+            raise exc
+
+        return fn
+
+    monkeypatch.setattr(sync_module, "sync_palace", _raise(MineAlreadyRunning("locked")))
+    r = service.run_sync({"palace_path": str(palace), "dry_run": True})
+    assert r["success"] is False
+    assert r["error_class"] == "LockHeldByOtherProcess"
+
+    monkeypatch.setattr(sync_module, "sync_palace", _raise(ValueError("bad scope")))
+    r = service.run_sync({"palace_path": str(palace), "dry_run": True})
+    assert r["success"] is False
+    assert r["exit_code"] == 2
+
+    monkeypatch.setattr(sync_module, "sync_palace", _raise(RuntimeError("boom")))
+    r = service.run_sync({"palace_path": str(palace), "dry_run": True})
+    assert r["success"] is False
+    assert "sync failed" in r["error"]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,457 @@
+import threading
+import time
+
+import pytest
+
+from mempalace import daemon
+from mempalace import service
+
+
+def _raise_not_ready(*a, **kw):
+    """Stand-in for DaemonClient when the spawned daemon must never come up."""
+    raise daemon.DaemonError("not ready")
+
+
+def test_prune_terminal_drops_old_terminal_jobs_keeps_active(tmp_path, monkeypatch):
+    """Terminal jobs older than the retention window are pruned; queued/running
+    and fresh terminal jobs are untouched. Bounded queue growth for the DB that
+    holds verbatim payloads."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+
+    old_term = store.enqueue("mine", {"source": "old"})
+    store.finish(old_term.id, state="succeeded", result={"success": True})
+    fresh_term = store.enqueue("mine", {"source": "fresh"})
+    store.finish(fresh_term.id, state="succeeded", result={"success": True})
+    queued = store.enqueue("mine", {"source": "queued"})
+
+    from datetime import datetime, timedelta, timezone
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    with store._lock, store._connect() as conn:
+        conn.execute(
+            "UPDATE jobs SET finished_at = ? WHERE id = ?",
+            (cutoff, old_term.id),
+        )
+
+    pruned = store.prune_terminal(older_than_days=7)
+    assert pruned == 1
+    # The old terminal job is gone; the fresh terminal and queued jobs survive.
+    with pytest.raises(daemon.DaemonError):
+        store.get(old_term.id)
+    assert store.get(fresh_term.id).state == "succeeded"
+    assert store.get(queued.id).state == "queued"
+
+
+def test_queue_dedupes_and_recovers_running_jobs(tmp_path, monkeypatch):
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    first = store.enqueue("mine", {"source": "a"}, dedupe_key="same")
+    second = store.enqueue("mine", {"source": "a"}, dedupe_key="same")
+
+    assert second.id == first.id
+
+    claimed = store.claim_next()
+    assert claimed.id == first.id
+    assert claimed.state == "running"
+
+    recovered = store.recover_running()
+    assert recovered == 1
+    assert store.get(first.id).state == "queued"
+
+
+def test_daemon_http_lifecycle_executes_job(tmp_path, monkeypatch):
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    calls = []
+
+    def fake_execute(kind, payload):
+        calls.append((kind, payload))
+        return {"success": True, "exit_code": 0, "stdout": "done\n"}
+
+    monkeypatch.setattr(service, "execute_job", fake_execute)
+
+    thread = threading.Thread(
+        target=daemon.run_server,
+        kwargs={"palace_path": str(palace), "port": 0},
+        daemon=True,
+    )
+    thread.start()
+
+    client = None
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        client = daemon.get_client_if_running(str(palace))
+        if client is not None:
+            break
+        time.sleep(0.05)
+
+    assert client is not None
+    health = client.health()
+    assert health["ok"] is True
+    assert health["palace_path"] == daemon.canonical_palace_path(str(palace))
+
+    job = client.submit("mine", {"source": "src"}, dedupe_key="job")
+    finished = client.wait(job["id"], timeout=5)
+
+    assert finished["state"] == "succeeded"
+    assert finished["result"]["stdout"] == "done\n"
+    assert calls == [("mine", {"source": "src", "palace_path": str(palace.resolve())})]
+
+    client.shutdown()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+
+
+def test_submit_job_uses_client_and_waits(monkeypatch, tmp_path):
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    class DummyClient:
+        def __init__(self):
+            self.submitted = None
+
+        def submit(self, kind, payload, dedupe_key=None, priority=0):
+            self.submitted = (kind, payload, dedupe_key, priority)
+            return {"id": "job-1", "state": "queued"}
+
+        def wait(self, job_id, timeout=daemon.DEFAULT_WAIT_TIMEOUT):
+            assert job_id == "job-1"
+            return {
+                "id": "job-1",
+                "state": "succeeded",
+                "result": {"success": True, "exit_code": 0},
+            }
+
+    dummy = DummyClient()
+    monkeypatch.setattr(daemon, "ensure_client", lambda *a, **kw: dummy)
+
+    job = daemon.submit_job(
+        "mine",
+        {"source": "src"},
+        palace_path=str(palace),
+        dedupe_key="dedupe",
+        wait=True,
+    )
+
+    assert job["state"] == "succeeded"
+    assert dummy.submitted[0] == "mine"
+    # palace_path is overridden (not trusted from the payload), never appended.
+    assert dummy.submitted[1]["palace_path"] == daemon.canonical_palace_path(str(palace))
+    assert dummy.submitted[2] == "dedupe"
+
+
+def test_service_tool_classification():
+    assert service.classify_tool("mempalace_search") == "read"
+    assert service.classify_tool("mempalace_add_drawer") == "write"
+    assert service.classify_tool("mempalace_mine") == "maintenance"
+    assert service.classify_tool("unknown") == "unknown"
+
+
+# --- helpers for HTTP-lifecycle tests ---
+
+
+def _start_server(tmp_path, monkeypatch, execute_fn):
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    monkeypatch.setattr(service, "execute_job", execute_fn)
+    thread = threading.Thread(
+        target=daemon.run_server,
+        kwargs={"palace_path": str(palace), "port": 0},
+        daemon=True,
+    )
+    thread.start()
+    client = None
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        client = daemon.get_client_if_running(str(palace))
+        if client is not None:
+            break
+        time.sleep(0.05)
+    assert client is not None
+    return client, thread, palace
+
+
+# --- ship-blocker regressions ---
+
+
+def test_systemexit_in_job_does_not_kill_worker(tmp_path, monkeypatch):
+    """A SystemExit (BaseException, not Exception) must be caught, the job
+    marked failed, and the worker kept alive for the next job. Regression for
+    the critical worker-death bug."""
+    state = {"first": True}
+
+    def fake_execute(kind, payload):
+        if state["first"]:
+            state["first"] = False
+            raise SystemExit("boom")
+        return {"success": True, "exit_code": 0}
+
+    client, thread, palace = _start_server(tmp_path, monkeypatch, fake_execute)
+    try:
+        first = client.submit("mine", {"source": "src"})
+        finished_first = client.wait(first["id"], timeout=5)
+        assert finished_first["state"] == "failed"
+        assert finished_first["error"]["error_class"] == "SystemExit"
+
+        # Worker must still be alive — health reports it and a second job runs.
+        assert client.health()["worker_alive"] is True
+        second = client.submit("mine", {"source": "src2"})
+        finished_second = client.wait(second["id"], timeout=5)
+        assert finished_second["state"] == "succeeded"
+    finally:
+        client.shutdown()
+        thread.join(timeout=5)
+    assert not thread.is_alive()
+
+
+def test_shutdown_cancels_active_job(tmp_path, monkeypatch):
+    """POST /shutdown must not leave an in-flight job 'running' for blind
+    re-queue on next start. The worker is drained (bounded), then the active
+    job is marked 'cancelled' so recover_running won't re-run it.
+
+    In production the serve process exits immediately after run_server returns,
+    killing the daemon worker thread before it can overwrite the cancelled
+    state. The test mirrors that by asserting the cancelled state *before*
+    releasing the blocked worker.
+    """
+    block = threading.Event()
+
+    def fake_execute(kind, payload):
+        # Simulate a long-running job that never finishes on its own.
+        block.wait(30)
+        return {"success": True, "exit_code": 0}
+
+    monkeypatch.setattr(daemon, "SHUTDOWN_DRAIN_SECONDS", 0.2)
+    client, thread, palace = _start_server(tmp_path, monkeypatch, fake_execute)
+    job = client.submit("mine", {"source": "src"}, dedupe_key="x")
+    # Wait until the worker has claimed it (state flips to running).
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if client.get_job(job["id"])["state"] == "running":
+            break
+        time.sleep(0.02)
+    assert client.get_job(job["id"])["state"] == "running"
+
+    client.shutdown()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+
+    # The interrupted job must be cancelled (terminal), not left running.
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    final = store.get(job["id"])
+    assert final.state == "cancelled"
+    # And recover_running must not re-queue a cancelled job.
+    assert store.recover_running() == 0
+
+    # Release the blocked worker so it (and the daemon thread) can exit.
+    block.set()
+
+
+def test_recover_running_dead_letters_exhausted_jobs(tmp_path, monkeypatch):
+    """A job that has crashed MAX_ATTEMPTS times must be dead-lettered to
+    'failed', not re-queued — non-idempotent kinds (diary_write) would
+    otherwise duplicate verbatim content on every restart."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    job = store.enqueue("diary_write", {"entry": "x"})
+    # Simulate MAX_ATTEMPTS claims that each crashed (running, attempts=MAX).
+    with store._lock, store._connect() as conn:
+        conn.execute(
+            "UPDATE jobs SET state='running', attempts=? WHERE id=?",
+            (daemon.MAX_ATTEMPTS, job.id),
+        )
+
+    recovered = store.recover_running()
+    assert recovered == 0  # not re-queued
+    final = store.get(job.id)
+    assert final.state == "failed"
+    assert final.attempts == daemon.MAX_ATTEMPTS
+
+
+def test_claim_next_does_not_reclaim_running_job(tmp_path, monkeypatch):
+    """The conditional UPDATE (WHERE state='queued') means a job already
+    flipped to 'running' cannot be claimed again — the cross-process
+    double-execution guard."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    job = store.enqueue("mine", {"source": "src"})
+    first = store.claim_next()
+    assert first.id == job.id
+    # Manually re-mark it queued but leave a second claim attempt: claim_next
+    # should still only ever return one running job per claim. After finishing
+    # the first, the next claim returns None (queue empty).
+    store.finish(first.id, state="succeeded", result={"success": True})
+    assert store.claim_next() is None
+
+
+def test_queue_db_file_is_owner_only(tmp_path, monkeypatch):
+    """The queue DB holds verbatim payloads — it must be 0600, not the sqlite
+    default 0644. Regression for the privacy-principle violation."""
+    import os as _os
+
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    store.enqueue("diary_write", {"entry": "secret verbatim content"})
+    mode = _os.stat(str(store.path)).st_mode & 0o777
+    assert mode == 0o600, f"queue.sqlite3 is {oct(mode)}, expected 0600"
+
+
+def test_token_file_is_owner_only(tmp_path, monkeypatch):
+    import os as _os
+
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    daemon.ensure_token(str(palace))
+    token_path = daemon.state_dir(str(palace)) / "token"
+    assert (_os.stat(str(token_path)).st_mode & 0o777) == 0o600
+
+
+def test_health_rejects_missing_and_wrong_token(tmp_path, monkeypatch):
+    from urllib import error as urlerror
+    from urllib import request as urlrequest
+
+    client, thread, palace = _start_server(tmp_path, monkeypatch, lambda k, p: {"success": True})
+    try:
+        base = f"http://127.0.0.1:{client.port}"
+        # No Authorization header → 401.
+        with pytest.raises(urlerror.HTTPError):
+            urlrequest.urlopen(urlrequest.Request(base + "/health"), timeout=3)
+        # Wrong token → 401.
+        with pytest.raises(urlerror.HTTPError):
+            urlrequest.urlopen(
+                urlrequest.Request(base + "/health", headers={"Authorization": "Bearer wrong"}),
+                timeout=3,
+            )
+    finally:
+        client.shutdown()
+        thread.join(timeout=5)
+
+
+def test_worker_overrides_client_palace_path(tmp_path, monkeypatch):
+    """An authenticated client must not be able to retarget the daemon at a
+    different palace by stuffing palace_path into the payload."""
+    seen = {}
+
+    def fake_execute(kind, payload):
+        seen["palace_path"] = payload.get("palace_path")
+        return {"success": True, "exit_code": 0}
+
+    client, thread, palace = _start_server(tmp_path, monkeypatch, fake_execute)
+    try:
+        job = client.submit(
+            "mine", {"source": "src", "palace_path": "/tmp/other-palace"}, dedupe_key="p"
+        )
+        client.wait(job["id"], timeout=5)
+    finally:
+        client.shutdown()
+        thread.join(timeout=5)
+    assert seen["palace_path"] == daemon.canonical_palace_path(str(palace))
+    assert seen["palace_path"] != "/tmp/other-palace"
+
+
+def test_mcp_tool_allowlist_rejects_non_write_tools(tmp_path, monkeypatch):
+    """The daemon queue is a durable write surface; read/maintenance/unknown
+    tools must be rejected so verbatim content can't be exfiltrated into the
+    queue or retried destructively."""
+    # read tool → rejected
+    out = service.run_mcp_tool({"name": "mempalace_search", "arguments": {}})
+    assert out["success"] is False
+    assert "only accepts write tools" in out["error"]
+    # maintenance tool → rejected (has its own kinds: mine/sync)
+    out = service.run_mcp_tool({"name": "mempalace_mine", "arguments": {}})
+    assert out["success"] is False
+    # unknown tool → rejected
+    out = service.run_mcp_tool({"name": "mempalace_bogus", "arguments": {}})
+    assert out["success"] is False
+    # write tool → passes the allowlist (handler not called here since TOOLS
+    # won't have it under the test name; but classification must let it through)
+    assert service.classify_tool("mempalace_add_drawer") == "write"
+
+
+def test_execute_job_isolates_env_per_job(monkeypatch):
+    """A job that mutates MEMPALACE_BACKEND must not leak into the next job's
+    env. Regression for the per-job isolation bug (_apply_backend poisoning)."""
+    import os as _os
+
+    monkeypatch.delenv("MEMPALACE_BACKEND", raising=False)
+    monkeypatch.delenv("MEMPALACE_PALACE_PATH", raising=False)
+
+    def fake_mine(payload):
+        _os.environ["MEMPALACE_BACKEND"] = "leaked-backend"
+        return {"success": True, "exit_code": 0}
+
+    monkeypatch.setattr(service, "run_mine", fake_mine)
+    service.execute_job("mine", {"palace_path": "/tmp/p", "source": "s"})
+    assert _os.environ.get("MEMPALACE_BACKEND") is None
+
+
+def test_daemon_client_raises_on_endpoint_missing_port(tmp_path, monkeypatch):
+    """A malformed endpoint.json must raise DaemonError, not a bare KeyError."""
+    import json as _json
+
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    daemon.ensure_token(str(palace))
+    # endpoint with no port
+    daemon.state_dir(str(palace)).mkdir(parents=True, exist_ok=True)
+    (daemon.state_dir(str(palace)) / "endpoint.json").write_text(
+        _json.dumps({"host": "127.0.0.1", "pid": 1}) + "\n", encoding="utf-8"
+    )
+
+    with pytest.raises(daemon.DaemonError):
+        daemon.DaemonClient(str(palace))
+
+
+def test_start_daemon_kills_orphan_on_readiness_timeout(tmp_path, monkeypatch):
+    """If the spawned daemon never becomes ready, start_daemon must kill and
+    reap the orphaned subprocess rather than leaking it with the port/token."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    daemon.ensure_token(str(palace))
+
+    monkeypatch.setattr(daemon, "get_client_if_running", lambda *a, **kw: None)
+
+    class FakeProc:
+        def __init__(self):
+            self.killed = False
+            self.returncode = None
+
+        def poll(self):
+            return self.returncode  # None == still alive
+
+        def kill(self):
+            self.killed = True
+
+        def wait(self):
+            self.returncode = -9
+            return self.returncode
+
+    fake = FakeProc()
+
+    def fake_popen(*a, **kw):
+        return fake
+
+    monkeypatch.setattr(daemon.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(daemon, "DaemonClient", _raise_not_ready)
+    monkeypatch.setattr(daemon.time, "sleep", lambda *a, **kw: None)
+
+    with pytest.raises(daemon.DaemonError):
+        daemon.start_daemon(str(palace), timeout=0.05)
+    assert fake.killed is True

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -16,6 +16,7 @@ from mempalace.hooks_cli import (
     _diary_agent_for_harness,
     _extract_recent_messages,
     _get_mine_targets,
+    _hooks_daemon_enabled,
     _log,
     _maybe_auto_ingest,
     _mempalace_python,
@@ -467,6 +468,45 @@ def test_stop_hook_checkpoint_visible_to_diary_read(monkeypatch, config, palace_
     assert legacy.get("entries") == []
 
 
+def test_save_diary_direct_daemon_opt_in_submits_job(tmp_path):
+    transcript = tmp_path / "session.jsonl"
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"message {i}"}} for i in range(3)],
+    )
+    env = {"MEMPALACE_HOOKS_DAEMON": "yes", "MEMPALACE_PALACE_PATH": str(palace_dir)}
+    job = {"id": "job", "state": "succeeded", "result": {"success": True, "entry_id": "e1"}}
+
+    with patch.dict("os.environ", env):
+        with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
+            with patch("mempalace.hooks_cli._daemon_available", return_value=True):
+                with patch("mempalace.daemon.submit_job", return_value=job) as mock_submit:
+                    result = _save_diary_direct(
+                        str(transcript),
+                        "sess1",
+                        wing="wing_project",
+                        agent_name="claude",
+                    )
+
+    assert result["count"] == 3
+    mock_submit.assert_called_once()
+    assert mock_submit.call_args.args[0] == "diary_write"
+    payload = mock_submit.call_args.args[1]
+    assert payload["agent_name"] == "claude"
+    assert payload["wing"] == "wing_project"
+    assert payload["topic"] == "checkpoint"
+    assert (tmp_path / "last_checkpoint").exists()
+
+
+def test_hooks_daemon_enabled_requires_explicit_true():
+    with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
+        assert _hooks_daemon_enabled() is False
+        mock_cfg_cls.return_value.hook_use_daemon = True
+        assert _hooks_daemon_enabled() is True
+
+
 # --- hook_session_start ---
 
 
@@ -786,6 +826,33 @@ def test_maybe_auto_ingest_with_env(tmp_path):
                     assert "mine" in cmd
                     assert str(mempal_dir.resolve()) in cmd
                     assert cmd[cmd.index("--mode") + 1] == "projects"
+
+
+def test_maybe_auto_ingest_daemon_opt_in_submits_job(tmp_path):
+    """Daemon-enabled hooks submit a background mine instead of spawning one."""
+    mempal_dir = tmp_path / "project"
+    palace_dir = tmp_path / "palace"
+    mempal_dir.mkdir()
+    palace_dir.mkdir()
+    env = {
+        "MEMPAL_DIR": str(mempal_dir),
+        "MEMPALACE_HOOKS_DAEMON": "yes",
+        "MEMPALACE_PALACE_PATH": str(palace_dir),
+    }
+    with patch.dict("os.environ", env):
+        with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
+            with patch("mempalace.hooks_cli._daemon_available", return_value=True):
+                with patch("mempalace.hooks_cli.subprocess.Popen") as mock_popen:
+                    with patch(
+                        "mempalace.daemon.submit_job", return_value={"id": "job"}
+                    ) as mock_submit:
+                        _maybe_auto_ingest()
+
+    mock_popen.assert_not_called()
+    mock_submit.assert_called_once()
+    assert mock_submit.call_args.args[0] == "mine"
+    assert mock_submit.call_args.args[1]["source"] == str(mempal_dir.resolve())
+    assert mock_submit.call_args.kwargs["wait"] is False
 
 
 def test_maybe_auto_ingest_uses_mempalace_python(tmp_path):
@@ -1112,6 +1179,31 @@ def test_ingest_transcript_uses_detached_kwargs(tmp_path):
                 kwargs = mock_popen.call_args.kwargs
                 assert kwargs.get("stdin") is subprocess.DEVNULL
                 assert kwargs.get("close_fds") is True
+
+
+def test_ingest_transcript_daemon_opt_in_submits_job(tmp_path):
+    transcript = tmp_path / "session.jsonl"
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    transcript.write_text("x" * 200)
+    env = {"MEMPALACE_HOOKS_DAEMON": "yes", "MEMPALACE_PALACE_PATH": str(palace_dir)}
+    with patch.dict("os.environ", env):
+        with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
+            with patch("mempalace.hooks_cli._daemon_available", return_value=True):
+                with patch("mempalace.hooks_cli.subprocess.Popen") as mock_popen:
+                    with patch(
+                        "mempalace.daemon.submit_job", return_value={"id": "job"}
+                    ) as mock_submit:
+                        from mempalace.hooks_cli import _ingest_transcript
+
+                        _ingest_transcript(str(transcript))
+
+    mock_popen.assert_not_called()
+    mock_submit.assert_called_once()
+    payload = mock_submit.call_args.args[1]
+    assert payload["source"] == str(tmp_path)
+    assert payload["mode"] == "convos"
+    assert payload["wing"] == "sessions"
 
 
 def test_ingest_transcript_skips_when_target_running(tmp_path):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -11,12 +11,6 @@ from pathlib import Path
 import chromadb
 import pytest
 
-# run_sync imports mempalace.mcp_server lazily; that import initializes the
-# embedder, which rebinds sys.stdout and defeats capsys/redirect_stdout for any
-# prints after sync_palace returns. Importing it here makes the lazy import a
-# cached no-op so the daemon-path report tests can capture run_sync's output.
-import mempalace.mcp_server  # noqa: F401
-
 
 def _seed_drawers(palace_path, repo_path, deleted_path, elsewhere_path):
     """Populate the drawers collection with 6 entries covering all buckets."""
@@ -1415,6 +1409,18 @@ class TestServiceRunSyncReport:
     formatting — opening the real Chroma collection reinitializes the embedder,
     which disturbs sys.stdout and defeats capsys.
     """
+
+    @pytest.fixture(autouse=True)
+    def _cache_mcp_server_import(self):
+        """run_sync lazily imports mempalace.mcp_server, whose import initializes
+        the embedder and rebinds sys.stdout — defeating capsys for any prints
+        after sync_palace returns. Lazy-load it here, scoped to just these report
+        tests (not the whole module at collection time), so the import is a cached
+        no-op by the time run_sync runs and its report output stays capturable.
+        """
+        import mempalace.mcp_server  # noqa: F401
+
+        yield
 
     def _fake_report(self, **overrides):
         report = {

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -11,6 +11,12 @@ from pathlib import Path
 import chromadb
 import pytest
 
+# run_sync imports mempalace.mcp_server lazily; that import initializes the
+# embedder, which rebinds sys.stdout and defeats capsys/redirect_stdout for any
+# prints after sync_palace returns. Importing it here makes the lazy import a
+# cached no-op so the daemon-path report tests can capture run_sync's output.
+import mempalace.mcp_server  # noqa: F401
+
 
 def _seed_drawers(palace_path, repo_path, deleted_path, elsewhere_path):
     """Populate the drawers collection with 6 entries covering all buckets."""
@@ -1397,3 +1403,81 @@ class TestSyncCli:
         with pytest.raises(SystemExit) as exc_info:
             cli.main()
         assert exc_info.value.code == 2
+
+
+class TestServiceRunSyncReport:
+    """Daemon path (service.run_sync) must render the same report shape as the
+    direct CLI path, with no KeyError on report['deleted'] (regression: the old
+    code read a non-existent 'deleted' key and dropped no_source/out_of_scope/
+    by_source and the Re-run/Removed hints).
+
+    sync_palace is mocked so the test exercises only run_sync's report
+    formatting — opening the real Chroma collection reinitializes the embedder,
+    which disturbs sys.stdout and defeats capsys.
+    """
+
+    def _fake_report(self, **overrides):
+        report = {
+            "scanned": 6,
+            "kept": 1,
+            "gitignored": 2,
+            "missing": 1,
+            "no_source": 1,
+            "out_of_scope": 1,
+            "removed_drawers": 0,
+            "removed_closets": 0,
+            "dry_run": True,
+            "by_source": {"src/a.py": 2, "src/b.py": 1},
+        }
+        report.update(overrides)
+        return report
+
+    def test_dry_run_renders_full_report(self, monkeypatch, tmp_dir, capsys):
+        import mempalace.sync as sync_module
+        from mempalace import service
+
+        palace = os.path.join(tmp_dir, "palace")
+        os.makedirs(palace)
+        # Satisfy run_sync's detect_backend_for_path guard without spinning up
+        # the real Chroma/embedder stack (which would disturb sys.stdout).
+        Path(palace, "chroma.sqlite3").touch()
+        monkeypatch.setattr(
+            sync_module,
+            "sync_palace",
+            lambda **kw: self._fake_report(dry_run=True),
+        )
+        result = service.run_sync({"palace_path": palace, "dir": tmp_dir, "dry_run": True})
+        assert result["success"] is True
+        out = capsys.readouterr().out
+        # The fields the stripped daemon report used to drop.
+        assert "No source:" in out
+        assert "Out of scope:" in out
+        # by_source top sources block.
+        assert "Top sources to remove" in out
+        assert "src/a.py  (2)" in out
+        # Re-run hint fires when there is something to remove.
+        assert "Re-run with --apply" in out
+        # The old KeyError line must not be present.
+        assert "Deleted:" not in out
+
+    def test_apply_renders_removed_counts(self, monkeypatch, tmp_dir, capsys):
+        import mempalace.sync as sync_module
+        from mempalace import service
+
+        palace = os.path.join(tmp_dir, "palace")
+        os.makedirs(palace)
+        Path(palace, "chroma.sqlite3").touch()
+        monkeypatch.setattr(
+            sync_module,
+            "sync_palace",
+            lambda **kw: self._fake_report(
+                dry_run=False, removed_drawers=3, removed_closets=2, by_source={"src/a.py": 3}
+            ),
+        )
+        result = service.run_sync({"palace_path": palace, "dir": tmp_dir, "dry_run": False})
+        assert result["success"] is True
+        out = capsys.readouterr().out
+        # Apply mode prints the removed-drawers/closets line, not the Re-run hint.
+        assert "Removed 3 drawers, 2 closets" in out
+        assert "Top sources removed" in out
+        assert "Re-run with --apply" not in out


### PR DESCRIPTION
## Status: DRAFT

Opening for early review. Core behavior is implemented and tested; a few test-gap follow-ups are tracked in the checklist at the bottom.

## What this adds

An **opt-in, local-first background daemon** for MemPalace writes. `mempalace/daemon.py` is a long-lived HTTP server bound to `127.0.0.1` that owns a SQLite WAL job queue and a single worker thread. `mempalace/service.py` is the transport-neutral execution surface the daemon calls into, so the same logic the CLI runs inline can instead be queued and run asynchronously without changing any verbatim-storage behavior.

This does not change the core promise: user content is still stored verbatim, never summarized, and never leaves the machine. The daemon is a scheduling layer over the existing storage path, not a new storage path.

## Opt-in design (privacy by architecture)

- **Strictly opt-in.** No flag, env var, or config key means no daemon is started and there is zero behavior change. Existing `mine` / `sync` / hook paths are untouched when the daemon is off.
- **Local-first.** The daemon listens only on `127.0.0.1`; it never opens a network port reachable from outside the host and never makes any outbound call. No telemetry, no phone-home, no external API dependency.
- **Owner-only filesystem.** Queue DB, bearer token, endpoint file, and log are all created with `0600`/`0700` permissions so only the owning user can read them. (The SQLite default of `0644` would have left verbatim payloads world-readable — explicitly corrected.)
- **Bearer-token auth.** Every request must present the per-install token (constant-time compare); unauthenticated or wrong-token requests are rejected.

## Queue + worker + auth

- SQLite (WAL mode) holds the job queue with state (`queued` / `running` / `succeeded` / `failed` / `cancelled`), attempts, dedupe keys, and timestamps.
- A single worker thread drains the queue serially so writes do not race on the storage backend.
- Cross-process claim safety: `claim_next` uses a conditional `UPDATE ... WHERE state='queued'` with a rowcount check, so two daemon processes can never double-execute the same job.
- TOCTOU-safe dedupe via a unique partial index on `dedupe_key` for active jobs.
- `mcp_tool` jobs are allowlisted to write-classified tools only; read/maintenance/unknown tools are rejected before dispatch (a durable, retried write surface must not become a verbatim-content exfiltration path).
- **Per-job env isolation:** each job restores the backend/palace env to a known baseline before running, so one job that switches backend or palace cannot leak its choice into the next job in the same process.

## Crash recovery + dead-lettering

- On startup, any job left `running` by a killed daemon is re-queued.
- Jobs that already exhausted `MAX_ATTEMPTS` are dead-lettered to `failed` instead of being retried. This matters specifically because `diary_write` is non-idempotent: blindly retrying on every restart would duplicate verbatim content. Dead-lettering prevents that.
- Shutdown drains the active job (bounded), then marks it `cancelled` so `recover_running` won't blindly re-run it on the next start.

## Bounded retention

- Terminal jobs (`succeeded` / `failed` / `cancelled`) older than `MEMPALACE_DAEMON_RETENTION_DAYS` (default 7) are pruned at worker startup.
- Queued and running jobs are never touched by the pruner, so a crash mid-prune cannot drop in-flight work (incremental-only honored).

## CLI surface

- `mempalace mine --daemon` / `mempalace sync --daemon` / `--background` submit to the queue instead of running inline.
- New `mempalace daemon {start,stop,status,jobs,wait}` subcommand:
  - `start` (default detached; `--foreground` runs in-process for debugging or process supervisors like systemd/launchd). Detached start spawns `python -m mempalace.daemon serve` and waits for `/health` readiness before returning; an orphaned spawn that never becomes ready is killed and reaped.
  - `stop` / `status` / `jobs` / `wait` for control and observation.
- Hooks opt in via `MEMPALACE_HOOKS_DAEMON` or `hooks.daemon` config. If the daemon is not already running, hooks fall back to the existing direct/spawn path so the 500ms hook budget is preserved. **Hooks never auto-start the daemon.**

## Sync-report parity

`service.run_sync` renders the same operator-facing report shape as the direct CLI sync path (`no_source`, `out_of_scope`, `by_source`, plus `Re-run` / `Removed` hints) and drops the old `KeyError`-prone `deleted` read. This is correct-from-the-start new code in `service.py`, guarded by `TestServiceRunSyncReport`; it is not a patch to pre-existing shipped code, so it is bundled with the daemon rather than split out (it has no standalone value without the daemon).

## Testing summary

- New `tests/test_daemon.py` covers the HTTP lifecycle, auth rejection, dead-lettering after `MAX_ATTEMPTS`, retention pruning, durable-queue reads from a stopped daemon, shutdown cancellation of active jobs, per-job env isolation, palace-path override protection, and the MCP-tool allowlist.
- `tests/test_cli.py` and `tests/test_hooks_cli.py` cover the `--daemon` submission paths, `daemon jobs` / `daemon wait`, and hook fallback behavior.
- `tests/test_sync.py` adds `TestServiceRunSyncReport` covering the report shape rendered by `service.run_sync`.
- Full suite passes; linter and format checks clean; coverage above the CI gate.

## Follow-up checklist (not blocking this draft)

- [ ] Add unit tests for `cmd_daemon start/stop/status` (mock `start_daemon` / `stop_daemon` / `get_client_if_running`).
- [ ] Add focused happy-path tests for `service.run_mine` (per-mode kwargs), `run_diary_write` (arg forwarding + `exit_code` default), and `run_mcp_tool` (write-tool handler dispatch + defaults).
- [ ] Make `_safe_finish` conditional on `state='running'` to remove the benign finish-vs-cancel timing reliance currently guarded by process-exit timing.
- [ ] Isolate the `import mempalace.mcp_server` side effect in `test_sync.py` (move `TestServiceRunSyncReport` to its own module, or use `redirect_stdout` in the caller) so the embedder/Chroma import chain is not forced at collection time for the existing sync tests.

## Design principles honored

Verbatim always · incremental-only / append-only (crash-safe) · local-first, zero external API by default · privacy by architecture (no telemetry) · background everything (zero tokens in chat) · hooks under 500ms.