### PR TITLE
fix(daemon): address post-merge review feedback on #1826

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -692,8 +692,8 @@ def cmd_sync(args):
         _submit_daemon_cli_job("sync", payload, args, background=getattr(args, "background", False))
         return
 
-    from .mcp_server import _wal_log
     from .palace import MineAlreadyRunning
+    from .wal import _wal_log
     from .backends import detect_backend_for_path
     from .palace import _backend_artifact_label, resolve_backend_name
     from .sync import sync_palace

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -32,6 +32,11 @@ from .config import MempalaceConfig
 HOST = "127.0.0.1"
 STATE_ROOT_ENV = "MEMPALACE_DAEMON_STATE_ROOT"
 DEFAULT_WAIT_TIMEOUT = 60.0 * 60.0
+# Liveness-probe timeout for the hook "is a daemon already running?" precheck.
+# Kept well under the ~500ms hook budget so a wedged daemon can't stall the hook
+# (it falls back to the direct/spawn path instead). A healthy local daemon
+# answers /health in single-digit ms, so this rarely false-negatives.
+HOOK_PROBE_TIMEOUT = 0.5
 TERMINAL_STATES = {"succeeded", "failed", "cancelled"}
 MAX_ATTEMPTS = 3
 MAX_BODY_BYTES = 1 << 20  # 1 MiB cap on request bodies (auth-gated DoS guard)
@@ -272,8 +277,15 @@ class QueueStore:
                 "ON jobs(dedupe_key) WHERE state IN ('queued', 'running')"
             )
         # The queue DB holds verbatim payloads (diary text, source paths) — lock it
-        # down to owner-only regardless of the invoking user's umask.
+        # down to owner-only regardless of the invoking user's umask. The WAL/SHM
+        # sidecars carry the same un-checkpointed payloads, so harden them too when
+        # present (the daemon also runs under a 0o077 umask; this covers any
+        # QueueStore opened outside that scope, e.g. the CLI `daemon jobs` path).
         _chmod_private(self.path)
+        for sidecar_suffix in ("-wal", "-shm"):
+            sidecar = self.path.with_name(self.path.name + sidecar_suffix)
+            if sidecar.exists():
+                _chmod_private(sidecar)
 
     def prune_terminal(self, older_than_days: int = JOB_RETENTION_DAYS) -> int:
         """Delete terminal (succeeded/failed/cancelled) jobs older than the
@@ -632,6 +644,13 @@ def run_server(palace_path: str, *, backend: str | None = None, port: int = 0) -
     if backend:
         os.environ["MEMPALACE_BACKEND_EXPLICIT"] = backend
         os.environ["MEMPALACE_BACKEND"] = backend
+    # Privacy by architecture: tighten the umask to owner-only BEFORE the queue
+    # DB is created. SQLite's WAL/SHM sidecars hold un-checkpointed verbatim
+    # payloads and are (re)created with the process umask on every open/close
+    # cycle, so the umask must already be tight when DaemonRuntime builds the
+    # QueueStore (its _init_db opens the DB in WAL mode) — not only once the HTTP
+    # server starts. Restored in the finally at the end of run_server.
+    prev_umask = os.umask(0o077)
     token = ensure_token(palace_path)
     runtime = DaemonRuntime(palace_path, backend=backend)
 
@@ -651,6 +670,11 @@ def run_server(palace_path: str, *, backend: str | None = None, port: int = 0) -
 
         def _read_json(self) -> dict[str, Any]:
             length = int(self.headers.get("Content-Length", "0") or "0")
+            # Reject a negative Content-Length explicitly: self.rfile.read(-1)
+            # would read until the client closes the connection, blocking the
+            # worker and bypassing the MAX_BODY_BYTES cap (an auth-gated DoS).
+            if length < 0:
+                raise ValueError("invalid Content-Length")
             if length > MAX_BODY_BYTES:
                 raise ValueError("request body too large")
             raw = self.rfile.read(length)
@@ -755,10 +779,9 @@ def run_server(palace_path: str, *, backend: str | None = None, port: int = 0) -
             self.server_name = host
             self.server_port = port
 
-    # Privacy by architecture: the queue DB holds verbatim user content (diary
-    # entries, source paths). Force owner-only perms on every file this process
-    # creates — queue.sqlite3, its WAL/SHM sidecars, and any future artifact.
-    prev_umask = os.umask(0o077)
+    # The owner-only umask set above (before DaemonRuntime built the queue DB)
+    # covers every file this process creates — queue.sqlite3, its WAL/SHM
+    # sidecars, and any future artifact — and is restored in the finally below.
     try:
         with _Server((HOST, port), _Handler) as httpd:
             actual_port = int(httpd.server_address[1])
@@ -889,8 +912,8 @@ class DaemonClient:
             # that only know how to handle DaemonError.
             raise DaemonError(f"daemon returned non-JSON response: {raw[:200]!r}") from exc
 
-    def health(self) -> dict[str, Any]:
-        return self.request("GET", "/health")
+    def health(self, *, timeout: float = 5.0) -> dict[str, Any]:
+        return self.request("GET", "/health", timeout=timeout)
 
     def submit(
         self,
@@ -926,10 +949,14 @@ class DaemonClient:
         return self.request("POST", "/shutdown", {})
 
 
-def get_client_if_running(palace_path: str) -> DaemonClient | None:
+def get_client_if_running(palace_path: str, *, health_timeout: float = 5.0) -> DaemonClient | None:
+    # health_timeout bounds the liveness probe. Hook callers (subject to the
+    # ~500ms hook budget) pass a short value via HOOK_PROBE_TIMEOUT so a wedged
+    # daemon — endpoint present, HTTP server not answering — can't stall the
+    # hook for the default 5s before it falls back to the direct path.
     try:
         client = DaemonClient(palace_path)
-        client.health()
+        client.health(timeout=health_timeout)
         return client
     except DaemonError:
         return None

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -533,10 +533,13 @@ def _daemon_available() -> bool:
     explicitly via `mempalace daemon start`; when it isn't up, hooks fall back
     to the existing direct (in-process / spawn) path instead of blocking.
     """
