### PR TITLE
feat(graph): auto-populate the associative graph from mined sessions

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1001,6 +1001,21 @@ def cmd_migrate_wings(args):
     )
 
 
+def cmd_hallways(args):
+    """List within-wing entity hallways (the auto-built associative graph)."""
+    from .hallways import list_hallways
+
+    rows = list_hallways(getattr(args, "wing", None))
+    if not rows:
+        print("No hallways yet — they are built from drawer entities when you mine.")
+        return
+    rows.sort(key=lambda h: h.get("co_occurrence_count", 0), reverse=True)
+    print(f"  {len(rows)} hallway(s):")
+    for h in rows[: args.limit]:
+        label = h.get("label") or f"{h.get('entity_a', '?')} <-> {h.get('entity_b', '?')}"
+        print(f"    {label}")
+
+
 def cmd_status(args):
     from .miner import status
 
@@ -1977,6 +1992,9 @@ def main():
     )
     p_migrate_wings.add_argument("--yes", action="store_true", help="Skip the confirmation prompt")
 
+    p_hallways = sub.add_parser("hallways", help="List entity hallways (associative graph)")
+    p_hallways.add_argument("--wing", default=None, help="Filter to one wing")
+    p_hallways.add_argument("--limit", type=int, default=50, help="Max hallways to show")
     p_status = sub.add_parser("status", help="Show what's been filed")
     p_status.add_argument(
         "--backend",
@@ -2061,6 +2079,7 @@ def main():
         "repair-status": cmd_repair_status,
         "migrate": cmd_migrate,
         "migrate-wings": cmd_migrate_wings,
+        "hallways": cmd_hallways,
         "status": cmd_status,
     }
     dispatch[args.command](args)

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1011,7 +1011,7 @@ def cmd_hallways(args):
         return
     rows.sort(key=lambda h: h.get("co_occurrence_count", 0), reverse=True)
     print(f"  {len(rows)} hallway(s):")
-    for h in rows[: args.limit]:
+    for h in rows[: max(0, args.limit)]:
         label = h.get("label") or f"{h.get('entity_a', '?')} <-> {h.get('entity_b', '?')}"
         print(f"    {label}")
 

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -20,6 +20,7 @@ from typing import Optional
 from .collision_scan import assert_no_collisions
 from .ids import ID_RECIPE, make_convo_drawer_id, make_convo_sentinel_id
 from .normalize import normalize
+from .entities import entities_metadata
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
@@ -463,6 +464,7 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                         "chunk_index": chunk["chunk_index"],
                         "added_by": agent,
                         "filed_at": filed_at,
+                        "entities": entities_metadata(chunk["content"]),
                         "ingest_mode": "convos",
                         "extract_mode": extract_mode,
                         "normalize_version": NORMALIZE_VERSION,
@@ -589,6 +591,22 @@ def mine_convos(
             dry_run=dry_run,
             extract_mode=extract_mode,
         )
