### PR TITLE
fix(palace): process-wide mine_palace_lock re-entrancy so the HTTP transport can write

### DIFF
--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -969,9 +969,28 @@ def _validate_palace_fts5_after_mine(palace_path: str) -> None:
 # "we hold it" semantically — the child must reacquire. The pid check clears
 # stale state so a forked child correctly hits the fcntl path. Access is guarded
 # by ``_palace_lock_guard`` because the set is now shared across threads.
+#
+# Fork safety: ``_palace_lock_guard`` is a real ``threading.Lock``, so a child
+# forked while another thread held it would inherit it locked (the holder thread
+# does not exist in the child) and deadlock on the next acquire. An at-fork
+# handler (registered below) replaces the guard with a fresh unlocked lock and
+# clears state in the child, which must reacquire the flock anyway.
 _palace_lock_guard = threading.Lock()
 _palace_lock_pid = None
 _palace_lock_keys = set()
+
+
+def _reset_palace_lock_state_after_fork() -> None:
+    """Reset lock state in a forked child to avoid an inherited-locked deadlock."""
+    global _palace_lock_guard, _palace_lock_pid, _palace_lock_keys
+    _palace_lock_guard = threading.Lock()
+    _palace_lock_keys = set()
+    _palace_lock_pid = os.getpid()
+
+
+# Availability: Unix (no-op elsewhere — Windows has no fork()).
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_palace_lock_state_after_fork)
 
 
 def _holder_keys_locked():

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -947,45 +947,60 @@ def _validate_palace_fts5_after_mine(palace_path: str) -> None:
         raise MineValidationError(palace_path, errors)
 
 
-# Per-thread record of palaces this thread already holds the lock for. Used by
-# `mine_palace_lock` to short-circuit re-entrant acquisition from the same
-# thread (e.g. miner.mine() acquires the outer lock then calls
+# Process-wide record of palaces this PROCESS already holds the lock for. Used
+# by `mine_palace_lock` to short-circuit re-entrant acquisition from the same
+# process (e.g. miner.mine() acquires the outer lock then calls
 # ChromaCollection.upsert which now also tries to acquire). Without this guard
 # the inner call would block on its own outer flock (Linux fcntl locks are per
-# open file description, so a same-thread second open of the lock file is a
-# distinct lock and self-deadlocks).
+# open file description, so a second open of the lock file from the same process
+# is a distinct lock and self-conflicts / EWOULDBLOCKs).
 #
-# The holder set is tagged with ``pid`` so that a forked child does NOT
-# inherit re-entrant credit from its parent: the OS-level flock IS NOT
-# inherited as a "we hold it" semantically — the child must reacquire — but
-# Python's ``threading.local`` IS inherited across fork. The pid check
-# clears stale state so a forked child correctly hits the fcntl path.
-_palace_lock_holders = threading.local()
+# This MUST be process-wide, not thread-local: the MCP HTTP transport
+# (ThreadingHTTPServer) acquires the long-lived writer-lease on one thread
+# (`mcp_server._acquire_mcp_writer_lock`) but dispatches each write request on a
+# different worker thread. A thread-local guard makes those handlers fail to see
+# the process-held lease, re-acquire the flock, and self-conflict
+# ("palace ... is held by PID <self>"). flock is per-process and HTTP writes are
+# serialized by `_HTTP_REQUEST_LOCK`, so the process is the correct re-entrancy
+# boundary.
+#
+# The holder set is tagged with ``pid`` so that a forked child does NOT inherit
+# re-entrant credit from its parent: the OS-level flock IS NOT inherited as a
+# "we hold it" semantically — the child must reacquire. The pid check clears
+# stale state so a forked child correctly hits the fcntl path. Access is guarded
+# by ``_palace_lock_guard`` because the set is now shared across threads.
+_palace_lock_guard = threading.Lock()
+_palace_lock_pid = None
+_palace_lock_keys = set()
 
 
-def _holder_state():
-    """Return the per-thread (pid, keys) record, refreshing after fork."""
-    keys = getattr(_palace_lock_holders, "keys", None)
-    pid = getattr(_palace_lock_holders, "pid", None)
+def _holder_keys_locked():
+    """Return the process-wide held-key set, refreshing after fork.
+
+    Caller MUST hold ``_palace_lock_guard``.
+    """
+    global _palace_lock_pid, _palace_lock_keys
     current_pid = os.getpid()
-    if keys is None or pid != current_pid:
-        keys = set()
-        _palace_lock_holders.keys = keys
-        _palace_lock_holders.pid = current_pid
-    return keys
+    if _palace_lock_pid != current_pid:
+        _palace_lock_keys = set()
+        _palace_lock_pid = current_pid
+    return _palace_lock_keys
 
 
-def _held_by_this_thread(lock_key: str) -> bool:
-    """Return True if this thread already holds ``mine_palace_lock`` for ``lock_key``."""
-    return lock_key in _holder_state()
+def _held_by_this_process(lock_key: str) -> bool:
+    """Return True if this process already holds ``mine_palace_lock`` for ``lock_key``."""
+    with _palace_lock_guard:
+        return lock_key in _holder_keys_locked()
 
 
 def _mark_held(lock_key: str) -> None:
-    _holder_state().add(lock_key)
+    with _palace_lock_guard:
+        _holder_keys_locked().add(lock_key)
 
 
 def _mark_released(lock_key: str) -> None:
-    _holder_state().discard(lock_key)
+    with _palace_lock_guard:
+        _holder_keys_locked().discard(lock_key)
 
 
 def _format_lock_holder(content: str) -> str:
