### PR TITLE
fix: spawn daemon with CREATE_NO_WINDOW to match hook miner (#1783)

### DIFF
--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -963,6 +963,21 @@ def get_client_if_running(palace_path: str, *, health_timeout: float = 5.0) -> D
 
 
 def _detached_kwargs(log_path: Path) -> dict[str, Any]:
+    """Kwargs that spawn the daemon with a hidden console, detached from the CLI.
+
+    Shares the Windows flag logic with ``hooks_cli._detached_popen_kwargs``
+    (which takes no args and opens no log file). On Windows we use
+    ``CREATE_NO_WINDOW`` rather than ``DETACHED_PROCESS``: the latter gives the
+    child no console, so a console-subsystem grandchild later allocates a fresh
+    *visible* window (#1783); ``CREATE_NO_WINDOW`` gives a hidden console that
+    descendants inherit instead. Surviving the launching terminal is carried by
+    ``CREATE_BREAKAWAY_FROM_JOB`` (escapes the parent Job Object's kill-on-close)
+    plus the daemon never being attached to that console -- not by the console
+    flag -- while ``CREATE_NEW_PROCESS_GROUP`` isolates Ctrl-C/Ctrl-Break routing.
+    ``CREATE_NO_WINDOW`` is ignored when OR'd with ``DETACHED_PROCESS``, so this
+    replaces that flag rather than adding it. ``stdin=DEVNULL`` and stdout/stderr
+    redirected to the log avoid the #1268 parent hang.
+    """
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_fh = open(log_path, "a", encoding="utf-8")
     # The daemon log may capture verbatim content in tracebacks — owner-only.
@@ -975,7 +990,7 @@ def _detached_kwargs(log_path: Path) -> dict[str, Any]:
     }
     if os.name == "nt":
         flags = 0
-        for name in ("DETACHED_PROCESS", "CREATE_NEW_PROCESS_GROUP", "CREATE_BREAKAWAY_FROM_JOB"):
+        for name in ("CREATE_NO_WINDOW", "CREATE_NEW_PROCESS_GROUP", "CREATE_BREAKAWAY_FROM_JOB"):
             flags |= getattr(subprocess, name, 0)
         if flags:
             kwargs["creationflags"] = flags

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import threading
 import time
 
@@ -855,3 +856,50 @@ def test_get_client_if_running_uses_short_probe_timeout(monkeypatch):
     client = daemon.get_client_if_running("/p", health_timeout=daemon.HOOK_PROBE_TIMEOUT)
     assert client is not None
     assert captured["timeout"] == daemon.HOOK_PROBE_TIMEOUT
+
+
+# --- _detached_kwargs ---
+
+
+def test_detached_kwargs_posix(tmp_path, monkeypatch):
+    monkeypatch.setattr("mempalace.daemon.os.name", "posix")
+    kwargs = daemon._detached_kwargs(tmp_path / "daemon.log")
+    fh = kwargs["stdout"]
+    try:
+        assert kwargs.get("start_new_session") is True
+        assert kwargs.get("stdin") is subprocess.DEVNULL
+        assert kwargs.get("close_fds") is True
+        assert "creationflags" not in kwargs
+    finally:
+        fh.close()
+
+
+def test_detached_kwargs_windows(tmp_path, monkeypatch):
+    monkeypatch.setattr("mempalace.daemon.os.name", "nt")
+    monkeypatch.setattr("mempalace.daemon.subprocess.CREATE_NO_WINDOW", 0x08000000, raising=False)
+    monkeypatch.setattr("mempalace.daemon.subprocess.DETACHED_PROCESS", 0x00000008, raising=False)
+    monkeypatch.setattr(
+        "mempalace.daemon.subprocess.CREATE_NEW_PROCESS_GROUP", 0x00000200, raising=False
+    )
+    monkeypatch.setattr(
+        "mempalace.daemon.subprocess.CREATE_BREAKAWAY_FROM_JOB", 0x01000000, raising=False
+    )
+    kwargs = daemon._detached_kwargs(tmp_path / "daemon.log")
+    fh = kwargs["stdout"]
+    try:
+        flags = kwargs.get("creationflags", 0)
+        assert flags & 0x08000000, "CREATE_NO_WINDOW must be set"
+        assert not (flags & 0x00000008), (
+            "DETACHED_PROCESS must NOT be set (it suppresses CREATE_NO_WINDOW)"
+        )
+        assert flags & 0x00000200, "CREATE_NEW_PROCESS_GROUP preserved (Ctrl-Break group isolation)"
+        assert flags & 0x01000000, (
+            "CREATE_BREAKAWAY_FROM_JOB preserved (survive parent Job-Object close)"
+        )
+        assert kwargs.get("stdin") is subprocess.DEVNULL
+        assert kwargs.get("close_fds") is True
+        # creationflags + start_new_session are mutually exclusive on Windows
+        # (Popen raises ValueError); the nt branch must not set the latter.
+        assert "start_new_session" not in kwargs
+    finally:
+        fh.close()


