### PR TITLE
fix(pgvector): strip NUL bytes so a transcript NUL no longer aborts the mine (#1829)

### DIFF
--- a/mempalace/backends/pgvector.py
+++ b/mempalace/backends/pgvector.py
@@ -80,6 +80,42 @@ def _json_dumps(obj: Any) -> str:
     return json.dumps(obj or {}, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
 
 
+def _strip_nul(value: Any) -> Any:
+    """Recursively strip NUL (0x00) from strings, list/tuple items, and dict keys
+    and values so pgvector can store the result.
+
+    PostgreSQL cannot store NUL in ``text`` or ``jsonb``: psycopg rejects a raw
+    NUL in a text column ("PostgreSQL text fields cannot contain NUL (0x00)
+    bytes"), and a NUL in metadata serializes to a JSON unicode escape that the
+    ``jsonb`` cast rejects ("unsupported Unicode escape sequence"). A single
+    transcript that captured NUL in tool output would otherwise abort the whole
+    mine run (#1829). ChromaDB and the SQLite backend store the byte verbatim,
+    so stripping only here keeps the same inputs ingestible.
+
+    Applied to id, document, and metadata in :meth:`_PgVectorClient.upsert_rows`
+    so the write path never carries a NUL into Postgres. Only ``str`` values are
+    rewritten; the ``int``/``float``/``bool``/``None`` scalars JSON metadata
+    normalizes to pass through unchanged. Stripping is not injective, so two keys
+    (or ids)
+    differing only by a NUL collapse to one (last wins); this does not occur in
+    practice because drawer ids are SHA-256 hashes and metadata keys are fixed
+    field names, so only transcript-derived values are ever actually changed.
+    Unlike ``config.sanitize_content`` (which rejects NUL in user-supplied
+    content), the bulk-mine path strips so one stray byte cannot abort a whole
+    backfill. ``str.replace`` returns the original string when it holds no NUL,
+    so a clean document is not reallocated.
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, dict):
+        return {_strip_nul(key): _strip_nul(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_strip_nul(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_strip_nul(item) for item in value)
+    return value
+
+
 def _tokenize(text: str) -> list[str]:
     if not text:
         return []
@@ -581,9 +617,12 @@ class _PgVectorClient:
         )
         params = [
             (
-                row["id"],
-                row["document"],
-                _json_dumps(row.get("metadata")),
+                # Strip NUL from every text-bound field so none can abort the
+                # insert. ids are generated NUL-free hashes, so for real rows the
+                # id strip is a no-op (it never rewrites the ON CONFLICT key).
+                _strip_nul(row["id"]),
+                _strip_nul(row["document"]),
+                _json_dumps(_strip_nul(row.get("metadata"))),
                 _vector_literal(row["embedding"]),
                 row.get("updated_at") or _utcnow(),
             )

--- a/tests/test_pgvector_backend.py
+++ b/tests/test_pgvector_backend.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import threading
@@ -22,6 +23,7 @@ from mempalace.backends.pgvector import (
     _matches_where,
     _vector_distance,
     _as_vector_array,
+    _strip_nul,
 )
 
 
@@ -651,3 +653,99 @@ def test_client_execute_after_close_raises(monkeypatch):
     with pytest.raises(BackendError, match="closed"):
         client.ping()
     assert len(created) == 1
+
+
+def test_pgvector_upsert_strips_nul_bytes(monkeypatch):
+    """A NUL (0x00) byte in id/document/metadata must never reach Postgres.
+
+    psycopg's text/jsonb dumpers reject NUL outright ("PostgreSQL text fields
+    cannot contain NUL (0x00) bytes"), which aborts the entire mine run (#1829)
+    when a single transcript captured a NUL in tool output. ChromaDB and the
+    SQLite backend store the byte verbatim, so pgvector strips it to keep the
+    same inputs ingestible. Strip, not reject: rejecting would re-abort the
+    mine or drop the drawer entirely (recall loss).
+    """
+    captured = []
+
+    class _FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def execute(self, sql, params=None):
+            return None
+
+        def executemany(self, sql, params=None):
+            captured.extend(params or [])
+
+        def fetchall(self):
+            return []
+
+    class _FakeConn:
+        def cursor(self):
+            return _FakeCursor()
+
+        def commit(self):
+            return None
+
+        def rollback(self):
+            return None
+
+        def close(self):
+            return None
+
+    fake_psycopg = types.ModuleType("psycopg")
+    fake_psycopg.connect = lambda _dsn: _FakeConn()
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
+    client.upsert_rows(
+        "drawers",
+        [
+            {
+                "id": "draw\x00er",
+                "document": "before\x00after",
+                "metadata": {"go\x00od": "v\x00w", "nested": ["a\x00b", 7]},
+                "embedding": [1.0, 0.0],
+                "updated_at": "2026-06-20T00:00:00Z",
+            }
+        ],
+    )
+
+    assert len(captured) == 1, "upsert_rows should bind exactly one row"
+    row_id, document, metadata_json = captured[0][0], captured[0][1], captured[0][2]
+
+    # No NUL survives into any text-bound parameter (id, document, metadata).
+    assert "\x00" not in row_id
+    assert "\x00" not in document
+    assert "\x00" not in metadata_json
+
+    # Stripping removes only the NUL; surrounding content is otherwise preserved.
+    assert row_id == "drawer"
+    assert document == "beforeafter"
+    assert json.loads(metadata_json) == {"good": "vw", "nested": ["ab", 7]}
+
+
+def test_strip_nul_helper():
+    """``_strip_nul`` removes NUL from strings, list/tuple items, and dict keys
+    and values; NUL-free input and non-string scalars are returned unchanged."""
+    assert _strip_nul("a\x00b") == "ab"
+    assert _strip_nul("clean") == "clean"
+    assert _strip_nul("") == ""
+    assert _strip_nul("\x00") == ""
+    # Keys, values, list items, and nested structures are all stripped.
+    assert _strip_nul({"k\x00": "v\x00", "n": [1, "x\x00y"]}) == {"k": "v", "n": [1, "xy"]}
+    assert _strip_nul([{"a\x00": "b\x00"}, "c\x00"]) == [{"a": "b"}, "c"]
+    # Tuples recurse too and stay tuples (defends direct callers that pass
+    # un-normalized metadata before the JSON round-trip).
+    assert _strip_nul(("a\x00b", 1, ["c\x00"])) == ("ab", 1, ["c"])
+    # Keys differing only by a NUL collapse, last wins (documented, harmless:
+    # real metadata keys are fixed field names, never NUL-only-distinguished).
+    assert _strip_nul({"a\x00": 1, "a": 2}) == {"a": 2}
+    # Non-string scalars pass through unchanged (bool stays bool, not int).
+    assert _strip_nul(7) == 7
+    assert _strip_nul(3.5) == 3.5
+    assert _strip_nul(True) is True
+    assert _strip_nul(None) is None


### PR DESCRIPTION
Fixes #1829

## Summary

PostgreSQL cannot store NUL (`0x00`) in `text` or `jsonb`, and the pgvector
write path hits this two ways:

- `document` is a `text` column, so a raw NUL is rejected by psycopg with
  `DataError: PostgreSQL text fields cannot contain NUL (0x00) bytes`.
- `metadata` is serialized to JSON, where the NUL becomes a unicode escape, and
  cast to `jsonb`, which Postgres rejects with `unsupported Unicode escape
  sequence`.

Either way `_execute` re-wraps the error as `BackendError` and the top-level
handler in `_mine_impl` re-raises, so the whole mine exits non-zero and every
file after the offending one is left unmined. A NUL encoded in a JSON transcript
decodes to a real NUL byte in the captured content, which is how the byte
reaches a drawer (reported in #1829).

This is pgvector-specific: ChromaDB, the SQLite backend, and Qdrant all store
the byte verbatim, so the same corpus mines cleanly on those backends.

The fix strips NUL from `id`, `document`, and `metadata` before they are bound
for insert, so the byte Postgres cannot hold never reaches it. This follows
`ChromaCollection._sanitize_documents_for_chromadb`, which already
sanitizes an unstorable byte class (lone surrogates) at the backend layer for
the same bulk-ingest paths that bypass `sanitize_content`. Stripping a NUL is a
deliberate, minimal exception to verbatim storage: the byte is an unstorable
control character, and the alternative is losing the whole drawer (and every
file after it). ChromaDB and SQLite keep the byte; pgvector stores the
NUL-stripped form, which is the most fidelity Postgres allows. Unlike
`config.sanitize_content`, which rejects NUL in user-supplied content, the
bulk-mine path strips so one stray byte cannot abort a backfill.

## Changes

`mempalace/backends/pgvector.py`
- Add `_strip_nul`, a small recursive helper that removes NUL from strings,
  list items, and dict keys and values.
- Apply it to `id`, `document`, and `metadata` in `upsert_rows`. ids are
  generated SHA-256 hashes and metadata keys are fixed field names, so for real
  rows the id and key passes are no-ops; only transcript-derived values change.

`tests/test_pgvector_backend.py`
- Unit test for `_strip_nul`: keys, values, list items, nested structures,
  empty/all-NUL strings, key-collision last-wins, and scalar pass-through.
- Integration test driving the real `_PgVectorClient.upsert_rows` through a fake
  connection, asserting no NUL reaches the bound id/document/metadata params
  while the surrounding content is preserved.

## Out of scope

The read path (`_field_sql` pushdown filter operands) is unchanged. A NUL in a
metadata filter value would still raise at query time, but filter values are
structural field names in practice, and since stored values are now NUL-free a
NUL filter cannot match a stored row anyway. Stripping it consistently also
needs the local-exact filter path, a separate concern from the mine abort.

## Testing

- `uv run pytest tests/test_pgvector_backend.py`: 27 passed, 1 skipped.
- `ruff check .` and `ruff format --check .`: clean.
- End-to-end against a live PostgreSQL 16 + pgvector through `PgVectorBackend`:
  on develop a NUL in document or id aborts with `PostgreSQL text fields cannot
  contain NUL (0x00) bytes` and a NUL in metadata aborts with `unsupported
  Unicode escape sequence`; with this change all insert successfully and the row
  is stored with the NUL removed. ChromaDB, SQLite, and Qdrant store the byte
  verbatim.

## Checklist

- [x] Tests added and passing
- [x] Lint and format clean
- [x] Scoped to the reported write-path bug; no behavior change for other backends

