### PR TITLE
fix(pgvector): push get(limit, offset) pagination into SQL (#1830)

### DIFF
--- a/mempalace/backends/pgvector.py
+++ b/mempalace/backends/pgvector.py
@@ -625,6 +625,8 @@ class _PgVectorClient:
         *,
         where: Optional[dict] = None,
         with_embedding: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> list[dict]:
         qi = _quote_identifier(table)
         params: list = []
@@ -633,6 +635,18 @@ class _PgVectorClient:
         if with_embedding:
             cols += ", embedding"
         sql = f"SELECT {cols} FROM {qi} WHERE {where_sql}"
+        # Push pagination into SQL when a page is requested. ORDER BY the
+        # primary key gives OFFSET a stable order (an unordered scan may skip
+        # or repeat rows across pages); callers that scroll the whole table
+        # pass neither bound, leaving their SQL unchanged.
+        if limit is not None or offset:
+            sql += " ORDER BY id"
+            if limit is not None:
+                params.append(int(limit))
+                sql += " LIMIT %s"
+            if offset:
+                params.append(int(offset))
+                sql += " OFFSET %s"
         rows = self._execute(sql, params, fetch=True)
         return [
             self._row(record, with_embedding=with_embedding, with_distance=False)
@@ -792,13 +806,19 @@ class PgVectorCollection(BaseCollection):
                 )
             self._known_dimension = existing_dim or dimension
 
-    def _scroll(self, *, where=None, with_embedding=False) -> list[dict]:
+    def _scroll(self, *, where=None, with_embedding=False, limit=None, offset=None) -> list[dict]:
         self._ensure_open()
         if not self._table_exists():
             if self._marker_exists():
                 raise CollectionNotInitializedError(self._collection_name)
             return []
-        return self._client.scroll_rows(self._table, where=where, with_embedding=with_embedding)
+        return self._client.scroll_rows(
+            self._table,
+            where=where,
+            with_embedding=with_embedding,
+            limit=limit,
+            offset=offset,
+        )
 
     def _rows(
         self,
@@ -1017,16 +1037,40 @@ class PgVectorCollection(BaseCollection):
         include=None,
     ) -> GetResult:
         spec = _IncludeSpec.resolve(include, default_distances=False)
-        rows = self._rows(
-            ids=ids, where=where, where_document=where_document, with_embedding=spec.embeddings
+        # Fast path for the common unfiltered page fetch (e.g.
+        # prefetch_mined_set's sweep): push LIMIT/OFFSET into the scan instead
+        # of fetching the whole table and slicing in Python, which is the
+        # O(rows x pages) cost this avoids. Only the no-filter case is pushed:
+        # the "metadata @> ..." pushdown is broader than the exact
+        # _matches_where re-filter for array/object values, so any filtered get
+        # keeps the full-scan path where that re-filter still runs. ids, where,
+        # where_document and negative bounds all fall through to the unchanged
+        # path below. (The document column is still selected for metadata-only
+        # pages; projecting it out needs the positional _row parser to change,
+        # so it stays a separate follow-up.)
+        push_page = (
+            ids is None
+            and not where
+            and not where_document
+            and (limit is None or limit >= 0)
+            and (offset is None or offset >= 0)
+            and (limit is not None or offset)
         )
-        if ids is not None:
-            by_id = {row["id"]: row for row in rows}
-            rows = [by_id[doc_id] for doc_id in ids if doc_id in by_id]
-        if offset:
-            rows = rows[offset:]
-        if limit is not None:
-            rows = rows[:limit]
+        if push_page:
+            rows = self._scroll(
+                where=None, with_embedding=spec.embeddings, limit=limit, offset=offset
+            )
+        else:
+            rows = self._rows(
+                ids=ids, where=where, where_document=where_document, with_embedding=spec.embeddings
+            )
+            if ids is not None:
+                by_id = {row["id"]: row for row in rows}
+                rows = [by_id[doc_id] for doc_id in ids if doc_id in by_id]
+            if offset:
+                rows = rows[offset:]
+            if limit is not None:
+                rows = rows[:limit]
         return GetResult(
             ids=[row["id"] for row in rows],
             documents=[row["document"] for row in rows] if spec.documents else [],

--- a/tests/test_pgvector_backend.py
+++ b/tests/test_pgvector_backend.py
@@ -39,6 +39,7 @@ class _FakePgVectorClient:
     def __init__(self, _config):
         self.tables: dict = {}
         self.query_calls: list = []
+        self.scroll_calls: list = []
         _FakePgVectorClient.instances.append(self)
 
     def ping(self):
@@ -89,9 +90,18 @@ class _FakePgVectorClient:
             out.append(item)
         return out
 
-    def scroll_rows(self, table, *, where=None, with_embedding=False):
+    def scroll_rows(self, table, *, where=None, with_embedding=False, limit=None, offset=None):
+        self.scroll_calls.append({"where": where, "limit": limit, "offset": offset})
+        rows = self._filtered(table, where)
+        if limit is not None or offset:
+            # Mirror the real backend: ORDER BY id, then LIMIT/OFFSET.
+            rows = sorted(rows, key=lambda row: row["id"])
+            if offset:
+                rows = rows[offset:]
+            if limit is not None:
+                rows = rows[:limit]
         out = []
-        for row in self._filtered(table, where):
+        for row in rows:
             out.append(
                 {
                     "id": row["id"],
@@ -360,6 +370,104 @@ def test_pgvector_get_limit_offset_and_embeddings(tmp_path, fake_pgvector):
     page = col.get(where={"wing": "x"}, limit=1, offset=1, include=["documents", "embeddings"])
     assert len(page.ids) == 1
     assert page.embeddings is not None and len(page.embeddings[0]) == 2
+
+
+def test_pgvector_get_unfiltered_page_pushes_limit_offset(tmp_path, fake_pgvector):
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["a", "b", "c", "d"],
+        documents=["da", "db", "dc", "dd"],
+        metadatas=[{"wing": "x"}, {"wing": "x"}, {"wing": "x"}, {"wing": "x"}],
+        embeddings=[[1, 0], [0, 1], [0.5, 0.5], [0.2, 0.8]],
+    )
+    client = fake_pgvector.instances[0]
+    client.scroll_calls.clear()
+
+    page = col.get(limit=2, offset=1, include=["metadatas"])
+
+    # An unfiltered page is pushed to SQL as LIMIT/OFFSET instead of fetching
+    # the whole table and slicing in Python (the O(rows x pages) path).
+    assert client.scroll_calls == [{"where": None, "limit": 2, "offset": 1}]
+    # ORDER BY id, then OFFSET 1 LIMIT 2 -> b, c.
+    assert page.ids == ["b", "c"]
+
+
+def test_pgvector_get_filtered_page_stays_on_full_scan(tmp_path, fake_pgvector):
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["a", "b", "c"],
+        documents=["da", "db", "dc"],
+        metadatas=[{"wing": "x"}, {"wing": "y"}, {"wing": "x"}],
+        embeddings=[[1, 0], [0, 1], [0.5, 0.5]],
+    )
+    client = fake_pgvector.instances[0]
+    client.scroll_calls.clear()
+
+    page = col.get(where={"wing": "x"}, limit=1, offset=1, include=["metadatas"])
+
+    # A filtered get keeps the full-scan path (no LIMIT/OFFSET pushed) so the
+    # exact _matches_where re-filter runs before pagination.
+    assert client.scroll_calls == [{"where": {"wing": "x"}, "limit": None, "offset": None}]
+    assert page.ids == ["c"]
+
+
+def test_pgvector_get_offset_only_and_limit_only_push(tmp_path, fake_pgvector):
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["a", "b", "c", "d"],
+        documents=["da", "db", "dc", "dd"],
+        metadatas=[{"wing": "x"}] * 4,
+        embeddings=[[1, 0], [0, 1], [0.5, 0.5], [0.2, 0.8]],
+    )
+    client = fake_pgvector.instances[0]
+
+    # offset-only (limit=None) is pushed.
+    client.scroll_calls.clear()
+    page = col.get(offset=2, include=["metadatas"])
+    assert client.scroll_calls == [{"where": None, "limit": None, "offset": 2}]
+    assert page.ids == ["c", "d"]
+
+    # limit-only (offset=None) is pushed.
+    client.scroll_calls.clear()
+    page = col.get(limit=2, include=["metadatas"])
+    assert client.scroll_calls == [{"where": None, "limit": 2, "offset": None}]
+    assert page.ids == ["a", "b"]
+
+
+def test_pgvector_get_negative_bounds_use_python_slice(tmp_path, fake_pgvector):
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["a", "b", "c"],
+        documents=["da", "db", "dc"],
+        metadatas=[{"wing": "x"}] * 3,
+        embeddings=[[1, 0], [0, 1], [0.5, 0.5]],
+    )
+    client = fake_pgvector.instances[0]
+    client.scroll_calls.clear()
+
+    # A negative offset must not reach SQL (OFFSET -1 would error); it falls
+    # through to the unchanged full-scan + Python-slice path.
+    page = col.get(offset=-1, include=["metadatas"])
+    assert client.scroll_calls == [{"where": None, "limit": None, "offset": None}]
+    assert page.ids == ["c"]
+
+
+def test_pgvector_get_pages_tile_without_overlap(tmp_path, fake_pgvector):
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["a", "b", "c", "d", "e"],
+        documents=["da", "db", "dc", "dd", "de"],
+        metadatas=[{"wing": "x"}] * 5,
+        embeddings=[[1, 0], [0, 1], [0.5, 0.5], [0.2, 0.8], [0.3, 0.7]],
+    )
+    # Consecutive pages tile the whole table exactly once, in stable id order.
+    p1 = col.get(limit=2, offset=0, include=["metadatas"]).ids
+    p2 = col.get(limit=2, offset=2, include=["metadatas"]).ids
+    p3 = col.get(limit=2, offset=4, include=["metadatas"]).ids
+    assert p1 == ["a", "b"]
+    assert p2 == ["c", "d"]
+    assert p3 == ["e"]
+    assert p1 + p2 + p3 == ["a", "b", "c", "d", "e"]
 
 
 def test_pgvector_delete_by_where_pushdown_and_local(tmp_path, fake_pgvector):


