### PR TITLE
fix(mcp): stop clobbering host app root logger at import (#1860)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -101,63 +101,118 @@ from .collision_scan import assert_no_collisions  # noqa: E402
 from .ids import ID_RECIPE, make_drawer_id_from_content  # noqa: E402
 
 
-def _init_logging() -> None:
-    """Root-logger init: always stderr, optionally append to ``MEMPALACE_LOG_FILE``.
+class _MempalaceLogFilter(logging.Filter):
+    """Pass only records emitted by mempalace's own loggers.
 
-    Stderr-only is the default. When ``MEMPALACE_LOG_FILE`` is set, a
-    ``FileHandler`` is attached so MCP-client failures that the client
-    does not surface (e.g. the ``-32000`` cold-load timeout in #1495)
-    remain diagnosable from the file.
+    Lets the ``MEMPALACE_LOG_FILE`` handler attach to an already-configured
+    root logger (a host app embedding the server, #1860) without copying the
+    host's — or a third-party library's — records into mempalace's diagnostic
+    file. mempalace loggers are ``mempalace`` / ``mempalace.*`` (the dotted
+    ``__name__`` family) plus the flat ``mempalace_mcp`` /
+    ``mempalace_format_miner`` / ``mempalace_hallways`` / ``mempalace_graph``
+    loggers — every one is prefixed ``mempalace``.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        name = record.name
+        return name == "mempalace" or name.startswith(("mempalace.", "mempalace_"))
+
+
+_logging_configured = False
+
+
+def _init_logging() -> None:
+    """Configure mempalace logging: stderr by default, optional file append.
+
+    ``MEMPALACE_LOG_FILE``, when set, attaches a ``FileHandler`` so MCP-client
+    failures the client never surfaces (e.g. the ``-32000`` cold-load timeout
+    in #1495) stay diagnosable from the file.
+
+    Root-logger ownership (#1860). The server must not hijack a host
+    application's logging, so the two cases are handled differently:
+
+    * **Root unconfigured** (standalone ``mempalace-mcp``): own it — a stderr
+      handler (plus the optional file handler) via ``basicConfig`` at INFO.
+      The historical behaviour.
+    * **Root already configured** (an app imported ``mempalace.mcp_server``
+      after setting up its own logging): leave the host's level, format, and
+      handlers untouched. Attach only the file handler, filtered to
+      mempalace's own records (`_MempalaceLogFilter`), so the host's logs do
+      not bleed into mempalace's file. With ``MEMPALACE_LOG_FILE`` unset the
+      root logger is not touched at all.
+
+    Previously this called ``logging.basicConfig(..., force=True)``, which
+    reset root's handlers/level/format unconditionally and silently clobbered
+    any host app that had configured logging first (#1860). ``force`` existed
+    (#1495) only to stop ``basicConfig`` no-op'ing when handlers already
+    existed; the filtered additive handler preserves that diagnostic contract
+    without the collateral reset.
+
+    The file handler is mempalace-filtered in both paths, so the file is a
+    clean mempalace-only stream. In the embedded path mempalace's records are
+    still subject to the host's root level — a host wanting INFO diagnostics in
+    the file should not raise root above INFO. The standalone path pins INFO.
 
     Failure modes:
 
-    * Invalid path (missing directory, no perms, Windows NUL byte) →
-      stderr-only with a warning. The env var must not become a new
-      server-start failure surface — that would defeat the diagnostic
-      goal. ``ValueError`` is included in the catch because Windows
-      raises it for paths with embedded NUL bytes, not ``OSError``.
-    * Root logger already configured (host app embedding the server,
-      transitive imports touching ``logging``) → ``force=True`` resets
-      the handlers so MEMPALACE_LOG_FILE's contract holds regardless
-      of what touched root logging first. Without ``force=True``,
-      ``basicConfig`` is a no-op when handlers exist and the env var
-      silently does nothing — exactly the diagnostic black hole #1495
-      exists to close.
-    * Concurrent writers (multiple ``mempalace-mcp`` processes pointing
-      at the same path) interleave at the line level. The handler uses
-      append mode so nothing is overwritten, but operators running
-      Claude Code + Claude Desktop simultaneously should give each
-      process its own log path.
+    * Invalid path (missing directory, no perms, Windows NUL byte) → the file
+      handler is skipped with a warning naming ``MEMPALACE_LOG_FILE``; the
+      server still starts. ``ValueError`` is in the catch because Windows
+      raises it for embedded-NUL paths, not ``OSError``.
+    * Concurrent writers (multiple ``mempalace-mcp`` processes at one path)
+      interleave at the line level; append mode means nothing is overwritten,
+      but give each process its own path.
 
-    ``delay=True`` is intentionally NOT set: deferring the open means an
-    invalid path raises at ``emit()`` time (unhandled), defeating the
-    fail-soft contract. With eager open the same error surfaces inside
-    ``FileHandler.__init__`` and lands in our ``except`` below.
+    ``delay=True`` is intentionally NOT set: deferring the open moves an
+    invalid-path error to ``emit()`` time (unhandled), defeating the fail-soft
+    contract. Eager open lands the same error in ``FileHandler.__init__`` and
+    our ``except`` below.
 
-    Module-level invocation: this function runs at import time, preserving
-    the side effect of the previous module-level ``logging.basicConfig``
-    call. Callers that import ``mempalace.mcp_server`` for introspection
-    (``TOOLS`` dict, handler functions) inherit the reset; this matches
-    pre-PR behaviour and is intentional for an MCP entry-point module.
+    Runs at import time (module-level call below) so importing the module for
+    introspection (``TOOLS`` dict, handler functions) configures logging once.
     """
-    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stderr)]
+    global _logging_configured
+    if _logging_configured:
+        # Idempotent: a second call (e.g. importlib.reload) must not add a
+        # duplicate file handler in the embedded path.
+        return
+    _logging_configured = True
+
     # MEMPALACE_LOG_FILE is operator-supplied and opt-in; this is a
     # local-first server (CLAUDE.md design principle), so no path
     # sanitization — the operator's process UID is the trust boundary.
     log_file = os.environ.get("MEMPALACE_LOG_FILE", "").strip()
+    file_handler: logging.Handler | None = None
     file_handler_error: Exception | None = None
     if log_file:
         try:
-            handlers.append(logging.FileHandler(log_file, mode="a", encoding="utf-8"))
+            file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+            # File is a mempalace-only diagnostic stream; keep host / library
+            # records out so it stays useful when the handler rides on a
+            # host-owned root logger (#1860).
+            file_handler.addFilter(_MempalaceLogFilter())
         except (OSError, ValueError) as exc:
             # Fail-soft: see "Invalid path" failure mode above. Broad on
             # (OSError, ValueError) because Windows raises ValueError for
             # NUL-byte paths while POSIX uses OSError for missing-dir / EPERM.
             file_handler_error = exc
-    logging.basicConfig(level=logging.INFO, format="%(message)s", handlers=handlers, force=True)
+
+    root = logging.getLogger()
+    if root.handlers:
+        # A host app (or a transitive import) already owns root logging. Do
+        # NOT reset it (#1860) — only add our filtered file handler, if any.
+        if file_handler is not None:
+            root.addHandler(file_handler)
+    else:
+        # Standalone server: own the unconfigured root logger as before.
+        handlers: list[logging.Handler] = [logging.StreamHandler(sys.stderr)]
+        if file_handler is not None:
+            handlers.append(file_handler)
+        logging.basicConfig(level=logging.INFO, format="%(message)s", handlers=handlers)
+
     if file_handler_error is not None:
         logging.getLogger("mempalace_mcp").warning(
-            "MEMPALACE_LOG_FILE=%r could not be opened (%s); using stderr only",
+            "MEMPALACE_LOG_FILE=%r could not be opened (%s); file logging disabled",
             log_file,
             file_handler_error,
         )

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -118,7 +118,11 @@ class _MempalaceLogFilter(logging.Filter):
         return name == "mempalace" or name.startswith(("mempalace.", "mempalace_"))
 
 
-_logging_configured = False
+# Preserved across importlib.reload via globals(): a reload re-executes this
+# module body, so a plain ``= False`` would reset the guard and let
+# _init_logging() stack a duplicate file handler. globals().get keeps the prior
+# True so the guard survives reload (#1885 review).
+_logging_configured = globals().get("_logging_configured", False)
 
 
 def _init_logging() -> None:
@@ -187,6 +191,11 @@ def _init_logging() -> None:
     if log_file:
         try:
             file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+            # Pin the format: the embedded path never calls basicConfig, so set
+            # it here instead of relying on logging's default formatter. The
+            # default already renders "%(message)s", but the explicit set makes
+            # both paths identical and independent of that default (#1885 review).
+            file_handler.setFormatter(logging.Formatter("%(message)s"))
             # File is a mempalace-only diagnostic stream; keep host / library
             # records out so it stays useful when the handler rides on a
             # host-owned root logger (#1860).

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -108,8 +108,9 @@ class TestColdStartDiagnostics:
 
     Each test runs ``main()`` in a fresh ``subprocess`` because
 
-    * ``_init_logging`` uses ``logging.basicConfig(force=True)`` which
-      would otherwise reset pytest's ``caplog`` handlers across cases,
+    * ``_init_logging`` configures logging only at module import, so each
+      case needs a fresh interpreter to observe a pristine root logger and
+      configure host logging *before* importing the server,
     * ``ChromaBackend._resolve_embedding_function`` is a class-level
       attribute that test monkeypatching mutates globally,
     * The whole point of the new env vars is process-startup behaviour
@@ -457,6 +458,112 @@ class TestColdStartDiagnostics:
             f"if banner is first, FileHandler was opened lazily (delay=True regression). "
             f"stderr={result.stderr!r}"
         )