@@ -1064,11 +1079,13 @@ def mine_palace_lock(palace_path: str):
     raise MineAlreadyRunning so the caller can exit cleanly instead of
     piling up as a waiting worker.
 
-    Re-entrant: if the current thread already holds the lock for the same
+    Re-entrant: if the current process already holds the lock for the same
     palace, the context manager passes through without re-acquiring. This
     lets ChromaCollection write methods (which acquire the lock themselves
     to protect MCP/direct callers) compose with miner.mine() (which holds
-    the outer lock for the entire mine pipeline) without self-deadlock.
+    the outer lock for the entire mine pipeline) without self-deadlock, and
+    lets the threaded MCP HTTP transport write from a worker thread while the
+    long-lived writer-lease is held on another thread of the same process.
     """
     lock_dir = os.path.join(os.path.expanduser("~"), ".mempalace", "locks")
     os.makedirs(lock_dir, exist_ok=True)
@@ -1077,8 +1094,8 @@ def mine_palace_lock(palace_path: str):
     palace_key = hashlib.sha256(lock_key_source.encode()).hexdigest()[:16]
     lock_path = os.path.join(lock_dir, f"mine_palace_{palace_key}.lock")
 
-    if _held_by_this_thread(palace_key):
-        # Same thread already holds the lock for this palace — pass through.
+    if _held_by_this_process(palace_key):
+        # This process already holds the lock for this palace — pass through.
         yield
         return
 

--- a/tests/test_palace_locks.py
+++ b/tests/test_palace_locks.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import threading
 import time
 import sys
 
@@ -66,6 +67,45 @@ def _hold_lock(palace_path: str, ready_flag: str, release_flag: str) -> int:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def test_mine_palace_lock_reentrant_across_threads_same_process(tmp_path):
+    """Process-wide re-entrancy: a second acquisition from a *different thread*
+    of the same process passes through instead of self-conflicting.
+
+    Regression for the MCP HTTP transport (ThreadingHTTPServer): the writer
+    lease is acquired on one thread (mcp_server._acquire_mcp_writer_lock) but
+    write requests are dispatched on other worker threads. With the old
+    thread-local re-entrancy those handlers re-acquired the process-held flock
+    and raised MineAlreadyRunning ("palace ... is held by PID <self>").
+    Re-entrancy is now process-wide, so same-process cross-thread acquisition is
+    a pass-through.
+    """
+    palace = str(tmp_path / "palace")
+    os.makedirs(palace, exist_ok=True)
+
+    outer = mine_palace_lock(palace)
+    outer.__enter__()  # main thread holds the lease, like the MCP writer-lease
+    try:
+        result: dict = {}
+
+        def worker():
+            try:
+                with mine_palace_lock(palace):
+                    result["acquired"] = True
+            except MineAlreadyRunning as exc:  # pragma: no cover - failure path
+                result["error"] = str(exc)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=5)
+
+        assert not t.is_alive(), "worker thread hung acquiring the palace lock"
+        assert result.get("acquired") is True, (
+            f"cross-thread same-process acquisition should pass through, got: {result}"
+        )
+    finally:
+        outer.__exit__(None, None, None)
 
 
 def test_single_acquire_succeeds(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

When MemPalace runs as a remote MCP server over the HTTP transport (`mempalace-mcp --transport http`), **reads work but writes fail** with:

```
palace ... is held by PID <self> (mempalace-mcp --transport http); wait for it to finish or stop the holder before retrying
```

The server reports the palace as held by *itself*, so `add_drawer` / `update_drawer` never succeed over HTTP. (Over stdio it's fine because everything runs on one thread.)

## Root cause

1. The HTTP server takes a long-lived per-palace **writer-lease** at startup via `_acquire_mcp_writer_lock()` → `mine_palace_lock(...).__enter__()` (`mcp_server.py`). That holds the flock for the process lifetime and records the lock as held **on the acquiring thread**.
2. `mine_palace_lock` re-entrancy is **thread-local** (`palace.py`: `_palace_lock_holders = threading.local()`, checked via `_held_by_this_thread`).
3. `ThreadingHTTPServer` dispatches each request on a **different worker thread**. A write handler runs on a worker thread where the thread-local guard is empty, so it tries to re-acquire the flock and hits `BlockingIOError` (the process already holds it via the lease fd) → `MineAlreadyRunning`.

Reads don't take the lock, so they're unaffected. This is distinct from the multi-*process* races in #1229/#974 — it is a multi-*thread*, single-process self-conflict specific to the threaded HTTP transport (#1801).

## Fix

Make the re-entrancy record **process-wide** instead of thread-local: a module-level set guarded by a `threading.Lock`, tagged with pid so a forked child does not inherit re-entrant credit. A write from any thread of the process that already holds the lease now passes through without re-acquiring.

Safe because:
- flock is per-process — two threads can't independently hold it anyway;
- HTTP writes are serialized by `_HTTP_REQUEST_LOCK`;
- fork-safety preserved via the pid check;
- same-thread nesting (`miner.mine` → `ChromaCollection.upsert`) still works;
- cross-process protection unchanged (`MineAlreadyRunning` still raised between processes).

## Testing

- New regression test `test_mine_palace_lock_reentrant_across_threads_same_process` (fails on the old thread-local code, passes now).
- `tests/test_palace_locks.py` → 12 passed; `test_chroma_collection_lock.py` + `test_mine_lock_lifecycle.py` + `test_mcp_http_transport.py` → 21 passed. No regressions.
- `ruff check` + `ruff format` clean.
- **Verified live:** deployed this branch to a remote `--transport http` server; `add_drawer` over MCP now succeeds (previously errored) and `status` reflects the new drawer.