### PR TITLE
fix(backends): forward facet_counts + get_all_metadata in EmbeddingCollection

### DIFF
--- a/mempalace/backends/embedding_wrapper.py
+++ b/mempalace/backends/embedding_wrapper.py
@@ -155,7 +155,9 @@ class EmbeddingCollection(BaseCollection):
     def lexical_search(self, *, query: str, n_results: int = 10, where: Optional[dict] = None):
         return self._inner.lexical_search(query=query, n_results=n_results, where=where)
 
-    def facet_counts(self, field: str, where: Optional[dict] = None, limit: int = 1000):
+    def facet_counts(
+        self, field: str, where: Optional[dict] = None, limit: int = 1000
+    ) -> dict[str, int]:
         # ``BaseCollection.facet_counts`` is a concrete method that raises
         # ``UnsupportedCapabilityError`` as its default. MRO resolves it on
         # this subclass before ``__getattr__`` ever fires, so without an

--- a/mempalace/backends/embedding_wrapper.py
+++ b/mempalace/backends/embedding_wrapper.py
@@ -155,6 +155,28 @@ class EmbeddingCollection(BaseCollection):
     def lexical_search(self, *, query: str, n_results: int = 10, where: Optional[dict] = None):
         return self._inner.lexical_search(query=query, n_results=n_results, where=where)
 
+    def facet_counts(self, field: str, where: Optional[dict] = None, limit: int = 1000):
+        # ``BaseCollection.facet_counts`` is a concrete method that raises
+        # ``UnsupportedCapabilityError`` as its default. MRO resolves it on
+        # this subclass before ``__getattr__`` ever fires, so without an
+        # explicit forwarder every facet call against a wrapped backend
+        # (qdrant, pgvector, sqlite_exact) raises and silently degrades to
+        # client-side counting in mcp_server's try/except.
+        return self._inner.facet_counts(field, where=where, limit=limit)
+
+    def get_all_metadata(self, where: Optional[dict] = None) -> list[dict]:
+        # ``BaseCollection.get_all_metadata`` ships a concrete default that
+        # pages through ``self.get(include=["metadatas"])``. Without this
+        # forwarder, MRO resolves the call here on the subclass and runs the
+        # base default — which routes back through ``self.get()`` (the
+        # wrapper's get, then ``__getattr__`` to the inner's get). Result:
+        # the inner's overridden ``get_all_metadata`` (e.g. pgvector's
+        # ``with_document=False`` fast path from #1892) is never reached,
+        # and every metadata-only fetch transfers the full document column
+        # over the wire. Same MRO-shadow pattern as ``facet_counts`` /
+        # ``lexical_search`` above.
+        return self._inner.get_all_metadata(where=where)
+
     def update(self, *, ids, documents=None, metadatas=None, embeddings=None):
         ids = _as_list(ids)
         if documents is not None:

--- a/tests/test_embedding_wrapper.py
+++ b/tests/test_embedding_wrapper.py
@@ -124,3 +124,98 @@ def test_add_wraps_bare_string_ids_and_dict_metadatas(monkeypatch):
     # documents / embeddings / ids / metadatas all length-aligned at 1
     assert call["documents"] == ["solo"]
     assert len(call["embeddings"]) == 1
