### PR TITLE
fix(hooks): hide conhost window on Windows in _mine_sync non-daemon path

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -660,6 +660,11 @@ def _mine_sync():
                     stdout=log_f,
                     stderr=log_f,
                     timeout=60,
+                    # Windows: hide the conhost window this sync mine would
+                    # otherwise flash on every fire. Mirrors the async paths
+                    # (_spawn_mine / _desktop_toast) via _detached_popen_kwargs().
+                    # 0 is a no-op off-Windows.
+                    creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
                 )
         except (OSError, subprocess.TimeoutExpired):
             pass


### PR DESCRIPTION
Fixes #1862

## Problem
On Windows, the non-daemon fallback in `_mine_sync()` (`mempalace/hooks_cli.py`) calls `subprocess.run([..., "mine", ...])` without `creationflags`, so the PreCompact synchronous mine flashes a visible conhost window on every fire.

The async/detached paths already get this right — `_spawn_mine()` and `_desktop_toast()` both pass `CREATE_NO_WINDOW` via `_detached_popen_kwargs()`. This one synchronous path was missed.

## Fix
One line, mirroring the package's existing pattern:

```python
creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
```

`getattr(..., 0)` is a no-op off-Windows, so POSIX behavior is unchanged. Verified the file still byte-compiles.

Present on `develop` and released 3.4.0 / 3.5.0.