### PR TITLE
[codex] add MCP transport health diagnostic

### DIFF
--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -1,6 +1,8 @@
 # MemPalace - Codex CLI Plugin
 
-Give your AI a persistent memory -- mine projects and conversations into a searchable palace backed by ChromaDB, with 35 MCP tools, auto-save hooks, and guided skills.
+Give your AI a persistent memory -- mine projects and conversations into a
+searchable palace backed by ChromaDB, with 35 MCP tools, auto-save hooks, and
+guided skills.
 
 ## Prerequisites
 
@@ -18,13 +20,13 @@ Give your AI a persistent memory -- mine projects and conversations into a searc
 cp -r .codex-plugin /path/to/your/project/.codex-plugin
 ```
 
-2. Verify the plugin is detected:
+1. Verify the plugin is detected:
 
 ```bash
 codex --plugins
 ```
 
-3. Initialize your palace:
+1. Initialize your palace:
 
 ```bash
 codex /init
@@ -39,7 +41,7 @@ git clone https://github.com/MemPalace/mempalace.git
 cd mempalace
 ```
 
-2. Install the Python package so the `mempalace-mcp` script lands on
+1. Install the Python package so the `mempalace-mcp` script lands on
    your PATH (the bundled `plugin.json` invokes it by bare name):
 
 ```bash
@@ -50,9 +52,10 @@ uv tool install --editable .   # or: pip install -e .
    `.venv/bin/`, which Codex will not find unless you activate the venv
    before launching Codex.
 
-3. The `.codex-plugin` directory is already in the repo root. Codex CLI will detect it automatically when you run Codex from inside the repository.
+1. The `.codex-plugin` directory is already in the repo root. Codex CLI will
+   detect it automatically when you run Codex from inside the repository.
 