+
+
+def test_facet_counts_forwards_to_inner():
+    """``BaseCollection.facet_counts`` is a concrete method (raises) — Python
+    MRO resolves it on the wrapper subclass before ``__getattr__`` ever fires,
+    so without an explicit forwarder the wrapper would raise
+    ``UnsupportedCapabilityError`` and silently degrade every wrapped backend
+    (qdrant/pgvector/sqlite_exact) to client-side counting in mcp_server."""
+
+    class _Inner:
+        def __init__(self):
+            self.calls = []
+
+        def facet_counts(self, field, where=None, limit=1000):
+            self.calls.append((field, where, limit))
+            return {"alpha": 2, "beta": 1}
+
+    inner = _Inner()
+    out = ew.EmbeddingCollection(inner).facet_counts("wing", where={"wing": "alpha"}, limit=50)
+    assert out == {"alpha": 2, "beta": 1}
+    assert inner.calls == [("wing", {"wing": "alpha"}, 50)]
+
+
+def test_get_all_metadata_forwards_to_inner():
+    """Same MRO-shadow pattern as ``facet_counts``: ``BaseCollection.get_all_
+    metadata`` ships a concrete default that pages through ``self.get()``.
+    Without this forwarder the wrapper runs the base default, the inner
+    backend's overridden ``get_all_metadata`` (e.g. pgvector's
+    ``with_document=False`` fast path from #1892) is unreachable, and every
+    metadata-only fetch transfers the full document column over the wire."""
+
+    class _Inner:
+        def __init__(self):
+            self.calls = []
+
+        def get_all_metadata(self, where=None):
+            self.calls.append(where)
+            return [{"wing": "alpha"}, {"wing": "beta"}]
+
+        # Provide a ``get`` so a missing forwarder would silently succeed via
+        # the BaseCollection default rather than crash — this is exactly the
+        # shape that hid the bug in production. Returning a sentinel here
+        # makes a wrong delegation observable: the test would receive
+        # ``[{"WRONG"}]``, not the inner's real list.
+        def get(self, **_kw):
+            from mempalace.backends.base import GetResult
+
+            return GetResult(ids=["bad"], documents=[""], metadatas=[{"WRONG": True}])
+
+    inner = _Inner()
+    out = ew.EmbeddingCollection(inner).get_all_metadata(where={"wing": "alpha"})
+    assert out == [{"wing": "alpha"}, {"wing": "beta"}]
+    assert inner.calls == [{"wing": "alpha"}]
+
+
+def test_wrapper_forwards_all_concrete_basecollection_methods():
+    """Every concrete (non-abstract) public method on ``BaseCollection`` must
+    be explicitly defined on ``EmbeddingCollection``. Without an override,
+    Python MRO resolves the call to ``BaseCollection``'s default before
+    ``__getattr__`` ever fires, silently shadowing the wrapped backend's real
+    implementation.
+
+    The bug class this catches: any new ``BaseCollection`` method with a
+    concrete default body (raises, returns ``{}``, returns a no-op, pages
+    through ``self.get()``) becomes a silent regression for every wrapped
+    backend the moment a backend overrides it. ``facet_counts`` (#1868) and
+    ``get_all_metadata`` (#1796 / #1892) both hit this; ``lexical_search``
+    would have hit it earlier if the wrapper hadn't been updated by hand.
+
+    If this test fails, add an explicit forwarder on ``EmbeddingCollection``
+    that calls ``self._inner.<name>(...)``."""
+    import inspect
+
+    from mempalace.backends.base import BaseCollection
+    from mempalace.backends.embedding_wrapper import EmbeddingCollection
+
+    concrete: set[str] = set()
+    for name, member in inspect.getmembers(BaseCollection):
+        if name.startswith("_"):
+            continue
+        if isinstance(member, property):
+            if member.fget and not getattr(member.fget, "__isabstractmethod__", False):
+                concrete.add(name)
+            continue
+        if callable(member) and not getattr(member, "__isabstractmethod__", False):
+            concrete.add(name)
+
+    forwarded = set(vars(EmbeddingCollection).keys())
+    missing = sorted(concrete - forwarded)
+    assert not missing, (
+        "EmbeddingCollection must explicitly forward these concrete "
+        "BaseCollection methods (otherwise MRO resolves the call here and "
+        "shadows the inner backend's implementation): "
+        f"{missing}"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a silent shadow that breaks two recent upstream optimizations (#1868 facet_counts, #1796/#1892 get_all_metadata) on every wrapped backend — qdrant, pgvector, sqlite_exact. Chroma is unwrapped and unaffected.

`BaseCollection.facet_counts` and `BaseCollection.get_all_metadata` are both *concrete* methods (one raises `UnsupportedCapabilityError`, the other pages through `self.get(include=["metadatas"])`). Python MRO resolves them on `EmbeddingCollection` before `__getattr__` can fire, so the wrapper silently runs the base default instead of delegating to the wrapped backend's optimized implementation. Same pattern as the existing explicit forwarders for `distance_metric`, `lexical_search`, and the embedder-identity trio.

## Production impact today

**facet_counts (#1868 regression).** Every `mempalace_status` / `list_wings` / `list_rooms` / `get_taxonomy` call on a wrapped backend logs `WARN Failed to fetch metadata facets, falling back to client-side loop: backend does not support facet_counts` and counts via the O(n) Python loop. The capability check passes — the wrapper silently raises one frame deeper. Exactly the behavior #1868 was designed to eliminate.

**get_all_metadata (#1796 / #1892 regression).** The base default pages through `self.get()`, which routes through the wrapper to the inner's `get()` — bypassing the inner's overridden `get_all_metadata`. On pgvector this means #1892's `with_document=False` fast path is unreachable: every metadata-only fetch transfers the full document column over the wire.

Repro:
```python
from unittest.mock import Mock
from mempalace.backends.embedding_wrapper import EmbeddingCollection

inner = Mock(spec=["facet_counts"])
inner.facet_counts.return_value = {"alpha": 1}

EmbeddingCollection(inner).facet_counts("wing")
# -> UnsupportedCapabilityError: backend does not support facet_counts
```

## Why no existing test caught it

Two test layers, neither covers the seam:

- Backend tests (`test_qdrant_backend.py`, `test_pgvector_backend.py`) call the method directly on the raw collection — wrapper not in the stack, no MRO shadow.
- `test_mcp_server.py` facet tests use `MagicMock()` for the collection, which synthesizes attributes on demand and bypasses Python's MRO entirely.

Production path (`palace.get_collection()` → `EmbeddingCollection` wrap → call method) is the only path where the bug exists, and no test went through it.

## Fix

Two one-line forwarders on `EmbeddingCollection`:

```python
def facet_counts(self, field, where=None, limit=1000):
    return self._inner.facet_counts(field, where=where, limit=limit)

def get_all_metadata(self, where=None):
    return self._inner.get_all_metadata(where=where)
```

Both follow the existing `lexical_search` / `distance_metric` pattern already documented in-file.

## Tests

Three new tests, ~95 lines:

1. `test_facet_counts_forwards_to_inner` — direct integration through the wrapper, asserts the inner's recorded call matches.
2. `test_get_all_metadata_forwards_to_inner` — same shape, plus a sentinel `get()` on the inner so a missing forwarder routes to the base default and returns the wrong data (observable failure, not silent).
3. `test_wrapper_forwards_all_concrete_basecollection_methods` — **meta-test** that enumerates every concrete public method on `BaseCollection` via `inspect.getmembers` and asserts each is explicitly defined on `EmbeddingCollection`. Catches the bug *class*: any future `BaseCollection` method with a concrete default body becomes a CI failure the moment it's added without a wrapper forwarder, with a message pointing straight at the file to edit.

## How to test

```
uv run pytest tests/test_embedding_wrapper.py -v
```

Full env-cleared suite: **3205 passed, 20 skipped, 0 failed**. `ruff check .` and `ruff format --check .` both clean.

## Checklist
- [x] Tests pass (`uv run pytest tests/ --ignore=tests/benchmarks`)
- [x] No hardcoded paths
- [x] Linter passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)