### PR TITLE
fix(repair): auto-heal isolated FTS5 inverted-index corruption (#1596)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1092,6 +1092,7 @@ def cmd_repair(args):
         _rebuild_collection_via_temp,
         check_extraction_safety,
         index_read_recovery_guidance,
+        maybe_autoheal_fts5_index,
         maybe_repair_poisoned_max_seq_id_before_rebuild,
         print_sqlite_integrity_abort,
         sqlite_integrity_errors,
@@ -1182,6 +1183,8 @@ def cmd_repair(args):
     # here so we can surface the clear recovery instructions and exit
     # cleanly before chromadb's compactor touches the disk.
     sqlite_errors = sqlite_integrity_errors(palace_path)
+    if sqlite_errors:
+        sqlite_errors = maybe_autoheal_fts5_index(palace_path, sqlite_errors)
     if sqlite_errors:
         print_sqlite_integrity_abort(palace_path, sqlite_errors)
         sys.exit(1)

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -638,6 +638,82 @@ def print_sqlite_integrity_abort(palace_path: str, errors: list[str]) -> None:
     print("    6. Re-run `mempalace repair --yes`.")
 
 
+# quick_check labels a corrupt FTS5 inverted index like:
+#   "malformed inverted index for FTS5 table main.embedding_fulltext_search"
+# That specific failure is recoverable in place: the index is derived from the
+# intact ``embedding_fulltext_search_content`` shadow table, so rebuilding it
+# restores full-text search without touching any drawer rows. Concurrent
+# killed-mid-write mines are the usual cause (#1596).
+_FTS5_MALFORMED_RE = re.compile(r"malformed inverted index for FTS5 table", re.IGNORECASE)
+
+
+def _errors_are_isolated_fts5(errors: list[str]) -> bool:
+    """True when every quick_check error is a malformed FTS5 inverted index.
+
+    Only an isolated FTS5 failure is safe to auto-heal: the inverted index is
+    derived data that ``rebuild`` regenerates from the content shadow table. If
+    quick_check also reports page/row corruption, the data itself may be damaged
+    and rebuilding the index over it would mask real loss — that still aborts.
+    """
+    return bool(errors) and all(_FTS5_MALFORMED_RE.search(e) for e in errors)
+
+
+def maybe_autoheal_fts5_index(palace_path: str, errors: list[str], *, progress=print) -> list[str]:
+    """Rebuild a malformed FTS5 inverted index in place; return remaining errors.
+
+    The repair preflight aborts when ``PRAGMA quick_check`` reports SQLite-layer
+    corruption. After concurrent killed-mid-write mines (#1596) the common
+    failure is an isolated ``malformed inverted index for FTS5 table``, which is
+    fully recoverable: the index rebuilds from the intact
+    ``embedding_fulltext_search_content`` table without touching drawer rows.
+
+    When the errors are isolated to FTS5, rebuild the index under the palace
+    write lock (so a live mine cannot race the rebuild) and re-run quick_check.
+    Returns the remaining quick_check errors — empty when the heal succeeded.
+    Broader corruption, a lock held by another writer, or a rebuild failure
+    leaves ``errors`` unchanged so the caller still aborts with the banner.
+    """
+    if not _errors_are_isolated_fts5(errors):
+        return errors
+
+    sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.exists(sqlite_path):
+        return errors
+
+    # Lazy import: palace.py is heavier and importing it at module load would
+    # widen repair.py's import graph for callers that never hit this path.
+    from .palace import MineAlreadyRunning, mine_palace_lock
+
+    progress(
+        "\n  Isolated FTS5 inverted-index corruption detected; attempting an\n"
+        "  in-place rebuild from the intact content table before aborting."
+    )
+    try:
+        with mine_palace_lock(palace_path):
+            with closing(sqlite3.connect(sqlite_path, isolation_level=None)) as conn:
+                conn.execute(
+                    "INSERT INTO embedding_fulltext_search"
+                    "(embedding_fulltext_search) VALUES('rebuild')"
+                )
+                conn.commit()
+    except MineAlreadyRunning as exc:
+        progress(
+            f"  Skipped FTS5 rebuild: palace is being written by another process ({exc}). "
+            "Stop it and re-run."
+        )
+        return errors
+    except Exception as exc:
+        progress(f"  FTS5 rebuild failed (leaving palace untouched): {exc}")
+        return errors
+
+    remaining = sqlite_integrity_errors(palace_path)
+    if remaining:
+        progress("  FTS5 rebuild did not clear quick_check; aborting for safety.")
+    else:
+        progress("  FTS5 index rebuilt from intact content; quick_check is clean.")
+    return remaining
+
+
 def index_read_recovery_guidance() -> str:
     """Recovery guidance for a failed drawer-index read in the legacy paths.
 
@@ -883,6 +959,8 @@ def rebuild_index(
     # corruption here lets us surface the clear recovery instructions and
     # exit cleanly before chromadb's compactor touches the disk.
     sqlite_errors = sqlite_integrity_errors(palace_path)
+    if sqlite_errors:
+        sqlite_errors = maybe_autoheal_fts5_index(palace_path, sqlite_errors, progress=progress)
     if sqlite_errors:
         print_sqlite_integrity_abort(palace_path, sqlite_errors)
         return

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1976,6 +1976,114 @@ def test_vacuum_and_rebuild_fts5_missing_sqlite(tmp_path):
     repair._vacuum_and_rebuild_fts5(str(tmp_path))  # no file — must not raise
 
 
+# ── FTS5 inverted-index auto-heal (#1596) ─────────────────────────────
+
+
+def _make_fts5_palace(tmp_path, *, corrupt: bool) -> str:
+    """Build a palace whose embedding_fulltext_search index is optionally
+    corrupted to the malformed-inverted-index quick_check state #1596 hits."""
+    sqlite_path = tmp_path / "chroma.sqlite3"
+    with closing(sqlite3.connect(str(sqlite_path))) as conn:
+        conn.execute(
+            "CREATE VIRTUAL TABLE embedding_fulltext_search"
+            " USING fts5(string_value, tokenize='unicode61')"
+        )
+        for i in range(200):
+            conn.execute(
+                "INSERT INTO embedding_fulltext_search(string_value) VALUES(?)",
+                (f"alpha beta gamma row{i} delta epsilon",),
+            )
+        conn.commit()
+        if corrupt:
+            # Zero the last index segment leaf: quick_check then reports
+            # "malformed inverted index" while the content table stays intact.
+            conn.execute(
+                "UPDATE embedding_fulltext_search_data SET block=zeroblob(length(block)) "
+                "WHERE id=(SELECT max(id) FROM embedding_fulltext_search_data)"
+            )
+            conn.commit()
+    return str(tmp_path)
+
+
+def test_errors_are_isolated_fts5_classification():
+    fts = "malformed inverted index for FTS5 table main.embedding_fulltext_search"
+    page = "Page 4 of B-tree 12345: database disk image is malformed"
+    assert repair._errors_are_isolated_fts5([fts])
+    assert repair._errors_are_isolated_fts5([fts, fts])
+    assert not repair._errors_are_isolated_fts5([])
+    assert not repair._errors_are_isolated_fts5([page])
+    # Any non-FTS5 error in the set means the data itself may be damaged.
+    assert not repair._errors_are_isolated_fts5([fts, page])
+
+
+def test_maybe_autoheal_fts5_index_heals_isolated_corruption(tmp_path):
+    palace = _make_fts5_palace(tmp_path, corrupt=True)
+    errors = repair.sqlite_integrity_errors(palace)
+    assert errors and repair._errors_are_isolated_fts5(errors)
+
+    remaining = repair.maybe_autoheal_fts5_index(palace, errors, progress=lambda *_: None)
+
+    assert remaining == []
+    # quick_check is clean and full-text search works again.
+    assert repair.sqlite_integrity_errors(palace) == []
+    with closing(sqlite3.connect(str(tmp_path / "chroma.sqlite3"))) as conn:
+        hits = conn.execute(
+            "SELECT count(*) FROM embedding_fulltext_search "
+            "WHERE embedding_fulltext_search MATCH 'gamma'"
+        ).fetchone()[0]
+    assert hits == 200
+
+
+def test_maybe_autoheal_fts5_index_leaves_non_fts5_errors_untouched(tmp_path):
+    palace = _make_fts5_palace(tmp_path, corrupt=False)
+    page_errors = ["Page 4 of B-tree 12345: database disk image is malformed"]
+
+    # Not isolated FTS5: returned unchanged and the rebuild is never attempted.
+    with patch("mempalace.palace.mine_palace_lock") as lock:
+        remaining = repair.maybe_autoheal_fts5_index(palace, page_errors, progress=lambda *_: None)
+    assert remaining == page_errors
+    lock.assert_not_called()
+
+
+def test_maybe_autoheal_fts5_index_skips_when_palace_is_being_mined(tmp_path):
+    from mempalace.palace import MineAlreadyRunning
+
+    palace = _make_fts5_palace(tmp_path, corrupt=True)
+    errors = repair.sqlite_integrity_errors(palace)
+
+    def _raise(_path):
+        raise MineAlreadyRunning("held by pid 999")
+
+    # A live mine holds the lock: do not race the rebuild — surface and abort.
+    with patch("mempalace.palace.mine_palace_lock", side_effect=_raise):
+        remaining = repair.maybe_autoheal_fts5_index(palace, errors, progress=lambda *_: None)
+
+    assert remaining == errors
+    # The FTS index is still corrupt because we refused to rebuild under contention.
+    assert repair.sqlite_integrity_errors(palace) == errors
+
+
+def test_rebuild_index_preflight_autoheals_isolated_fts5_then_proceeds(tmp_path, monkeypatch):
+    """The preflight no longer hard-aborts on isolated FTS5 corruption (#1596):
+    it rebuilds the index, then continues into the rebuild path."""
+    palace = _make_fts5_palace(tmp_path, corrupt=True)
+
+    called = {}
+
+    def _fake_max_seq(_palace_path, **_kwargs):
+        # Reached only if the preflight did NOT abort — record and stop early
+        # so the test doesn't need a real chromadb collection.
+        called["reached"] = True
+        return {"stopped": True}
+
+    monkeypatch.setattr(repair, "maybe_repair_poisoned_max_seq_id_before_rebuild", _fake_max_seq)
+
+    repair.rebuild_index(palace_path=palace, progress=lambda *_: None)
+
+    assert called.get("reached") is True
+    assert repair.sqlite_integrity_errors(palace) == []
+
+
 @patch("mempalace.repair.shutil")
 @patch("mempalace.repair.ChromaBackend")
 def test_rebuild_index_calls_vacuum(mock_backend_cls, mock_shutil, tmp_path):


### PR DESCRIPTION
## Problem

When several `mempalace mine` processes end concurrently (Stop hook fan-out, compaction, multiple windows) and one is killed mid-write, `embedding_fulltext_search` is left with a **malformed FTS5 inverted index**. `PRAGMA quick_check` fails, but `PRAGMA integrity_check` returns `ok` — the underlying embedding rows are intact; only the derived inverted index is corrupt.

The repair preflight runs `quick_check` and **hard-aborts** on any error, before it ever reaches the FTS5 rebuild step (`_vacuum_and_rebuild_fts5` runs only at the *end* of a successful rebuild). So:

```
$ mempalace repair
ABORT: SQLite-layer corruption detected before repair rebuild.
  quick_check output:
    - malformed inverted index for FTS5 table main.embedding_fulltext_search
```

`mempalace repair` refuses to run and full-text search stays broken — and it recurs on every concurrent session end (#1596). The post-mine `MineValidationError` banner even tells the user "`repair --yes` rebuilds the FTS5 virtual table automatically," which the preflight abort made **untrue**.

## Fix

Add `maybe_autoheal_fts5_index()`. When **every** `quick_check` error is an isolated `malformed inverted index for FTS5 table` failure, it rebuilds the index in place from the intact `embedding_fulltext_search_content` table:

```sql
INSERT INTO embedding_fulltext_search(embedding_fulltext_search) VALUES('rebuild');
```

then re-runs `quick_check`. The rebuild touches **no drawer rows**. It runs under `mine_palace_lock` so a live mine can't race it. Wired into both repair preflights (`rebuild_index` and CLI `cmd_repair`).

Conservative by construction — the heal is skipped (errors returned unchanged, caller still aborts with the full recovery banner) when:
- any non-FTS5 error is present (the data itself may be damaged — never silently rebuild over it),
- the palace is being written by another process (`MineAlreadyRunning`),
- the rebuild fails or doesn't clear `quick_check`.

## Scope note

This is the narrow recovery half of #1596. The concurrency root cause (overlapping mines) is already largely serialized by `mine_palace_lock` keyed on palace path; this PR makes the resulting corruption **recoverable** instead of a dead end. It is intentionally independent of the much larger #1598, which bundles this with search-retry/BM25-fallback/HNSW-freshness changes and is currently conflicting.

## Tests

- `_errors_are_isolated_fts5` classification (isolated FTS5 vs page corruption vs mixed vs empty).
- `maybe_autoheal_fts5_index` heals real corruption — deterministic: zero the last `embedding_fulltext_search_data` segment leaf → `quick_check` reports the malformed index → heal → `quick_check` clean, all 200 rows searchable again.
- Leaves non-FTS5 errors untouched (rebuild never attempted).
- Skips the rebuild when the palace is being mined (`MineAlreadyRunning`) and leaves the corruption in place.
- `rebuild_index` preflight auto-heals isolated FTS5 then proceeds instead of aborting.

Full suite: 3130 passed, 20 skipped. Lint + format clean.

Closes #1596