### PR TITLE
fix(backends): push sqlite_exact get(limit, offset) pagination into SQL (#1841)

### DIFF
--- a/mempalace/backends/sqlite_exact.py
+++ b/mempalace/backends/sqlite_exact.py
@@ -496,19 +496,32 @@ class SQLiteExactCollection(BaseCollection):
                 )
                 self._replace_fts(cur, collection_id, doc_id, doc)
 
-    def _rows(self, cur, *, where=None, where_document=None) -> list[dict]:
+    def _rows(self, cur, *, where=None, where_document=None, limit=None, offset=None) -> list[dict]:
         _validate_where(where)
         _validate_where(where_document)
         collection_id = self._collection_id(cur)
-        rows = cur.execute(
-            """
-            SELECT id, document, metadata_json, embedding
-            FROM documents
-            WHERE collection_id = ?
-            ORDER BY rowid
-            """,
-            (collection_id,),
-        ).fetchall()
+        sql = (
+            "SELECT id, document, metadata_json, embedding\n"
+            "FROM documents\n"
+            "WHERE collection_id = ?\n"
+            "ORDER BY rowid"
+        )
+        params = [collection_id]
+        # Emit SQL LIMIT/OFFSET only on an unfiltered page. With a
+        # where/where_document the post-filter loop below drops rows *after*
+        # this scan, so a SQL LIMIT/OFFSET would cut the wrong rows; those
+        # callers scan in full and paginate in Python. SQLite requires a LIMIT
+        # before OFFSET, so an offset-only page uses "LIMIT -1" (unbounded).
+        if where is None and where_document is None and (limit is not None or offset):
+            if limit is not None:
+                sql += "\nLIMIT ?"
+                params.append(int(limit))
+            elif offset:
+                sql += "\nLIMIT -1"
+            if offset:
+                sql += "\nOFFSET ?"
+                params.append(int(offset))
+        rows = cur.execute(sql, params).fetchall()
         out = []
         for doc_id, doc, meta_json, emb_blob in rows:
             meta = _json_loads(meta_json)
@@ -603,15 +616,33 @@ class SQLiteExactCollection(BaseCollection):
         include=None,
     ) -> GetResult:
         spec = _IncludeSpec.resolve(include, default_distances=False)
+        # Fast path for the common unfiltered page (e.g. the prefetch_mined_set
+        # and status sweeps): push LIMIT/OFFSET into the scan instead of
+        # materializing the whole collection and slicing in Python. Safe only
+        # with no post-filter (ids/where/where_document drop rows after the
+        # scan) and non-negative bounds: SQLite does not honor a negative LIMIT
+        # or OFFSET the way a Python slice does, so those keep the slice path.
+        push_page = (
+            ids is None
+            and where is None
+            and where_document is None
+            and (limit is None or limit >= 0)
+            and (offset is None or offset >= 0)
+            and (limit is not None or offset)
+        )
         with self._cursor() as cur:
