### PR TITLE
Add opt-in MCP audit telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,31 @@ cross-wing navigation, drawer management, and agent diaries. Installation
 and the full tool list:
 [mempalaceofficial.com/reference/mcp-tools](https://mempalaceofficial.com/reference/mcp-tools.html).
 
+### Audit telemetry (opt-in)
+
+Opt-in per-request audit telemetry for the HTTP transport, **off by default** —
+no behaviour change and nothing is written to disk unless you enable it:
+
+- **Audit telemetry** (`MEMPALACE_AUDIT=1`) — appends a per-request JSONL event
+  (method, tool, latency, fingerprinted args, result summary) to
+  `~/.mempalace/service_logs/mcp_audit.jsonl` (override with
+  `MEMPALACE_AUDIT_FILE`). Sensitive content is stored as a length plus a
+  truncated SHA-256 fingerprint (first 16 hex chars), never raw, unless
+  `MEMPALACE_AUDIT_SEARCH_RESPONSE_TEXT=1` is also set — and even then the raw
+  text is bounded by `MEMPALACE_AUDIT_SEARCH_RESPONSE_MAX_CHARS`. Summarise the
+  log with `mempalace audit`.
+
+| Env var | Default | Effect |
+|---|---|---|
+| `MEMPALACE_AUDIT` | off | Enable per-request audit telemetry |
+| `MEMPALACE_AUDIT_FILE` | `~/.mempalace/service_logs/mcp_audit.jsonl` | Audit log path |
+| `MEMPALACE_AUDIT_SEARCH_RESPONSE_TEXT` | off | Also store raw search-response snippets (default: fingerprint only) |
+| `MEMPALACE_AUDIT_SEARCH_RESPONSE_MAX_CHARS` | `2000` | Max chars of raw search-response text kept when the above is on |
+| `MEMPALACE_AUDIT_TEXT_PREVIEW` | off | Also store a short raw preview of sensitive args (`content`, `text`, `context`, …); off keeps them fingerprint-only |
+
+Telemetry sits behind the transport's existing Host/Origin policy and the
+optional `MEMPALACE_MCP_HTTP_TOKEN` bearer auth.
+
 ## Agents
 
 Each specialist agent gets its own wing and diary in the palace.

--- a/mempalace/audit.py
+++ b/mempalace/audit.py
@@ -1,0 +1,227 @@
+"""Summarise MemPalace MCP audit telemetry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+def default_audit_path() -> Path:
+    return Path(
+        os.environ.get(
+            "MEMPALACE_AUDIT_FILE",
+            os.path.expanduser("~/.mempalace/service_logs/mcp_audit.jsonl"),
+        )
+    )
+
+
+def _parse_ts(value: str):
+    try:
+        return datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def iter_events(path: Path, *, since: datetime | None = None):
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = _parse_ts(event.get("timestamp"))
+            if since and ts and ts < since:
+                continue
+            yield event
+
+
+def _percentile(values: list[float], pct: float):
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((len(ordered) - 1) * pct)))
+    return ordered[index]
+
+
+def summarize_events(events: list[dict]) -> dict:
+    tools = Counter()
+    methods = Counter()
+    searches = []
+    empty_searches = []
+    writes = []
+    errors = []
+    latencies = []
+    clients = Counter()
+    matched_via = Counter()
+    top_queries = Counter()
+
+    write_tools = {
+        "mempalace_add_drawer",
+        "mempalace_checkpoint",
+        "mempalace_create_tunnel",
+        "mempalace_delete_by_source",
+        "mempalace_delete_drawer",
+        "mempalace_delete_tunnel",
+        "mempalace_diary_write",
+        "mempalace_kg_add",
+        "mempalace_kg_invalidate",
+        "mempalace_update_drawer",
+    }
+
+    for event in events:
+        method = event.get("method") or "(parse-error)"
+        methods[method] += 1
+        if event.get("remote"):
+            clients[event["remote"]] += 1
+        if isinstance(event.get("latency_ms"), (int, float)):
+            latencies.append(float(event["latency_ms"]))
+        if not event.get("ok", False):
+            errors.append(event)
+
+        tool = event.get("tool")
+        if not tool:
+            continue
+        tools[tool] += 1
+        if tool in write_tools:
+            writes.append(event)
+        if tool == "mempalace_search":
+            searches.append(event)
+            result = event.get("result") or {}
+            query = result.get("query") or (event.get("tool_args") or {}).get("query")
+            if query:
+                top_queries[str(query)] += 1
+            if (result.get("result_count") or 0) == 0:
+                empty_searches.append(event)
+            for hit in result.get("top_results") or []:
+                if hit.get("matched_via"):
+                    matched_via[hit["matched_via"]] += 1
+
+    return {
+        "events": len(events),
+        "methods": methods,
+        "tools": tools,
+        "search_count": len(searches),
+        "empty_search_count": len(empty_searches),
+        "write_count": len(writes),
+        "error_count": len(errors),
+        "clients": clients,
+        "matched_via": matched_via,
+        "top_queries": top_queries,
+        "latency_p50": _percentile(latencies, 0.50),
+        "latency_p95": _percentile(latencies, 0.95),
+        "recent_searches": searches[-10:],
+        "recent_errors": errors[-10:],
+    }
+
+
+def print_summary(
+    path: Path | None = None,
+    *,
+    hours: float = 24,
+    limit: int = 10,
+    show_text: bool = False,
+    text_chars: int = 500,
+) -> None:
+    path = path or default_audit_path()
+    since = datetime.now() - timedelta(hours=hours) if hours else None
+    events = list(iter_events(path, since=since) or [])
+    summary = summarize_events(events)
+
+    print(f"Audit file: {path}")
+    print(f"Window: last {hours:g} hours" if hours else "Window: all events")
+    print(f"Events: {summary['events']}")
+    print(f"Errors: {summary['error_count']}")
+    if summary["latency_p50"] is not None:
+        print(
+            "Latency: "
+            f"p50={summary['latency_p50']:.1f}ms "
+            f"p95={summary['latency_p95']:.1f}ms"
+        )
+
+    print("\nMethods")
+    for name, count in summary["methods"].most_common(limit):
+        print(f"  {count:5d}  {name}")
+
+    print("\nTools")
+    for name, count in summary["tools"].most_common(limit):
+        print(f"  {count:5d}  {name}")
+
+    print("\nSearches")
+    search_count = summary["search_count"]
+    empty_count = summary["empty_search_count"]
+    empty_rate = (empty_count / search_count * 100) if search_count else 0.0
+    print(f"  total={search_count} empty={empty_count} empty_rate={empty_rate:.1f}%")
+    if summary["matched_via"]:
+        print("  matched_via:")
+        for name, count in summary["matched_via"].most_common(limit):
+            print(f"    {count:5d}  {name}")
+
+    if summary["top_queries"]:
+        print("\nTop Queries")
+        for query, count in summary["top_queries"].most_common(limit):
+            print(f"  {count:5d}  {query}")
+
+    print("\nRecent Searches")
+    for event in summary["recent_searches"][-limit:]:
+        result = event.get("result") or {}
+        print(
+            f"  {event.get('timestamp')} "
+            f"{result.get('result_count', '?')} hits "
+            f"{result.get('query')}"
+        )
+        for hit in (result.get("top_results") or [])[:3]:
+            print(
+                "         "
+                f"#{hit.get('rank')} {hit.get('wing')}/{hit.get('room')} "
+                f"sim={hit.get('similarity')} via={hit.get('matched_via')} "
+                f"src={hit.get('source_file')}"
+            )
+            response_text = hit.get("response_text") or {}
+            text = response_text.get("text")
+            if show_text and text:
+                snippet = str(text).replace("\r", " ").replace("\n", " ")
+                if text_chars > 0 and len(snippet) > text_chars:
+                    snippet = snippet[:text_chars] + "..."
+                suffix = " truncated" if response_text.get("truncated") else ""
+                print(f"             response{suffix}: {snippet}")
+
+    if summary["recent_errors"]:
+        print("\nRecent Errors")
+        for event in summary["recent_errors"][-limit:]:
+            error = event.get("error") or {}
+            print(
+                f"  {event.get('timestamp')} "
+                f"{event.get('method')} {event.get('tool') or ''} "
+                f"{error.get('code')}: {error.get('message')}"
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Summarise MemPalace MCP audit telemetry")
+    parser.add_argument("--file", default=None, help="Audit JSONL file to read")
+    parser.add_argument("--hours", type=float, default=24, help="Hours to include; 0 = all")
+    parser.add_argument("--limit", type=int, default=10, help="Rows to print per section")
+    parser.add_argument("--show-text", action="store_true", help="Print stored search-response text snippets")
+    parser.add_argument("--text-chars", type=int, default=500, help="Characters per response snippet")
+    args = parser.parse_args(argv)
+    print_summary(
+        Path(args.file) if args.file else None,
+        hours=args.hours,
+        limit=args.limit,
+        show_text=args.show_text,
+        text_chars=args.text_chars,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1090,6 +1090,18 @@ def cmd_repair_status(args):
     repair_status(palace_path=palace_path)
 
 
+def cmd_audit(args):
+    from .audit import print_summary
+
+    print_summary(
+        Path(args.file).expanduser() if args.file else None,
+        hours=args.hours,
+        limit=args.limit,
+        show_text=args.show_text,
+        text_chars=args.text_chars,
+    )
+
+
 def cmd_repair(args):
     """Rebuild palace vector index from SQLite metadata.
 
@@ -2199,6 +2211,15 @@ def main():
         help="Storage backend to use for status (default: config/env/detected/chroma)",
     )
 