-    from .daemon import get_client_if_running
+    from .daemon import HOOK_PROBE_TIMEOUT, get_client_if_running
 
     try:
-        return get_client_if_running(MempalaceConfig().palace_path) is not None
+        return (
+            get_client_if_running(MempalaceConfig().palace_path, health_timeout=HOOK_PROBE_TIMEOUT)
+            is not None
+        )
     except Exception:
         return False
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -464,83 +464,12 @@ def _refresh_vector_disabled_flag() -> None:
 # Every write operation is logged to a JSONL file before execution.
 # This provides an audit trail for detecting memory poisoning and
 # enables review/rollback of writes from external or untrusted sources.
-
-_WAL_FILE = Path(os.path.expanduser("~/.mempalace/wal")) / "write_log.jsonl"
-_WAL_INITIALIZED_DIR = None
-
-
-def _ensure_wal() -> None:
-    """Create (and re-harden) the WAL directory lazily, on the first write.
-
-    This must NOT run at import time: a user who removed ``~/.mempalace`` has
-    engaged the documented kill-switch (``hooks_cli._palace_root_exists()``,
-    #1305), and recreating the directory just by importing this module would
-    silently re-arm the autosave/mining hooks they disabled (#1676). Creating
-    it on the first real write keeps the kill-switch contract intact.
-
-    It is deliberately not gated on ``_palace_root_exists()``: by the time a
-    write reaches here the palace is already being recreated by the ChromaDB/KG
-    layer regardless, so gating would only drop audit records, not prevent
-    recreation. Runtime kill-switch enforcement for MCP writes is the broader
-    question tracked in #504.
-
-    Hardening is attempted once per directory and the path cached in
-    ``_WAL_INITIALIZED_DIR`` regardless of outcome (keyed on the path, so a
-    test repointing ``_WAL_FILE`` re-initialises), so a persistent failure on a
-    restricted filesystem does not retry on every write. ``mkdir`` runs only
-    when the initial ``chmod`` raises ``FileNotFoundError`` (EAFP). The parent
-    ``~/.mempalace`` keeps its umask mode, like the other palace directories;
-    the WAL file is created atomically with mode 0o600 by ``_wal_log``.
-    """
-    global _WAL_INITIALIZED_DIR
-    wal_dir = _WAL_FILE.parent
-    if _WAL_INITIALIZED_DIR == wal_dir:
-        return
-    try:
-        wal_dir.chmod(0o700)
-    except FileNotFoundError:
-        try:
-            wal_dir.mkdir(parents=True, exist_ok=True)
-            wal_dir.chmod(0o700)
-        except (OSError, NotImplementedError):
-            pass
-    except (OSError, NotImplementedError):
-        pass
-    # Cache regardless of outcome: one attempt per directory, so a persistent
-    # chmod/mkdir failure (restricted FS) is not retried on every write.
-    _WAL_INITIALIZED_DIR = wal_dir
-
-
-# Keys whose values should be redacted in WAL entries to avoid logging sensitive content
-_WAL_REDACT_KEYS = frozenset(
-    {"content", "content_preview", "document", "entry", "entry_preview", "query", "text"}
-)
-
-
-def _wal_log(operation: str, params: dict, result: dict = None):
-    """Append a write operation to the write-ahead log."""
-    # Redact sensitive content from params before logging
-    safe_params = {}
-    for k, v in params.items():
-        if k in _WAL_REDACT_KEYS:
-            safe_params[k] = f"[REDACTED {len(v)} chars]" if isinstance(v, str) else "[REDACTED]"
-        else:
-            safe_params[k] = v
-    entry = {
-        "timestamp": datetime.now().isoformat(),
-        "operation": operation,
-        "params": safe_params,
-        "result": result,
-    }
-    try:
-        # Dir setup shares the append's exception handler below: any WAL
-        # failure is logged and non-fatal, never crashing the tool call.
-        _ensure_wal()
-        fd = os.open(str(_WAL_FILE), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
-        with os.fdopen(fd, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, default=str) + "\n")
-    except Exception as e:
-        logger.error(f"WAL write failed: {e}")
+#
+# The implementation lives in mempalace.wal — a side-effect-free module — so the
+# CLI sync path and the daemon service layer can audit writes without importing
+# this module, whose import installs MCP stdio protection (os.dup2(2, 1) and
+# sys.stdout = sys.stderr) that would misroute their output.
+from .wal import _wal_log  # noqa: E402
 
 
 def _get_client():

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -283,8 +283,8 @@ def run_sync(payload: dict[str, Any]) -> dict[str, Any]:
     print(f"{'-' * 55}\n")
 
     try:
