### PR TITLE
fix(mcp): route _sqlite_graph_stats through sqlite_read_uri

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1048,7 +1048,7 @@ def _sqlite_graph_stats():
     # graph_stats degrades to build_graph() rather than raising — mirroring the
     # sibling sqlite fast paths (_sqlite_taxonomy / _sqlite_wing_room_counts).
     try:
-        conn = _sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn = _sqlite3.connect(sqlite_read_uri(db_path), uri=True)
         try:
             conn.execute("PRAGMA busy_timeout = 3000")
             if (


### PR DESCRIPTION
Tiny follow-up promised in #1838. The `_sqlite_graph_stats` reader (added in #1837) and the `sqlite_read_uri` encoding helper (added in #1838) merged in parallel, so this one reader was left on the naive `f"file:{db_path}?mode=ro"` construction that mis-parses paths with spaces/special characters.

This routes it through `sqlite_read_uri` too — now **every** read-only sqlite reader percent-encodes its path. `sqlite_read_uri` is already imported in `mcp_server` (from #1838), so it's a one-line call-site change.

Covered by the existing `test_graph_stats_uses_sqlite_fast_path` (which opens the DB through this reader); ruff clean.