### PR TITLE
Fix/wing slug special chars

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -954,15 +954,18 @@ _ENCODED_PARENT_PREFIXES = (
 def _safe_wing_slug(name: str) -> str:
     """Normalize a project directory name into a wing slug ``sanitize_name`` accepts.
 
-    Besides the historical space/hyphen handling, collapse any run of non-word
-    characters to ``_`` and trim leading/trailing underscores. Without this, a
-    folder containing a character outside the validator's set (e.g. ``+`` in
-    ``+project``) produced ``wing_+project``, which ``sanitize_name`` rejects,
-    silently breaking diary auto-save for that project. Falls back to ``sessions``
-    when a name reduces to nothing (e.g. ``+``).
+    Builds on the historical space/hyphen handling: map characters outside
+    ``sanitize_name``'s set to ``_`` while keeping ``.`` and ``'`` so existing wings
+    for names like ``my.app`` are preserved (renaming a wing would orphan diary
+    entries already filed under it), collapse ``..`` which the validator rejects as
+    path traversal, and trim edge separators it won't accept. Without this a folder
+    containing e.g. a leading ``+`` produced ``wing_+project``, which ``sanitize_name``
+    rejects — silently breaking diary auto-save. Falls back to ``sessions`` when a
+    name reduces to nothing (e.g. ``+``).
     """
     slug = name.lower().replace(" ", "_").replace("-", "_")
-    slug = re.sub(r"\W+", "_", slug).strip("_")
+    slug = re.sub(r"[^\w.']+", "_", slug)
+    slug = re.sub(r"\.{2,}", ".", slug).strip("_.'")
     return slug or "sessions"
 
 

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -958,14 +958,16 @@ def _safe_wing_slug(name: str) -> str:
     ``sanitize_name``'s set to ``_`` while keeping ``.`` and ``'`` so existing wings
     for names like ``my.app`` are preserved (renaming a wing would orphan diary
     entries already filed under it), collapse ``..`` which the validator rejects as
-    path traversal, and trim edge separators it won't accept. Without this a folder
-    containing e.g. a leading ``+`` produced ``wing_+project``, which ``sanitize_name``
-    rejects — silently breaking diary auto-save. Falls back to ``sessions`` when a
-    name reduces to nothing (e.g. ``+``).
+    path traversal, trim edge separators it won't accept, and cap the length so
+    ``wing_<slug>`` stays within ``sanitize_name``'s 128-character limit. Without
+    this a folder containing e.g. a leading ``+`` produced ``wing_+project``, which
+    ``sanitize_name`` rejects — silently breaking diary auto-save. Falls back to
+    ``sessions`` when a name reduces to nothing (e.g. ``+``).
     """
     slug = name.lower().replace(" ", "_").replace("-", "_")
     slug = re.sub(r"[^\w.']+", "_", slug)
-    slug = re.sub(r"\.{2,}", ".", slug).strip("_.'")
+    slug = re.sub(r"\.{2,}", ".", slug)
+    slug = slug[:120].strip("_.'")
     return slug or "sessions"
 
 

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -951,6 +951,21 @@ _ENCODED_PARENT_PREFIXES = (
 )
 
 
+def _safe_wing_slug(name: str) -> str:
+    """Normalize a project directory name into a wing slug ``sanitize_name`` accepts.
+
+    Besides the historical space/hyphen handling, collapse any run of non-word
+    characters to ``_`` and trim leading/trailing underscores. Without this, a
+    folder containing a character outside the validator's set (e.g. ``+`` in
+    ``+project``) produced ``wing_+project``, which ``sanitize_name`` rejects,
+    silently breaking diary auto-save for that project. Falls back to ``sessions``
+    when a name reduces to nothing (e.g. ``+``).
+    """
+    slug = name.lower().replace(" ", "_").replace("-", "_")
+    slug = re.sub(r"\W+", "_", slug).strip("_")
+    return slug or "sessions"
+
+
 def _wing_from_jsonl_cwd(transcript_path: str) -> Optional[str]:
     """Read ``cwd`` from the first JSONL line that records it.
 
@@ -984,8 +999,7 @@ def _wing_from_jsonl_cwd(transcript_path: str) -> Optional[str]:
                     continue
                 project = cwd_norm.rsplit("/", 1)[-1]
                 if project:
-                    slug = project.lower().replace(" ", "_").replace("-", "_")
-                    return f"wing_{slug}"
+                    return f"wing_{_safe_wing_slug(project)}"
     except OSError:
         pass
     return None