-            rows = self._rows(cur, where=where, where_document=where_document)
-        if ids is not None:
-            by_id = {row["id"]: row for row in rows}
-            rows = [by_id[doc_id] for doc_id in ids if doc_id in by_id]
-        if offset:
-            rows = rows[offset:]
-        if limit is not None:
-            rows = rows[:limit]
+            if push_page:
+                rows = self._rows(cur, limit=limit, offset=offset)
+            else:
+                rows = self._rows(cur, where=where, where_document=where_document)
+        if not push_page:
+            if ids is not None:
+                by_id = {row["id"]: row for row in rows}
+                rows = [by_id[doc_id] for doc_id in ids if doc_id in by_id]
+            if offset:
+                rows = rows[offset:]
+            if limit is not None:
+                rows = rows[:limit]
         return GetResult(
             ids=[row["id"] for row in rows],
             documents=[row["document"] for row in rows] if spec.documents else [],

--- a/tests/test_sqlite_exact_backend.py
+++ b/tests/test_sqlite_exact_backend.py
@@ -139,6 +139,159 @@ def test_sqlite_exact_get_preserves_requested_id_order_and_duplicates(tmp_path):
     assert result.documents == ["doc b", "doc a", "doc b"]
 
 
+def _doc_select_sql(col, action):
+    """Run ``action`` while tracing SQL; return (result, [documents SELECTs]).
+
+    The documents-table scan in ``_rows`` is the only statement that is both
+    ``FROM documents`` and ``ORDER BY rowid`` (``count`` lacks the ORDER BY),
+    so filtering on both isolates it from collection-id lookups and commits.
+    """
+    statements = []
+    conn = col._handle.conn
+    conn.set_trace_callback(statements.append)
+    try:
+        result = action()
+    finally:
+        conn.set_trace_callback(None)
+    selects = [s for s in statements if "FROM documents" in s and "ORDER BY rowid" in s]
+    return result, selects
+
+
+def _seed(col, n):
+    col.add(
+        ids=[f"d{i}" for i in range(n)],
+        documents=[f"doc {i}" for i in range(n)],
+        metadatas=[{"wing": "w", "n": i} for i in range(n)],
+        embeddings=[[float(i), 1.0] for i in range(n)],
+    )
+
+
+def test_sqlite_exact_get_unfiltered_page_pushes_limit_offset(tmp_path):
+    _backend, col = _collection(tmp_path)
+    _seed(col, 10)
+
+    result, selects = _doc_select_sql(
+        col, lambda: col.get(limit=3, offset=2, include=["documents"])
+    )
+
+    assert result.ids == ["d2", "d3", "d4"]
+    assert result.documents == ["doc 2", "doc 3", "doc 4"]
+    assert len(selects) == 1
+    assert "LIMIT" in selects[0]
+    assert "OFFSET" in selects[0]
+
+
+def test_sqlite_exact_get_filtered_page_stays_on_full_scan(tmp_path):
+    _backend, col = _collection(tmp_path)
+    _seed(col, 6)
+
+    # With a filter the rows are dropped after the scan, so LIMIT/OFFSET must
+    # not reach SQL; the page is taken in Python over the filtered rows.
+    result, selects = _doc_select_sql(
+        col,
+        lambda: col.get(where={"wing": "w"}, limit=2, offset=1, include=["metadatas"]),
+    )
+
+    assert result.ids == ["d1", "d2"]
+    assert len(selects) == 1
+    assert "LIMIT" not in selects[0]
+    assert "OFFSET" not in selects[0]
+
+
+def test_sqlite_exact_get_offset_only_and_limit_only_push(tmp_path):
+    _backend, col = _collection(tmp_path)
+    _seed(col, 5)
+
+    limit_only, limit_sql = _doc_select_sql(col, lambda: col.get(limit=2))
+    assert limit_only.ids == ["d0", "d1"]
+    assert len(limit_sql) == 1
+    assert "LIMIT" in limit_sql[0]
+    assert "OFFSET" not in limit_sql[0]
+
+    offset_only, offset_sql = _doc_select_sql(col, lambda: col.get(offset=3))
+    assert offset_only.ids == ["d3", "d4"]
+    assert len(offset_sql) == 1
+    assert "OFFSET" in offset_sql[0]
+    # SQLite requires a LIMIT before OFFSET; an offset-only page uses LIMIT -1.
+    assert "LIMIT" in offset_sql[0]
+
+
+def test_sqlite_exact_get_negative_bounds_use_python_slice(tmp_path):
+    _backend, col = _collection(tmp_path)
+    _seed(col, 5)
+
+    # Negative limit means Python "all but last", which a SQL LIMIT (negative ==
+    # unbounded in SQLite) cannot express, so it must stay on the slice path.
+    neg_limit, neg_limit_sql = _doc_select_sql(col, lambda: col.get(limit=-1))
+    assert neg_limit.ids == ["d0", "d1", "d2", "d3"]
+    assert len(neg_limit_sql) == 1
+    assert "LIMIT" not in neg_limit_sql[0]
+
+    # Negative offset means Python "last N"; it must not reach SQL either.
+    neg_offset, neg_offset_sql = _doc_select_sql(col, lambda: col.get(offset=-2))
+    assert neg_offset.ids == ["d3", "d4"]
+    assert len(neg_offset_sql) == 1
+    assert "OFFSET" not in neg_offset_sql[0]
+
+
+def test_sqlite_exact_get_pages_tile_without_overlap(tmp_path):
+    _backend, col = _collection(tmp_path)
+    _seed(col, 10)
+
+    seen = []
+    offset = 0
+    while True:
+        page = col.get(limit=4, offset=offset)
+        if not page.ids:
+            break
+        seen.extend(page.ids)
+        offset += len(page.ids)
+
+    assert seen == [f"d{i}" for i in range(10)]
+    # The same set, same rowid order, as a single unfiltered scan.
+    assert col.get().ids == seen
+
+
+def test_sqlite_exact_get_limit_zero_pushes_empty_page(tmp_path):
+    _backend, col = _collection(tmp_path)
+    _seed(col, 3)
+
+    # limit=0 is a real bound, not "no limit": it pushes LIMIT 0 and returns
+    # nothing, matching the old rows[:0] slice. Guards the `is not None` check
+    # against an `if limit:` regression that would treat 0 as unbounded.
+    result, selects = _doc_select_sql(col, lambda: col.get(limit=0))
+    assert result.ids == []
+    assert len(selects) == 1
+    assert "LIMIT" in selects[0]
+
+
+def test_sqlite_exact_get_offset_zero_is_a_full_scan(tmp_path):
+    _backend, col = _collection(tmp_path)
+    _seed(col, 3)
+
+    # offset=0 with no limit is not a page request, so it stays on the full scan.
+    result, selects = _doc_select_sql(col, lambda: col.get(offset=0))
+    assert result.ids == ["d0", "d1", "d2"]
+    assert len(selects) == 1
+    assert "LIMIT" not in selects[0]
+    assert "OFFSET" not in selects[0]
+
+
+def test_sqlite_exact_get_ids_with_page_slices_in_python(tmp_path):
+    _backend, col = _collection(tmp_path)
+    _seed(col, 5)
+
+    # ids force the Python path even with a page: the requested order is kept,
+    # then offset/limit slice the reordered list with no SQL LIMIT/OFFSET.
+    result, selects = _doc_select_sql(
+        col, lambda: col.get(ids=["d4", "d3", "d2", "d1"], offset=1, limit=2)
+    )
+    assert result.ids == ["d3", "d2"]
+    assert len(selects) == 1
+    assert "LIMIT" not in selects[0]
+    assert "OFFSET" not in selects[0]
+
+
 def test_sqlite_exact_upsert_delete_and_multi_collection_isolation(tmp_path):
     backend, drawers = _collection(tmp_path, "drawers")
     palace = PalaceRef(id=str(tmp_path), local_path=str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

Fixes #1841.

On the `sqlite_exact` backend, `SQLiteExactCollection.get(limit=, offset=)` ignored pagination at the SQL layer. `_rows()` ran `SELECT id, document, metadata_json, embedding FROM documents WHERE collection_id = ? ORDER BY rowid` with no `LIMIT`/`OFFSET`, returning the whole collection and decoding every row's metadata; `get()` then sliced `rows[offset:][:limit]` in Python.

`palace.prefetch_mined_set()` pages the whole palace on every mine to build the already-filed set:

```python
total = collection.count()
offset = 0
while offset < total:
    batch = collection.get(limit=1000, offset=offset, include=["metadatas"])
    ...
    offset += len(batch["ids"])
```

So a palace of N drawers issues N/1000 pages, and each page scans and materializes all N rows (including the large `document` text), making the sweep O(N^2) in rows materialized. Every other paginating reader (`miner.status`, the MCP metadata sweep, exporter, migrate, dedup, sync, closet_llm, layers, palace_graph, repair) pays the same cost.

This change pushes pagination into the scan, taken only when the page needs no Python post-filter:

- `_rows()` gains optional `limit`/`offset`. When there is no `where`/`where_document` and a bound is given, it appends `LIMIT`/`OFFSET` to the `ORDER BY rowid` scan. SQLite requires a `LIMIT` before `OFFSET`, so an offset-only page uses `LIMIT -1` (unbounded). With a filter present, or with no bound, the SQL is unchanged, so `query`, `lexical_search` and `delete` are byte-for-byte identical.
- `get()` uses the pushed path only when `ids is None`, there is no `where`/`where_document`, and the bounds are non-negative. A filtered `get` keeps the full-scan path: `_matches_where`/`_matches_where_document` drop rows after the scan, so the page must be taken after that filter rather than in SQL. Negative bounds keep Python-slice semantics (SQLite does not honor a negative `LIMIT`/`OFFSET` the way a Python slice does), so they fall back too.

`documents.rowid` is monotonic and indexed, so `ORDER BY rowid LIMIT/OFFSET` is a stable, index-backed page.

## How to test

Unit:

```
python -m pytest tests/test_sqlite_exact_backend.py -v
```

New tests cover: an unfiltered page pushes `LIMIT`/`OFFSET` to SQL (not a Python slice); a filtered page stays on the full-scan path (the re-filter is preserved); offset-only and limit-only push; `limit=0` pushes an empty page; `offset=0` is a full scan; negative bounds fall back to the Python slice; `ids` with a page slices in Python; consecutive pages tile the table exactly once in stable rowid order.

Driving `palace.prefetch_mined_set()` over a 5,000-drawer `sqlite_exact` palace (page size 1,000), counting `documents` rows materialized per sweep:

| | rows materialized (whole sweep) | rows in one `get` | page SQL |
|---|---|---|---|
| before | 25,000 | 5,000 (full table) | `... ORDER BY rowid` |
| after | 5,000 | 1,000 | `... ORDER BY rowid LIMIT 1000 OFFSET ...` |

The prefetched set is identical before and after (same drawers, same order); the gap grows quadratically with palace size.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
