### PR TITLE
fix: use CREATE_NO_WINDOW so Windows hook miner spawns don't flash a console (#1783)

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -25,7 +25,7 @@ PALACE_ROOT = Path.home() / ".mempalace"
 
 
 def _detached_popen_kwargs() -> dict:
-    """Kwargs that fully detach a Popen child so the hook process can exit.
+    """Kwargs that give a Popen child a hidden console so the hook can exit.
 
     Without these, Windows holds the parent open until the child closes the
     inherited stdout/stderr handles — manifesting as "Stop hook hangs" at
@@ -36,7 +36,7 @@ def _detached_popen_kwargs() -> dict:
     kwargs: dict = {"stdin": subprocess.DEVNULL, "close_fds": True}
     if os.name == "nt":
         flags = 0
-        for name in ("DETACHED_PROCESS", "CREATE_NEW_PROCESS_GROUP", "CREATE_BREAKAWAY_FROM_JOB"):
+        for name in ("CREATE_NO_WINDOW", "CREATE_NEW_PROCESS_GROUP", "CREATE_BREAKAWAY_FROM_JOB"):
             flags |= getattr(subprocess, name, 0)
         if flags:
             kwargs["creationflags"] = flags

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -1035,17 +1035,26 @@ def test_detached_popen_kwargs_posix(monkeypatch):
 
 
 def test_detached_popen_kwargs_windows(monkeypatch):
-    """On Windows, kwargs include creationflags that fully detach the child.
+    """On Windows, the miner child gets a hidden console (CREATE_NO_WINDOW),
+    not a detached/no-console child (DETACHED_PROCESS).
 