+
+
+def _compute_hallways_for_wing_safe(wing, collection, drawers_filed):
+    """Auto-populate the associative graph from the entities just mined.
+
+    Best-effort: hallway computation must never fail an otherwise-good mine, and is
+    skipped when nothing new was filed.
+    """
+    if drawers_filed <= 0:
+        return
+    try:
+        from .hallways import compute_hallways_for_wing
+
+        compute_hallways_for_wing(wing, col=collection)
+    except Exception as exc:
+        print(f"  (hallways skipped: {exc})")
 
 
 def _mine_convos_impl(
@@ -741,6 +759,10 @@ def _mine_convos_impl(
             break
 
     if not dry_run:
+        # Compute hallways before the FTS5 validation: the latter opens a direct sqlite
+        # connection to the Chroma DB, which can invalidate the live collection handle on
+        # some Chroma builds and make the hallway fetch fail.
+        _compute_hallways_for_wing_safe(wing, collection, total_drawers)
         _validate_palace_fts5_after_mine(palace_path)
 
     print(f"\n{'=' * 55}")

--- a/mempalace/entities.py
+++ b/mempalace/entities.py
@@ -22,8 +22,10 @@ _PATH = re.compile(r"\b[\w.-]+/[\w./-]*\.[A-Za-z][A-Za-z0-9]{0,4}\b")
 _QUALIFIED = re.compile(r"\b[A-Za-z][A-Za-z0-9_]+(?:\.[A-Za-z][A-Za-z0-9_]+)+\b")
 # CamelCase with >=2 humps — strongly code-specific: ChromaBackend, MemoryStack.
 _CAMEL = re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)+\b")
-# snake_case (must contain an underscore, so it can't match plain English): do_thing.
-_SNAKE = re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b")
+# snake_case (must contain an underscore, so it can't match plain English): do_thing,
+# _extract_authored_at. The optional leading/trailing `_?` matches dunder-style names
+# whose underscore would otherwise fall outside the `\b` boundary (`_` is a word char).
+_SNAKE = re.compile(r"\b_?[a-z][a-z0-9]*(?:_[a-z0-9]+)+_?\b")
 
 _MAX_ENTITIES = 24
 _MIN_LEN = 2
@@ -31,7 +33,9 @@ _MAX_LEN = 64
 
 
 def _clean(token):
-    return token.strip().strip("`.,:;()[]{}<>\"'").strip()
+    # `;` is the entities-metadata separator, so it must never survive inside an entity
+    # (e.g. a URL query string or a backtick span) or it would split the field.
+    return token.replace(";", " ").strip().strip("`.,:()[]{}<>\"'").strip()
 
 
 def extract_structural_entities(text, max_entities=_MAX_ENTITIES):

--- a/mempalace/entities.py
+++ b/mempalace/entities.py
@@ -1,0 +1,66 @@
+"""No-LLM structural entity extraction for the associative graph.
+
+Pulls deterministic, *structural* tokens from text — author-quoted code spans, URLs,
+file paths, qualified identifiers, and CamelCase symbols — to populate the ``entities``
+drawer-metadata field that hallways/tunnels consume. Structural-only by design: no
+wordlists, no NLP models, no domain vocabulary, so it stays language-neutral and
+predictable, and biases to precision (only tokens that are unambiguously "a thing being
+referred to") over recall.
+
+The output format matches what ``hallways._parse_entities`` expects: a ``;``-joined string.
+"""
+import re
+
+# Author-quoted code spans are the highest-signal structural marker: `foo`, `obj.method()`.
+_BACKTICK = re.compile(r"`([^`\n]{2,64})`")
+# URLs.
+_URL = re.compile(r"https?://[^\s)>\]}\"']+")
+# Paths with a separator and a short extension: rag/foo.py, a/b/c.tsx.
+_PATH = re.compile(r"\b[\w.-]+/[\w./-]*\.[A-Za-z][A-Za-z0-9]{0,4}\b")
+# Qualified dotted identifiers; each segment starts with a letter and is >=2 chars, so
+# "1.2.3", "e.g", and "i.e" are excluded: module.func, pkg.Class.method.
+_QUALIFIED = re.compile(r"\b[A-Za-z][A-Za-z0-9_]+(?:\.[A-Za-z][A-Za-z0-9_]+)+\b")
+# CamelCase with >=2 humps — strongly code-specific: ChromaBackend, MemoryStack.
+_CAMEL = re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)+\b")
+# snake_case (must contain an underscore, so it can't match plain English): do_thing.
+_SNAKE = re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b")
+
+_MAX_ENTITIES = 24
+_MIN_LEN = 2
+_MAX_LEN = 64
+
+
+def _clean(token):
+    return token.strip().strip("`.,:;()[]{}<>\"'").strip()
+
+
+def extract_structural_entities(text, max_entities=_MAX_ENTITIES):
+    """Return up to ``max_entities`` structural entities from ``text``.
+
+    Deterministic and order-stable: entities are ranked by occurrence count (ties broken
+    by first appearance), deduplicated case-insensitively, preserving the first-seen
+    surface form.
+    """
+    if not text:
+        return []
+    counts = {}
+    order = {}
+    seq = 0
+    for pattern in (_BACKTICK, _URL, _PATH, _QUALIFIED, _CAMEL, _SNAKE):
+        for match in pattern.finditer(text):
+            token = _clean(match.group(1) if pattern is _BACKTICK else match.group(0))
+            if not (_MIN_LEN <= len(token) <= _MAX_LEN):
+                continue
+            key = token.lower()
+            if key not in counts:
+                counts[key] = 0
+                order[key] = (seq, token)
+                seq += 1
+            counts[key] += 1
+    ranked = sorted(order, key=lambda k: (-counts[k], order[k][0]))
+    return [order[k][1] for k in ranked[:max_entities]]
+
+
+def entities_metadata(text, max_entities=_MAX_ENTITIES):
+    """``;``-joined entity string for drawer metadata, or ``""`` when none are found."""
+    return ";".join(extract_structural_entities(text, max_entities=max_entities))

--- a/tests/test_cli_hallways.py
+++ b/tests/test_cli_hallways.py
@@ -29,6 +29,17 @@ def test_respects_limit(monkeypatch, capsys):
     assert capsys.readouterr().out.count("<->") == 2
 
 