-        from .mcp_server import _wal_log
         from .sync import sync_palace
+        from .wal import _wal_log
 
         report = sync_palace(
             palace_path=palace_path,
@@ -379,7 +379,12 @@ def run_mcp_tool(payload: dict[str, Any]) -> dict[str, Any]:
         return {"success": False, "error": f"unknown MCP tool: {name}", "exit_code": 2}
     result = TOOLS[name]["handler"](**arguments)
     if isinstance(result, dict):
-        result.setdefault("success", True)
+        # Several write tools signal failure with a bare {"error": ...} and no
+        # explicit success flag (e.g. tool_create_tunnel / tool_delete_tunnel
+        # validation paths). Infer failure from the "error" key so the daemon
+        # does not persist a failed write as succeeded with exit_code 0.
+        if "success" not in result:
+            result["success"] = "error" not in result
         result.setdefault("exit_code", 0 if result.get("success") else 1)
         return result
     return {"success": True, "value": result, "exit_code": 0}

--- a/mempalace/wal.py
+++ b/mempalace/wal.py
@@ -1,0 +1,97 @@
+"""Side-effect-free write-ahead log for MemPalace write operations.
+
+This lives in its own module so callers that only need WAL audit logging — the
+CLI ``sync`` path and the daemon's ``service`` layer — can obtain ``_wal_log``
+without importing :mod:`mempalace.mcp_server`. Importing ``mcp_server`` runs its
+module-level stdio protection (``os.dup2(2, 1)`` and ``sys.stdout = sys.stderr``,
+required so the MCP stdio JSON stream isn't corrupted by C-level library
+banners). In a non-MCP process — e.g. the daemon worker or ``mempalace sync`` —
+that redirect is an unwanted import side effect that misroutes operator output,
+so the WAL machinery is kept here, free of any such side effects.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_WAL_FILE = Path(os.path.expanduser("~/.mempalace/wal")) / "write_log.jsonl"
+_WAL_INITIALIZED_DIR = None
+
+# Keys whose values should be redacted in WAL entries to avoid logging sensitive content
+_WAL_REDACT_KEYS = frozenset(
+    {"content", "content_preview", "document", "entry", "entry_preview", "query", "text"}
+)
+
+
+def _ensure_wal() -> None:
+    """Create (and re-harden) the WAL directory lazily, on the first write.
+
+    This must NOT run at import time: a user who removed ``~/.mempalace`` has
+    engaged the documented kill-switch (``hooks_cli._palace_root_exists()``,
+    #1305), and recreating the directory just by importing this module would
+    silently re-arm the autosave/mining hooks they disabled (#1676). Creating
+    it on the first real write keeps the kill-switch contract intact.
+
+    It is deliberately not gated on ``_palace_root_exists()``: by the time a
+    write reaches here the palace is already being recreated by the ChromaDB/KG
+    layer regardless, so gating would only drop audit records, not prevent
+    recreation. Runtime kill-switch enforcement for MCP writes is the broader
+    question tracked in #504.
+
+    Hardening is attempted once per directory and the path cached in
+    ``_WAL_INITIALIZED_DIR`` regardless of outcome (keyed on the path, so a
+    test repointing ``_WAL_FILE`` re-initialises), so a persistent failure on a
+    restricted filesystem does not retry on every write. ``mkdir`` runs only
+    when the initial ``chmod`` raises ``FileNotFoundError`` (EAFP). The parent
+    ``~/.mempalace`` keeps its umask mode, like the other palace directories;
+    the WAL file is created atomically with mode 0o600 by ``_wal_log``.
+    """
+    global _WAL_INITIALIZED_DIR
+    wal_dir = _WAL_FILE.parent
+    if _WAL_INITIALIZED_DIR == wal_dir:
+        return
+    try:
+        wal_dir.chmod(0o700)
+    except FileNotFoundError:
+        try:
+            wal_dir.mkdir(parents=True, exist_ok=True)
+            wal_dir.chmod(0o700)
+        except (OSError, NotImplementedError):
+            pass
+    except (OSError, NotImplementedError):
+        pass
+    # Cache regardless of outcome: one attempt per directory, so a persistent
+    # chmod/mkdir failure (restricted FS) is not retried on every write.
+    _WAL_INITIALIZED_DIR = wal_dir
+
+
+def _wal_log(operation: str, params: dict, result: dict = None):
+    """Append a write operation to the write-ahead log."""
+    # Redact sensitive content from params before logging
+    safe_params = {}
+    for k, v in params.items():
+        if k in _WAL_REDACT_KEYS:
+            safe_params[k] = f"[REDACTED {len(v)} chars]" if isinstance(v, str) else "[REDACTED]"
+        else:
+            safe_params[k] = v
+    entry = {
+        "timestamp": datetime.now().isoformat(),
+        "operation": operation,
+        "params": safe_params,
+        "result": result,
+    }
+    try:
+        # Dir setup shares the append's exception handler below: any WAL
+        # failure is logged and non-fatal, never crashing the tool call.
+        _ensure_wal()
+        fd = os.open(str(_WAL_FILE), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
+        with os.fdopen(fd, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, default=str) + "\n")
+    except Exception as e:
+        logger.error(f"WAL write failed: {e}")

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -748,3 +748,109 @@ def test_run_sync_structured_errors_on_sync_failures(tmp_path, monkeypatch):
     r = service.run_sync({"palace_path": str(palace), "dry_run": True})
     assert r["success"] is False
     assert "sync failed" in r["error"]
+
+
+# --- post-merge review follow-ups (Copilot review on #1826) ---
+
+
+@_posix_only_perms
+def test_run_server_tightens_umask_before_building_queue(tmp_path, monkeypatch):
+    """The owner-only umask must be active BEFORE the queue DB is built.
+
+    SQLite's WAL/SHM sidecars hold un-checkpointed verbatim payloads and are
+    created with the process umask, so a loose umask at DaemonRuntime/QueueStore
+    construction time would leave them world-readable. Capture the umask at the
+    moment DaemonRuntime is constructed and assert it is already 0o077.
+    """
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    captured = {}
+
+    def _spy_runtime(*args, **kwargs):
+        current = os.umask(0o022)
+        os.umask(current)  # restore without changing
+        captured["umask"] = current
+        raise RuntimeError("stop before binding a real socket")
+
+    monkeypatch.setattr(daemon, "DaemonRuntime", _spy_runtime)
+    with pytest.raises(RuntimeError):
+        daemon.run_server(str(palace), port=0)
+    assert captured["umask"] == 0o077
+
+
+def test_negative_content_length_is_rejected_without_blocking(tmp_path, monkeypatch):
+    """A POST with Content-Length: -1 must get a prompt 400, not hang the worker.
+
+    rfile.read(-1) would read until the client closes the socket (an auth-gated
+    DoS) and bypass the MAX_BODY_BYTES cap. The recv timeout below turns a
+    regression into a failure instead of a hang.
+    """
+    import socket
+
+    client, thread, palace, holders = _start_server(
+        tmp_path, monkeypatch, lambda k, p: {"success": True}
+    )
+    try:
+        sock = socket.create_connection((client.host, client.port), timeout=5)
+        sock.settimeout(5)
+        request = (
+            "POST /jobs HTTP/1.1\r\n"
+            "Host: daemon\r\n"
+            f"Authorization: Bearer {client.token}\r\n"
+            "Content-Length: -1\r\n"
+            "Connection: close\r\n\r\n"
+        )
+        sock.sendall(request.encode("ascii"))
+        status_line = sock.recv(4096).decode("latin-1").split("\r\n", 1)[0]
+        sock.close()
+        assert "400" in status_line, f"expected 400, got {status_line!r}"
+    finally:
+        _stop_server(client, thread, holders)
+
+
+def test_run_mcp_tool_marks_bare_error_dict_as_failure(monkeypatch):
+    """A write tool that returns {"error": ...} with no success flag must be
+    recorded as a failed job, not succeeded (Copilot review)."""
+    import mempalace.mcp_server as mcp
+    from mempalace import service
+
+    monkeypatch.setattr(
+        mcp,
+        "TOOLS",
+        {"mempalace_create_tunnel": {"handler": lambda **kw: {"error": "bad endpoint"}}},
+    )
+    out = service.run_mcp_tool({"name": "mempalace_create_tunnel", "arguments": {}})
+    assert out["success"] is False
+    assert out["exit_code"] == 1
+    assert out["error"] == "bad endpoint"
+
+    # A result with neither an explicit success flag nor an error is a success.
+    monkeypatch.setattr(
+        mcp, "TOOLS", {"mempalace_create_tunnel": {"handler": lambda **kw: {"tunnel_id": "t1"}}}
+    )
+    out = service.run_mcp_tool({"name": "mempalace_create_tunnel", "arguments": {}})
+    assert out["success"] is True
+    assert out["exit_code"] == 0
+
+
+def test_get_client_if_running_uses_short_probe_timeout(monkeypatch):
+    """The hook liveness precheck must pass a short health timeout so a wedged
+    daemon can't stall the hook past its budget (Copilot review)."""
+    captured = {}
+
+    class _FakeClient:
+        def __init__(self, palace_path):
+            pass
+
+        def health(self, *, timeout):
+            captured["timeout"] = timeout
+            return {"ok": True}
+
+    monkeypatch.setattr(daemon, "DaemonClient", _FakeClient)
+
+    assert daemon.HOOK_PROBE_TIMEOUT <= 0.5
+    client = daemon.get_client_if_running("/p", health_timeout=daemon.HOOK_PROBE_TIMEOUT)
+    assert client is not None
+    assert captured["timeout"] == daemon.HOOK_PROBE_TIMEOUT

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1189,12 +1189,12 @@ class TestSearchTool:
 
     def test_wal_redacts_sensitive_fields(self, monkeypatch, config, kg, tmp_path):
         _patch_mcp_server(monkeypatch, config, kg)
-        from mempalace import mcp_server
+        from mempalace import wal
 
         wal_file = tmp_path / "write_log.jsonl"
-        monkeypatch.setattr(mcp_server, "_WAL_FILE", wal_file)
+        monkeypatch.setattr(wal, "_WAL_FILE", wal_file)
 
-        mcp_server._wal_log(
+        wal._wal_log(
             "test",
             {"content": "secret note", "query": "private search", "safe": "ok"},
         )
@@ -2932,13 +2932,13 @@ class TestImportKillSwitchSafety:
         Proves the deferred setup still works (defers WAL creation to write
         time, does not disable it) and preserves the WAL permission bits.
         """
-        from mempalace import mcp_server
+        from mempalace import wal
 
         wal_file = tmp_path / "fresh" / "wal" / "write_log.jsonl"
         assert not wal_file.parent.exists()
-        monkeypatch.setattr(mcp_server, "_WAL_FILE", wal_file)
+        monkeypatch.setattr(wal, "_WAL_FILE", wal_file)
 
-        mcp_server._wal_log("test_op", {"safe": "ok"})
+        wal._wal_log("test_op", {"safe": "ok"})
 
         assert wal_file.exists(), "lazy WAL init did not create the log on first write"
         entry = json.loads(wal_file.read_text().strip())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1355,16 +1355,16 @@ class TestSyncCli:
     def test_cli_emits_wal_on_apply(self, monkeypatch, synced_world):
         """F8 regression: cmd_sync must wire `_wal_log` so CLI deletes are
         audited. Without this, scripted CLI invocations leave no trail."""
-        from mempalace import cli, mcp_server
+        from mempalace import cli, wal
 
         seen = []
-        original = mcp_server._wal_log
+        original = wal._wal_log
 
         def recording_wal(operation, params, result=None):
             seen.append((operation, params, result))
             original(operation, params, result)
 
-        monkeypatch.setattr(mcp_server, "_wal_log", recording_wal)
+        monkeypatch.setattr(wal, "_wal_log", recording_wal)
 
         argv = [
             "mempalace",

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -1,0 +1,42 @@
+import subprocess
+import sys
+
+
+def test_wal_import_has_no_mcp_server_side_effect():
+    """Importing mempalace.wal must NOT import mempalace.mcp_server.
+
+    mcp_server installs MCP stdio protection at import time (os.dup2(2, 1) and
+    sys.stdout = sys.stderr). The CLI sync path and the daemon service layer
+    obtain _wal_log from mempalace.wal precisely so they can audit writes
+    without triggering that process-global redirect. Run in a fresh subprocess
+    so the already-imported mcp_server in this test session can't mask a
+    regression.
+    """
+    code = (
+        "import sys\n"
+        "import mempalace.wal\n"
+        "assert 'mempalace.mcp_server' not in sys.modules, "
+        "'importing mempalace.wal pulled in mempalace.mcp_server'\n"
+        "print('ok')\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_wal_log_redacts_and_writes(tmp_path, monkeypatch):
+    """_wal_log lives in mempalace.wal now; smoke-test redaction + write there."""
+    import json
+
+    from mempalace import wal
+
+    wal_file = tmp_path / "wal" / "write_log.jsonl"
+    monkeypatch.setattr(wal, "_WAL_FILE", wal_file)
+    monkeypatch.setattr(wal, "_WAL_INITIALIZED_DIR", None)
+
+    wal._wal_log("op", {"entry": "secret diary text", "safe": "ok"})
+
+    entry = json.loads(wal_file.read_text().strip())
+    assert entry["operation"] == "op"
+    assert entry["params"]["entry"].startswith("[REDACTED")
+    assert entry["params"]["safe"] == "ok"


### PR DESCRIPTION
Follow-up to #1826 (merged), addressing the five points from the Copilot review. All are real, verified issues; #3 was also pre-existing on the plain `mempalace sync` CLI path.

## Fixes

1. **Privacy — WAL/SHM sidecar permissions.** `QueueStore` created `queue.sqlite3-wal`/`-shm` (which hold un-checkpointed verbatim payloads) *before* `run_server` tightened the umask, and only the main `.sqlite3` was `chmod`'d. The owner-only umask is now set **before** `DaemonRuntime` builds the queue, and `_init_db` hardens any existing sidecars as defense-in-depth.

2. **DoS guard — negative `Content-Length`.** `Content-Length: -1` → `rfile.read(-1)` blocked until client disconnect and bypassed `MAX_BODY_BYTES`. Now rejected with a 400.

3. **Import side effects — extract WAL.** `service.run_sync`/`cli.cmd_sync` got `_wal_log` via `from .mcp_server import _wal_log`, which runs mcp_server's import-time stdio protection (`os.dup2(2, 1)`, `sys.stdout = sys.stderr`) in a non-MCP process and misroutes operator output. `_wal_log` (+ `_ensure_wal`, `_WAL_FILE`, `_WAL_REDACT_KEYS`) now live in a new side-effect-free `mempalace/wal.py`; `mcp_server`/`cli`/`service` import from there.

4. **Correctness — `run_mcp_tool` success inference.** A write tool returning a bare `{"error": ...}` (e.g. `tool_create_tunnel`/`tool_delete_tunnel` validation) was recorded as succeeded. The `error` key now infers failure.

5. **Hook budget — liveness-probe timeout.** `get_client_if_running()`/`health()` take an explicit timeout; the hook "is the daemon up?" precheck uses a short `HOOK_PROBE_TIMEOUT` (0.5s) so a wedged daemon can't stall the hook for the default 5s.

## Tests
New `tests/test_wal.py` (import isolation in a clean subprocess + redaction) and daemon tests for the umask ordering (POSIX-only), negative `Content-Length` (no hang), `run_mcp_tool` error inference, and the short probe timeout. Existing WAL tests in `test_mcp_server.py`/`test_sync.py` repointed to `mempalace.wal`.

Full suite green locally (2718 passed, 241 skipped); ruff check + format clean.