### PR TITLE
fix(repair): point index-read failures to repair --mode from-sqlite (#1843)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1076,6 +1076,7 @@ def cmd_repair(args):
         _post_rebuild_cleanup,
         _rebuild_collection_via_temp,
         check_extraction_safety,
+        index_read_recovery_guidance,
         maybe_repair_poisoned_max_seq_id_before_rebuild,
         print_sqlite_integrity_abort,
         sqlite_integrity_errors,
@@ -1189,7 +1190,7 @@ def cmd_repair(args):
         print(f"  Drawers found: {total}")
     except Exception as e:
         print(f"  Error reading palace: {e}")
-        print("  Cannot recover — palace may need to be re-mined from source files.")
+        print(index_read_recovery_guidance())
         return
 
     if total == 0:

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -564,6 +564,40 @@ def print_sqlite_integrity_abort(palace_path: str, errors: list[str]) -> None:
     print("    6. Re-run `mempalace repair --yes`.")
 
 
+def index_read_recovery_guidance() -> str:
+    """Recovery guidance for a failed drawer-index read in the legacy paths.
+
+    Both ``cmd_repair`` (cli.py) and :func:`rebuild_index` read the drawers
+    collection via ``Collection.count()`` as their first step. The common
+    reason that read raises is the chromadb compactor failing to apply the
+    WAL into the HNSW segment (``InternalError: Failed to apply logs to the
+    hnsw segment writer``, issues #1308 / #1843): the on-disk HNSW index is
+    corrupt while the rows stay intact in ``chroma.sqlite3``, so
+    :func:`rebuild_from_sqlite` (``repair --mode from-sqlite``) recovers them
+    and re-mining would needlessly drop drawers added through the MCP server
+    and diary entries that have no source file.
+
+    The other thing that strands this read is a live MemPalace server or
+    mine still holding the palace open, so the guidance says to stop it and
+    retry before assuming corruption. Worded conditionally because the bare
+    ``except Exception`` cannot prove which case it caught. Returned as a
+    pre-indented block so the ``print``-based CLI path and the
+    ``progress``-callable rebuild path emit it unchanged.
+    """
+    return (
+        "  If a MemPalace server or mine is still running against this palace,\n"
+        "  stop it and retry. Otherwise the drawer index is likely corrupt\n"
+        "  (for example a failed chromadb HNSW compaction) while your drawer\n"
+        "  rows remain in chroma.sqlite3. Rebuild the index from SQLite rather\n"
+        "  than re-mining:\n"
+        "\n"
+        "      mempalace repair --mode from-sqlite --archive-existing\n"
+        "\n"
+        "  (Re-mining from source files would drop drawers added via the MCP\n"
+        "  server and diary entries, which have no source file.)"
+    )
+
+
 def maybe_repair_poisoned_max_seq_id_before_rebuild(
     palace_path: str,
     *,
@@ -792,7 +826,7 @@ def rebuild_index(
         total = col.count()
     except Exception as e:
         progress(f"  Error reading palace: {e}")
-        progress("  Palace may need to be re-mined from source files.")
+        progress(index_read_recovery_guidance())
         return
 
     progress(f"  Drawers found: {total}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1017,6 +1017,35 @@ def test_cmd_repair_error_reading(mock_config_cls, tmp_path, capsys):
 
 
 @patch("mempalace.cli.MempalaceConfig")
+def test_cmd_repair_error_reading_points_to_from_sqlite_not_remine(
+    mock_config_cls, tmp_path, capsys
+):
+    """When the drawer-index read fails (the chromadb HNSW compactor cannot
+    apply WAL logs to the segment), legacy repair must point the user at
+    ``repair --mode from-sqlite`` — the rows are intact in chroma.sqlite3 —
+    and must NOT advise re-mining from source files, which silently drops
+    drawers added via the MCP server and diary entries (#1843)."""
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
+    mock_config_cls.return_value.palace_path = str(palace_dir)
+    mock_config_cls.return_value.collection_name = "mempalace_drawers"
+    args = argparse.Namespace(palace=None)
+    mock_col = MagicMock()
+    mock_col.count.side_effect = Exception(
+        "Error executing plan: Error sending backfill request to compactor: "
+        "Failed to apply logs to the hnsw segment writer"
+    )
+    mock_backend = MagicMock()
+    mock_backend.get_collection.return_value = mock_col
+    with patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend):
+        cmd_repair(args)
+    out = capsys.readouterr().out
+    assert "mempalace repair --mode from-sqlite --archive-existing" in out
+    assert "may need to be re-mined" not in out
+
+
+@patch("mempalace.cli.MempalaceConfig")
 def test_cmd_repair_zero_drawers(mock_config_cls, tmp_path, capsys):
     palace_dir = tmp_path / "palace"
     palace_dir.mkdir()

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -312,6 +312,32 @@ def test_rebuild_index_empty_palace(mock_backend_cls, mock_shutil, tmp_path):
     mock_backend.delete_collection.assert_not_called()
 
 
+@patch("mempalace.repair.ChromaBackend")
+def test_rebuild_index_read_failure_points_to_from_sqlite(mock_backend_cls, tmp_path):
+    """A chromadb HNSW compactor failure makes the first ``count()`` read
+    raise; rebuild_index cannot recover it, so it must direct the user to
+    ``repair --mode from-sqlite`` (rows are intact in chroma.sqlite3) rather
+    than re-mining from source files, which drops MCP-added drawers (#1843)."""
+    sqlite3.connect(str(tmp_path / "chroma.sqlite3")).close()
+    mock_col = MagicMock()
+    mock_col.count.side_effect = Exception("Failed to apply logs to the hnsw segment writer")
+    mock_backend_cls.return_value.get_collection.return_value = mock_col
+    msgs: list[str] = []
+    repair.rebuild_index(palace_path=str(tmp_path), progress=msgs.append)
+    out = "\n".join(msgs)
+    assert "mempalace repair --mode from-sqlite --archive-existing" in out
+    assert "may need to be re-mined" not in out
+
+
+def test_index_read_recovery_guidance_recommends_from_sqlite():
+    """The shared guidance helper names the from-sqlite recovery command in
+    full and never tells the user the palace ``may need to be re-mined`` —
+    the harmful pre-#1843 advice that silently drops MCP-added drawers."""
+    msg = repair.index_read_recovery_guidance()
+    assert "mempalace repair --mode from-sqlite --archive-existing" in msg
+    assert "may need to be re-mined" not in msg
+
+
 @patch("mempalace.repair.shutil")
 @patch("mempalace.repair.ChromaBackend")
 def test_rebuild_index_success(mock_backend_cls, mock_shutil, tmp_path):


### PR DESCRIPTION
Addresses #1843.

## What does this PR do?

When the chromadb compactor cannot apply the WAL into the drawers HNSW
segment (`InternalError: Failed to apply logs to the hnsw segment writer`),
`mempalace repair` (default legacy mode) and the library `rebuild_index`
both fail on their first read (`Collection.count()`) and then print:

    Cannot recover — palace may need to be re-mined from source files.

That advice is harmful: the drawer rows are intact in `chroma.sqlite3`, and
`repair --mode from-sqlite` rebuilds the index from them. Re-mining instead
silently drops drawers added through the MCP server and diary entries, which
have no source file to mine. That is the data loss #1843 reports.

Both legacy read-failure sites now emit shared guidance pointing at the
working recovery:

    If a MemPalace server or mine is still running against this palace,
    stop it and retry. Otherwise the drawer index is likely corrupt
    (for example a failed chromadb HNSW compaction) while your drawer
    rows remain in chroma.sqlite3. Rebuild the index from SQLite rather
    than re-mining:

        mempalace repair --mode from-sqlite --archive-existing

    (Re-mining from source files would drop drawers added via the MCP
    server and diary entries, which have no source file.)

The message is worded conditionally (it also covers a live server/mine still
holding the palace open) because the `except Exception` cannot prove which
case it caught.

### Scope

This is the "at minimum, change the message" part of #1843's first request.
The larger asks (auto-fallback to from-sqlite, MCP reconnect resilience,
decoupling the durable SQLite write from HNSW indexing in `add_drawer`) are
out of scope here; the compaction failure itself lives in chromadb's core.

Two other `repair.py` re-mine messages are left as-is on purpose:
`check_extraction_safety` (a row-count truncation abort, not an index read)
and the `RebuildCollectionError` no-backup-after-live-swap path (where the
collection is genuinely gone and re-mining is a legitimate last resort).

## How to test

    uv run pytest tests/test_cli.py tests/test_repair.py -q

New regression tests:
- `test_cmd_repair_error_reading_points_to_from_sqlite_not_remine`
- `test_rebuild_index_read_failure_points_to_from_sqlite`
- `test_index_read_recovery_guidance_recommends_from_sqlite`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