+def test_negative_limit_shows_nothing_not_tail(monkeypatch, capsys):
+    rows = [
+        {"entity_a": f"E{i}", "entity_b": "X", "co_occurrence_count": i, "label": f"E{i} <-> X"}
+        for i in range(5)
+    ]
+    monkeypatch.setattr(hallways_mod, "list_hallways", lambda wing=None: list(rows))
+    cmd_hallways(Namespace(wing=None, limit=-2))
+    # A negative limit must not slice from the end (which would print all-but-2).
+    assert capsys.readouterr().out.count("<->") == 0
+
+
 def test_empty_message(monkeypatch, capsys):
     monkeypatch.setattr(hallways_mod, "list_hallways", lambda wing=None: [])
     cmd_hallways(Namespace(wing="x", limit=50))

--- a/tests/test_cli_hallways.py
+++ b/tests/test_cli_hallways.py
@@ -1,0 +1,35 @@
+"""Tests for the `hallways` CLI command."""
+from argparse import Namespace
+
+import mempalace.hallways as hallways_mod
+from mempalace.cli import cmd_hallways
+
+
+def test_lists_sorted_by_count(monkeypatch, capsys):
+    rows = [
+        {"entity_a": "C", "entity_b": "D", "co_occurrence_count": 1, "wing": "w", "label": "C <-> D (x1)"},
+        {"entity_a": "A", "entity_b": "B", "co_occurrence_count": 3, "wing": "w", "label": "A <-> B (x3)"},
+    ]
+    monkeypatch.setattr(hallways_mod, "list_hallways", lambda wing=None: list(rows))
+    cmd_hallways(Namespace(wing=None, limit=50))
+    out = capsys.readouterr().out
+    assert "2 hallway(s)" in out
+    assert "A <-> B (x3)" in out
+    # Highest co-occurrence first.
+    assert out.index("A <-> B") < out.index("C <-> D")
+
+
+def test_respects_limit(monkeypatch, capsys):
+    rows = [
+        {"entity_a": f"E{i}", "entity_b": "X", "co_occurrence_count": i, "label": f"E{i} <-> X"}
+        for i in range(5)
+    ]
+    monkeypatch.setattr(hallways_mod, "list_hallways", lambda wing=None: list(rows))
+    cmd_hallways(Namespace(wing=None, limit=2))
+    assert capsys.readouterr().out.count("<->") == 2
+
+
+def test_empty_message(monkeypatch, capsys):
+    monkeypatch.setattr(hallways_mod, "list_hallways", lambda wing=None: [])
+    cmd_hallways(Namespace(wing="x", limit=50))
+    assert "No hallways yet" in capsys.readouterr().out

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -468,3 +468,36 @@ class TestFileChunksLocked:
         assert dict(room_counts) == {}
         assert skipped is False
         assert col.batch_sizes == [2, 2, 1]
+
+    def test_populates_entities_metadata(self, monkeypatch):
+        import mempalace.convo_miner as convo_miner
+
+        class FakeCol:
+            def __init__(self):
+                self.metas = []
+
+            def delete(self, *args, **kwargs):
+                pass
+
+            def get(self, ids=None, include=None, **kwargs):
+                return {"ids": [], "metadatas": []}
+
+            def upsert(self, documents, ids, metadatas):
+                self.metas.extend(metadatas)
+
+        chunks = [
+            {"content": "We changed `MemoryStack` in rag/foo.py via do_thing_now().", "chunk_index": 0}
+        ]
+        col = FakeCol()
+        monkeypatch.setattr(
+            convo_miner, "file_already_mined", lambda collection, source_file, **kwargs: False
+        )
+        monkeypatch.setattr(convo_miner, "mine_lock", lambda source_file: contextlib.nullcontext())
+        monkeypatch.setattr(convo_miner, "_detect_hall_cached", lambda content: "conversations")
+
+        _file_chunks_locked(col, "chat.txt", chunks, "wing", "general", "agent", "exchange")
+
+        entities = col.metas[0]["entities"].split(";")
+        assert "MemoryStack" in entities
+        assert "rag/foo.py" in entities
+        assert "do_thing_now" in entities

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -44,6 +44,22 @@ def test_respects_max_entities():
     assert len(extract_structural_entities(text, max_entities=10)) == 10
 
 
+def test_extracts_leading_underscore_snake_in_plain_text():
+    # Not in backticks — must still be caught by the snake-case pattern.
+    ents = extract_structural_entities("we called _extract_authored_at and _do_thing here")
+    assert "_extract_authored_at" in ents
+    assert "_do_thing" in ents
+
+
+def test_semicolon_in_entity_does_not_corrupt_metadata():
+    # A backtick span containing ';' must not split the ;-joined metadata field.
+    md = entities_metadata("see `a(); b()` and TwoThing")
+    parts = md.split(";")
+    # Every part is a whole entity — no fragment is a bare separator artifact.
+    assert all(p.strip() for p in parts)
+    assert "TwoThing" in parts
+
+
 def test_metadata_is_semicolon_joined():
     text = "`one_thing` and TwoThing"
     md = entities_metadata(text)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,52 @@