### PR DESCRIPTION
## What does this PR do?

Fixes #1830.

On the pgvector backend, `PgVectorCollection.get(limit=, offset=)` ignored pagination at the SQL layer. `_PgVectorClient.scroll_rows` ran `SELECT id, document, metadata FROM <table> WHERE <where>` with no `LIMIT`/`OFFSET`, returning every row; `get()` then built all rows in Python and sliced `rows[offset:][:limit]`.

`palace.prefetch_mined_set()` pages the whole palace on every mine to build the already-filed set:

```python
total = collection.count()
offset = 0
while offset < total:
    batch = collection.get(limit=1000, offset=offset, include=["metadatas"])
    ...
    offset += len(batch["ids"])
```

So a palace of N drawers issues N/1000 calls, and each call scans and transfers all N rows (including the large `document` text), making mining O(N^2) in rows transferred and Python objects built. Every other paginating caller (exporter, migrate, repair, hallways, closet_llm, miner, palace_graph) pays the same cost.

This change pushes pagination into the scan, taken only when the page needs no Python post-filter:

- `scroll_rows` / `_scroll` gain optional `limit`/`offset`. When a bound is given they append `ORDER BY id` (the primary key, for stable offset pagination) then `LIMIT`/`OFFSET`. With no bound the SQL is unchanged, so `search`, `lexical_search`/bm25 and every other full-scroll caller are byte-for-byte identical.
- `get()` uses the pushed path only when `ids is None`, there is no `where`/`where_document`, and the bounds are non-negative. A filtered `get` keeps the full-scan path: the `metadata @> ...` pushdown is broader than the exact `_matches_where` re-filter for array/object metadata values, so that re-filter must run before pagination; pushing `LIMIT`/`OFFSET` there could return rows it would have removed.