@@ -1042,15 +1056,12 @@ def _wing_from_transcript_path(transcript_path: str) -> str:
             if encoded.startswith(prefix):
                 encoded = encoded[len(prefix) :]
                 break
-        project = encoded.lower().replace(" ", "_").replace("-", "_")
-        if project:
-            return f"wing_{project}"
+        return f"wing_{_safe_wing_slug(encoded)}"
 
     # 3. Legacy — explicit -Projects-<name> segment
     match = re.search(r"-Projects-([^/]+?)(?:/|$)", normalized)
     if match:
-        project = match.group(1).lower().replace(" ", "_").replace("-", "_")
-        return f"wing_{project}"
+        return f"wing_{_safe_wing_slug(match.group(1))}"
 
     # 4. Default
     return "wing_sessions"

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -8,8 +8,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 import mempalace.hooks_cli as hooks_cli_mod
+from mempalace.config import sanitize_name
 from mempalace.hooks_cli import (
     SAVE_INTERVAL,
     _count_human_messages,
@@ -23,6 +26,7 @@ from mempalace.hooks_cli import (
     _mine_already_running,
     _mine_sync,
     _parse_harness_input,
+    _safe_wing_slug,
     _sanitize_session_id,
     _save_diary_direct,
     _validate_transcript_path,
@@ -719,6 +723,59 @@ def test_wing_from_transcript_path_cwd_handles_non_string_cwd(tmp_path):
         encoding="utf-8",
     )
     assert _wing_from_transcript_path(str(transcript)) == "wing_proper_name"
+
+
+# --- _safe_wing_slug: special-character project dirs (e.g. +project) ---
+
+
+def test_safe_wing_slug_strips_leading_plus():
+    """Regression: a ``+``-prefixed folder (e.g. ``+project``) leaked ``+`` into the
+    slug, producing ``wing_+project`` which ``sanitize_name`` rejects — silently
+    breaking diary auto-save for that project."""
+    assert _safe_wing_slug("+project") == "project"
+
+
+def test_safe_wing_slug_replaces_inner_special_chars():
+    assert _safe_wing_slug("foo+bar") == "foo_bar"
+
+
+def test_safe_wing_slug_preserves_space_and_hyphen_behavior():
+    # spaces and hyphens still collapse to underscores (no regression)
+    assert _safe_wing_slug("React Native") == "react_native"
+    assert _safe_wing_slug("claude-code") == "claude_code"
+
+
+def test_safe_wing_slug_falls_back_to_sessions_when_empty():
+    # names made entirely of disallowed characters reduce to nothing
+    assert _safe_wing_slug("+") == "sessions"
+    assert _safe_wing_slug("@#$") == "sessions"
+
+
+def test_wing_from_transcript_path_cwd_plus_prefixed_dir(tmp_path):
+    """Reporter's case: a ``+``-prefixed working directory must yield a sanitizable
+    wing (``wing_project``), not the rejected ``wing_+project``."""
+    project_dir = tmp_path / "encoded-dir"
+    project_dir.mkdir()
+    transcript = project_dir / "session.jsonl"
+    transcript.write_text(
+        '{"type":"user","cwd":"/Users/me/code/+project","content":"hi"}\n',
+        encoding="utf-8",
+    )
+    assert _wing_from_transcript_path(str(transcript)) == "wing_project"
+
+
+def test_wing_from_transcript_path_legacy_plus_prefixed_project():
+    """Legacy ``-Projects-<name>`` path with a ``+``-prefixed project folder."""
+    path = "/Users/me/foo/-Projects-+app/session.jsonl"
+    assert _wing_from_transcript_path(path) == "wing_app"
+
+
+@given(st.text(min_size=1, max_size=40))
+def test_safe_wing_slug_always_yields_sanitizable_wing(name):
+    """Property: for ANY non-empty input, ``wing_<slug>`` must pass sanitize_name —
+    the entire contract of the helper (a rejected wing silently breaks auto-save)."""
+    wing = f"wing_{_safe_wing_slug(name)}"
+    assert sanitize_name(wing) == wing
 
 
 # --- _log ---

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -745,6 +745,23 @@ def test_safe_wing_slug_preserves_space_and_hyphen_behavior():
     assert _safe_wing_slug("claude-code") == "claude_code"
 
 
+def test_safe_wing_slug_preserves_existing_valid_names():
+    """Backward compatibility: a name that already produced a valid wing keeps the
+    same slug, so previously-filed diary entries aren't orphaned (AGENTS.md: never
+    destroy existing data). ``.`` and ``'`` are both accepted by sanitize_name and
+    must survive."""
+    assert _safe_wing_slug("myapp") == "myapp"
+    assert _safe_wing_slug("my.app") == "my.app"
+    assert _safe_wing_slug("v1.2.3") == "v1.2.3"
+    assert _safe_wing_slug("o'brien") == "o'brien"
+
+
+def test_safe_wing_slug_collapses_double_dots():
+    """``..`` must collapse — sanitize_name rejects it as path traversal."""
+    assert _safe_wing_slug("my..app") == "my.app"
+    assert _safe_wing_slug("..hidden..") == "hidden"
+
+
 def test_safe_wing_slug_falls_back_to_sessions_when_empty():
     # names made entirely of disallowed characters reduce to nothing
     assert _safe_wing_slug("+") == "sessions"

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -762,6 +762,14 @@ def test_safe_wing_slug_collapses_double_dots():
     assert _safe_wing_slug("..hidden..") == "hidden"
 
 
+def test_safe_wing_slug_caps_length_for_sanitize_name():
+    """sanitize_name rejects names over 128 chars; the slug stays short enough that
+    wing_<slug> never trips that limit, even for very long directory names."""
+    slug = _safe_wing_slug("a" * 500)
+    assert len(slug) <= 120
+    sanitize_name(f"wing_{slug}")  # must not raise
+
+
 def test_safe_wing_slug_falls_back_to_sessions_when_empty():
     # names made entirely of disallowed characters reduce to nothing
     assert _safe_wing_slug("+") == "sessions"
@@ -787,7 +795,7 @@ def test_wing_from_transcript_path_legacy_plus_prefixed_project():
     assert _wing_from_transcript_path(path) == "wing_app"
 
 
-@given(st.text(min_size=1, max_size=40))
+@given(st.text(min_size=1, max_size=300))
 def test_safe_wing_slug_always_yields_sanitizable_wing(name):
     """Property: for ANY non-empty input, ``wing_<slug>`` must pass sanitize_name —
     the entire contract of the helper (a rejected wing silently breaks auto-save)."""


### PR DESCRIPTION
Fixes diary auto-save silently failing for project folders whose name contains a
character outside `sanitize_name`'s allowed set (e.g. a leading `+`).

## What does this PR do?

Project folders containing characters outside `config.sanitize_name`'s set
(e.g. a leading `+`) leaked into the derived wing name, producing names like
`wing_+project` that `sanitize_name` rejects — silently breaking diary
auto-save for that project (the hook fails quietly; nothing is filed).

- Adds `_safe_wing_slug()`: lowercases, keeps the existing space/hyphen → `_`
handling, maps any remaining character outside `sanitize_name`'s set to `_`
**while preserving `.` and `'`** (both accepted by the validator), collapses
`..` (which `sanitize_name` rejects as path traversal), trims edge separators,
and falls back to `sessions` when a name reduces to nothing (e.g. `+`).
- Routes the three wing-derivation sites in `_wing_from_jsonl_cwd` /
`_wing_from_transcript_path` through it.

**Backward compatibility:** names that already produced a valid wing are
unchanged — including ones with dots or apostrophes (`my.app` → `wing_my.app`,
`v1.2.3` → `wing_v1.2.3`, `o'brien` → `wing_o'brien`) and the long-standing
space/hyphen behavior (`claude-code` → `wing_claude_code`). Only names that
previously produced an *invalid* wing change — and those never filed anything,
so no existing diary entries are orphaned. No new dependencies.

## How to test

Repro (before the fix): point a session at a working directory with a leading
`+` (e.g. `cwd` = `/some/path/+project`). The derived wing is `wing_+project`,
which `sanitize_name` rejects, so the diary auto-save hook fails silently and
nothing is filed. With the fix the wing becomes `wing_project` and saves.

Automated:
```bash
uv run pytest tests/test_hooks_cli.py -k "safe_wing_slug or wing_from_transcript_path" -v
uv run pytest tests/ --ignore=tests/benchmarks   # full suite
```
The added `hypothesis` property test asserts `wing_<slug>` passes `sanitize_name`
for any input — the failure-space the bug lived in. Backward-compatibility tests
assert previously-valid names keep their slug.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`) — 2984 passed, 5 skipped
- [x] No hardcoded paths — source has none; tests use synthetic path strings (matching the existing
`_wing_from_transcript_path` tests) and `tmp_path` for real files
- [x] Linter passes (`ruff check .`) — clean; `ruff format --check .` clean too