+
+    def test_host_root_logger_config_survives_import(self, tmp_path):
+        """#1860: importing the server must NOT clobber a host app's root
+        logger. ``_init_logging`` previously called
+        ``logging.basicConfig(force=True)`` at import, resetting root's
+        level, format, and handlers — silently overriding any app that
+        configured logging before importing ``mempalace.mcp_server``."""
+        marker = tmp_path / "rootstate.txt"
+        extra = (
+            "import logging, pathlib\n"
+            # Host app configures logging BEFORE importing mempalace.
+            "logging.basicConfig(level=logging.DEBUG, "
+            "format='HOST %(levelname)s %(message)s')\n"
+            "_sentinel = logging.NullHandler()\n"
+            "logging.getLogger().addHandler(_sentinel)\n"
+            "from mempalace import mcp_server  # noqa: F401 — triggers _init_logging()\n"
+            "_root = logging.getLogger()\n"
+            "_fmt = next((h.formatter._fmt for h in _root.handlers "
+            "if h.formatter is not None), None)\n"
+            f"pathlib.Path({str(marker)!r}).write_text(\n"
+            "    f'level={logging.getLevelName(_root.level)}|'\n"
+            "    f'sentinel={_sentinel in _root.handlers}|'\n"
+            "    f'nhandlers={len(_root.handlers)}|'\n"
+            "    f'fmt={_fmt!r}'\n"
+            ")\n"
+            "raise SystemExit(0)\n"
+        )
+        result = self._run_main({"MEMPALACE_LOG_FILE": None}, extra_code=extra)
+        assert result.returncode == 0, f"stderr={result.stderr!r}"
+        state = marker.read_text()
+        # Root logger must remain exactly as the host configured it.
+        assert "level=DEBUG" in state, state
+        assert "sentinel=True" in state, state
+        # MEMPALACE_LOG_FILE unset + host owns root → mempalace adds no handler.
+        assert "nhandlers=2" in state, state
+        assert "fmt='HOST %(levelname)s %(message)s'" in state, state
+
+    def test_log_file_with_host_root_captures_mempalace_only(self, tmp_path):
+        """#1860 + #1495: when a host app owns the root logger and
+        MEMPALACE_LOG_FILE is set, the file still captures mempalace's own
+        records — including the dotted ``mempalace.*`` family (the cold-load
+        path) — but NOT the host's. Proves the additive, mempalace-filtered
+        file handler: a naive 'reset root' or 'single dedicated logger' fix
+        would either leak host logs into the file or drop the dotted family."""
+        log_path = tmp_path / "mcp.log"
+        extra = (
+            "import logging\n"
+            # Host owns root logging before the import.
+            "logging.basicConfig(level=logging.DEBUG, format='%(message)s')\n"
+            "from mempalace import mcp_server  # noqa: F401 — triggers _init_logging()\n"
+            "logging.getLogger('host.app').warning('HOST-ONLY-LINE-xyz')\n"
+            "logging.getLogger('mempalace.embedding').info('MEMPALACE-DOTTED-LINE-xyz')\n"
+            "logging.getLogger('mempalace_mcp').info('MEMPALACE-FLAT-LINE-xyz')\n"
+            "logging.shutdown()\n"
+            "raise SystemExit(0)\n"
+        )
+        result = self._run_main({"MEMPALACE_LOG_FILE": str(log_path)}, extra_code=extra)
+        assert result.returncode == 0, f"stderr={result.stderr!r}"
+        assert log_path.exists(), f"log file missing; stderr={result.stderr!r}"
+        body = log_path.read_text(encoding="utf-8")
+        assert "MEMPALACE-DOTTED-LINE-xyz" in body, body
+        assert "MEMPALACE-FLAT-LINE-xyz" in body, body
+        assert "HOST-ONLY-LINE-xyz" not in body, body
+
+    def test_embedded_host_warning_root_gates_mempalace_info(self, tmp_path):
+        """Documents the intentional embedded-mode level-gating tradeoff: when
+        a host owns root at WARNING, mempalace INFO heartbeats do NOT reach
+        MEMPALACE_LOG_FILE (the file handler rides on the host-gated root), but
+        WARNING/ERROR cold-load failure diagnostics still do. #1860 never
+        raises the host's level; #1495's motivating case is a standalone launch
+        (root empty -> INFO pinned) and is unaffected."""
+        log_path = tmp_path / "mcp.log"
+        extra = (
+            "import logging\n"
+            "logging.basicConfig(level=logging.WARNING, format='%(message)s')\n"
+            "from mempalace import mcp_server  # noqa: F401 — triggers _init_logging()\n"
+            "logging.getLogger('mempalace_mcp').info('INFO-HEARTBEAT-xyz')\n"
+            "logging.getLogger('mempalace_mcp').warning('WARN-DIAG-xyz')\n"
+            "logging.shutdown()\n"
+            "raise SystemExit(0)\n"
+        )
+        result = self._run_main({"MEMPALACE_LOG_FILE": str(log_path)}, extra_code=extra)
+        assert result.returncode == 0, f"stderr={result.stderr!r}"
+        body = log_path.read_text(encoding="utf-8")
+        assert "WARN-DIAG-xyz" in body, body
+        assert "INFO-HEARTBEAT-xyz" not in body, body
+
+    def test_standalone_log_file_excludes_third_party_records(self, tmp_path):
+        """The MEMPALACE_LOG_FILE stream is mempalace-only in standalone mode
+        too: third-party library records reaching the root logger are kept out
+        of the file by ``_MempalaceLogFilter`` (the file stays a clean
+        mempalace diagnostic stream)."""
+        log_path = tmp_path / "mcp.log"
+        extra = (
+            "import logging\n"
+            "from mempalace import mcp_server  # noqa: F401 — standalone: root starts empty\n"
+            "logging.getLogger('chromadb.fake').warning('THIRDPARTY-LINE-xyz')\n"
+            "logging.getLogger('mempalace.embedding').info('MEMPALACE-STD-LINE-xyz')\n"
+            "logging.shutdown()\n"
+            "raise SystemExit(0)\n"
+        )
+        result = self._run_main({"MEMPALACE_LOG_FILE": str(log_path)}, extra_code=extra)
+        assert result.returncode == 0, f"stderr={result.stderr!r}"
+        body = log_path.read_text(encoding="utf-8")
+        assert "MEMPALACE-STD-LINE-xyz" in body, body
+        assert "THIRDPARTY-LINE-xyz" not in body, body
 
 
 # ── Protocol Layer ──────────────────────────────────────────────────────

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -521,6 +521,10 @@ class TestColdStartDiagnostics:
         assert "MEMPALACE-DOTTED-LINE-xyz" in body, body
         assert "MEMPALACE-FLAT-LINE-xyz" in body, body
         assert "HOST-ONLY-LINE-xyz" not in body, body