-4. Initialize your palace:
+2. Initialize your palace:
 
 ```bash
 codex /init
@@ -61,7 +64,7 @@ codex /init
 ## Available Skills
 
 | Skill | Description |
-|-------|-------------|
+| --- | --- |
 | `/help` | Show available commands and usage tips |
 | `/init` | Initialize a new memory palace |
 | `/search` | Semantic search across all mined memories |
@@ -70,11 +73,30 @@ codex /init
 
 ## Hooks
 
-The plugin includes auto-save hooks that run on session stop (every 15 messages) and before context compaction, automatically preserving conversation context into your palace.
+The plugin includes auto-save hooks that run on session stop (every 15
+messages) and before context compaction, automatically preserving conversation
+context into your palace.
 
-Set the `MEMPAL_DIR` environment variable to a directory path to automatically run `mempalace mine` on that directory during each save trigger.
+Set the `MEMPAL_DIR` environment variable to a directory path to automatically
+run `mempalace mine` on that directory during each save trigger.
+
+## MCP Transport Diagnostics
+
+If Codex reports `Transport closed` for `mcp__mempalace`, do not treat that as
+an empty palace or empty wing. The in-thread MCP handle is unavailable, so call
+the shell diagnostic instead:
+
+```bash
+mempalace mcp-health --json
+```
+
+`mcp_transport: "ok"` means a fresh MemPalace MCP server can answer over
+stdio.
+`mcp_transport: "transport_unavailable"` means the agent should use the CLI
+fallback commands in the JSON payload, report a runtime MCP transport failure,
+and retry MCP only after the host restarts or `mempalace_reconnect` is callable.
 
 ## Support
 
-- Repository: https://github.com/MemPalace/mempalace
-- Issues: https://github.com/MemPalace/mempalace/issues
+- Repository: <https://github.com/MemPalace/mempalace>
+- Issues: <https://github.com/MemPalace/mempalace/issues>

--- a/integrations/shared/recall-protocol.md
+++ b/integrations/shared/recall-protocol.md
@@ -28,7 +28,9 @@ question-driven, not reflexive.
 
 ## The protocol
 
-1. **On wake-up** (if a session-start hook injected context, honour its wing scoping / `additional_context`): scope recall to the wing inferred from the workspace, then continue.
+1. **On wake-up**: if a session-start hook injected context, honour its
+   wing scoping / `additional_context`; scope recall to the wing inferred
+   from the workspace, then continue.
 2. **Before responding** about people, projects, past events, or prior
    decisions: call `mempalace_search` first. For relational or temporal
    facts ("who reported to whom in March", "what was true then"), call
@@ -47,12 +49,12 @@ question-driven, not reflexive.
 ## Tool selection
 
 | You need | Tool |
-|---|---|
+| --- | --- |
 | Find any memory by meaning | `mempalace_search` (start here) |
 | Relational / time-bound facts about an entity | `mempalace_kg_query` |
 | The chronological story of an entity | `mempalace_kg_timeline` |
 | Recent session continuity | `mempalace_diary_read` |
-| Which wings / rooms exist (when scope unknown) | `mempalace_list_wings`, `mempalace_list_rooms` |
+| Wing / room inventory | `mempalace_list_wings`, `mempalace_list_rooms` |
 | Record this session | `mempalace_diary_write` |
 
 `mempalace_search` takes a short natural-language `query` (keywords or a
@@ -64,9 +66,15 @@ question — not a system prompt or pasted conversation) plus optional
 - **Empty results.** Say the palace has nothing on this; do not invent an
   answer to fill the gap. Offer to widen the search (drop the wing
   filter) or to file the new information.
-- **MCP unavailable / tool error.** Surface the error plainly and suggest
-  the user verify the server (`mempalace status`, or re-run install).
-  Do not silently fall back to guessing from model memory.
+- **MCP unavailable / tool error.** Surface the error plainly. If the
+  host reports `Transport closed` or the MCP tool namespace disappears,
+  classify it as transport failure, not as an empty or stale palace. Run
+  `mempalace mcp-health --json` from the shell to verify whether a fresh
+  MemPalace MCP process can answer over stdio, then use
+  `mempalace status` / `mempalace search` as CLI fallback while reporting
+  the MCP runtime failure. If MCP still answers but cached handles look
+  stale, call `mempalace_reconnect` before retrying. Do not silently fall
+  back to guessing from model memory.
 - **Palace index corrupt / compactor error.** When the server returns an
   error mentioning the HNSW segment writer, a ChromaDB compaction
   failure, or a stuck "Not connected" state after a write, the on-disk
@@ -90,8 +98,10 @@ from the agent (it can break other live clients):
    host editor).
 2. Optional backup of the palace directory (`--archive-existing` already
    moves the old palace aside, so this is belt-and-suspenders):
-   - macOS / Linux: `cp -a ~/.mempalace/palace ~/.mempalace/palace.bak.$(date +%F)`
-   - Windows (PowerShell): `Copy-Item -Recurse "$env:USERPROFILE\.mempalace\palace" "$env:USERPROFILE\.mempalace\palace.bak"`
+   - macOS / Linux:
+     `cp -a ~/.mempalace/palace ~/.mempalace/palace.bak.$(date +%F)`
+   - Windows PowerShell:
+     `Copy-Item -Recurse "$env:USERPROFILE\.mempalace\palace" "$env:USERPROFILE\.mempalace\palace.bak"`
 3. Rebuild from SQLite:
    `mempalace repair --mode from-sqlite --archive-existing --yes`
 4. Verify: `mempalace repair-status` (divergence should read 0).

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -17,6 +17,7 @@ Commands:
     mempalace mine <dir> --mode extract   Mine binary office documents (PDF/DOCX/etc.)
     mempalace search "query"              Find anything, exact words
     mempalace mcp                         Show MCP setup command
+    mempalace mcp-health                  Diagnose MCP transport availability
     mempalace wake-up                     Show L0 + L1 wake-up context
     mempalace wake-up --wing my_app       Wake-up for a specific project
     mempalace status                      Show what's been filed
@@ -33,6 +34,10 @@ import os
 import sys
 import shlex
 import argparse
+import json
+import subprocess
+import threading
+from queue import Empty, Queue
 from pathlib import Path
 
 from .config import MempalaceConfig
@@ -1324,12 +1329,214 @@ def cmd_mcp(args):
     print(f"  codex mcp add mempalace -- {server_cmd}")
     print("\nRun the server directly:")
     print(f"  {server_cmd}")
+    print("\nDiagnose MCP transport:")
+    print("  mempalace mcp-health --json")
 
     if not args.palace:
         print("\nOptional custom palace:")
         print(f"  claude mcp add mempalace -- {base_server_cmd} --palace /path/to/palace")
         print(f"  codex mcp add mempalace -- {base_server_cmd} --palace /path/to/palace")
         print(f"  {base_server_cmd} --palace /path/to/palace")
+
+
+def _mcp_health_server_command(args) -> list[str]:
+    if args.server_command:
+        return shlex.split(args.server_command)
+
+    cmd = ["mempalace-mcp"]
+    if args.palace:
+        cmd.extend(["--palace", str(Path(args.palace).expanduser())])
+    backend = _backend_arg(args)
+    if backend:
+        cmd.extend(["--backend", str(backend).strip().lower()])
+    return cmd
+
+
+def _mcp_health_cli_status_command(args) -> str:
+    cmd = ["mempalace"]
+    if args.palace:
+        cmd.extend(["--palace", str(Path(args.palace).expanduser())])
+    backend = _backend_arg(args)
+    if backend:
+        cmd.extend(["--backend", str(backend).strip().lower()])
+    cmd.append("status")
+    return " ".join(shlex.quote(part) for part in cmd)
+
+
+def _readline_with_timeout(stream, timeout: float) -> str:
+    q: Queue = Queue(maxsize=1)
+
+    def _reader():
+        try:
+            q.put(stream.readline())
+        except Exception as exc:  # noqa: BLE001 - surfaced as transport diagnostic
+            q.put(exc)
+
+    threading.Thread(target=_reader, daemon=True).start()
+    try:
+        result = q.get(timeout=timeout)
+    except Empty as exc:
+        raise TimeoutError(f"timed out waiting for MCP response after {timeout:g}s") from exc
+    if isinstance(result, BaseException):
+        raise result
+    return result
+
+
+def _mcp_health_request(proc, payload: dict, timeout: float) -> dict:
+    if proc.stdin is None or proc.stdout is None:
+        raise RuntimeError("MCP process was not started with stdio pipes")
+
+    try:
+        proc.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        proc.stdin.flush()
+    except BrokenPipeError as exc:
+        raise ConnectionError("MCP transport closed while sending request") from exc
+
+    line = _readline_with_timeout(proc.stdout, timeout)
+    if line == "":
+        raise ConnectionError("MCP transport closed before a response was returned")
+    return json.loads(line)
+
+
+def _mcp_health_fallback_payload(args, command: list[str], exc: BaseException, stderr: str) -> dict:
+    return {
+        "mcp_transport": "transport_unavailable",
+        "failure_mode": "mcp_transport_closed"
+        if isinstance(exc, (ConnectionError, BrokenPipeError))
+        else "mcp_transport_timeout"
+        if isinstance(exc, TimeoutError)
+        else "mcp_transport_error",
+        "error_class": type(exc).__name__,
+        "message": str(exc),
+        "server_command": " ".join(shlex.quote(part) for part in command),
+        "server_stderr": stderr[-4000:] if stderr else "",
+        "fallback": {
+            "needed": True,
+            "classification": "MCP transport unavailable",
+            "cli_status_command": _mcp_health_cli_status_command(args),
+            "reconnect_tool": "mempalace_reconnect",
+        },
+        "agent_guidance": (
+            "mcp_transport_unavailable_not_empty_palace: do not classify this as "
+            "an empty or stale wing. Use CLI fallback commands, report a runtime "
+            "MCP transport failure, and only retry MCP after the host restarts or "
+            "mempalace_reconnect is callable again."
+        ),
+    }
+
+
+def cmd_mcp_health(args):
+    """Check whether the MemPalace MCP stdio transport is reachable.
+
+    This is intentionally a CLI-side probe, not an MCP tool. When a Codex
+    thread reports "Transport closed", the model cannot call any MemPalace MCP
+    tool, including ``mempalace_reconnect``. This command gives the agent a
+    shell fallback that distinguishes transport failure from "palace empty".
+    """
+
+    command = _mcp_health_server_command(args)
+    env = os.environ.copy()
+    if args.palace:
+        env["MEMPALACE_PALACE_PATH"] = str(Path(args.palace).expanduser())
+    backend = _backend_arg(args)
+    if backend:
+        env[_EXPLICIT_BACKEND_ENV] = str(backend).strip().lower()
+        env["MEMPALACE_BACKEND"] = str(backend).strip().lower()
+
+    proc = None
+    stderr_tail = ""
+    try:
+        proc = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+        )
+        init = _mcp_health_request(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": "mempalace-mcp-health-init",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "clientInfo": {"name": "mempalace-mcp-health", "version": __version__},
+                },
+            },
+            args.timeout,
+        )
+        if "error" in init:
+            raise RuntimeError(f"initialize failed: {init['error']}")
+        tools = _mcp_health_request(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": "mempalace-mcp-health-tools",
+                "method": "tools/list",
+            },
+            args.timeout,
+        )
+        if "error" in tools:
+            raise RuntimeError(f"tools/list failed: {tools['error']}")
+
+        tool_names = {
+            tool.get("name")
+            for tool in tools.get("result", {}).get("tools", [])
+            if isinstance(tool, dict)
+        }
+        payload = {
+            "mcp_transport": "ok",
+            "failure_mode": None,
+            "server_command": " ".join(shlex.quote(part) for part in command),
+            "server": init.get("result", {}).get("serverInfo", {}),
+            "tools": {
+                "count": len(tool_names),
+                "has_status": "mempalace_status" in tool_names,
+                "has_reconnect": "mempalace_reconnect" in tool_names,
+            },
+            "fallback": {
+                "needed": False,
+                "cli_status_command": _mcp_health_cli_status_command(args),
+                "reconnect_tool": "mempalace_reconnect",
+            },
+        }
+        exit_code = 0
+    except Exception as exc:  # noqa: BLE001 - diagnostic command must classify broadly
+        if proc is not None and proc.stderr is not None:
+            try:
+                proc.terminate()
+                stderr_tail = proc.communicate(timeout=1)[1] or ""
+            except Exception:
+                proc.kill()
+                stderr_tail = proc.communicate(timeout=1)[1] or ""
+        payload = _mcp_health_fallback_payload(args, command, exc, stderr_tail)
+        exit_code = 2
+    finally:
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.communicate(timeout=1)
+            except Exception:
+                proc.kill()
+                proc.communicate(timeout=1)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        if payload["mcp_transport"] == "ok":
+            print("MemPalace MCP transport: ok")
+            print(f"Server: {payload['server'].get('name', 'unknown')}")
+            print(f"Tools: {payload['tools']['count']}")
+        else:
+            print("MemPalace MCP transport: unavailable")
+            print(f"Failure mode: {payload['failure_mode']}")
+            print(f"Fallback: {payload['fallback']['cli_status_command']}")
+            print(payload["agent_guidance"])
+    raise SystemExit(exit_code)
 
 
 def cmd_compress(args):
@@ -1934,6 +2141,33 @@ def main():
         help="Storage backend to include in the MCP startup command",
     )
 
+    # mcp-health
+    p_mcp_health = sub.add_parser(
+        "mcp-health",
+        help="Probe the MemPalace MCP stdio transport and print fallback diagnostics",
+    )
+    p_mcp_health.add_argument(
+        "--backend",
+        default=None,
+        help="Storage backend to use for the default MCP startup command",
+    )
+    p_mcp_health.add_argument(
+        "--server-command",
+        default=None,
+        help="Override the MCP server command to probe (default: mempalace-mcp plus global flags)",
+    )
+    p_mcp_health.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Seconds to wait for each JSON-RPC response (default: 10)",
+    )
+    p_mcp_health.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON diagnostics",
+    )
+
     # status
     # migrate
     p_migrate = sub.add_parser(
@@ -2039,6 +2273,7 @@ def main():
         "sweep": cmd_sweep,
         "sync": cmd_sync,
         "mcp": cmd_mcp,
+        "mcp-health": cmd_mcp_health,
         "compress": cmd_compress,
         "wake-up": cmd_wakeup,
         "repair": cmd_repair,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -868,6 +868,7 @@ def test_mcp_command_prints_setup_guidance(monkeypatch, capsys):
     assert "MemPalace MCP quick setup:" in captured.out
     assert "claude mcp add mempalace -- mempalace-mcp" in captured.out
     assert "codex mcp add mempalace -- mempalace-mcp" in captured.out
+    assert "mempalace mcp-health --json" in captured.out
     assert "\nOptional custom palace:\n" in captured.out
     assert "mempalace-mcp --palace /path/to/palace" in captured.out
     assert "[--palace /path/to/palace]" not in captured.out

--- a/tests/test_mcp_health_e2e.py
+++ b/tests/test_mcp_health_e2e.py
@@ -1,0 +1,82 @@
+"""End-to-end diagnostics for MCP transport availability.
+
+These tests exercise the CLI and a real child process over stdio. They cover
+the operator path agents need when the in-thread MCP handle is already closed:
+run a shell command, classify the failure as transport-level, and use CLI
+fallback guidance instead of treating the palace as empty.
+"""
+
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_mcp_health(server_command: str, tmp_path: Path):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mempalace",
+            "--palace",
+            str(tmp_path / "palace"),
+            "mcp-health",
+            "--json",
+            "--timeout",
+            "5",
+            "--server-command",
+            server_command,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+
+
+def test_mcp_health_reports_ok_for_real_stdio_server(tmp_path):
+    server_command = " ".join(
+        shlex.quote(part)
+        for part in [
+            sys.executable,
+            "-m",
+            "mempalace.mcp_server",
+            "--backend",
+            "sqlite_exact",
+            "--palace",
+            str(tmp_path / "palace"),
+        ]
+    )
+
+    result = _run_mcp_health(server_command, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["mcp_transport"] == "ok"
+    assert payload["server"]["name"] == "mempalace"
+    assert payload["tools"]["has_status"] is True
+    assert payload["fallback"]["needed"] is False
+
+
+def test_mcp_health_distinguishes_transport_closed_from_empty_palace(tmp_path):
+    server_command = " ".join(
+        shlex.quote(part)
+        for part in [
+            sys.executable,
+            "-c",
+            "import sys; sys.exit(42)",
+        ]
+    )
+
+    result = _run_mcp_health(server_command, tmp_path)
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["mcp_transport"] == "transport_unavailable"
+    assert payload["failure_mode"] == "mcp_transport_closed"
+    assert payload["fallback"]["needed"] is True
+    assert payload["fallback"]["classification"] == "MCP transport unavailable"
+    assert payload["fallback"]["cli_status_command"].startswith("mempalace ")
+    assert payload["fallback"]["cli_status_command"].endswith(" status")
+    assert "not_empty_palace" in payload["agent_guidance"]


### PR DESCRIPTION
## Summary

- Add `mempalace mcp-health` as a CLI-side stdio probe for MemPalace MCP transport availability.
- Classify closed MCP transport separately from empty/stale memory, with CLI fallback guidance for Codex agents.
- Document the fallback path for Codex plugin users and shared recall protocol users.

## Why

When a Codex thread reports `Transport closed`, the in-thread MCP handle can be unusable while a fresh MemPalace CLI/server path is still healthy. Agents need a deterministic way to distinguish runtime MCP transport failure from an empty palace or stale wing.

Tracked from `pierrefrns/agent-workflows#32`.

## Validation

- `uv run pytest -q tests/test_mcp_health_e2e.py tests/test_cli.py tests/test_mcp_stdio_protection.py tests/test_mcp_http_transport.py` -> `97 passed`
- `uv run ruff check mempalace/cli.py tests/test_mcp_health_e2e.py tests/test_cli.py` -> passed
- `npx --yes markdownlint-cli2 .codex-plugin/README.md integrations/shared/recall-protocol.md /home/dev/code/docs/guides/agent-memory/current-state.md /home/dev/code/docs/guides/codex-config/current-state.md /home/dev/code/docs/guides/agent-harness/current-state.md` -> `0 error(s)`
- Live healthy smoke: `mempalace mcp-health --json` against `mempalace-mcp` returns `mcp_transport: "ok"`, 35 tools, `has_status: true`, `has_reconnect: true`.
- Live closed-transport smoke: probing a process that exits immediately returns exit code 2 with `mcp_transport: "transport_unavailable"` and `failure_mode: "mcp_transport_closed"`.