+"""Tests for no-LLM structural entity extraction."""
+from mempalace.entities import entities_metadata, extract_structural_entities
+
+
+def test_extracts_code_symbols_paths_urls():
+    text = (
+        "We patched `_extract_authored_at` in rag/convo_miner.py so MemoryStack and "
+        "ChromaBackend agree. See module.func and pkg.Class.method, plus do_thing_now. "
+        "Ref https://github.com/MemPalace/mempalace/pull/1890 for details."
+    )
+    ents = set(extract_structural_entities(text))
+    assert "_extract_authored_at" in ents
+    assert "rag/convo_miner.py" in ents
+    assert "MemoryStack" in ents
+    assert "ChromaBackend" in ents
+    assert "module.func" in ents
+    assert "pkg.Class.method" in ents
+    assert "do_thing_now" in ents
+    assert any(e.startswith("https://github.com/MemPalace") for e in ents)
+
+
+def test_excludes_prose_noise():
+    text = "This is a normal sentence, e.g. with i.e. abbreviations and version 1.2.3 here."
+    ents = extract_structural_entities(text)
+    # No plain prose words, no "e.g"/"i.e", no bare version numbers.
+    assert ents == []
+
+
+def test_ranked_by_frequency_then_order():
+    text = "alpha_one alpha_one alpha_one beta_two beta_two gamma_three"
+    ents = extract_structural_entities(text)
+    assert ents[:3] == ["alpha_one", "beta_two", "gamma_three"]
+
+
+def test_dedup_case_insensitive_keeps_first_form():
+    text = "`MemoryStack` and memorystack and MEMORYSTACK"
+    ents = extract_structural_entities(text)
+    assert ents.count("MemoryStack") == 1
+    assert ents == ["MemoryStack"]
+
+
+def test_respects_max_entities():
+    text = " ".join(f"sym_{i}_x" for i in range(50))
+    assert len(extract_structural_entities(text, max_entities=10)) == 10
+
+
+def test_metadata_is_semicolon_joined():
+    text = "`one_thing` and TwoThing"
+    md = entities_metadata(text)
+    assert md == "one_thing;TwoThing"
+    assert entities_metadata("") == ""
+    assert entities_metadata("just plain prose with nothing structural") == ""


### PR DESCRIPTION
## What

Auto-populate the associative (hallway) graph from mined conversations.

`compute_hallways_for_wing` consumes an `entities` drawer-metadata field, but the convos
miner never set it — so mined sessions produced an **empty** associative graph and starved
the entity-navigation / tunnel features built on top. See #1894 for the product gap (and the
stale-vs-superseded failure mode that motivates feeding MemPalace's graph layers).

## Changes

- **`mempalace/entities.py`** — a no-LLM **structural** entity extractor: author-quoted code
  spans, URLs, file paths, qualified dotted identifiers, CamelCase and snake_case symbols.
  No wordlists, no NLP model; precision-biased (prose yields nothing). Output is the
  `;`-joined form `hallways._parse_entities` expects.
- **`mempalace/convo_miner.py`** — set `entities` metadata per chunk, and run
  `compute_hallways_for_wing` after a convos mine (mirroring the project-file path).
  Hallways are computed *before* `_validate_palace_fts5_after_mine`, which opens a direct
  sqlite connection to the Chroma DB that can invalidate the live collection handle on some
  Chroma builds (observed `'RustBindingsAPI' object has no attribute 'bindings'` on
  chromadb 1.5.9). Best-effort: a hallway failure never breaks a mine.
- **`mempalace/cli.py`** — `mempalace hallways [--wing] [--limit]` lists the associative
  graph, for CLI parity with the existing `list_hallways` MCP tool.
- **tests** — extractor precision/ranking/dedup, `entities` populated at mine time, and the
  CLI command.

## Backend safety

No vector-backend code is touched. This is drawer metadata plus the existing hallway store;
it works identically across chroma / sqlite_exact / qdrant / pgvector.

## Verified end-to-end

Mining 3 sessions that share entities produces drawers with populated `entities` and a
15-edge hallway graph (`MemoryStack ↔ ChromaBackend`, `ChromaBackend ↔ search_memories`, …),
listed by `mempalace hallways`. Sessions previously produced zero entities/hallways.

```
pytest tests/test_entities.py tests/test_cli_hallways.py tests/test_convo_miner_unit.py \
       tests/test_convo_miner.py tests/test_hallways.py    # 94 passed
ruff check   # clean
```

## Scope / follow-ups

Deliberately scoped to the **no-LLM associative graph**. Populating the temporal **KG**
(subject–predicate–object facts) wants an opt-in, off-by-default LLM extractor — a natural
follow-up discussed in #1894.

Closes #1894