### PR DESCRIPTION
## What does this PR do?

`daemon.py:_detached_kwargs` was the last production spawn site still using
`DETACHED_PROCESS`. This swaps it to `CREATE_NO_WINDOW`, matching the hook
miner's `_detached_popen_kwargs` that was fixed in #1848 — the dedicated
follow-up the review bot asked for there ("a dedicated change addressing all
occurrences"). After this, `grep -rn DETACHED_PROCESS mempalace/` returns zero
production hits; every detached spawn now uses
`CREATE_NO_WINDOW + CREATE_NEW_PROCESS_GROUP + CREATE_BREAKAWAY_FROM_JOB`.

**Why it's safe — daemon survivability is unchanged.** The "survive the
launching terminal/IDE" behavior is carried by `CREATE_BREAKAWAY_FROM_JOB`
(escapes the parent's Job Object kill-on-close) plus the daemon never being
attached to the launching console — both unchanged. `CREATE_NEW_PROCESS_GROUP`
(also kept) isolates Ctrl-C/Ctrl-Break routing. The console flag does not govern
lifetime: `DETACHED_PROCESS` gives the child no console, so a console-subsystem
grandchild allocates a fresh **visible** window (the #1783 flash), whereas
`CREATE_NO_WINDOW` gives a hidden console that descendants inherit, so nothing
flashes. The daemon already redirects stdout/stderr to `daemon.log` and reads no
stdin, so it needs no console for I/O either way. Per the Win32 `CreateProcess`
docs, `CREATE_NO_WINDOW` is **ignored** when OR'd with `DETACHED_PROCESS`, so
this is a replace, not an add — the new test asserts `DETACHED_PROCESS` is absent
to lock that in.

Related #1783. Follows up #1848.

## How to test

```
uv run pytest tests/test_daemon.py -v
```

Adds the first tests for `_detached_kwargs`: `test_detached_kwargs_posix` and
`test_detached_kwargs_windows` (cross-platform monkeypatch of the Windows-only
flag constants — Win32 creation flags can't be exercised at runtime on
Linux/macOS CI). The windows test asserts `CREATE_NO_WINDOW` is set,
`DETACHED_PROCESS` is absent, and that `CREATE_NEW_PROCESS_GROUP` +
`CREATE_BREAKAWAY_FROM_JOB` are preserved (for a long-lived daemon the breakaway
flag is the load-bearing survive-subtree-kill flag).

## Caveats / scope

- Windows-only behavior; verified by-construction (the kwargs flag shape) plus
  parity with the merged #1848 hook fix, **not** a live Windows window test — no
  CI job can assert "no window flashed".
- Scope is intentionally one line + a parity docstring + tests. The two
  `_detached_*` helpers are now near-identical; de-duping them across the
  `hooks_cli`/`daemon` module boundary is a separate design call (happy to file
  an issue if you'd like it).

## Checklist
- [x] Tests pass — `uv run pytest tests/ -v` → **3104 passed, 20 skipped, 0 failed**
- [x] No hardcoded paths
- [x] Linter passes — `uv run ruff check .` → All checks passed!

---
<sub>Authored with the help of an AI coding assistant; all changes reviewed and validated locally by the author.</sub>
