### PR TITLE
perf: sqlite fast-path for overview tools + embedder thread cap (#1748, #1379, #1068)

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -645,6 +645,37 @@ class MempalaceConfig:
             return env_val.strip().lower()
         return str(self._file_config.get("embedding_model", "minilm")).strip().lower()
 
+    @property
+    def embedding_threads(self) -> int:
+        """Cap on the embedder's ONNX Runtime intra-op thread pool (#1068).
+
+        ChromaDB's ONNX embedder builds its ``InferenceSession`` with no thread
+        cap, so the intra-op pool defaults to the physical core count and a
+        background ``mine`` pins every core — stacked Stop-hook fires turn into
+        thermal events. ``OMP_NUM_THREADS`` is inert here (ORT owns its own
+        pool), so the cap is applied via ``SessionOptions`` in
+        :mod:`mempalace.embedding`.
+
+        Read from env ``MEMPALACE_EMBEDDING_THREADS`` first, then
+        ``embedding_threads`` in ``config.json``. Semantics:
+
+        - unset / ``"auto"`` → half the logical CPUs (min 1), so a background
+          mine leaves the machine usable out of the box.
+        - a positive integer → exactly that many intra-op threads.
+        - ``0`` or negative → uncapped: ORT's default (physical core count),
+          for users who want maximum indexing throughput.
+        """
+        raw = os.environ.get("MEMPALACE_EMBEDDING_THREADS")
+        if raw is None:
+            raw = self._file_config.get("embedding_threads")
+        if raw is None or str(raw).strip().lower() in ("", "auto"):
+            return max(1, (os.cpu_count() or 2) // 2)
+        try:
+            val = int(str(raw).strip())
+        except (TypeError, ValueError):
+            return max(1, (os.cpu_count() or 2) // 2)
+        return val if val > 0 else 0
+
     def set_embedding_model(self, model: str) -> None:
         """Persist the embedding-model choice to ``config.json``.
 

--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -32,6 +32,7 @@ rather than hard-failing — mining must still work on a laptop without CUDA.
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from typing import Optional
 
@@ -112,6 +113,35 @@ def _resolve_providers(device: str) -> tuple[list, str]:
     return (requested, device)
 
 
+def _intra_op_session_options(intra_op_num_threads: int):
+    """Build ORT ``SessionOptions`` capping the intra-op thread pool (#1068).
+
+    Returns ``None`` when ``intra_op_num_threads <= 0`` so the caller leaves
+    ORT at its default (≈ physical core count). ChromaDB's embedder ignores
+    ``OMP_NUM_THREADS`` — ORT owns its own intra-op pool, settable only via
+    ``SessionOptions`` at session construction — so a cap has to be threaded
+    through here rather than via the environment.
+    """
+    if not intra_op_num_threads or intra_op_num_threads <= 0:
+        return None
+    import onnxruntime as ort
+
+    so = ort.SessionOptions()
+    so.intra_op_num_threads = intra_op_num_threads
+    return so
+
+
+def _resolve_intra_op_threads() -> int:
+    """Read the configured ORT intra-op thread cap (``0`` = uncapped, #1068)."""
+    try:
+        from .config import MempalaceConfig
+
+        return MempalaceConfig().embedding_threads
+    except Exception:
+        logger.debug("embedding_threads resolution failed; leaving ORT default", exc_info=True)
+        return 0
+
+
 def _build_ef_class():
     """Subclass ``ONNXMiniLM_L6_V2`` with name ``"default"``.
 
@@ -122,12 +152,50 @@ def _build_ef_class():
     palaces created with ``DefaultEmbeddingFunction`` *and* palaces we
     create ourselves, with the same GPU-capable ``preferred_providers``.
     """
+    from functools import cached_property
+
     from chromadb.utils.embedding_functions import ONNXMiniLM_L6_V2
 
     class _MempalaceONNX(ONNXMiniLM_L6_V2):
+        def __init__(self, preferred_providers=None, intra_op_num_threads=0):
+            super().__init__(preferred_providers=preferred_providers)
+            self._intra_op_num_threads = intra_op_num_threads
+
         @staticmethod
         def name() -> str:
             return "default"
+
+        @cached_property
+        def model(self):
+            # Upstream builds the InferenceSession with no intra-op thread cap,
+            # so ORT defaults its pool to the physical core count and a
+            # background mine pins every core (#1068). Rebuild the session the
+            # same way upstream does (same SessionOptions, same CoreML pruning,
+            # same model path) but with our cap applied. If upstream's
+            # internals shift, fall back to its uncapped build so embedding
+            # still works.
+            cap = getattr(self, "_intra_op_num_threads", 0)
+            if not cap or cap <= 0:
+                return ONNXMiniLM_L6_V2.model.func(self)
+            try:
+                ort = self.ort
+                providers = self._preferred_providers or ort.get_available_providers()
+                providers = [p for p in providers if p != "CoreMLExecutionProvider"]
+                so = ort.SessionOptions()
+                so.log_severity_level = 3
+                so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+                so.intra_op_num_threads = cap
+                return ort.InferenceSession(
+                    os.path.join(self.DOWNLOAD_PATH, self.EXTRACTED_FOLDER_NAME, "model.onnx"),
+                    providers=providers,
+                    sess_options=so,
+                )
+            except Exception:
+                logger.warning(
+                    "thread-capped ORT session build failed; using ORT defaults",
+                    exc_info=True,
+                )
+                return ONNXMiniLM_L6_V2.model.func(self)
 
     return _MempalaceONNX
 
@@ -173,13 +241,19 @@ class EmbeddinggemmaONNX:
         # when switching models. Keep it stable.
         return "embeddinggemma_300m"
 
-    def __init__(self, preferred_providers=None, batch_size: int = _EMBEDDINGGEMMA_BATCH_SIZE):
+    def __init__(
+        self,
+        preferred_providers=None,
+        batch_size: int = _EMBEDDINGGEMMA_BATCH_SIZE,
+        intra_op_num_threads: int = 0,
+    ):
         if batch_size < 1:
             raise ValueError(f"batch_size must be >= 1, got {batch_size}")
         self._providers = (
             list(preferred_providers) if preferred_providers else ["CPUExecutionProvider"]
         )
         self._batch_size = batch_size
+        self._intra_op_num_threads = intra_op_num_threads
         self._session = None
         self._tokenizer = None
         self._np = None
@@ -221,7 +295,11 @@ class EmbeddinggemmaONNX:
             )
             tok_path = hf_hub_download(_EMBEDDINGGEMMA_REPO, filename="tokenizer.json")
 
-            session = ort.InferenceSession(model_path, providers=self._providers)
+            session = ort.InferenceSession(
+                model_path,
+                sess_options=_intra_op_session_options(self._intra_op_num_threads),
+                providers=self._providers,
+            )
             out_names = [o.name for o in session.get_outputs()]
             # Model card: sentence_embedding is the pooled output (last_hidden_state
             # is the per-token output we don't want).
@@ -309,12 +387,13 @@ def get_embedding_function(device: Optional[str] = None, model: Optional[str] = 
         if cached is not None:
             return cached
 
+        threads = _resolve_intra_op_threads()
         if model == "embeddinggemma":
-            ef = EmbeddinggemmaONNX(preferred_providers=providers)
+            ef = EmbeddinggemmaONNX(preferred_providers=providers, intra_op_num_threads=threads)
         else:
             # Default: minilm (or anything we don't recognize — back-compat win).
             ef_cls = _build_ef_class()
-            ef = ef_cls(preferred_providers=providers)
+            ef = ef_cls(preferred_providers=providers, intra_op_num_threads=threads)
 
         _EF_CACHE[cache_key] = ef
     logger.info(

--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -176,7 +176,7 @@ def _build_ef_class():
             # still works.
             cap = getattr(self, "_intra_op_num_threads", 0)
             if not cap or cap <= 0:
-                return ONNXMiniLM_L6_V2.model.func(self)
+                return super().model
             try:
                 ort = self.ort
                 providers = self._preferred_providers or ort.get_available_providers()
@@ -195,7 +195,7 @@ def _build_ef_class():
                     "thread-capped ORT session build failed; using ORT defaults",
                     exc_info=True,
                 )
-                return ONNXMiniLM_L6_V2.model.func(self)
+                return super().model
 
     return _MempalaceONNX
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -973,6 +973,29 @@ def _tool_status_via_sqlite() -> dict:
     return result
 
 
+def _sqlite_taxonomy():
+    """Fast wing→room tally straight from ``chroma.sqlite3`` (#1748 / #1379).
+
+    Returns ``(total, {wing: {room: count}})`` or ``None`` to signal the
+    caller to fall back to the ChromaDB client pagination path. ``None`` means
+    a non-chroma backend, a missing/unbootstrapped palace, or a sqlite error —
+    exactly the cases ``backends.chroma._sqlite_wing_room_counts`` already
+    handles for the CLI ``miner.status()``. The point is to answer the
+    overview tools from the relational metadata without cold-loading the HNSW
+    index, which costs tens of seconds per call on large palaces and is what
+    times them out under the MCP host limit.
+    """
+    if not _is_chroma_backend():
+        return None
+    try:
+        from .backends.chroma import _sqlite_wing_room_counts
+
+        return _sqlite_wing_room_counts(_config.palace_path, _config.collection_name)
+    except Exception:
+        logger.debug("sqlite taxonomy fast path failed; falling back", exc_info=True)
+        return None
+
+
 def tool_status():
     # Run the safe sqlite/pickle probe before we touch chromadb. In the
     # #1222 failure mode, opening the persistent client to call .count()
@@ -983,6 +1006,29 @@ def tool_status():
 
     if _vector_disabled:
         return _tool_status_via_sqlite()
+
+    # Fast path: tally wing/room straight from sqlite so overview tools stay
+    # responsive on large palaces instead of cold-loading the HNSW index or
+    # paging hundreds of MB of metadata through the client (#1748 / #1379).
+    # ``None`` (non-chroma backend / non-standard layout) falls through to the
+    # client path below.
+    fast = _sqlite_taxonomy()
+    if fast is not None:
+        total, wing_rooms = fast
+        wings = {}
+        rooms = {}
+        for w, room_counts in wing_rooms.items():
+            wings[w] = wings.get(w, 0) + sum(room_counts.values())
+            for r, n in room_counts.items():
+                rooms[r] = rooms.get(r, 0) + n
+        return {
+            "total_drawers": total,
+            "wings": wings,
+            "rooms": rooms,
+            "protocol": PALACE_PROTOCOL,
+            "aaak_dialect": AAAK_SPEC,
+            "backend": _selected_backend_name(),
+        }
 
     # Use create=True only when a palace DB already exists on disk -- this
     # bootstraps the ChromaDB collection on a valid-but-empty palace without
@@ -1050,6 +1096,13 @@ When WRITING AAAK: use entity codes, mark emotions, keep structure tight."""
 
 
 def tool_list_wings():
+    fast = _sqlite_taxonomy()
+    if fast is not None:
+        _total, wing_rooms = fast
+        wings = {}
+        for w, room_counts in wing_rooms.items():
+            wings[w] = wings.get(w, 0) + sum(room_counts.values())
+        return {"wings": wings}
     col = _get_collection()
     if not col:
         return _collection_error_or_no_palace()
@@ -1073,6 +1126,16 @@ def tool_list_rooms(wing: str = None):
         wing = _sanitize_optional_name(wing, "wing")
     except ValueError as e:
         return {"error": str(e)}
+    fast = _sqlite_taxonomy()
+    if fast is not None:
+        _total, wing_rooms = fast
+        rooms = {}
+        for w, room_counts in wing_rooms.items():
+            if wing and w != wing:
+                continue
+            for r, n in room_counts.items():
+                rooms[r] = rooms.get(r, 0) + n
+        return {"wing": wing or "all", "rooms": rooms}
     col = _get_collection()
     if not col:
         return _collection_error_or_no_palace()
@@ -1093,6 +1156,10 @@ def tool_list_rooms(wing: str = None):
 
 
 def tool_get_taxonomy():
+    fast = _sqlite_taxonomy()
+    if fast is not None:
+        _total, wing_rooms = fast
+        return {"taxonomy": {w: dict(room_counts) for w, room_counts in wing_rooms.items()}}
     col = _get_collection()
     if not col:
         return _collection_error_or_no_palace()

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -990,10 +990,28 @@ def _sqlite_taxonomy():
     try:
         from .backends.chroma import _sqlite_wing_room_counts
 
-        return _sqlite_wing_room_counts(_config.palace_path, _config.collection_name)
+        counts = _sqlite_wing_room_counts(_config.palace_path, _config.collection_name)
     except Exception:
         logger.debug("sqlite taxonomy fast path failed; falling back", exc_info=True)
         return None
+    if counts is None:
+        return None
+
+    # Preserve the client path's output contract: drawers missing wing/room
+    # read as "unknown" (the ``m.get("wing", "unknown")`` default), not the
+    # sqlite COALESCE placeholder "?". Without this, the fast path would be an
+    # observable API change for MCP clients on legacy/partial drawers.
+    def _norm(key):
+        return "unknown" if key in (None, "?") else key
+
+    total, wing_rooms = counts
+    normalized: dict = {}
+    for wing, room_counts in wing_rooms.items():
+        dest = normalized.setdefault(_norm(wing), {})
+        for room, n in room_counts.items():
+            rkey = _norm(room)
+            dest[rkey] = dest.get(rkey, 0) + n
+    return total, normalized
 
 
 def tool_status():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,6 +100,54 @@ def test_embedding_device_env_overrides_config(tmp_path, monkeypatch):
     assert cfg.embedding_device == "coreml"
 
 
+def test_embedding_threads_defaults_to_half_cpus(monkeypatch):
+    monkeypatch.delenv("MEMPALACE_EMBEDDING_THREADS", raising=False)
+    monkeypatch.setattr("os.cpu_count", lambda: 10)
+    cfg = MempalaceConfig(config_dir=tempfile.mkdtemp())
+    # unset / "auto" → half the logical CPUs so a background mine stays tame
+    assert cfg.embedding_threads == 5
+
+
+def test_embedding_threads_auto_keyword(tmp_path, monkeypatch):
+    monkeypatch.delenv("MEMPALACE_EMBEDDING_THREADS", raising=False)
+    monkeypatch.setattr("os.cpu_count", lambda: 8)
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump({"embedding_threads": "auto"}, f)
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.embedding_threads == 4
+
+
+def test_embedding_threads_positive_value_from_config(tmp_path, monkeypatch):
+    monkeypatch.delenv("MEMPALACE_EMBEDDING_THREADS", raising=False)
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump({"embedding_threads": 3}, f)
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.embedding_threads == 3
+
+
+def test_embedding_threads_zero_means_uncapped(tmp_path, monkeypatch):
+    monkeypatch.delenv("MEMPALACE_EMBEDDING_THREADS", raising=False)
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump({"embedding_threads": 0}, f)
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.embedding_threads == 0
+
+
+def test_embedding_threads_env_overrides_config(tmp_path, monkeypatch):
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump({"embedding_threads": 2}, f)
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_THREADS", "6")
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.embedding_threads == 6
+
+
+def test_embedding_threads_invalid_falls_back_to_auto(tmp_path, monkeypatch):
+    monkeypatch.setattr("os.cpu_count", lambda: 4)
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_THREADS", "not-a-number")
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.embedding_threads == 2
+
+
 def test_env_override():
     raw = "/env/palace"
     os.environ["MEMPALACE_PALACE_PATH"] = raw

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -73,7 +73,7 @@ def test_onnxruntime_import_error_falls_back_to_cpu(monkeypatch):
 
 def test_get_embedding_function_caches_by_resolved_provider_tuple(monkeypatch):
     class DummyEF:
-        def __init__(self, preferred_providers):
+        def __init__(self, preferred_providers, intra_op_num_threads=0):
             self.preferred_providers = preferred_providers
 
     monkeypatch.setattr(embedding, "_build_ef_class", lambda: DummyEF)
@@ -81,11 +81,83 @@ def test_get_embedding_function_caches_by_resolved_provider_tuple(monkeypatch):
         embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
     )
 
-    first = embedding.get_embedding_function("cpu")
-    second = embedding.get_embedding_function("auto")
+    first = embedding.get_embedding_function("cpu", "minilm")
+    second = embedding.get_embedding_function("auto", "minilm")
 
     assert first is second
     assert first.preferred_providers == ["CPUExecutionProvider"]
+
+
+def test_intra_op_session_options_caps_threads():
+    so = embedding._intra_op_session_options(3)
+    assert so is not None
+    assert so.intra_op_num_threads == 3
+
+
+def test_intra_op_session_options_uncapped_returns_none():
+    assert embedding._intra_op_session_options(0) is None
+    assert embedding._intra_op_session_options(-1) is None
+
+
+def test_get_embedding_function_threads_cap_passed_to_minilm_ef(monkeypatch):
+    captured = {}
+
+    class DummyEF:
+        def __init__(self, preferred_providers, intra_op_num_threads=0):
+            captured["threads"] = intra_op_num_threads
+
+    monkeypatch.setattr(embedding, "_build_ef_class", lambda: DummyEF)
+    monkeypatch.setattr(
+        embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
+    )
+    monkeypatch.setattr(embedding, "_resolve_intra_op_threads", lambda: 2)
+
+    embedding.get_embedding_function("cpu", "minilm")
+
+    assert captured["threads"] == 2
+
+
+def test_get_embedding_function_threads_cap_passed_to_embeddinggemma(monkeypatch):
+    captured = {}
+
+    class DummyGemma:
+        def __init__(self, preferred_providers=None, intra_op_num_threads=0):
+            captured["threads"] = intra_op_num_threads
+
+    monkeypatch.setattr(embedding, "EmbeddinggemmaONNX", DummyGemma)
+    monkeypatch.setattr(
+        embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
+    )
+    monkeypatch.setattr(embedding, "_resolve_intra_op_threads", lambda: 4)
+
+    embedding.get_embedding_function("cpu", "embeddinggemma")
+
+    assert captured["threads"] == 4
+
+
+def test_minilm_ef_model_override_applies_thread_cap(monkeypatch):
+    """The ``_MempalaceONNX.model`` override must construct the ORT session
+    with the configured ``intra_op_num_threads`` (#1068). We stub
+    ``InferenceSession`` to capture the ``SessionOptions`` it receives, so the
+    test never downloads or loads the real model."""
+    import onnxruntime as ort
+
+    captured = {}
+
+    def fake_session(model_path, providers=None, sess_options=None):
+        captured["sess_options"] = sess_options
+        captured["providers"] = providers
+        return object()
+
+    monkeypatch.setattr(ort, "InferenceSession", fake_session)
+
+    ef_cls = embedding._build_ef_class()
+    ef = ef_cls(preferred_providers=["CPUExecutionProvider"], intra_op_num_threads=2)
+    _ = ef.model  # triggers the cached_property build
+
+    assert captured["sess_options"] is not None
+    assert captured["sess_options"].intra_op_num_threads == 2
+    assert "CoreMLExecutionProvider" not in captured["providers"]
 
 
 def test_describe_device_uses_resolved_effective_device(monkeypatch):

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -160,6 +160,30 @@ def test_minilm_ef_model_override_applies_thread_cap(monkeypatch):
     assert "CoreMLExecutionProvider" not in captured["providers"]
 
 
+def test_minilm_ef_model_override_falls_back_when_uncapped(monkeypatch):
+    """With no cap (0), the override must defer to the parent build via
+    ``super().model`` — not reach into ``cached_property`` internals (#1068
+    review). Proves super() resolves the parent descriptor without error."""
+    import onnxruntime as ort
+
+    captured = {}
+
+    def fake_session(model_path, providers=None, sess_options=None):
+        captured["sess_options"] = sess_options
+        return object()
+
+    monkeypatch.setattr(ort, "InferenceSession", fake_session)
+
+    ef_cls = embedding._build_ef_class()
+    ef = ef_cls(preferred_providers=["CPUExecutionProvider"], intra_op_num_threads=0)
+    session = ef.model  # cap <= 0 → super().model (upstream builder)
+
+    assert session is not None
+    # Upstream leaves intra_op at ORT's default (0 = unset), confirming we
+    # deferred to it rather than applying our cap.
+    assert captured["sess_options"].intra_op_num_threads == 0
+
+
 def test_describe_device_uses_resolved_effective_device(monkeypatch):
     monkeypatch.setattr(
         embedding,

--- a/tests/test_embeddinggemma.py
+++ b/tests/test_embeddinggemma.py
@@ -347,7 +347,7 @@ def test_cache_key_separates_models(monkeypatch):
     """
 
     class DummyMiniLM:
-        def __init__(self, preferred_providers=None):
+        def __init__(self, preferred_providers=None, intra_op_num_threads=0):
             self.kind = "minilm"
 
     monkeypatch.setattr(embedding, "_build_ef_class", lambda: DummyMiniLM)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -845,6 +845,35 @@ class TestReadTools:
         assert result["taxonomy"]["project"]["frontend"] == 1
         assert result["taxonomy"]["notes"]["planning"] == 1
 
+    def test_overview_tools_use_sqlite_fast_path(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        """Overview tools must answer from the sqlite cross-tab without paging
+        all metadata through the chroma client (#1748 / #1379). A tripwire on
+        the pagination helper fails loudly if the fast path regresses to the
+        slow client path that times out on large palaces."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        def _boom(*_a, **_k):
+            raise AssertionError("pagination path used instead of sqlite fast path")
+
+        monkeypatch.setattr(mcp_server, "_metadata_cache", None)
+        monkeypatch.setattr(mcp_server, "_fetch_all_metadata", _boom)
+
+        status = mcp_server.tool_status()
+        assert status["total_drawers"] == 4
+        assert status["wings"] == {"project": 3, "notes": 1}
+
+        assert mcp_server.tool_list_wings()["wings"] == {"project": 3, "notes": 1}
+
+        rooms = mcp_server.tool_list_rooms(wing="project")["rooms"]
+        assert rooms == {"backend": 2, "frontend": 1}
+
+        tax = mcp_server.tool_get_taxonomy()["taxonomy"]
+        assert tax["project"] == {"backend": 2, "frontend": 1}
+        assert tax["notes"] == {"planning": 1}
+
     def test_no_palace_returns_error(self, monkeypatch, config, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_status

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -874,6 +874,29 @@ class TestReadTools:
         assert tax["project"] == {"backend": 2, "frontend": 1}
         assert tax["notes"] == {"planning": 1}
 
+    def test_overview_tools_normalize_missing_wing_room_to_unknown(
+        self, monkeypatch, config, palace_path, collection, kg
+    ):
+        """Fast path must keep the client path's contract: drawers missing
+        wing/room metadata read as 'unknown', not the sqlite COALESCE
+        placeholder '?' (#1748 review)."""
+        collection.add(
+            ids=["no_meta_drawer"],
+            documents=["a drawer with no wing or room metadata"],
+            metadatas=[{"source_file": "loose.txt"}],
+        )
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_metadata_cache", None)
+
+        tax = mcp_server.tool_get_taxonomy()["taxonomy"]
+        assert tax == {"unknown": {"unknown": 1}}
+
+        status = mcp_server.tool_status()
+        assert status["wings"] == {"unknown": 1}
+        assert status["rooms"] == {"unknown": 1}
+
     def test_no_palace_returns_error(self, monkeypatch, config, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_status


### PR DESCRIPTION
Two focused performance fixes for large palaces, verified against current `develop`. Disjoint files, one combined PR; two commits.

## #1748 / #1379 — overview tools no longer time out on large palaces
`tool_status` / `list_wings` / `list_rooms` / `get_taxonomy` paged the whole collection metadata through the chroma client (`_fetch_all_metadata`, a 1000-row offset loop), cold-loading HNSW and materializing hundreds of MB of dicts. On six-figure palaces these exceed the MCP host tool-call limit (~3-4 min at 180k drawers; timeout at 349k). The 5s metadata cache only dedups repeat calls — it never prevented the cold-call timeout.

The fix wires in the SQL cross-tab that **already existed and was already the CLI default** (`backends.chroma._sqlite_wing_room_counts`, used by `miner.status`) but which the MCP tools never used. New `_sqlite_taxonomy()` guards on `_is_chroma_backend()` and returns `None` to fall back, so non-chroma backends (qdrant, sqlite_exact) and unbootstrapped/legacy layouts keep the existing client path unchanged. All four tools now answer from one `GROUP BY` without touching HNSW.

`graph_stats` (also named in #1379) builds an in-memory graph via `build_graph()` and needs its own treatment — **tracked separately, not in this PR**. So this partially addresses #1379.

## #1068 — background mine no longer pins every core
ChromaDB's ONNX embedder builds its `InferenceSession` with no thread cap, so ORT's intra-op pool defaults to physical-core count (`OMP_NUM_THREADS` is inert — ORT owns its own pool). A background `mempalace mine` pins 4-5 cores; stacked Stop-hook fires become thermal events.

New `embedding_threads` config (env `MEMPALACE_EMBEDDING_THREADS` / `config.json`):
- unset / `"auto"` → **half the logical CPUs** (min 1) — keeps a fresh install usable out of the box
- positive int → exact count
- `0` / negative → uncapped (ORT default) for max throughput

Applied via `SessionOptions`: `_MempalaceONNX` overrides the `model` cached_property (falls back to upstream's uncapped build if chromadb internals shift); `EmbeddinggemmaONNX` uses the shared `_intra_op_session_options()` helper.

## Tests
- New: overview-tools-use-sqlite-fast-path tripwire (fails loudly if the slow path regresses); `embedding_threads` config resolution; SessionOptions wiring; the `_MempalaceONNX.model` override (stubs `InferenceSession`, no model download).
- Full suite (excl. benchmarks): **2730 passed, 241 skipped, 0 failures**; ruff check + format clean.

Closes #1748
Closes #1068