-    Without these, the parent hook hangs at session end on Windows because
-    the child's inherited stdout/stderr handles keep the parent's exit
-    blocked (#1268 root cause for the Python hook path).
+    DETACHED_PROCESS gave the child no console at all, which caused any
+    console grandchild it spawned to allocate a fresh *visible* window
+    (#1783). CREATE_NO_WINDOW gives a real-but-invisible console that all
+    descendants inherit, so nothing flashes — while still fixing the
+    #1268 hang (stdin=DEVNULL, close_fds, explicit stdout/stderr redirect,
+    and CREATE_NEW_PROCESS_GROUP for the signal boundary are unchanged).
+    Per the Win32 CreateProcess docs CREATE_NO_WINDOW is ignored when OR'd
+    with DETACHED_PROCESS, so the two must be mutually exclusive.
     """
     from mempalace.hooks_cli import _detached_popen_kwargs
 
     monkeypatch.setattr("mempalace.hooks_cli.os.name", "nt")
-    # Simulate Windows-only Popen flag constants. Patch on the imported
-    # subprocess module within hooks_cli so getattr() picks them up.
+    # Simulate Windows-only Popen flag constants on the imported subprocess
+    # module so getattr() picks them up cross-platform.
+    monkeypatch.setattr(
+        "mempalace.hooks_cli.subprocess.CREATE_NO_WINDOW", 0x08000000, raising=False
+    )
     monkeypatch.setattr(
         "mempalace.hooks_cli.subprocess.DETACHED_PROCESS", 0x00000008, raising=False
     )
@@ -1056,7 +1065,10 @@ def test_detached_popen_kwargs_windows(monkeypatch):
     assert kwargs.get("stdin") is subprocess.DEVNULL
     assert kwargs.get("close_fds") is True
     flags = kwargs.get("creationflags", 0)
-    assert flags & 0x00000008, "DETACHED_PROCESS must be set"
+    assert flags & 0x08000000, "CREATE_NO_WINDOW must be set"
+    assert not (flags & 0x00000008), (
+        "DETACHED_PROCESS must NOT be set (it suppresses CREATE_NO_WINDOW)"
+    )
     assert flags & 0x00000200, "CREATE_NEW_PROCESS_GROUP must be set"
 
 


### PR DESCRIPTION
## What

In `mempalace/hooks_cli.py`, `_detached_popen_kwargs()` builds the
`creationflags` for the background miner process it spawns at hook time
(session-start / stop). On Windows it previously OR'd in `DETACHED_PROCESS`.
This PR replaces that one flag with `CREATE_NO_WINDOW`:

```diff
-        for name in ("DETACHED_PROCESS", "CREATE_NEW_PROCESS_GROUP", "CREATE_BREAKAWAY_FROM_JOB"):
+        for name in ("CREATE_NO_WINDOW", "CREATE_NEW_PROCESS_GROUP", "CREATE_BREAKAWAY_FROM_JOB"):
```

The function's one-line docstring summary is updated from "fully detach a Popen
child" to "give a Popen child a hidden console" to keep it honest.

## Why

`DETACHED_PROCESS` gives the child **no console at all**. When that child later
spawns a console grandchild (the miner shells out), the grandchild has no
console to inherit, so Windows allocates a **fresh, visible** console window —
the console flash users report in #1783.

`CREATE_NO_WINDOW` instead gives the child a real but **invisible** console that
all descendants inherit, so nothing flashes.

These two flags are mutually exclusive on Win32: per the
[`CreateProcess` docs](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags),
**`CREATE_NO_WINDOW` is ignored when it is OR'd with `DETACHED_PROCESS`**.
So the fix has to *replace* `DETACHED_PROCESS`, not add to it — simply adding
`CREATE_NO_WINDOW` alongside the existing flag would be a no-op.

### What stays intact

This change is scoped to the single `creationflags` flag. The rest of the
hang-fix for #1268 is untouched:

- `stdin=subprocess.DEVNULL` and `close_fds=True` — unchanged.
- The two spawn sites pass `stdout=log_f, stderr=log_f` explicitly, so miner
  output is still captured to `~/.mempalace/hook_state/…` regardless of
  `creationflags` — **stdout/stderr are not dropped**.
- `CREATE_NEW_PROCESS_GROUP` (signal boundary) and `CREATE_BREAKAWAY_FROM_JOB`
  — unchanged.
- POSIX is unaffected: that branch uses `start_new_session=True` and never
  touches `creationflags`.

The sibling loop in `daemon.py` is intentionally **not** touched — #1783 reports
the hook-spawn console-flash path only, and the daemon miner is a separate path
out of this issue's scope.

Fixes #1783

## Base branch

This PR targets **`develop`** (the repo's default branch).

## AI-assisted disclosure

This change was prepared with the assistance of an AI coding agent (Claude). A
human reviewed the diff, ran the test suite locally, and verified the RED→GREEN
behavior and the Win32 flag rationale before opening this PR. The repository's
`CONTRIBUTING.md` anticipates agentic coding tools (see the "Git identity for
contributions" note); the commit author email is set to a real GitHub-associated
address accordingly.

## Test evidence (RED → GREEN)

The existing test `tests/test_hooks_cli.py::test_detached_popen_kwargs_windows`
was updated first to assert the new contract (CREATE_NO_WINDOW set,
DETACHED_PROCESS not set), then the source was changed. It uses the existing
`monkeypatch.setattr` Windows-simulation pattern, so it runs on Linux/macOS CI.

**RED** — updated test run *before* the source swap (source still yields
`DETACHED_PROCESS`, value `520` = `0x208` = `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`,
missing `CREATE_NO_WINDOW` = `0x08000000` = `134217728`):

```
        flags = kwargs.get("creationflags", 0)
>       assert flags & 0x08000000, "CREATE_NO_WINDOW must be set"
E       AssertionError: CREATE_NO_WINDOW must be set
E       assert (520 & 134217728)

tests/test_hooks_cli.py:1068: AssertionError
=========================== short test summary info ============================
FAILED tests/test_hooks_cli.py::test_detached_popen_kwargs_windows - Assertio...
1 failed, 1 passed, 122 deselected in 0.22s
```

**GREEN** — same test *after* the one-line source swap:

```
$ uv run pytest tests/test_hooks_cli.py -q -k detached_popen_kwargs
..                                                                       [100%]
2 passed, 122 deselected in 0.08s
```

Full file, after the fix:

```
$ uv run pytest tests/test_hooks_cli.py -q
........................................................................ [ 58%]
................s...................................                     [100%]
123 passed, 1 skipped in 9.23s
```

Lint/format on the changed files:

```
$ uv run ruff check mempalace/hooks_cli.py tests/test_hooks_cli.py
All checks passed!
$ uv run ruff format --check mempalace/hooks_cli.py tests/test_hooks_cli.py
2 files already formatted
```
