### PR TITLE
fix(chroma): stop quarantining valid all-layer-0 HNSW segments (#1716)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -82,13 +82,52 @@ def _hnsw_link_to_data_ratio(seg_dir: str) -> Optional[float]:
     return link_size / data_size
 
 
-def _hnsw_link_lists_is_usable_for_payload(seg_dir: str) -> bool:
-    """Return False when a non-trivial HNSW payload lacks usable link lists.
+def _hnsw_metadata_marker_intact(seg_dir: str) -> bool:
+    """Return True when ``index_metadata.pickle`` bears a complete envelope.
 
-    A missing or empty link_lists.bin is acceptable only for a fresh/empty
-    segment. Once data_level0.bin has real payload, a zero-byte link_lists.bin
-    is not a harmless async-flush shape: ChromaDB can later hand the broken
-    graph to hnswlib and crash in native code.
+    ChromaDB writes ``index_metadata.pickle`` last during a persist, so an
+    intact pickle envelope — protocol marker ``0x80`` at the head, ``STOP``
+    byte ``0x2e`` at the tail — proves the flush finished. Used as a
+    persist-completion marker: when present, the segment's on-disk shape
+    (including an all-layer-0 index with an empty ``link_lists.bin``) is the
+    one chromadb intentionally serialized, not a half-written one.
+
+    Deliberately byte-sniffs only; never deserializes. Deserialization can
+    execute arbitrary code, and the byte-sniff is enough to tell a complete
+    write from truncation or zero-fill. Assumes pickle protocol >= 2.
+    """
+    meta_path = os.path.join(seg_dir, "index_metadata.pickle")
+    try:
+        if not os.path.isfile(meta_path) or os.path.getsize(meta_path) < 16:
+            return False
+        with open(meta_path, "rb") as f:
+            head = f.read(2)
+            f.seek(-1, 2)  # last byte
+            tail = f.read(1)
+    except OSError:
+        return False
+    return len(head) == 2 and head[0] == 0x80 and tail == b"\x2e"
+
+
+def _hnsw_link_lists_is_usable_for_payload(seg_dir: str) -> bool:
+    """Return False when a non-trivial HNSW payload looks like a partial flush.
+
+    A zero-byte ``link_lists.bin`` is *not* corruption on its own. hnswlib
+    stores the entire layer-0 graph inside ``data_level0.bin`` and only writes
+    ``link_lists.bin`` for elements promoted to level > 0. A small or
+    low-fanout index where every element stays on layer 0 therefore
+    serializes an empty ``link_lists.bin`` and loads/searches fine (#1716).
+    Treating that shape as corruption produced a self-perpetuating quarantine
+    loop: repair rebuilt the byte-identical all-layer-0 segment, which the next
+    cold start quarantined again, accumulating drift dirs without bound.
+
+    An empty ``link_lists.bin`` only signals trouble when the persist was
+    interrupted before it could finish. ChromaDB writes
+    ``index_metadata.pickle`` last, so an intact metadata envelope proves the
+    flush completed and the empty ``link_lists.bin`` is the legitimate
+    all-layer-0 shape. Only when there is real payload, an empty
+    ``link_lists.bin``, *and* no completion marker do we treat the segment as a
+    partial flush.
     """
     data_path = os.path.join(seg_dir, "data_level0.bin")
     link_path = os.path.join(seg_dir, "link_lists.bin")
@@ -101,9 +140,15 @@ def _hnsw_link_lists_is_usable_for_payload(seg_dir: str) -> bool:
         if data_size <= _HNSW_MISSING_METADATA_DATA_FLOOR:
             return True
 
-        return os.path.isfile(link_path) and os.path.getsize(link_path) > 0
+        if os.path.isfile(link_path) and os.path.getsize(link_path) > 0:
+            return True
     except OSError:
         return False
+
+    # Real payload with an empty/absent link_lists.bin: legitimate only when
+    # the persist completed (all-layer-0 index), proven by an intact metadata
+    # marker. Otherwise it is a half-written segment chromadb could segfault on.
+    return _hnsw_metadata_marker_intact(seg_dir)
 
 
 def _hnsw_payload_appears_sane(seg_dir: str) -> bool:
@@ -337,17 +382,7 @@ def _segment_appears_healthy(seg_dir: str) -> bool:
     if not _hnsw_payload_appears_sane(seg_dir):
         return False
 
-    try:
-        size = os.path.getsize(meta_path)
-        if size < 16:
-            return False
-        with open(meta_path, "rb") as f:
-            head = f.read(2)
-            f.seek(-1, 2)  # last byte
-            tail = f.read(1)
-    except OSError:
-        return False
-    return len(head) == 2 and head[0] == 0x80 and tail == b"\x2e"
+    return _hnsw_metadata_marker_intact(seg_dir)
 
 
 def quarantine_stale_hnsw(palace_path: str, stale_seconds: float = 300.0) -> list[str]:

--- a/tests/test_hnsw_payload_health.py
+++ b/tests/test_hnsw_payload_health.py
@@ -113,8 +113,11 @@ def test_quarantine_leaves_reasonable_payload_in_place(tmp_path):
     assert seg_dir.exists()
 
 
-def test_segment_health_rejects_zero_byte_link_lists_with_payload(tmp_path):
-    """Regression #1457: real HNSW payload with empty link_lists.bin is corrupt."""
+def test_segment_health_accepts_zero_byte_link_lists_with_valid_pickle(tmp_path):
+    """Regression #1716: an all-layer-0 HNSW index serializes an empty
+    link_lists.bin (level-0 links live in data_level0.bin). With a complete
+    index_metadata.pickle the persist finished, so the segment is healthy —
+    not the partial-flush corruption a missing marker would imply."""
     seg_dir = tmp_path / "11111111-2222-3333-4444-555555555555"
 
     _write_segment(
@@ -124,11 +127,32 @@ def test_segment_health_rejects_zero_byte_link_lists_with_payload(tmp_path):
         write_metadata=True,
     )
 
+    assert _segment_appears_healthy(str(seg_dir))
+
+
+def test_segment_health_rejects_zero_byte_link_lists_with_truncated_pickle(tmp_path):
+    """An empty link_lists.bin with real payload but a truncated metadata
+    envelope is a partial flush, not an all-layer-0 index — still rejected.
+    The completion marker (intact pickle), not link_lists content, is what
+    distinguishes the two."""
+    seg_dir = tmp_path / "11111111-2222-3333-4444-555555555555"
+
+    _write_segment(
+        seg_dir,
+        data_size=2_000,
+        link_size=0,
+        write_metadata=False,
+    )
+    # Persist started (0x80 head) but never wrote the STOP terminator.
+    (seg_dir / "index_metadata.pickle").write_bytes(b"\x80" + b"x" * 20)
+
     assert not _segment_appears_healthy(str(seg_dir))
 
 
-def test_quarantine_catches_zero_byte_link_lists_when_stale(tmp_path):
-    """Regression #1457: stale segments with empty link_lists.bin are quarantined."""
+def test_quarantine_leaves_zero_byte_link_lists_with_valid_pickle(tmp_path):
+    """Regression #1716: a stale all-layer-0 segment with a complete pickle is
+    left in place. Quarantining it spawned the self-perpetuating loop — repair
+    rebuilds the byte-identical empty-link_lists shape and it re-quarantines."""
     palace = tmp_path / "palace"
     palace.mkdir()
 
@@ -150,9 +174,5 @@ def test_quarantine_catches_zero_byte_link_lists_when_stale(tmp_path):
 
     moved = quarantine_stale_hnsw(str(palace), stale_seconds=300)
 
-    assert len(moved) == 1
-    assert not seg_dir.exists()
-
-    moved_path = Path(moved[0])
-    assert moved_path.exists()
-    assert moved_path.name.startswith("11111111-2222-3333-4444-555555555555.drift-")
+    assert moved == []
+    assert seg_dir.exists()


### PR DESCRIPTION
## Problem

`_hnsw_link_lists_is_usable_for_payload()` misclassified a **legitimate 0-byte `link_lists.bin`** as structural corruption, causing a self-perpetuating quarantine loop on small / low-fanout HNSW indexes (#1716).

A zero-byte `link_lists.bin` is **not** corruption on its own: hnswlib stores the entire layer-0 graph inside `data_level0.bin` and only writes `link_lists.bin` for elements promoted to level > 0. An index where every element stays on layer 0 therefore serializes an empty `link_lists.bin` and loads/searches fine.

The old heuristic (`data_level0.bin > floor AND link_lists.bin == 0 → corrupt`) triggered the loop the reporter observed:

1. Segment quarantined as `<uuid>.drift-<ts>` (`data_level0.bin` = 167,600 B, `link_lists.bin` = 0 B).
2. Self-repair rebuilds → the rebuilt **live** segment has the byte-identical all-layer-0 shape.
3. Next cold-start check quarantines it again → loop (**20 drift dirs / 221 MB** before being noticed), with no ingestion involved. The per-process `_quarantined_paths` gate resets on every MCP process spawn, so it re-fires every session.

## Fix

Use the **persist-completion marker** as the discriminator. ChromaDB writes `index_metadata.pickle` last during a flush, so an intact pickle envelope (`0x80` head, `0x2e` STOP tail) proves the persist finished — the empty `link_lists.bin` is then the legitimate all-layer-0 shape, not a half-written one.

An empty `link_lists.bin` is treated as a partial flush **only** when there is real payload **and** no completion marker (pickle absent or truncated). This preserves the #1457 partial-flush protection while eliminating the false positive.

The byte-sniff is factored into `_hnsw_metadata_marker_intact()` and reused by `_segment_appears_healthy()` (no behavior change there — same `0x80…0x2e` envelope check, deduplicated).

Also resolves the related single-writer stale-quarantine false positive (**#1564**), which shares the all-layer-0 root cause: an idle small collection failed the health sniff after the 300s mtime gap.

## Tests

- `test_segment_health_accepts_zero_byte_link_lists_with_valid_pickle` — all-layer-0 + complete pickle is healthy (#1716).
- `test_quarantine_leaves_zero_byte_link_lists_with_valid_pickle` — stale all-layer-0 segment is left in place (breaks the loop).
- `test_segment_health_rejects_zero_byte_link_lists_with_truncated_pickle` — empty link_lists + truncated marker is still rejected (partial-flush protection intact).
- Existing missing-metadata / link-bloat / divergence tests unchanged and passing.

Full suite: 3125 passed, 20 skipped.

Closes #1716

cc #1564