+        # Format is "%(message)s" in the embedded path too: the line is the bare
+        # message with no "LEVEL:name:" prefix (the file handler sets its own
+        # formatter, independent of basicConfig which never runs here).
+        assert any(line == "MEMPALACE-FLAT-LINE-xyz" for line in body.splitlines()), body
 
     def test_embedded_host_warning_root_gates_mempalace_info(self, tmp_path):
         """Documents the intentional embedded-mode level-gating tradeoff: when
@@ -564,6 +568,33 @@ class TestColdStartDiagnostics:
         body = log_path.read_text(encoding="utf-8")
         assert "MEMPALACE-STD-LINE-xyz" in body, body
         assert "THIRDPARTY-LINE-xyz" not in body, body
+
+    def test_reload_does_not_duplicate_file_handler(self, tmp_path):
+        """#1885 review: the idempotency guard must survive ``importlib.reload``,
+        not only a direct second call. A reload re-executes the module body; the
+        guard flag is restored from ``globals()`` so ``_init_logging`` early-exits
+        and does not stack a second ``FileHandler`` on root."""
+        log_path = tmp_path / "mcp.log"
+        marker = tmp_path / "counts.txt"
+        extra = (
+            "import logging, importlib, pathlib\n"
+            "from mempalace import mcp_server\n"
+            "def _nfile():\n"
+            "    return sum(\n"
+            "        isinstance(h, logging.FileHandler)\n"
+            "        for h in logging.getLogger().handlers\n"
+            "    )\n"
+            "_before = _nfile()\n"
+            "importlib.reload(mcp_server)\n"
+            "_after = _nfile()\n"
+            f"pathlib.Path({str(marker)!r}).write_text(f'{{_before}},{{_after}}')\n"
+            "raise SystemExit(0)\n"
+        )
+        result = self._run_main({"MEMPALACE_LOG_FILE": str(log_path)}, extra_code=extra)
+        assert result.returncode == 0, f"stderr={result.stderr!r}"
+        before, after = marker.read_text().split(",")
+        assert before == "1", f"expected one file handler after import, got {before}"
+        assert after == "1", f"reload duplicated the file handler: {before}->{after}"
 
 
 # ── Protocol Layer ──────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #1860

## What does this PR do?

`mempalace.mcp_server._init_logging()` runs at import and called
`logging.basicConfig(level=INFO, format="%(message)s", handlers=[...], force=True)`.
The `force=True` resets the root logger's level, format, and handlers
unconditionally, so an application that configures logging before importing
`mempalace.mcp_server` loses its setup: a host on DEBUG drops back to INFO,
custom formatters are replaced, and existing handlers are removed.

`force=True` was added in #1495 so that `MEMPALACE_LOG_FILE` (the opt-in
FileHandler used to diagnose the `-32000` cold-load timeout) would not be
dropped when handlers already existed on root. This change keeps that
diagnostic contract without the collateral reset:

- **Standalone `mempalace-mcp`** (root has no handlers): configure a stderr
  handler plus the optional file handler via `basicConfig` at INFO, as before.
  (`force` was a no-op in this case anyway, since root was empty.)
- **Embedded** (a host already configured root logging): leave the host's
  level, format, and handlers untouched. Only the `MEMPALACE_LOG_FILE` handler
  is attached, and it is filtered to mempalace's own records so the host's logs
  are not copied into mempalace's file. With `MEMPALACE_LOG_FILE` unset, root is
  not touched at all.

mempalace logs through both a dotted `mempalace.*` family and the flat
`mempalace_mcp` / `mempalace_format_miner` / `mempalace_hallways` /
`mempalace_graph` loggers. A new `_MempalaceLogFilter` matches all of them by
the `mempalace` prefix and only them, so the file keeps capturing the cold-load
path (`mempalace.embedding`) that a single-logger approach would drop.

One documented limitation: in the embedded path the file handler rides on the
host-owned root, so mempalace INFO heartbeats follow the host's root level. A
host on WARNING still gets mempalace WARNING/ERROR cold-load failure
diagnostics in the file, but not INFO lines. The standalone path (the case
#1495 was reported under) pins INFO and is unaffected.

## How to test

`uv run pytest tests/test_mcp_server.py::TestColdStartDiagnostics -q` passes 28
tests, including 4 new cases: host root config survives import; embedded file
capture is mempalace-only; embedded WARNING root gates INFO heartbeats;
standalone file excludes third-party records.

Manual repro of the original bug:

```python
import logging
logging.basicConfig(level=logging.DEBUG, format="%(levelname)s - %(message)s")
import mempalace.mcp_server
# before: root reset to INFO and "%(message)s"; after: DEBUG and custom format kept
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
