### PR TITLE
fix: expand tilde in palace_path when read from config file

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -340,7 +340,7 @@ class MempalaceConfig:
             # code path (mcp_server.py:62) and prevent surprise redirection
             # when the env var contains unresolved components.
             return os.path.abspath(os.path.expanduser(env_val))
-        return self._file_config.get("palace_path", DEFAULT_PALACE_PATH)
+        return os.path.expanduser(self._file_config.get("palace_path", DEFAULT_PALACE_PATH))
 
     @property
     def tunnel_file(self):

--- a/tests/test_config_palace_path.py
+++ b/tests/test_config_palace_path.py
@@ -1,0 +1,33 @@
+"""Tests for palace_path tilde expansion in MempalaceConfig."""
+
+import os
+from mempalace.config import MempalaceConfig
+
+
+def test_palace_path_expands_tilde_from_config_file():
+    """palace_path must expand ~ even when read from config.json, not env."""
+    cfg = MempalaceConfig()
+    cfg._file_config["palace_path"] = "~/.mempalace/palace"
+    result = cfg.palace_path
+    assert not result.startswith("~"), (
+        f"palace_path returned unexpanded tilde: {result!r}. "
+        "This causes mempalace mine to create a literal '~' directory "
+        "relative to CWD instead of writing to the home directory."
+    )
+    assert result == os.path.expanduser("~/.mempalace/palace")
+
+
+def test_palace_path_expands_tilde_nested():
+    """Nested tilde paths (e.g. ~/custom/palace) are also expanded."""
+    cfg = MempalaceConfig()
+    cfg._file_config["palace_path"] = "~/custom/mempalace"
+    result = cfg.palace_path
+    assert not result.startswith("~")
+    assert result == os.path.expanduser("~/custom/mempalace")
+
+
+def test_palace_path_absolute_unchanged():
+    """Absolute paths pass through without modification."""
+    cfg = MempalaceConfig()
+    cfg._file_config["palace_path"] = "/tmp/test_palace"
+    assert cfg.palace_path == "/tmp/test_palace"


### PR DESCRIPTION
MempalaceConfig.palace_path correctly called expanduser for env-var paths but not for paths read from config.json. One-line fix: wrap the _file_config fallback in os.path.expanduser(), mirroring line 342. DEFAULT_PALACE_PATH is already absolute so this is a no-op on the default case. Symptoms: palace always empty, search returns Collection does not exist, data scattered across CWD-relative directories. Adds tests/test_config_palace_path.py (3 cases, all pass).