### PR TITLE
feat(mcp): add since/before date filter to list_drawers (#1128)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1270,6 +1270,77 @@ def _sanitize_optional_source_file(value: str = None) -> str:
     return value
 
 
+def _parse_date_filter(value: Optional[str] = None, field_name: str = "date") -> Optional[datetime]:
+    """Parse an optional ISO-8601 date/datetime filter bound (#1128).
+
+    Accepts a date (``"2026-04-01"``), a naive timestamp
+    (``"2026-04-01T09:30:00"``), or one carrying a ``Z``/``+HH:MM`` offset.
+    Returns a naive ``datetime`` for wall-clock
+    comparison against drawer ``filed_at`` values, which are stored as naive
+    local ISO strings (``datetime.now().isoformat()``). Any timezone offset on
+    the input is dropped so an aware bound never raises a ``TypeError`` against
+    a naive ``filed_at``. Comparison is therefore wall-clock, which is what the
+    local-first single-machine model wants; an offset bound is matched on its
+    wall-clock fields, not its absolute instant, so a bound whose offset differs
+    from the zone ``filed_at`` was recorded in is matched by clock time.
+    The accepted grammar is a date, an ISO timestamp (optionally fractional),
+    and an optional ``Z``/``±HH:MM`` offset; other ISO 8601 forms (basic format,
+    week dates) are outside the contract and are rejected on the Python 3.9 floor
+    even where a newer ``fromisoformat`` would accept them.
+    Blank / whitespace-only means "no filter" (``None``).
+    Raises ``ValueError`` on an unparseable value so the caller can surface a
+    clear error, mirroring the wing/room sanitizers.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be an ISO date string")
+    value = value.strip()
+    if not value:
+        return None
+    # datetime.fromisoformat before Python 3.11 rejects a trailing "Z" (Zulu),
+    # and appending "+00:00" would break a date-only value on 3.9/3.10
+    # ("2026-04-01+00:00" is rejected there). Any offset is dropped below for
+    # wall-clock comparison anyway, so just strip a trailing Z/z; both date and
+    # date-time Zulu inputs then parse on the 3.9 floor.
+    iso = value[:-1] if value.endswith(("Z", "z")) else value
+    try:
+        parsed = datetime.fromisoformat(iso)
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must be an ISO date string "
+            f"(e.g. '2026-04-01' or '2026-04-01T09:30:00'), got {value!r}"
+        ) from exc
+    if parsed.tzinfo is not None:
+        parsed = parsed.replace(tzinfo=None)
+    return parsed
+
+
+def _filed_at_in_window(
+    filed_at, since_dt: Optional[datetime], before_dt: Optional[datetime]
+) -> bool:
+    """True if a drawer's ``filed_at`` falls in ``[since, before)`` (#1128).
+
+    ``since`` is inclusive and ``before`` is exclusive, matching the issue spec.
+    Parsing (``Z``/offset normalization, tz drop) is delegated to
+    ``_parse_date_filter`` so a bound and a ``filed_at`` are compared
+    identically. A drawer whose ``filed_at`` is missing or unparseable cannot
+    be confirmed in-window, so it is EXCLUDED whenever a bound is active — a
+    date-filtered listing must never silently include rows of unknown age.
+    """
+    try:
+        filed_dt = _parse_date_filter(filed_at, "filed_at")
+    except ValueError:
+        return False
+    if filed_dt is None:
+        return False
+    if since_dt is not None and filed_dt < since_dt:
+        return False
+    if before_dt is not None and filed_dt >= before_dt:
+        return False
+    return True
+
+
 # ==================== READ TOOLS ====================
 
 
@@ -2793,14 +2864,34 @@ def tool_get_drawer(drawer_id: str):
         return {"error": str(e)}
 
 
-def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offset: int = 0):
-    """List logical drawers with pagination."""
+def tool_list_drawers(
+    wing: str = None,
+    room: str = None,
+    since: str = None,
+    before: str = None,
+    limit: int = 20,
+    offset: int = 0,
+):
+    """List logical drawers with pagination.
+
+    Optional ``since`` / ``before`` filter by drawer ``filed_at`` (ISO date or
+    timestamp): ``since`` is inclusive, ``before`` is exclusive (#1128). A
+    drawer whose ``filed_at`` is missing or unparseable is excluded while a
+    date bound is active. The filter is applied in Python after the rows are
+    fetched — ChromaDB rejects string operands for ``$gte``/``$lt`` (1.5.7),
+    and ``filed_at`` is stored as an ISO string, so a server-side ``where``
+    comparison is not available.
+    """
     limit = max(1, min(limit, _MAX_RESULTS))
     offset = max(0, offset)
 
     try:
         wing = _sanitize_optional_name(wing, "wing")
         room = _sanitize_optional_name(room, "room")
+        since_dt = _parse_date_filter(since, "since")
+        before_dt = _parse_date_filter(before, "before")
+        if since_dt is not None and before_dt is not None and since_dt >= before_dt:
+            raise ValueError(f"since ({since!r}) must be earlier than before ({before!r})")
     except ValueError as e:
         return {"error": str(e)}
 
@@ -2824,6 +2915,14 @@ def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offse
 
         ids, documents, metadatas = _fetch_drawer_rows(col, where=where)
         drawers = _collapse_drawer_rows(ids, documents, metadatas)
+
+        if since_dt is not None or before_dt is not None:
+            drawers = [
+                d
+                for d in drawers
+                if _filed_at_in_window(d.get("metadata", {}).get("filed_at"), since_dt, before_dt)
+            ]
+
         page = drawers[offset : offset + limit]
 
         return {
@@ -2834,6 +2933,7 @@ def tool_list_drawers(wing: str = None, room: str = None, limit: int = 20, offse
             "limit": limit,
         }
     except Exception as e:
+        logger.exception("tool_list_drawers failed")
         return {"error": str(e)}
 
 
@@ -4047,12 +4147,20 @@ TOOLS = {
         "handler": tool_get_drawer,
     },
     "mempalace_list_drawers": {
-        "description": "List drawers with pagination. Optional wing/room filter. Returns IDs, wings, rooms, content previews, and total matching count for pagination.",
+        "description": "List drawers with pagination. Optional wing/room filter and since/before date filter on filed_at (since inclusive, before exclusive; drawers without a parseable filed_at are excluded when a date bound is set). Returns IDs, wings, rooms, content previews, and total matching count for pagination.",
         "input_schema": {
             "type": "object",
             "properties": {
                 "wing": {"type": "string", "description": "Filter by wing (optional)"},
                 "room": {"type": "string", "description": "Filter by room (optional)"},
+                "since": {
+                    "type": "string",
+                    "description": "Only drawers filed on or after this ISO date/time, inclusive (e.g. '2026-04-01'). Optional.",
+                },
+                "before": {
+                    "type": "string",
+                    "description": "Only drawers filed before this ISO date/time, exclusive (e.g. '2026-05-01'). Optional.",
+                },
                 "limit": {
                     "type": "integer",
                     "description": "Max results per page (default 20, max 100)",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,17 @@ def _reset_mcp_cache():
                 if hasattr(mcp_server, "_kg_by_path"):
                     mcp_server._kg_by_path.clear()
 
+                # Close (not just dereference) the cached chromadb client so its
+                # rust-side file handles are released; on Windows a bare deref
+                # leaves them locked and leaks across the session (#1128).
+                cached_client = getattr(mcp_server, "_client_cache", None)
+                if cached_client is not None:
+                    close = getattr(cached_client, "close", None)
+                    if callable(close):
+                        try:
+                            close()
+                        except Exception:
+                            pass
                 mcp_server._client_cache = None
                 mcp_server._collection_cache = None
                 if hasattr(mcp_server, "_collection_cache_backend"):
@@ -154,7 +165,11 @@ def collection(palace_path):
     col = client.get_or_create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
     yield col
     client.delete_collection("mempalace_drawers")
-    del client
+    # close() (not a bare dereference) releases chromadb's rust-side SQLite/HNSW
+    # file handles. On Windows a mere `del` leaves them locked, so the temp
+    # palace cannot be removed and handles leak across the whole test session
+    # until a later test's HNSW write fails (#1128 Windows CI).
+    client.close()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,29 @@ def _reset_mcp_cache():
         except (ImportError, AttributeError):
             pass
 
+        # Release chromadb clients opened through the backend layer. Many tests
+        # reach the store via palace.get_collection() (sweep, repair, CLI, ...),
+        # which caches one PersistentClient per palace_path on the long-lived
+        # backend singleton and never closes it. chromadb frees the rust-side
+        # SQLite/HNSW file handles only on client.close(); on POSIX the open
+        # handles are harmless, but on Windows they stay locked and accumulate
+        # across the session until a later test's HNSW segment write fails
+        # (#1128 Windows CI). close_palace() closes the client and drops the
+        # handle without marking the backend closed, so it stays reusable.
+        try:
+            from mempalace import palace as _palace
+
+            backend = getattr(_palace, "_DEFAULT_BACKEND", None)
+            clients = getattr(backend, "_clients", None)
+            if clients:
+                for path in list(clients):
+                    try:
+                        backend.close_palace(path)
+                    except Exception:
+                        pass
+        except (ImportError, AttributeError):
+            pass
+
     _clear_cache()
     yield
     _clear_cache()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1973,6 +1973,141 @@ class TestWriteTools:
         result = tool_list_drawers(offset=-5)
         assert result["offset"] == 0
 
+    def test_list_drawers_since_filter_inclusive(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # seeded filed_at values: 2026-01-01..2026-01-04; since is inclusive.
+        result = tool_list_drawers(since="2026-01-03")
+        assert result["total"] == 2
+        assert result["count"] == 2
+        filed = sorted(d["metadata"]["filed_at"] for d in result["drawers"])
+        assert filed == ["2026-01-03T00:00:00", "2026-01-04T00:00:00"]
+
+    def test_list_drawers_before_filter_exclusive(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # before is exclusive: 2026-01-03 keeps only 01 and 02.
+        result = tool_list_drawers(before="2026-01-03")
+        assert result["total"] == 2
+        filed = sorted(d["metadata"]["filed_at"] for d in result["drawers"])
+        assert filed == ["2026-01-01T00:00:00", "2026-01-02T00:00:00"]
+
+    def test_list_drawers_since_and_before_window(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # [since, before): 02 and 03 kept, 01 below, 04 at/above the bound.
+        result = tool_list_drawers(since="2026-01-02", before="2026-01-04")
+        assert result["total"] == 2
+        filed = sorted(d["metadata"]["filed_at"] for d in result["drawers"])
+        assert filed == ["2026-01-02T00:00:00", "2026-01-03T00:00:00"]
+
+    def test_list_drawers_date_window_single_day(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # since inclusive + before exclusive isolates exactly 2026-01-02.
+        result = tool_list_drawers(since="2026-01-02", before="2026-01-03")
+        assert result["total"] == 1
+        assert result["drawers"][0]["metadata"]["filed_at"] == "2026-01-02T00:00:00"
+
+    def test_list_drawers_date_filter_combines_with_wing(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # project wing = 01,02,03; since 2026-01-02 narrows to 02,03.
+        result = tool_list_drawers(wing="project", since="2026-01-02")
+        assert result["total"] == 2
+        assert all(d["wing"] == "project" for d in result["drawers"])
+
+    def test_list_drawers_no_date_filter_unchanged(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # Omitting since/before leaves the full set (regression guard).
+        assert tool_list_drawers()["total"] == 4
+
+    def test_list_drawers_rejects_invalid_since(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        result = tool_list_drawers(since="not-a-date")
+        assert "error" in result
+        assert "since" in result["error"]
+
+    def test_list_drawers_rejects_invalid_before(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        result = tool_list_drawers(before="2026-99-99")
+        assert "error" in result
+        assert "before" in result["error"]
+
+    def test_list_drawers_rejects_inverted_window(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # since must be earlier than before; inverted bounds are a clear error,
+        # not a silently empty result.
+        result = tool_list_drawers(since="2026-06-01", before="2026-01-01")
+        assert "error" in result
+        assert "since" in result["error"]
+        assert "before" in result["error"]
+
+    def test_list_drawers_excludes_undated_drawer_when_filtered(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # A drawer with no filed_at is present unfiltered but excluded once a
+        # date bound is active (its age cannot be confirmed in-window).
+        seeded_collection.add(
+            ids=["drawer_no_filed_at"],
+            documents=["A drawer without a filed_at timestamp."],
+            metadatas=[{"wing": "project", "room": "backend"}],
+        )
+        assert tool_list_drawers()["total"] == 5
+        filtered = tool_list_drawers(since="2026-01-01")
+        ids = [d["drawer_id"] for d in filtered["drawers"]]
+        assert "drawer_no_filed_at" not in ids
+        assert filtered["total"] == 4
+
+    def test_list_drawers_date_filter_paginates_on_filtered_total(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_list_drawers
+
+        # window [01-01, 01-04) keeps 01, 02, 03; pagination runs on that
+        # filtered total, not the grand total of 4.
+        page1 = tool_list_drawers(since="2026-01-01", before="2026-01-04", limit=2, offset=0)
+        page2 = tool_list_drawers(since="2026-01-01", before="2026-01-04", limit=2, offset=2)
+        assert page1["total"] == 3
+        assert page1["count"] == 2
+        assert page2["total"] == 3
+        assert page2["count"] == 1
+
     def test_update_drawer_content(self, monkeypatch, config, palace_path, seeded_collection, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace.mcp_server import tool_update_drawer, tool_get_drawer
@@ -4727,3 +4862,119 @@ def test_sqlite_integrity_refusal_handles_none_palace_path(monkeypatch):
     assert result["error"]["data"]["palace"] == ""
     assert result["error"]["data"]["sqlite_path"] == ""
     assert result["error"]["data"]["tool"] == "mempalace_kg_add"
+
+
+class TestListDrawersDateFilters:
+    """Unit tests for the #1128 date-filter helpers in mcp_server."""
+
+    def test_parse_date_filter_none_and_blank(self):
+        from mempalace.mcp_server import _parse_date_filter
+
+        assert _parse_date_filter(None, "since") is None
+        assert _parse_date_filter("   ", "since") is None
+
+    def test_parse_date_filter_date_only(self):
+        from datetime import datetime
+
+        from mempalace.mcp_server import _parse_date_filter
+
+        assert _parse_date_filter("2026-04-01", "since") == datetime(2026, 4, 1)
+
+    def test_parse_date_filter_full_timestamp(self):
+        from datetime import datetime
+
+        from mempalace.mcp_server import _parse_date_filter
+
+        assert _parse_date_filter("2026-04-01T09:30:00", "since") == datetime(2026, 4, 1, 9, 30)
+
+    def test_parse_date_filter_drops_timezone(self):
+        from datetime import datetime
+
+        from mempalace.mcp_server import _parse_date_filter
+
+        # tz offset dropped -> naive wall-clock, never raises vs naive filed_at.
+        parsed = _parse_date_filter("2026-04-01T09:30:00+02:00", "since")
+        assert parsed == datetime(2026, 4, 1, 9, 30)
+        assert parsed.tzinfo is None
+
+    def test_parse_date_filter_rejects_garbage(self):
+        import pytest
+
+        from mempalace.mcp_server import _parse_date_filter
+
+        with pytest.raises(ValueError, match="since"):
+            _parse_date_filter("not-a-date", "since")
+
+    def test_parse_date_filter_rejects_impossible_date(self):
+        import pytest
+
+        from mempalace.mcp_server import _parse_date_filter
+
+        with pytest.raises(ValueError):
+            _parse_date_filter("2026-13-40", "before")
+
+    def test_filed_at_in_window_since_inclusive(self):
+        from datetime import datetime
+
+        from mempalace.mcp_server import _filed_at_in_window
+
+        since = datetime(2026, 1, 2)
+        assert _filed_at_in_window("2026-01-02T00:00:00", since, None) is True
+        assert _filed_at_in_window("2026-01-01T23:59:59", since, None) is False
+
+    def test_filed_at_in_window_before_exclusive(self):
+        from datetime import datetime
+
+        from mempalace.mcp_server import _filed_at_in_window
+
+        before = datetime(2026, 1, 3)
+        assert _filed_at_in_window("2026-01-02T23:59:59", None, before) is True
+        assert _filed_at_in_window("2026-01-03T00:00:00", None, before) is False
+
+    def test_filed_at_in_window_missing_or_malformed_excluded(self):
+        from datetime import datetime
+
+        from mempalace.mcp_server import _filed_at_in_window
+
+        since = datetime(2026, 1, 1)
+        assert _filed_at_in_window(None, since, None) is False
+        assert _filed_at_in_window("", since, None) is False
+        assert _filed_at_in_window("garbage", since, None) is False
+        assert _filed_at_in_window(12345, since, None) is False
+
+    def test_filed_at_in_window_tz_aware_wall_clock(self):
+        from datetime import datetime
+
+        from mempalace.mcp_server import _filed_at_in_window
+
+        # tz dropped on both sides -> wall-clock compare, no TypeError raised.
+        since = datetime(2026, 1, 2)
+        assert _filed_at_in_window("2026-01-02T08:00:00+05:00", since, None) is True
+
+    def test_parse_date_filter_accepts_zulu_suffix(self):
+        from datetime import datetime
+
+        from mempalace.mcp_server import _parse_date_filter
+
+        # "Z" is not accepted by datetime.fromisoformat before 3.11; the helper
+        # strips it so Zulu inputs parse on the 3.9 floor, tz then dropped.
+        parsed = _parse_date_filter("2026-04-01T09:30:00Z", "since")
+        assert parsed == datetime(2026, 4, 1, 9, 30)
+        assert parsed.tzinfo is None
+
+        # Date-only with a Zulu suffix must also parse on 3.9/3.10 (appending
+        # "+00:00" would have raised there; stripping Z does not).
+        parsed_date = _parse_date_filter("2026-04-01Z", "since")
+        assert parsed_date == datetime(2026, 4, 1)
+        assert parsed_date.tzinfo is None
+
+        # Lowercase z is tolerated too.
+        assert _parse_date_filter("2026-04-01t09:30:00z", "since") == datetime(2026, 4, 1, 9, 30)
+
+    def test_filed_at_in_window_accepts_zulu_filed_at(self):
+        from datetime import datetime
+
+        from mempalace.mcp_server import _filed_at_in_window
+
+        since = datetime(2026, 1, 2)
+        assert _filed_at_in_window("2026-01-02T08:00:00Z", since, None) is True


### PR DESCRIPTION
## What does this PR do?

Fixes #1128.

`mempalace_list_drawers` only filtered by `wing` and `room`, so there was no way to ask for drawers by when they were filed. This adds two optional bounds on `filed_at`:

- `since` (ISO date or timestamp): include drawers with `filed_at >= since` (inclusive)
- `before` (ISO date or timestamp): include drawers with `filed_at < before` (exclusive)

Both are optional; behavior is unchanged when neither is set.

The filter runs in Python, after the rows are fetched. ChromaDB 1.5.7 (the pinned version) rejects string operands for `$gte`/`$lt` (`ValueError: Expected operand value to be an int or a float`), and `filed_at` is stored as an ISO string, so a server-side `where` comparison is not possible without a schema change. `tool_list_drawers` already collapses and paginates the full result set in Python, so the date filter slots into the existing path with no extra fetch cost.

Details:

- Bounds are parsed with `datetime.fromisoformat`; a timezone offset is dropped so an aware bound never fails against the naive `filed_at` values the miners write.
- A drawer whose `filed_at` is missing or unparseable is excluded while a bound is active, since its age cannot be confirmed in the window. This is noted in the tool description.
- Inverted bounds (`since >= before`) return a clear error instead of a silently empty result.
- `total` reflects the filtered count, the same way the existing `wing`/`room` filter behaves.

Scope: this covers `mempalace_list_drawers` only. Date filtering for `mempalace_search` is a separate, older request (#463) with different trade-offs (semantic top-k vs. enumeration), so it is intentionally left out here.

Prior art: #1460 proposed a `since`-only variant for this tool and reached the same conclusion about ChromaDB's string-operand rejection. That PR is stale and currently conflicting; this one is independent, adds `before`, handles timezones and unparseable dates explicitly, and keeps pagination. Thanks to @Osezno-byte for the earlier exploration.

## How to test

```bash
uv run pytest tests/test_mcp_server.py -k "list_drawers and (since or before or date or window or rejects or excludes)" -v
uv run pytest tests/test_mcp_server.py -k "TestListDrawersDateFilters" -v
```

Manual check through the MCP tool against a palace with drawers of known `filed_at`:

```
mempalace_list_drawers(since="2026-03-01")                      # filed_at >= 2026-03-01
mempalace_list_drawers(before="2026-03-01")                     # filed_at <  2026-03-01
mempalace_list_drawers(since="2026-01-01", before="2026-02-01") # January only
```

## Checklist

- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