+    p_audit = sub.add_parser("audit", help="Summarise MCP memory usage telemetry")
+    p_audit.add_argument("--file", default=None, help="Audit JSONL file to read")
+    p_audit.add_argument("--hours", type=float, default=24, help="Hours to include; 0 = all")
+    p_audit.add_argument("--limit", type=int, default=10, help="Rows to print per section")
+    p_audit.add_argument(
+        "--show-text", action="store_true", help="Print stored search-response text snippets"
+    )
+    p_audit.add_argument("--text-chars", type=int, default=500, help="Characters per response snippet")
+
     p_palace = sub.add_parser("palace", help="Palace maintenance commands")
     palace_sub = p_palace.add_subparsers(dest="palace_action")
     p_set_embedder = palace_sub.add_parser(
@@ -2279,6 +2300,7 @@ def main():
         "migrate-wings": cmd_migrate_wings,
         "hallways": cmd_hallways,
         "status": cmd_status,
+        "audit": cmd_audit,
     }
     dispatch[args.command](args)
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -232,6 +232,277 @@ _init_logging()
 logger = logging.getLogger("mempalace_mcp")
 
 
+# MCP audit telemetry is opt-in (default off): set MEMPALACE_AUDIT=1 to record a
+# per-request JSONL log of memory-tool usage (method, tool, latency, fingerprinted
+# args). Intended for operators who want a usage/compliance trail; it never runs
+# and never touches disk unless explicitly enabled.
+_AUDIT_ENABLED = os.environ.get("MEMPALACE_AUDIT", "").strip().lower() in {"1", "true", "yes", "on"}
+
+_AUDIT_FILE = Path(
+    os.environ.get(
+        "MEMPALACE_AUDIT_FILE",
+        os.path.expanduser("~/.mempalace/service_logs/mcp_audit.jsonl"),
+    )
+)
+
+_AUDIT_TEXT_PREVIEW = os.environ.get("MEMPALACE_AUDIT_TEXT_PREVIEW", "0") == "1"
+_AUDIT_MAX_TEXT = 250
+_AUDIT_SEARCH_RESPONSE_MAX_CHARS_DEFAULT = 2000
+
+
+def _audit_positive_int_env(name: str, default: int) -> int:
+    """Parse a positive int env var, returning ``default`` for a missing, blank,
+    non-integer, or non-positive value. Keeps a misconfigured env var from
+    crashing the server at import time."""
+    try:
+        value = int(os.environ.get(name, "").strip())
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+# Privacy-conservative default: store only a length + truncated SHA-256
+# fingerprint of search-response text. Set MEMPALACE_AUDIT_SEARCH_RESPONSE_TEXT=1
+# to also store the raw snippet, always bounded by
+# MEMPALACE_AUDIT_SEARCH_RESPONSE_MAX_CHARS (default 2000) so the log can never
+# grow without limit even when raw capture is enabled.
+_AUDIT_SEARCH_RESPONSE_TEXT = os.environ.get("MEMPALACE_AUDIT_SEARCH_RESPONSE_TEXT", "0") == "1"
+_AUDIT_SEARCH_RESPONSE_MAX_CHARS = _audit_positive_int_env(
+    "MEMPALACE_AUDIT_SEARCH_RESPONSE_MAX_CHARS", _AUDIT_SEARCH_RESPONSE_MAX_CHARS_DEFAULT
+)
+_AUDIT_SENSITIVE_KEYS = frozenset(
+    {
+        "content",
+        "content_preview",
+        "context",
+        "document",
+        "documents",
+        "entry",
+        "entry_preview",
+        "text",
+    }
+)
+
+
+def _short_hash(value: str) -> str:
+    # Truncated SHA-256: the first 16 hex chars (64 bits) are enough to
+    # correlate identical content without storing it, while keeping the log
+    # compact. Recorded under the honestly-named ``sha256_16`` field.
+    return hashlib.sha256(value.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+def _text_fingerprint(value: str, include_preview: bool = False) -> dict:
+    info = {"chars": len(value), "sha256_16": _short_hash(value)}
+    if include_preview:
+        info["preview"] = value[:_AUDIT_MAX_TEXT]
+    return info
+
+
+def _audit_search_response_text(value: str) -> dict:
+    info = _text_fingerprint(value)
+    if not _AUDIT_SEARCH_RESPONSE_TEXT:
+        return info
+    max_chars = _AUDIT_SEARCH_RESPONSE_MAX_CHARS
+    if max_chars > 0 and len(value) > max_chars:
+        info["text"] = value[:max_chars]
+        info["truncated"] = True
+    else:
+        info["text"] = value
+        info["truncated"] = False
+    return info
+
+
+def _audit_value(key: str, value):
+    if isinstance(value, str):
+        if key == "query":
+            return value[:_AUDIT_MAX_TEXT]
+        if key in _AUDIT_SENSITIVE_KEYS:
+            return _text_fingerprint(value, include_preview=_AUDIT_TEXT_PREVIEW)
+        return value[:_AUDIT_MAX_TEXT]
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return [_audit_value(key, item) for item in value[:10]]
+    if isinstance(value, dict):
+        return {str(k): _audit_value(str(k), v) for k, v in value.items()}
+    return str(value)[:_AUDIT_MAX_TEXT]
+
+
+def _audit_args(params: dict) -> dict:
+    args = params.get("arguments") or {}
+    if not isinstance(args, dict):
+        return {"arguments_type": type(args).__name__}
+    return {str(k): _audit_value(str(k), v) for k, v in args.items()}
+
+
+def _summarize_search_result(result: dict) -> dict:
+    hits = result.get("results") or []
+    top = []
+    for rank, hit in enumerate(hits[:5], start=1):
+        hit = hit or {}
+        text = hit.get("text") or ""
+        top.append(
+            {
+                "rank": rank,
+                "drawer_id": hit.get("id") or hit.get("drawer_id"),
+                "wing": hit.get("wing"),
+                "room": hit.get("room"),
+                "source_file": hit.get("source_file"),
+                "similarity": hit.get("similarity"),
+                "distance": hit.get("distance"),
+                "effective_distance": hit.get("effective_distance"),
+                "closet_boost": hit.get("closet_boost"),
+                "matched_via": hit.get("matched_via"),
+                "text_chars": len(text) if isinstance(text, str) else None,
+                "response_text": _audit_search_response_text(text) if isinstance(text, str) else None,
+                "drawer_index": hit.get("drawer_index"),
+                "total_drawers": hit.get("total_drawers"),
+            }
+        )
+    return {
+        "query": result.get("query"),
+        "filters": result.get("filters"),
+        "result_count": len(hits),
+        "total_before_filter": result.get("total_before_filter"),
+        "query_sanitized": bool(result.get("query_sanitized")),
+        "top_results": top,
+    }
+
+
+def _summarize_tool_result(tool_name: str, result) -> dict:
+    if not isinstance(result, dict):
+        return {"result_type": type(result).__name__}
+    if "error" in result:
+        return {"error": str(result.get("error"))[:_AUDIT_MAX_TEXT]}
+
+    if tool_name == "mempalace_search":
+        return _summarize_search_result(result)
+    if tool_name == "mempalace_status":
+        return {
+            "total_drawers": result.get("total_drawers"),
+            "wing_count": len(result.get("wings") or {}),
+            "room_count": len(result.get("rooms") or {}),
+            "palace_path": result.get("palace_path"),
+        }
+    if tool_name in {"mempalace_list_wings", "mempalace_list_rooms"}:
+        key = "wings" if "wings" in result else "rooms"
+        values = result.get(key) or {}
+        return {f"{key}_count": len(values), "top": dict(list(values.items())[:10])}
+    if tool_name == "mempalace_get_taxonomy":
+        taxonomy = result.get("taxonomy") or {}
+        room_count = sum(len(rooms or {}) for rooms in taxonomy.values())
+        return {"wing_count": len(taxonomy), "room_count": room_count}
+    if tool_name == "mempalace_get_drawer":
+        content = result.get("content") or ""
+        return {
+            "drawer_id": result.get("drawer_id"),
+            "wing": result.get("wing"),
+            "room": result.get("room"),
+            "content_chars": len(content) if isinstance(content, str) else None,
+        }
+    if tool_name == "mempalace_list_drawers":
+        drawers = result.get("drawers") or []
+        return {
+            "count": result.get("count"),
+            "offset": result.get("offset"),
+            "limit": result.get("limit"),
+            "top_drawers": [
+                {
+                    "drawer_id": drawer.get("drawer_id"),
+                    "wing": drawer.get("wing"),
+                    "room": drawer.get("room"),
+                }
+                for drawer in drawers[:10]
+                if isinstance(drawer, dict)
+            ],
+        }
+    if tool_name in {
+        "mempalace_add_drawer",
+        "mempalace_checkpoint",
+        "mempalace_create_tunnel",
+        "mempalace_delete_by_source",
+        "mempalace_delete_drawer",
+        "mempalace_delete_tunnel",
+        "mempalace_diary_write",
+        "mempalace_kg_add",
+        "mempalace_kg_invalidate",
+        "mempalace_update_drawer",
+    }:
+        allowed = {
+            "agent",
+            "diary_id",
+            "drawer_id",
+            "error",
+            "fact",
+            "invalidated",
+            "reason",
+            "room",
+            "success",
+            "topic",
+            "triple_id",
+            "wing",
+        }
+        return {k: _audit_value(k, v) for k, v in result.items() if k in allowed}
+    if "count" in result:
+        return {"count": result.get("count")}
+    if "success" in result:
+        return {"success": result.get("success"), "error": result.get("error")}
+    return {"keys": sorted(str(k) for k in result.keys())[:20]}
+
+
+def _response_error(response) -> dict | None:
+    if not isinstance(response, dict):
+        return None
+    error = response.get("error")
+    if not isinstance(error, dict):
+        return None
+    return {
+        "code": error.get("code"),
+        "message": str(error.get("message", ""))[:_AUDIT_MAX_TEXT],
+    }
+
+
+def _extract_tool_result(response):
+    try:
+        text = response["result"]["content"][0]["text"]
+        return json.loads(text)
+    except Exception:
+        return None
+
+
+def _audit_log(event: dict) -> None:
+    if not _AUDIT_ENABLED:
+        return
+    try:
+        _AUDIT_FILE.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            _AUDIT_FILE.parent.chmod(0o700)
+        except (OSError, NotImplementedError):
+            pass
+        fd = os.open(str(_AUDIT_FILE), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
+        # The 0o600 mode above only applies when this call creates the file; an
+        # already-existing log keeps its own perms. Best-effort tighten so a
+        # pre-existing audit file can't stay broader than intended.
+        try:
+            os.chmod(_AUDIT_FILE, 0o600)
+        except (OSError, NotImplementedError):
+            pass
+        with os.fdopen(fd, "a", encoding="utf-8") as f:
+            f.write(json.dumps(event, default=str, ensure_ascii=False) + "\n")
+    except Exception as exc:
+        logger.error("MCP audit write failed: %s", exc)
+
+
+def _audit_context_from_http(handler, body_len: int, path: str) -> dict:
+    return {
+        "remote": handler.client_address[0] if handler.client_address else None,
+        "user_agent": handler.headers.get("user-agent"),
+        "session_id": handler.headers.get("mcp-session-id"),
+        "content_length": body_len,
+        "path": path,
+    }
+
+
 def _get_result_ids(result) -> list:
     """Return ``get()`` result ids for both typed and dict-like collection results."""
     if result is None:
@@ -4717,7 +4988,7 @@ def _decorate_mcp_tool_result(tool_name: str, result):
     return result
 
 
-def handle_request(request):
+def _handle_request_impl(request):
     global _last_request_time
     if not isinstance(request, dict):
         return {
@@ -4904,6 +5175,81 @@ def handle_request(request):
         "id": req_id,
         "error": {"code": -32601, "message": f"Unknown method: {method}"},
     }
+
+
+def handle_request(request, audit_context: dict | None = None):
+    # Fast path when auditing is off: add zero overhead — no timer, no event
+    # construction, no extra dict work — just dispatch straight through.
+    if not _AUDIT_ENABLED:
+        return _handle_request_impl(request)
+
+    start = time.perf_counter()
+    if isinstance(request, dict):
+        method = request.get("method") or ""
+        params = request.get("params") or {}
+        req_id = request.get("id")
+    else:
+        method = ""
+        params = {}
+        req_id = None
+    tool_name = params.get("name") if isinstance(params, dict) else None
+    response = None
+    raised = None
+
+    try:
+        response = _handle_request_impl(request)
+        return response
+    except Exception as exc:
+        raised = exc
+        raise
+    finally:
+        # Telemetry must never disrupt the request: any failure building or
+        # writing the audit event is logged and swallowed here, never raised
+        # out of this finally (which would mask the real response or exception).
+        try:
+            latency_ms = round((time.perf_counter() - start) * 1000, 3)
+            error = (
+                {"code": "exception", "message": str(raised)[:_AUDIT_MAX_TEXT]}
+                if raised is not None
+                else _response_error(response)
+            )
+            event = {
+                "timestamp": datetime.now().isoformat(),
+                "event": "mcp_request",
+                "method": method,
+                "request_id": req_id,
+                "ok": error is None,
+                "latency_ms": latency_ms,
+            }
+            if audit_context:
+                event.update(audit_context)
+            if tool_name:
+                event["tool"] = tool_name
+                event["tool_args"] = _audit_args(params if isinstance(params, dict) else {})
+                tool_result = _extract_tool_result(response)
+                if tool_result is not None:
+                    event["result"] = _summarize_tool_result(tool_name, tool_result)
+            if error:
+                event["error"] = error
+            elif response is None:
+                event["notification"] = True
+            elif isinstance(response, dict) and "result" in response and method != "tools/call":
+                result = response.get("result")
+                if method == "tools/list" and isinstance(result, dict):
+                    event["result"] = {"tool_count": len(result.get("tools") or [])}
+                elif method == "initialize" and isinstance(result, dict):
+                    event["result"] = {
+                        "protocolVersion": result.get("protocolVersion"),
+                        "serverInfo": result.get("serverInfo"),
+                    }
+                    if isinstance(params, dict):
+                        event["client"] = {
+                            "protocolVersion": params.get("protocolVersion"),
+                            "clientInfo": _audit_value("clientInfo", params.get("clientInfo")),
+                        }
+            _audit_log(event)
+        except Exception as exc:
+            logger.error("MCP audit telemetry failed: %s", exc)
 
 
 def _restore_stdout():
@@ -5203,7 +5549,7 @@ def _http_origin_allowed(origin: str) -> bool:
     return host in ("127.0.0.1", "localhost", "::1")
 
 
-def _build_http_server(host: str, port: int):
+def _build_http_server(host: str, port: int):  # noqa: C901
     """Construct (but do not start) the MCP HTTP server.
 
     Split out from :func:`_serve_http` so tests can bind an ephemeral port,
@@ -5278,6 +5624,16 @@ def _build_http_server(host: str, port: int):
             body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
             self._send_bytes(status, body, "application/json; charset=utf-8")
 
+        def _discard_small_request_body(self) -> None:
+            if self.command != "POST":
+                return
+            try:
+                content_length = int(self.headers.get("Content-Length", "0") or "0")
+            except (TypeError, ValueError):
+                return
+            if 0 < content_length <= 65536:
+                self.rfile.read(content_length)
+
         def _request_rejected(self, require_auth: bool) -> bool:
             """Enforce the transport's access policy before any dispatch.
 
@@ -5291,27 +5647,30 @@ def _build_http_server(host: str, port: int):
                 host_hdr = (self.headers.get("Host") or "").strip().lower()
                 if host_hdr not in srv.allowed_hosts:
                     logger.warning("HTTP request rejected: Host %r not allowed", host_hdr)
+                    self._discard_small_request_body()
                     self.send_error(403, "Forbidden")
                     return True
             origin = self.headers.get("Origin")
             if origin and not _http_origin_allowed(origin):
                 logger.warning("HTTP request rejected: cross-origin %r", origin)
+                self._discard_small_request_body()
                 self.send_error(403, "Forbidden")
                 return True
             if require_auth and srv.auth_token:
                 provided = self.headers.get("Authorization", "")
                 if not hmac.compare_digest(provided, f"Bearer {srv.auth_token}"):
                     logger.warning("HTTP request rejected: missing/invalid bearer token")
+                    self._discard_small_request_body()
                     self.send_error(401, "Unauthorized")
                     return True
             return False
 
         def do_GET(self):
+            path = urlparse(self.path).path
             # Liveness probe is policy-gated for Host/Origin but never requires
             # the token, so an orchestrator's health check works without creds.
-            if self._request_rejected(require_auth=False):
+            if self._request_rejected(require_auth=(path != "/healthz")):
                 return
-            path = urlparse(self.path).path
             if path == "/healthz":
                 self._send_bytes(200, b"ok\n", "text/plain; charset=utf-8")
                 return
@@ -5322,14 +5681,16 @@ def _build_http_server(host: str, port: int):
             if self._request_rejected(require_auth=True):
                 return
             path = urlparse(self.path).path
-            if path != "/mcp":
-                self.send_error(404, "Not Found")
-                return
-
             try:
                 content_length = int(self.headers.get("Content-Length", "0") or "0")
             except (TypeError, ValueError):
                 content_length = 0
+
+            if path != "/mcp":
+                if 0 < content_length <= 65536:
+                    self.rfile.read(content_length)
+                self._send_bytes(404, b"not found\n", "text/plain; charset=utf-8")
+                return
 
             if content_length < 0 or content_length > _HTTP_MAX_REQUEST_BYTES:
                 self._send_json(
@@ -5342,11 +5703,23 @@ def _build_http_server(host: str, port: int):
                 )
                 return
 
+            audit_context = _audit_context_from_http(self, max(content_length, 0), path)
             try:
                 raw = self.rfile.read(content_length)
+                audit_context["content_length"] = len(raw)
                 request = json.loads(raw.decode("utf-8"))
             except Exception as exc:
                 logger.warning("HTTP JSON-RPC read or parse error: %s", exc)
+                _audit_log(
+                    {
+                        "timestamp": datetime.now().isoformat(),
+                        "event": "mcp_parse_error",
+                        "method": None,
+                        "ok": False,
+                        **audit_context,
+                        "error": {"code": -32700, "message": "Parse error"},
+                    }
+                )
                 self._send_json(400, _json_rpc_parse_error())
                 return
 
@@ -5354,7 +5727,7 @@ def _build_http_server(host: str, port: int):
             # stdio deployments rely on. HTTP gives us a safer transport, not
             # concurrent Chroma/HNSW mutation.
             with _HTTP_REQUEST_LOCK:
-                response = handle_request(request)
+                response = handle_request(request, audit_context)
 
             if response is None:
                 # JSON-RPC notifications intentionally have no response body.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from mempalace.cli import (
+    cmd_audit,
     cmd_compress,
     cmd_hook,
     cmd_init,
@@ -145,6 +146,31 @@ def test_cmd_search_error_exits(mock_config_cls):
         with pytest.raises(SystemExit) as exc_info:
             cmd_search(args)
         assert exc_info.value.code == 1
+
+
+# ── cmd_audit ──────────────────────────────────────────────────────────
+
+
+def test_cmd_audit_calls_print_summary():
+    args = argparse.Namespace(
+        file=None, hours=24, limit=10, show_text=False, text_chars=500
+    )
+    with patch("mempalace.audit.print_summary") as mock_summary:
+        cmd_audit(args)
+        mock_summary.assert_called_once_with(
+            None, hours=24, limit=10, show_text=False, text_chars=500
+        )
+
+
+def test_cmd_audit_expands_file_path():
+    args = argparse.Namespace(
+        file="~/audit.jsonl", hours=0, limit=5, show_text=True, text_chars=200
+    )
+    with patch("mempalace.audit.print_summary") as mock_summary:
+        cmd_audit(args)
+        called_path = mock_summary.call_args.args[0]
+        assert isinstance(called_path, Path)
+        assert "~" not in str(called_path)
 
 
 # ── cmd_instructions ───────────────────────────────────────────────────
@@ -827,6 +853,15 @@ def test_main_init_dispatches():
     with (
         patch("sys.argv", ["mempalace", "init", "/some/dir"]),
         patch("mempalace.cli.cmd_init") as mock_cmd,
+    ):
+        main()
+        mock_cmd.assert_called_once()
+
+
+def test_main_audit_dispatches():
+    with (
+        patch("sys.argv", ["mempalace", "audit"]),
+        patch("mempalace.cli.cmd_audit") as mock_cmd,
     ):
         main()
         mock_cmd.assert_called_once()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1340,6 +1340,24 @@ class TestNoneMetadataSafety:
         stub_col.delete.assert_called_once_with(ids=["drawer_none_meta"])
 
 
+# ── Audit env parsing ───────────────────────────────────────────────────
+
+
+def test_audit_positive_int_env_falls_back_on_bad_values(monkeypatch):
+    from mempalace import mcp_server
+
+    for bad in ("not-a-number", "", "0", "-5", "3.5"):
+        monkeypatch.setenv("MEMPALACE_TEST_AUDIT_INT", bad)
+        # A typo'd or non-positive value must never crash; it returns the default.
+        assert mcp_server._audit_positive_int_env("MEMPALACE_TEST_AUDIT_INT", 2000) == 2000
+
+    monkeypatch.setenv("MEMPALACE_TEST_AUDIT_INT", "  512  ")
+    assert mcp_server._audit_positive_int_env("MEMPALACE_TEST_AUDIT_INT", 2000) == 512
+
+    monkeypatch.delenv("MEMPALACE_TEST_AUDIT_INT", raising=False)
+    assert mcp_server._audit_positive_int_env("MEMPALACE_TEST_AUDIT_INT", 2000) == 2000
+
+
 # ── Search Tool ─────────────────────────────────────────────────────────
 
 
@@ -1354,6 +1372,123 @@ class TestSearchTool:
         # Top result should be the auth drawer
         top = result["results"][0]
         assert "JWT" in top["text"] or "authentication" in top["text"].lower()
+
+    def test_audit_log_records_tool_calls_without_content(self, monkeypatch, config, kg, tmp_path):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        audit_file = tmp_path / "mcp_audit.jsonl"
+        monkeypatch.setattr(mcp_server, "_AUDIT_FILE", audit_file)
+        monkeypatch.setattr(mcp_server, "_AUDIT_ENABLED", True)
+
+        resp = mcp_server.handle_request(
+            {
+                "method": "tools/call",
+                "id": 42,
+                "params": {
+                    "name": "mempalace_check_duplicate",
+                    "arguments": {"content": "private background note"},
+                },
+            },
+            {"remote": "127.0.0.1", "user_agent": "pytest"},
+        )
+
+        assert resp["id"] == 42
+        entry = json.loads(audit_file.read_text().strip())
+        assert entry["method"] == "tools/call"
+        assert entry["tool"] == "mempalace_check_duplicate"
+        assert entry["ok"] is True
+        assert entry["remote"] == "127.0.0.1"
+        assert entry["tool_args"]["content"]["chars"] == len("private background note")
+        assert "private background note" not in audit_file.read_text()
+
+    def test_audit_search_summary_records_result_text(
+        self, monkeypatch, config, seeded_collection, seeded_kg, tmp_path
+    ):
+        del seeded_collection
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace import mcp_server
+
+        audit_file = tmp_path / "mcp_audit.jsonl"
+        monkeypatch.setattr(mcp_server, "_AUDIT_FILE", audit_file)
+        monkeypatch.setattr(mcp_server, "_AUDIT_ENABLED", True)
+        monkeypatch.setattr(mcp_server, "_AUDIT_SEARCH_RESPONSE_TEXT", True)
+
+        resp = mcp_server.handle_request(
+            {
+                "method": "tools/call",
+                "id": 7,
+                "params": {
+                    "name": "mempalace_search",
+                    "arguments": {"query": "JWT tokens", "limit": 2},
+                },
+            }
+        )
+
+        assert "result" in resp
+        entry = json.loads(audit_file.read_text().strip())
+        assert entry["tool"] == "mempalace_search"
+        assert entry["result"]["query"] == "JWT tokens"
+        assert entry["result"]["result_count"] >= 1
+        assert entry["result"]["top_results"][0]["wing"] == "project"
+        response_text = entry["result"]["top_results"][0]["response_text"]
+        assert response_text["chars"] > 0
+        assert response_text["sha256_16"]
+        assert "JWT tokens" in response_text["text"]
+        assert response_text["truncated"] is False
+
+    def test_audit_disabled_writes_nothing(self, monkeypatch, config, kg, tmp_path):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        audit_file = tmp_path / "mcp_audit.jsonl"
+        monkeypatch.setattr(mcp_server, "_AUDIT_FILE", audit_file)
+        # _AUDIT_ENABLED left at its default (False) -> no telemetry is written.
+
+        resp = mcp_server.handle_request(
+            {
+                "method": "tools/call",
+                "id": 99,
+                "params": {
+                    "name": "mempalace_check_duplicate",
+                    "arguments": {"content": "private background note"},
+                },
+            },
+            {"remote": "127.0.0.1", "user_agent": "pytest"},
+        )
+
+        assert resp["id"] == 99
+        assert not audit_file.exists()
+
+    def test_audit_search_response_fingerprint_only_by_default(
+        self, monkeypatch, config, seeded_collection, seeded_kg, tmp_path
+    ):
+        del seeded_collection
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace import mcp_server
+
+        audit_file = tmp_path / "mcp_audit.jsonl"
+        monkeypatch.setattr(mcp_server, "_AUDIT_FILE", audit_file)
+        monkeypatch.setattr(mcp_server, "_AUDIT_ENABLED", True)
+        # _AUDIT_SEARCH_RESPONSE_TEXT stays at its default (False) -> fingerprint only.
+
+        resp = mcp_server.handle_request(
+            {
+                "method": "tools/call",
+                "id": 8,
+                "params": {
+                    "name": "mempalace_search",
+                    "arguments": {"query": "JWT tokens", "limit": 2},
+                },
+            }
+        )
+
+        assert "result" in resp
+        entry = json.loads(audit_file.read_text().strip())
+        response_text = entry["result"]["top_results"][0]["response_text"]
+        assert response_text["chars"] > 0
+        assert response_text["sha256_16"]
+        assert "text" not in response_text
 
     def test_search_with_wing_filter(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)


### PR DESCRIPTION
## Opt-in MCP audit telemetry

Adds opt-in, off-by-default per-request audit telemetry to the in-process HTTP transport. No behaviour change and no disk I/O unless an operator sets `MEMPALACE_AUDIT=1`.

- Appends a per-request JSONL event (method, tool, latency, fingerprinted args, result summary) to `~/.mempalace/service_logs/mcp_audit.jsonl` (override via `MEMPALACE_AUDIT_FILE`); log created `0600`, directory `0700`, and an existing log best-effort re-tightened to `0600`.
- Privacy-first: sensitive content (search responses, drawer text, context) is stored as a length + truncated SHA-256 fingerprint (`sha256_16`), never raw, unless `MEMPALACE_AUDIT_SEARCH_RESPONSE_TEXT=1` is also set — and even then the raw text is bounded by `MEMPALACE_AUDIT_SEARCH_RESPONSE_MAX_CHARS` (default 2000, parsed defensively so a bad value can't crash startup).
- Zero overhead when disabled: `handle_request` takes a fast-path and builds no event. Telemetry construction/write is wrapped so a failure can never disrupt the request it observes.
- `mempalace audit` summarises the log (methods, tools, search empty-rate, latency p50/p95, top queries, recent errors).

Sits behind the transport's existing Host/Origin policy and the optional `MEMPALACE_MCP_HTTP_TOKEN` bearer auth.

> The read-only `/dashboard` endpoint that was originally part of this PR has been **dropped** per maintainer feedback — this PR is now audit-only.
