### PR TITLE
fix(backends): require SQLite magic header for chroma + sqlite_exact detect() (#1893)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -2228,7 +2228,26 @@ class ChromaBackend(BaseBackend):
 
     @classmethod
     def detect(cls, path: str) -> bool:
-        return os.path.isfile(os.path.join(path, "chroma.sqlite3"))
+        """Return True when ``path`` looks like a chroma palace.
+
+        Verifies the SQLite magic header rather than file presence alone.
+        Bare ``sqlite3.connect()`` against a missing path leaves a 0-byte
+        file behind (the SQLite header is written on the first statement,
+        not on connection), so file-presence alone treats those artifacts
+        as real chroma palaces and breaks multi-backend resolution. The
+        16-byte ``SQLite format 3\\x00`` magic prefix is written as soon
+        as chromadb's ``PersistentClient`` does any work, so this check
+        accepts every real chroma palace while rejecting empty / garbage
+        files. See #1893.
+        """
+        db_path = os.path.join(path, "chroma.sqlite3")
+        if not os.path.isfile(db_path):
+            return False
+        try:
+            with open(db_path, "rb") as f:
+                return f.read(16) == b"SQLite format 3\x00"
+        except OSError:
+            return False
 
     # ------------------------------------------------------------------
     # Legacy (pre-RFC 001) surface — retained while callers migrate.

--- a/mempalace/backends/sqlite_exact.py
+++ b/mempalace/backends/sqlite_exact.py
@@ -1045,7 +1045,23 @@ class SQLiteExactBackend(BaseBackend):
 
     @classmethod
     def detect(cls, path: str) -> bool:
-        return os.path.isfile(os.path.join(path, _DB_FILENAME))
+        """Return True when ``path`` looks like a sqlite_exact palace.
+
+        Verifies the SQLite magic header rather than file presence alone, for
+        the same reason as :py:meth:`mempalace.backends.chroma.ChromaBackend.detect`:
+        bare ``sqlite3.connect()`` against a missing path leaves a 0-byte file
+        behind because the SQLite header is written on the first statement,
+        not on connection. The 16-byte ``SQLite format 3\\x00`` magic prefix
+        accepts every real palace while rejecting empty / garbage files. See #1893.
+        """
+        db_path = os.path.join(path, _DB_FILENAME)
+        if not os.path.isfile(db_path):
+            return False
+        try:
+            with open(db_path, "rb") as f:
+                return f.read(16) == b"SQLite format 3\x00"
+        except OSError:
+            return False
 
     def create_collection(self, palace_path: str, collection_name: str) -> SQLiteExactCollection:
         return self.get_collection(palace_path, collection_name, create=True)

--- a/tests/_chroma_palace_helper.py
+++ b/tests/_chroma_palace_helper.py
@@ -1,0 +1,34 @@
+"""Shared helper: create a minimal valid `chroma.sqlite3` for tests.
+
+Many tests want to stand up "a chroma palace" cheaply — historically they did
+this with ``(path / "chroma.sqlite3").touch()`` or ``write_bytes(b"")``,
+relying on ``ChromaBackend.detect()``'s old ``os.path.isfile()`` semantics.
+Post-#1893, ``detect()`` requires a valid SQLite magic header, so the empty
+stand-in no longer registers. This helper creates the minimum required to
+make detection fire without standing up a full chroma collection.
+
+This module is intentionally not a ``test_*`` file: it ships utilities, not
+tests.
+"""
+
+import sqlite3
+from pathlib import Path
+from typing import Union
+
+
+def make_minimal_chroma_sqlite(palace_path: Union[Path, str]) -> Path:
+    """Create ``<palace_path>/chroma.sqlite3`` with a valid SQLite header.
+
+    Returns the path to the file. Writing any statement is sufficient to land
+    the 16-byte ``SQLite format 3\\x00`` magic prefix that
+    :py:meth:`mempalace.backends.chroma.ChromaBackend.detect` checks.
+    """
+
+    db_path = Path(palace_path) / "chroma.sqlite3"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE _detect_smoke(x)")
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path

--- a/tests/_chroma_palace_helper.py
+++ b/tests/_chroma_palace_helper.py
@@ -1,11 +1,12 @@
-"""Shared helper: create a minimal valid `chroma.sqlite3` for tests.
+"""Shared helpers: create minimal valid palace-marker SQLite files for tests.
 
-Many tests want to stand up "a chroma palace" cheaply — historically they did
-this with ``(path / "chroma.sqlite3").touch()`` or ``write_bytes(b"")``,
-relying on ``ChromaBackend.detect()``'s old ``os.path.isfile()`` semantics.
-Post-#1893, ``detect()`` requires a valid SQLite magic header, so the empty
-stand-in no longer registers. This helper creates the minimum required to
-make detection fire without standing up a full chroma collection.
+Many tests want to stand up "a chroma / sqlite_exact palace" cheaply —
+historically they did this with ``(path / "<marker>.sqlite3").touch()`` or
+``write_bytes(b"")``, relying on the backend ``detect()`` methods' old
+``os.path.isfile()`` semantics. Post-#1893, both ``ChromaBackend.detect()``
+and ``SQLiteExactBackend.detect()`` require a valid SQLite magic header, so
+the empty stand-in no longer registers. These helpers create the minimum
+required to make detection fire without standing up a full palace.
 
 This module is intentionally not a ``test_*`` file: it ships utilities, not
 tests.
@@ -16,19 +17,41 @@ from pathlib import Path
 from typing import Union
 
 
-def make_minimal_chroma_sqlite(palace_path: Union[Path, str]) -> Path:
-    """Create ``<palace_path>/chroma.sqlite3`` with a valid SQLite header.
+def _write_minimal_sqlite_file(db_path: Path) -> None:
+    """Write a valid SQLite magic header at ``db_path``.
 
-    Returns the path to the file. Writing any statement is sufficient to land
-    the 16-byte ``SQLite format 3\\x00`` magic prefix that
-    :py:meth:`mempalace.backends.chroma.ChromaBackend.detect` checks.
+    Writing any statement is sufficient to land the 16-byte
+    ``SQLite format 3\\x00`` magic prefix that the backend ``detect()``
+    methods check.
     """
 
-    db_path = Path(palace_path) / "chroma.sqlite3"
     conn = sqlite3.connect(db_path)
     try:
         conn.execute("CREATE TABLE _detect_smoke(x)")
         conn.commit()
     finally:
         conn.close()
+
+
+def make_minimal_chroma_sqlite(palace_path: Union[Path, str]) -> Path:
+    """Create ``<palace_path>/chroma.sqlite3`` with a valid SQLite header.
+
+    Returns the path to the file. Backs
+    :py:meth:`mempalace.backends.chroma.ChromaBackend.detect`.
+    """
+
+    db_path = Path(palace_path) / "chroma.sqlite3"
+    _write_minimal_sqlite_file(db_path)
+    return db_path
+
+
+def make_minimal_sqlite_exact_sqlite(palace_path: Union[Path, str]) -> Path:
+    """Create ``<palace_path>/sqlite_exact.sqlite3`` with a valid SQLite header.
+
+    Returns the path to the file. Backs
+    :py:meth:`mempalace.backends.sqlite_exact.SQLiteExactBackend.detect`.
+    """
+
+    db_path = Path(palace_path) / "sqlite_exact.sqlite3"
+    _write_minimal_sqlite_file(db_path)
     return db_path

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -178,10 +178,42 @@ def test_resolve_backend_priority_order(tmp_path):
     assert resolve_backend_for_palace() == "chroma"
 
 
-def test_chroma_detect_matches_palace_with_chroma_sqlite(tmp_path):
-    (tmp_path / "chroma.sqlite3").write_bytes(b"")
+def test_chroma_detect_matches_palace_with_sqlite_header(tmp_path):
+    """A real SQLite database at ``<path>/chroma.sqlite3`` registers as chroma.
+
+    Uses ``sqlite3.connect`` + a write so the SQLite magic header is actually
+    on disk — the only thing detection looks at.
+    """
+    db_path = tmp_path / "chroma.sqlite3"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE detect_smoke(x)")
+    conn.commit()
+    conn.close()
     assert ChromaBackend.detect(str(tmp_path)) is True
     assert ChromaBackend.detect(str(tmp_path.parent)) is False
+
+
+def test_chroma_detect_rejects_empty_chroma_sqlite(tmp_path):
+    """A 0-byte ``chroma.sqlite3`` is not a chroma palace (closes #1893).
+
+    Bare ``sqlite3.connect()`` against a missing path leaves a 0-byte file
+    behind because the SQLite header is written on the first statement, not
+    on connect. Detection must reject that artifact so it cannot trip
+    ``BackendMismatchError`` against a real non-chroma backend marker in the
+    same directory.
+    """
+    (tmp_path / "chroma.sqlite3").write_bytes(b"")
+    assert ChromaBackend.detect(str(tmp_path)) is False
+
+
+def test_chroma_detect_rejects_non_sqlite_file(tmp_path):
+    """A non-SQLite file at the ``chroma.sqlite3`` path is not chroma.
+
+    Defends against partial writes / garbage content / anything that lands at
+    the canonical path but isn't actually a SQLite database.
+    """
+    (tmp_path / "chroma.sqlite3").write_bytes(b"not a sqlite file" * 4)
+    assert ChromaBackend.detect(str(tmp_path)) is False
 
 
 def test_chroma_lexical_search_uses_sqlite_fts_not_full_collection_scan(tmp_path):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -5,6 +5,8 @@ import time
 
 import pytest
 
+from _chroma_palace_helper import make_minimal_chroma_sqlite
+
 from mempalace import daemon
 from mempalace import service
 
@@ -728,7 +730,7 @@ def test_run_sync_structured_errors_on_sync_failures(tmp_path, monkeypatch):
 
     palace = tmp_path / "palace"
     palace.mkdir()
-    (palace / "chroma.sqlite3").touch()
+    make_minimal_chroma_sqlite(palace)
 
     def _raise(exc):
         def fn(**kw):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,6 +16,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from _chroma_palace_helper import make_minimal_chroma_sqlite
+
 
 # ── MCP entry point: PYTHONPATH stripping ────────────────────────────────
 
@@ -210,7 +212,7 @@ class TestColdStartDiagnostics:
         """
         palace = tmp_path / "palace"
         palace.mkdir()
-        (palace / "chroma.sqlite3").touch()
+        make_minimal_chroma_sqlite(palace)
         return str(palace)
 
     @staticmethod

--- a/tests/test_palace.py
+++ b/tests/test_palace.py
@@ -2,6 +2,8 @@
 
 import chromadb
 
+from _chroma_palace_helper import make_minimal_chroma_sqlite
+
 from mempalace.backends import CollectionNotInitializedError, PalaceNotFoundError
 from mempalace.palace import _open_collection_or_explain, get_collection
 
@@ -94,7 +96,7 @@ def test_open_collection_or_explain_state_e_unexpected_error(tmp_path, monkeypat
     emit, lines = _capture()
     palace = tmp_path / "palace"
     palace.mkdir()
-    (palace / "chroma.sqlite3").touch()  # pass the isfile guard
+    make_minimal_chroma_sqlite(palace)  # pass the isfile guard
 
     def boom(*args, **kwargs):
         raise RuntimeError("disk on fire")
@@ -125,7 +127,7 @@ def test_open_collection_or_explain_propagates_palace_not_found_from_backend(tmp
     emit, lines = _capture()
     palace = tmp_path / "palace"
     palace.mkdir()
-    (palace / "chroma.sqlite3").touch()
+    make_minimal_chroma_sqlite(palace)
 
     def raise_pnf(*args, **kwargs):
         raise PalaceNotFoundError(str(palace))
@@ -151,7 +153,7 @@ def test_open_collection_or_explain_reraises_backend_closed_error(tmp_path, monk
 
     palace = tmp_path / "palace"
     palace.mkdir()
-    (palace / "chroma.sqlite3").touch()
+    make_minimal_chroma_sqlite(palace)
 
     def raise_closed(*args, **kwargs):
         raise BackendClosedError("ChromaBackend has been closed")
@@ -171,7 +173,7 @@ def test_open_collection_or_explain_distinguishes_collection_subclass(tmp_path, 
     emit, lines = _capture()
     palace = tmp_path / "palace"
     palace.mkdir()
-    (palace / "chroma.sqlite3").touch()
+    make_minimal_chroma_sqlite(palace)
 
     def raise_cnie(*args, **kwargs):
         raise CollectionNotInitializedError(str(palace))

--- a/tests/test_qdrant_backend.py
+++ b/tests/test_qdrant_backend.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from _backend_conformance import assert_partition_isolation
+from _chroma_palace_helper import make_minimal_chroma_sqlite
 
 from mempalace.backends import (
     BackendError,
@@ -362,7 +363,7 @@ def test_qdrant_marker_participates_in_backend_mismatch(tmp_path, monkeypatch, f
     backend, col = _collection(tmp_path)
     col.upsert(ids=["a"], documents=["one"], metadatas=[{}], embeddings=[[1, 0]])
     backend.close()
-    (tmp_path / "chroma.sqlite3").write_bytes(b"")
+    make_minimal_chroma_sqlite(tmp_path)
     monkeypatch.setenv("MEMPALACE_BACKEND_EXPLICIT", "chroma")
 
     with pytest.raises(BackendMismatchError):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from _chroma_palace_helper import make_minimal_chroma_sqlite
+
 from mempalace import repair
 
 
@@ -583,7 +585,7 @@ def test_status_returns_empty_when_db_present_no_drawers(tmp_path, capsys):
     'uninitialized' (#1498). Mocks sqlite_drawer_count to assert the
     return-shape contract; see the real-disk sibling below for the
     no-chromadb-client invariant."""
-    (tmp_path / "chroma.sqlite3").touch()
+    make_minimal_chroma_sqlite(tmp_path)
     with patch("mempalace.repair.sqlite_drawer_count", return_value=0):
         result = repair.status(palace_path=str(tmp_path))
 
@@ -622,7 +624,7 @@ def test_status_falls_through_to_capacity_when_sqlite_count_unreadable(tmp_path)
     """When sqlite_drawer_count returns None (schema drift / locked file),
     repair.status must fall through to hnsw_capacity_status instead of
     short-circuiting on 'empty' (#1498)."""
-    (tmp_path / "chroma.sqlite3").touch()
+    make_minimal_chroma_sqlite(tmp_path)
     with (
         patch("mempalace.repair.sqlite_drawer_count", return_value=None),
         patch("mempalace.repair.hnsw_capacity_status") as capacity_status,
@@ -658,7 +660,7 @@ def test_status_default_uses_configured_drawer_collection(tmp_path):
     # Provide the on-disk preconditions the stratified state helper (#1498)
     # checks before reaching the capacity probe: chroma.sqlite3 file exists
     # and sqlite_drawer_count returns a positive number (palace not empty).
-    (tmp_path / "chroma.sqlite3").touch()
+    make_minimal_chroma_sqlite(tmp_path)
     with (
         patch("mempalace.repair._drawers_collection_name", return_value="custom_drawers"),
         patch("mempalace.repair.sqlite_drawer_count", return_value=1),

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from _chroma_palace_helper import make_minimal_chroma_sqlite
+
 from mempalace.searcher import SearchError, build_where_filter, search, search_memories
 
 
@@ -349,7 +351,7 @@ def fake_palace_path(tmp_path):
     backend instead of raising on State A / State B."""
     p = tmp_path / "palace"
     p.mkdir()
-    (p / "chroma.sqlite3").touch()
+    make_minimal_chroma_sqlite(p)
     return str(p)
 
 

--- a/tests/test_sqlite_exact_backend.py
+++ b/tests/test_sqlite_exact_backend.py
@@ -4,7 +4,7 @@ import threading
 
 import pytest
 
-from _chroma_palace_helper import make_minimal_chroma_sqlite
+from _chroma_palace_helper import make_minimal_chroma_sqlite, make_minimal_sqlite_exact_sqlite
 
 import mempalace.backends.sqlite_exact as sqlite_exact_module
 from mempalace.backends import (
@@ -423,11 +423,43 @@ def test_mixed_backend_artifacts_are_rejected_even_when_chroma_selected(tmp_path
     from mempalace.palace import resolve_backend_name
 
     make_minimal_chroma_sqlite(tmp_path)
-    (tmp_path / "sqlite_exact.sqlite3").write_bytes(b"")
+    make_minimal_sqlite_exact_sqlite(tmp_path)
     monkeypatch.setenv("MEMPALACE_BACKEND_EXPLICIT", "chroma")
 
     with pytest.raises(BackendMismatchError):
         resolve_backend_name(str(tmp_path))
+
+
+def test_sqlite_exact_detect_matches_palace_with_sqlite_header(tmp_path):
+    """A real SQLite database at ``<path>/sqlite_exact.sqlite3`` registers
+    as sqlite_exact. Mirrors the chroma analog at
+    ``test_chroma_detect_matches_palace_with_sqlite_header``.
+    """
+    make_minimal_sqlite_exact_sqlite(tmp_path)
+    assert SQLiteExactBackend.detect(str(tmp_path)) is True
+    assert SQLiteExactBackend.detect(str(tmp_path.parent)) is False
+
+
+def test_sqlite_exact_detect_rejects_empty_sqlite_exact_sqlite(tmp_path):
+    """A 0-byte ``sqlite_exact.sqlite3`` is not a sqlite_exact palace (#1893).
+
+    Same root cause as the chroma side: bare ``sqlite3.connect()`` against
+    a missing path leaves a 0-byte file behind because the SQLite header is
+    written on the first statement, not on connect. Detection must reject
+    that artifact so it cannot trip ``BackendMismatchError`` against a real
+    non-sqlite_exact backend marker in the same directory.
+    """
+    (tmp_path / "sqlite_exact.sqlite3").write_bytes(b"")
+    assert SQLiteExactBackend.detect(str(tmp_path)) is False
+
+
+def test_sqlite_exact_detect_rejects_non_sqlite_file(tmp_path):
+    """A non-SQLite file at the ``sqlite_exact.sqlite3`` path is not
+    sqlite_exact. Defends against partial writes / garbage content / anything
+    that lands at the canonical path but isn't actually a SQLite database.
+    """
+    (tmp_path / "sqlite_exact.sqlite3").write_bytes(b"not a sqlite file" * 4)
+    assert SQLiteExactBackend.detect(str(tmp_path)) is False
 
 
 def test_sqlite_exact_exact_ranking_uses_cosine(tmp_path):

--- a/tests/test_sqlite_exact_backend.py
+++ b/tests/test_sqlite_exact_backend.py
@@ -4,6 +4,8 @@ import threading
 
 import pytest
 
+from _chroma_palace_helper import make_minimal_chroma_sqlite
+
 import mempalace.backends.sqlite_exact as sqlite_exact_module
 from mempalace.backends import (
     BackendMismatchError,
@@ -410,7 +412,7 @@ def test_palace_wrapper_embeds_for_sqlite_exact(tmp_path, monkeypatch):
 def test_backend_mismatch_protection(tmp_path, monkeypatch):
     from mempalace.palace import get_collection
 
-    (tmp_path / "chroma.sqlite3").write_bytes(b"")
+    make_minimal_chroma_sqlite(tmp_path)
     monkeypatch.setenv("MEMPALACE_BACKEND_EXPLICIT", "sqlite_exact")
 
     with pytest.raises(BackendMismatchError):
@@ -420,7 +422,7 @@ def test_backend_mismatch_protection(tmp_path, monkeypatch):
 def test_mixed_backend_artifacts_are_rejected_even_when_chroma_selected(tmp_path, monkeypatch):
     from mempalace.palace import resolve_backend_name
 
-    (tmp_path / "chroma.sqlite3").write_bytes(b"")
+    make_minimal_chroma_sqlite(tmp_path)
     (tmp_path / "sqlite_exact.sqlite3").write_bytes(b"")
     monkeypatch.setenv("MEMPALACE_BACKEND_EXPLICIT", "chroma")
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import chromadb
 import pytest
 
+from _chroma_palace_helper import make_minimal_chroma_sqlite
+
 
 def _seed_drawers(palace_path, repo_path, deleted_path, elsewhere_path):
     """Populate the drawers collection with 6 entries covering all buckets."""
@@ -1446,7 +1448,7 @@ class TestServiceRunSyncReport:
         os.makedirs(palace)
         # Satisfy run_sync's detect_backend_for_path guard without spinning up
         # the real Chroma/embedder stack (which would disturb sys.stdout).
-        Path(palace, "chroma.sqlite3").touch()
+        make_minimal_chroma_sqlite(palace)
         monkeypatch.setattr(
             sync_module,
             "sync_palace",
@@ -1472,7 +1474,7 @@ class TestServiceRunSyncReport:
 
         palace = os.path.join(tmp_dir, "palace")
         os.makedirs(palace)
-        Path(palace, "chroma.sqlite3").touch()
+        make_minimal_chroma_sqlite(palace)
         monkeypatch.setattr(
             sync_module,
             "sync_palace",


### PR DESCRIPTION
## What does this PR do?

Fixes #1893.

`ChromaBackend.detect()` and `SQLiteExactBackend.detect()` were both returning `True` for a 0-byte SQLite marker file (`chroma.sqlite3` / `sqlite_exact.sqlite3`) because each check was just `os.path.isfile(...)`. On a palace that has any other backend marker alongside one of those stale 0-byte files, `resolve_backend_name` then raises `BackendMismatchError: palace at '<path>' contains multiple backend artifacts: <a>, <b>` and the palace becomes unopenable until the user manually `rm`s the empty file.

The 0-byte file appears as a side effect of any `sqlite3.connect()` on a missing path — Python creates the file immediately but writes the SQLite header only on the first statement. So any code path that touches the marker path with bare `sqlite3.connect()`, including chromadb's own `PersistentClient` lazy-init (see the comment at `backends/chroma.py:2052`), can leave a 0-byte artifact behind.

## Change

Both `ChromaBackend.detect` and `SQLiteExactBackend.detect` now check the SQLite magic header (`b"SQLite format 3\x00"`, the first 16 bytes) instead of file presence alone. One extra `open()` + 16-byte `read()` per backend — detection isn't a hot path.

Properties of the new check (identical for both backends):
- Rejects 0-byte files (the symptom #1893 is about)
- Rejects non-SQLite garbage at the canonical path (partial writes, leftover content)
- Doesn't false-negative on real palaces: any palace whose backend has done any work has the magic header on disk (verified empirically — `CREATE TABLE` is enough to land the header)
- Doesn't couple `detect()` to any backend-specific schema — magic header is stable across chromadb releases / sqlite_exact schema changes

Both backends fixed together for repo-wide consistency, per the review request on the initial chroma-only revision of this PR.

## Test sweep — context for the larger-than-expected diff

Many existing tests used `(<path> / "chroma.sqlite3").touch()` or `.write_bytes(b"")` (and one site `(<path> / "sqlite_exact.sqlite3").write_bytes(b"")`) as a "fake palace" shortcut, exploiting the loose `os.path.isfile()` semantics. One of these sites even has the comment:

```python
(palace / "chroma.sqlite3").touch()  # pass the isfile guard
```

— signaling that the convention was a known shortcut, not a contract. After the magic-header check, those stand-ins no longer register, so each call site needed to create a real (if minimal) SQLite database.

To avoid duplicating the same `sqlite3.connect + CREATE TABLE` boilerplate, this PR introduces `tests/_chroma_palace_helper.py` following the existing `tests/_backend_conformance.py` precedent for private-module test utilities. It exports:

- `make_minimal_chroma_sqlite(palace_path)` — `chroma.sqlite3` with header
- `make_minimal_sqlite_exact_sqlite(palace_path)` — `sqlite_exact.sqlite3` with header

Both wrap a shared `_write_minimal_sqlite_file(db_path)` private helper.

Each previously-shortcut call site now reads `make_minimal_<...>_sqlite(palace)` — same one-line shape, just honest about producing a real SQLite file.

Files updated for the sweep: `test_backends.py`, `test_daemon.py`, `test_mcp_server.py`, `test_palace.py` (4 sites), `test_qdrant_backend.py`, `test_repair.py` (3 sites), `test_searcher.py`, `test_sqlite_exact_backend.py` (3 sites), `test_sync.py` (2 sites).

`test_migrate.py` also writes to `chroma.sqlite3` paths, but with non-empty payloads (`b"original"`) used to verify rename/relocation behavior, not detection. Those tests don't exercise the detect path and continue to work unchanged.

## How to test

```
uv run pytest tests/ -v --ignore=tests/benchmarks
```

For each backend the trio of dedicated detection tests:

**chroma:**
- `test_chroma_detect_matches_palace_with_sqlite_header`
- `test_chroma_detect_rejects_empty_chroma_sqlite`
- `test_chroma_detect_rejects_non_sqlite_file`

**sqlite_exact:**
- `test_sqlite_exact_detect_matches_palace_with_sqlite_header`
- `test_sqlite_exact_detect_rejects_empty_sqlite_exact_sqlite`
- `test_sqlite_exact_detect_rejects_non_sqlite_file`

Full env-cleared suite: **3140 passed, 20 skipped, 0 failed**. `ruff check .` and `ruff format --check .` both clean.

## Checklist
- [x] Tests pass (`uv run pytest tests/ -v --ignore=tests/benchmarks`)
- [x] No hardcoded paths
- [x] Linter passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)