pgvector exposes a real SQL cursor, so pagination is pushed straight to the engine. Two limits are intentional: the `document` column is still selected for metadata-only pages (projecting it out needs the positional row parser to change, left as a separate follow-up to keep this low-risk), and `OFFSET` is still walked server-side, so a full sweep remains quadratic on the server, but it no longer transfers N rows or builds N Python objects per page, which was the dominant cost.

## How to test

Unit:

```
python -m pytest tests/test_pgvector_backend.py -v
```

New tests cover: an unfiltered page pushes `LIMIT`/`OFFSET` to the client (not a Python slice); a filtered page stays on the full-scan path (the re-filter is preserved); offset-only and limit-only push; negative bounds fall back to the Python slice; consecutive pages tile the table exactly once in stable id order.

Against a real PostgreSQL + pgvector, a prefetch-style sweep over 5,000 drawers (page size 1,000), counting rows actually fetched per `SELECT`:

| | rows fetched (whole sweep) | rows in one `get` | page SQL |
|---|---|---|---|
| before | 25,000 | 5,000 (full table) | `... WHERE TRUE` |
| after | 5,000 | 1,000 | `... WHERE TRUE ORDER BY id LIMIT %s OFFSET %s` |

Coverage stays exact (every row once); after the change page order is stable by id (it was unspecified before). The gap grows quadratically with palace size.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
