### PR TITLE
Add Milvus storage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,50 +108,23 @@ CUDA-accelerated embeddings, build the GPU variant with
 
 ## Storage backends
 
-ChromaDB is the default. For the pluggable-backend preview, MemPalace also
-ships `sqlite_exact` for local exact-vector correctness checks and opt-in
-backends including `milvus` (Milvus Lite by default, Milvus server / Zilliz
-Cloud when configured), `qdrant` (REST), and `pgvector` (Postgres). These
-backends exercise the storage contract on different substrates, so it is not
-accidentally shaped around one vendor.
+ChromaDB is the default and needs no configuration. MemPalace also ships a
+pluggable backend contract, exercised across deliberately different substrates
+so the contract is never accidentally shaped around one vendor. Every
+non-default backend is opt-in.
 
-```bash
-# local no-service backend
-mempalace mine ~/projects/myapp --backend sqlite_exact
+| Backend | Mode | Install | Namespaces | Lexical | Configure with |
+| ------- | ---- | ------- | :--------: | :-----: | -------------- |
+| `chroma` _(default)_ | Local (embedded) | bundled | – | ✓ | – |
+| `sqlite_exact` | Local (exact) | bundled | – | ✓ | – |
+| `milvus` | Local (Lite) · Server opt-in | `mempalace[milvus]` | ✓ | ✓ | `MEMPALACE_MILVUS_URI` |
+| `qdrant` | Server (REST) | bundled | ✓ | ✓ | `MEMPALACE_QDRANT_URL` |
+| `pgvector` | Server (Postgres) | `mempalace[pgvector]` | ✓ | ✓ | `MEMPALACE_PGVECTOR_DSN` |
 
-# Milvus backend, defaulting to per-palace Milvus Lite at <palace>/milvus.db
-#   needs the optional driver: pip install mempalace[milvus]
-mempalace mine ~/projects/myapp --backend milvus
-
-# Zilliz Cloud or Milvus server
-MEMPALACE_MILVUS_URI=https://your-cluster.api.region.zillizcloud.com \
-MEMPALACE_MILVUS_TOKEN=your-token \
-  mempalace mine ~/projects/myapp --backend milvus
-
-# Qdrant backend, defaulting to http://localhost:6333
-MEMPALACE_QDRANT_URL=http://localhost:6333 \
-  mempalace mine ~/projects/myapp --backend qdrant
-
-# Postgres + pgvector backend, defaulting to postgresql://localhost:5432/mempalace
-#   needs the optional driver: pip install mempalace[pgvector]
-#   and the `vector` extension available on the server
-MEMPALACE_PGVECTOR_DSN=postgresql://localhost:5432/mempalace \
-  mempalace mine ~/projects/myapp --backend pgvector
-```
-
-Milvus can also be configured with `MEMPALACE_MILVUS_DB_NAME`,
-`MEMPALACE_MILVUS_NAMESPACE`, and `MEMPALACE_MILVUS_CONSISTENCY_LEVEL`;
-Qdrant with `MEMPALACE_QDRANT_API_KEY`, `MEMPALACE_QDRANT_NAMESPACE`, and
-`MEMPALACE_QDRANT_TIMEOUT`; pgvector with `MEMPALACE_PGVECTOR_NAMESPACE`.
-The server-capable backends isolate tenants by namespace (advertised via the
-`supports_namespace_isolation` capability) and write a local marker
-(`milvus_backend.json` / `qdrant_backend.json` / `pgvector_backend.json`) to
-guard against silently opening a palace against the wrong server.
-
-When `MEMPALACE_MILVUS_URI`, `MEMPALACE_QDRANT_URL`, or `MEMPALACE_PGVECTOR_DSN`
-points anywhere other than your own local or trusted
-self-hosted service, MemPalace will send and store verbatim drawer text and
-metadata there. That is an explicit opt-in backend choice, never the default.
+Select with `--backend <name>`, `MEMPALACE_BACKEND=<name>`, or
+`"backend": "<name>"` in `config.json`. See
+[Storage backends](/guide/configuration#storage-backends) for connection
+variables, namespace behavior, and deployment notes.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -109,15 +109,24 @@ CUDA-accelerated embeddings, build the GPU variant with
 ## Storage backends
 
 ChromaDB is the default. For the pluggable-backend preview, MemPalace also
-ships `sqlite_exact` for local exact-vector correctness checks, and two opt-in
-external service backends — `qdrant` (REST) and `pgvector` (Postgres). The two
-external backends exercise the storage contract on different substrates (a
-REST/dict store and a SQL/JSONB store), so it is not accidentally shaped around
-one vendor.
+ships `sqlite_exact` for local exact-vector correctness checks, `milvus`
+(Milvus Lite by default, Milvus server / Zilliz Cloud when configured), and two
+other opt-in external service backends — `qdrant` (REST) and `pgvector`
+(Postgres). These backends exercise the storage contract on different
+substrates, so it is not accidentally shaped around one vendor.
 
 ```bash
 # local no-service backend
 mempalace mine ~/projects/myapp --backend sqlite_exact
+
+# Milvus backend, defaulting to per-palace Milvus Lite at <palace>/milvus.db
+#   needs the optional driver: pip install mempalace[milvus]
+mempalace mine ~/projects/myapp --backend milvus
+
+# Zilliz Cloud or Milvus server
+MEMPALACE_MILVUS_URI=https://your-cluster.api.region.zillizcloud.com \
+MEMPALACE_MILVUS_TOKEN=your-token \
+  mempalace mine ~/projects/myapp --backend milvus
 
 # Qdrant backend, defaulting to http://localhost:6333
 MEMPALACE_QDRANT_URL=http://localhost:6333 \
@@ -130,17 +139,18 @@ MEMPALACE_PGVECTOR_DSN=postgresql://localhost:5432/mempalace \
   mempalace mine ~/projects/myapp --backend pgvector
 ```
 
-Qdrant can also be configured with `MEMPALACE_QDRANT_API_KEY`,
-`MEMPALACE_QDRANT_NAMESPACE`, and `MEMPALACE_QDRANT_TIMEOUT`; pgvector with
-`MEMPALACE_PGVECTOR_NAMESPACE`. Both external backends isolate tenants by
-namespace (advertised via the `supports_namespace_isolation` capability) and
-write a local marker (`qdrant_backend.json` / `pgvector_backend.json`) to guard
-against silently opening a palace against the wrong server.
+Milvus can also be configured with `MEMPALACE_MILVUS_NAMESPACE`; Qdrant with
+`MEMPALACE_QDRANT_API_KEY`, `MEMPALACE_QDRANT_NAMESPACE`, and
+`MEMPALACE_QDRANT_TIMEOUT`; pgvector with `MEMPALACE_PGVECTOR_NAMESPACE`.
+The server-capable backends isolate tenants by namespace (advertised via the
+`supports_namespace_isolation` capability) and write a local marker
+(`milvus_backend.json` / `qdrant_backend.json` / `pgvector_backend.json`) to
+guard against silently opening a palace against the wrong server.
 
-When `MEMPALACE_QDRANT_URL` or `MEMPALACE_PGVECTOR_DSN` points anywhere other
-than your own local or trusted self-hosted service, MemPalace will send and
-store verbatim drawer text and metadata there. That is an explicit opt-in
-backend choice, never the default.
+When `MEMPALACE_MILVUS_URI`, `MEMPALACE_QDRANT_URL`, or `MEMPALACE_PGVECTOR_DSN`
+points anywhere other than your own local or trusted
+self-hosted service, MemPalace will send and store verbatim drawer text and
+metadata there. That is an explicit opt-in backend choice, never the default.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ CUDA-accelerated embeddings, build the GPU variant with
 ## Storage backends
 
 ChromaDB is the default. For the pluggable-backend preview, MemPalace also
-ships `sqlite_exact` for local exact-vector correctness checks, `milvus`
-(Milvus Lite by default, Milvus server / Zilliz Cloud when configured), and two
-other opt-in external service backends — `qdrant` (REST) and `pgvector`
-(Postgres). These backends exercise the storage contract on different
-substrates, so it is not accidentally shaped around one vendor.
+ships `sqlite_exact` for local exact-vector correctness checks and opt-in
+backends including `milvus` (Milvus Lite by default, Milvus server / Zilliz
+Cloud when configured), `qdrant` (REST), and `pgvector` (Postgres). These
+backends exercise the storage contract on different substrates, so it is not
+accidentally shaped around one vendor.
 
 ```bash
 # local no-service backend
@@ -139,8 +139,9 @@ MEMPALACE_PGVECTOR_DSN=postgresql://localhost:5432/mempalace \
   mempalace mine ~/projects/myapp --backend pgvector
 ```
 
-Milvus can also be configured with `MEMPALACE_MILVUS_NAMESPACE`; Qdrant with
-`MEMPALACE_QDRANT_API_KEY`, `MEMPALACE_QDRANT_NAMESPACE`, and
+Milvus can also be configured with `MEMPALACE_MILVUS_DB_NAME`,
+`MEMPALACE_MILVUS_NAMESPACE`, and `MEMPALACE_MILVUS_CONSISTENCY_LEVEL`;
+Qdrant with `MEMPALACE_QDRANT_API_KEY`, `MEMPALACE_QDRANT_NAMESPACE`, and
 `MEMPALACE_QDRANT_TIMEOUT`; pgvector with `MEMPALACE_PGVECTOR_NAMESPACE`.
 The server-capable backends isolate tenants by namespace (advertised via the
 `supports_namespace_isolation` capability) and write a local marker

--- a/mempalace/backends/__init__.py
+++ b/mempalace/backends/__init__.py
@@ -36,6 +36,7 @@ from .base import (
     UnsupportedMaintenanceKindError,
 )
 from .chroma import ChromaBackend, ChromaCollection
+from .milvus import MilvusBackend, MilvusCollection
 from .pgvector import PgVectorBackend, PgVectorCollection
 from .qdrant import QdrantBackend, QdrantCollection
 from .sqlite_exact import SQLiteExactBackend, SQLiteExactCollection
@@ -67,6 +68,8 @@ __all__ = [
     "LexicalHit",
     "LexicalResult",
     "MaintenanceResult",
+    "MilvusBackend",
+    "MilvusCollection",
     "PalaceNotFoundError",
     "PalaceRef",
     "PgVectorBackend",

--- a/mempalace/backends/milvus.py
+++ b/mempalace/backends/milvus.py
@@ -22,7 +22,11 @@ from typing import Any, Optional
 
 import numpy as np
 
-from ..config import DEFAULT_MILVUS_CONSISTENCY_LEVEL, strip_lone_surrogates
+from ..config import (
+    DEFAULT_MILVUS_CONSISTENCY_LEVEL,
+    normalize_milvus_consistency_level,
+    strip_lone_surrogates,
+)
 from ._sidecar import EMBEDDER_SIDECAR_FILENAME, read_embedder_sidecar, write_embedder_sidecar
 from .base import (
     BackendClosedError,
@@ -48,13 +52,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_DB_FILENAME = "milvus.db"
 _MARKER_FILENAME = "milvus_backend.json"
 _MAX_QUERY_WINDOW = 16384
-_MILVUS_CONSISTENCY_LEVELS = {
-    "strong": "Strong",
-    "session": "Session",
-    "bounded": "Bounded",
-    "eventually": "Eventually",
-}
-
 FIELD_ID = "id"
 FIELD_DOCUMENT = "document"
 FIELD_METADATA = "metadata"
@@ -73,6 +70,7 @@ RESERVED_FIELDS = {
 }
 
 _FIELD_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 
 def _utcnow() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -229,6 +227,10 @@ def _clean_text(value: Any) -> str:
     return strip_lone_surrogates(text).replace("\x00", "")
 
 
+def _utf8_len(value: str) -> int:
+    return len(value.encode("utf-8"))
+
+
 def _jsonable_metadata(meta: dict | None) -> dict:
     cleaned = {}
     for key, value in (meta or {}).items():
@@ -250,15 +252,6 @@ def _slug(value: str, fallback: str = "collection") -> str:
         return safe
     digest = sha256(value.encode("utf-8", errors="surrogatepass")).hexdigest()[:12]
     return f"{safe[:107]}_{digest}"
-
-
-def _normalize_consistency_level(value: Any) -> str:
-    raw = DEFAULT_MILVUS_CONSISTENCY_LEVEL if value is None else str(value).strip()
-    normalized = _MILVUS_CONSISTENCY_LEVELS.get(raw.lower())
-    if normalized:
-        return normalized
-    allowed = ", ".join(_MILVUS_CONSISTENCY_LEVELS.values())
-    raise BackendError(f"milvus consistency_level must be one of: {allowed}")
 
 
 @dataclass(frozen=True)
@@ -299,11 +292,15 @@ class _MilvusConfig:
             or os.environ.get("MEMPALACE_MILVUS_NAMESPACE")
             or getattr(cfg, "milvus_namespace", None)
         )
-        consistency_level = (
-            options.get("consistency_level")
-            or os.environ.get("MEMPALACE_MILVUS_CONSISTENCY_LEVEL")
-            or getattr(cfg, "milvus_consistency_level", DEFAULT_MILVUS_CONSISTENCY_LEVEL)
-        )
+        try:
+            consistency_level = (
+                options.get("consistency_level")
+                or os.environ.get("MEMPALACE_MILVUS_CONSISTENCY_LEVEL")
+                or getattr(cfg, "milvus_consistency_level", DEFAULT_MILVUS_CONSISTENCY_LEVEL)
+            )
+            consistency_level = normalize_milvus_consistency_level(consistency_level)
+        except ValueError as exc:
+            raise BackendError(str(exc)) from exc
         db_filename = options.get("db_filename") or DEFAULT_DB_FILENAME
         return cls(
             uri=str(uri).strip() if uri else None,
@@ -311,7 +308,7 @@ class _MilvusConfig:
             db_name=str(db_name).strip() if db_name else None,
             namespace=str(namespace).strip() if namespace else None,
             db_filename=str(db_filename).strip() or DEFAULT_DB_FILENAME,
-            consistency_level=_normalize_consistency_level(consistency_level),
+            consistency_level=consistency_level,
         )
 
 
@@ -356,6 +353,14 @@ class MilvusCollection(BaseCollection):
     @property
     def distance_metric(self) -> str:
         return "cosine"
+
+    def _vector_score_to_distance(self, score: Any) -> float:
+        if score is None:
+            return 1.0
+        value = float(score)
+        if self._config.uri and _is_server_uri(self._config.uri):
+            return 1.0 - max(-1.0, min(1.0, value))
+        return value
 
     def _remote_dimension(self) -> Optional[int]:
         if not self._remote_exists():
@@ -497,14 +502,16 @@ class MilvusCollection(BaseCollection):
         ):
             if not isinstance(doc_id, str) or not doc_id:
                 raise ValueError(f"row {idx}: id must be a non-empty string")
-            if len(doc_id) > DRAWER_ID_MAX_LENGTH:
+            doc_id_bytes = _utf8_len(doc_id)
+            if doc_id_bytes > DRAWER_ID_MAX_LENGTH:
                 raise ValueError(
-                    f"row {idx}: id length {len(doc_id)} exceeds {DRAWER_ID_MAX_LENGTH}"
+                    f"row {idx}: id byte length {doc_id_bytes} exceeds {DRAWER_ID_MAX_LENGTH}"
                 )
             document = _clean_text(document)
-            if len(document) > DOCUMENT_MAX_LENGTH:
+            document_bytes = _utf8_len(document)
+            if document_bytes > DOCUMENT_MAX_LENGTH:
                 raise ValueError(
-                    f"row {idx}: document length {len(document)} exceeds "
+                    f"row {idx}: document byte length {document_bytes} exceeds "
                     f"Milvus VARCHAR limit {DOCUMENT_MAX_LENGTH}; chunk before storing"
                 )
             row = {
@@ -536,6 +543,7 @@ class MilvusCollection(BaseCollection):
                 raise ValueError(f"ids already exist in milvus collection: {existing.ids}")
         self._ensure_remote_collection(dimension)
         self._client.insert(collection_name=self._remote_collection, data=rows)
+        self._backend._write_marker(self._palace, self._config)
 
     def upsert(self, *, documents, ids, metadatas=None, embeddings=None):
         if embeddings is None:
@@ -550,6 +558,7 @@ class MilvusCollection(BaseCollection):
             return
         self._ensure_remote_collection(dimension)
         self._client.upsert(collection_name=self._remote_collection, data=rows)
+        self._backend._write_marker(self._palace, self._config)
 
     def update(self, *, ids, documents=None, metadatas=None, embeddings=None):
         if documents is None and metadatas is None and embeddings is None:
@@ -568,23 +577,28 @@ class MilvusCollection(BaseCollection):
             for i, rid in enumerate(existing.ids)
             if existing.embeddings is not None
         }
-        missing = [doc_id for doc_id in ids if doc_id not in by_id]
-        if missing:
-            raise KeyError(f"update: ids not found: {missing}")
+        out_ids = []
         out_docs = []
         out_metas = []
         out_embeddings = []
         for idx, doc_id in enumerate(ids):
+            if doc_id not in by_id:
+                continue
             prev_doc, prev_meta, prev_embedding = by_id[doc_id]
+            out_ids.append(doc_id)
             out_docs.append(documents[idx] if documents is not None else prev_doc)
             meta = dict(prev_meta or {})
             if metadatas is not None:
                 meta.update(metadatas[idx] or {})
             out_metas.append(meta)
             out_embeddings.append(embeddings[idx] if embeddings is not None else prev_embedding)
-        self.upsert(
-            documents=out_docs, ids=list(ids), metadatas=out_metas, embeddings=out_embeddings
-        )
+        if out_ids:
+            self.upsert(
+                documents=out_docs,
+                ids=out_ids,
+                metadatas=out_metas,
+                embeddings=out_embeddings,
+            )
 
     def query(
         self,
@@ -653,7 +667,9 @@ class MilvusCollection(BaseCollection):
                 [self._extract_metadata(row) for row in rows] if spec.metadatas else []
             )
             outer_dists.append(
-                [float(row.get("distance", 1.0)) for row in rows] if spec.distances else []
+                [self._vector_score_to_distance(row.get("distance")) for row in rows]
+                if spec.distances
+                else []
             )
             if spec.embeddings:
                 outer_embeddings.append([row.get(FIELD_VECTOR) or [] for row in rows])

--- a/mempalace/backends/milvus.py
+++ b/mempalace/backends/milvus.py
@@ -1,0 +1,1216 @@
+"""Milvus backend for MemPalace.
+
+The backend uses the modern ``pymilvus.MilvusClient`` API only. By default each
+local palace gets its own Milvus Lite database at ``<palace>/milvus.db``. Users
+can opt into Milvus server or Zilliz Cloud by configuring a URI and token.
+
+Embeddings are supplied by MemPalace's core embedding wrapper. This backend
+declares ``requires_explicit_embeddings`` and stores/query vectors directly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import re
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Any, Optional
+
+import numpy as np
+
+from ..config import strip_lone_surrogates
+from ._sidecar import EMBEDDER_SIDECAR_FILENAME, read_embedder_sidecar, write_embedder_sidecar
+from .base import (
+    BackendClosedError,
+    BackendError,
+    BackendMismatchError,
+    BaseBackend,
+    BaseCollection,
+    CollectionNotInitializedError,
+    DimensionMismatchError,
+    GetResult,
+    HealthStatus,
+    LexicalHit,
+    LexicalResult,
+    PalaceNotFoundError,
+    PalaceRef,
+    QueryResult,
+    UnsupportedFilterError,
+    _IncludeSpec,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DB_FILENAME = "milvus.db"
+_MARKER_FILENAME = "milvus_backend.json"
+_MAX_QUERY_WINDOW = 16384
+
+FIELD_ID = "id"
+FIELD_DOCUMENT = "document"
+FIELD_METADATA = "metadata"
+FIELD_VECTOR = "vector"
+DOCUMENT_MAX_LENGTH = 65535
+DRAWER_ID_MAX_LENGTH = 512
+RESERVED_FIELDS = {FIELD_ID, FIELD_DOCUMENT, FIELD_METADATA, FIELD_VECTOR, "distance", "score"}
+
+_FIELD_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _is_server_uri(uri: str) -> bool:
+    normalized = uri.lower()
+    return normalized.startswith(("http://", "https://", "tcp://", "grpc://"))
+
+
+def _quote_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if value is None:
+        raise UnsupportedFilterError("Milvus filters do not support null comparisons")
+    text = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{text}"'
+
+
+def _like_value(value: Any) -> str:
+    text = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"%{text}%"'
+
+
+def _field_name(name: str) -> str:
+    if not isinstance(name, str) or not _FIELD_RE.match(name):
+        raise UnsupportedFilterError(f"Milvus filter field {name!r} is not a safe identifier")
+    return name
+
+
+def _translate_field(field: str, expected: Any) -> str:
+    field = _field_name(field)
+    if isinstance(expected, dict):
+        parts = []
+        for op, operand in expected.items():
+            if op == "$eq":
+                parts.append(f"{field} == {_quote_value(operand)}")
+            elif op == "$ne":
+                parts.append(f"{field} != {_quote_value(operand)}")
+            elif op == "$in":
+                if not isinstance(operand, list) or not operand:
+                    raise UnsupportedFilterError(f"$in requires a non-empty list for {field!r}")
+                items = ", ".join(_quote_value(item) for item in operand)
+                parts.append(f"{field} in [{items}]")
+            elif op == "$nin":
+                if not isinstance(operand, list) or not operand:
+                    raise UnsupportedFilterError(f"$nin requires a non-empty list for {field!r}")
+                items = ", ".join(_quote_value(item) for item in operand)
+                parts.append(f"{field} not in [{items}]")
+            elif op == "$gt":
+                parts.append(f"{field} > {_quote_value(operand)}")
+            elif op == "$gte":
+                parts.append(f"{field} >= {_quote_value(operand)}")
+            elif op == "$lt":
+                parts.append(f"{field} < {_quote_value(operand)}")
+            elif op == "$lte":
+                parts.append(f"{field} <= {_quote_value(operand)}")
+            elif op == "$contains":
+                parts.append(f"{field} like {_like_value(operand)}")
+            else:
+                raise UnsupportedFilterError(f"operator {op!r} not supported by milvus")
+        return " and ".join(parts)
+    return f"{field} == {_quote_value(expected)}"
+
+
+def _translate_clause(clause: dict) -> str:
+    if not isinstance(clause, dict):
+        raise UnsupportedFilterError(f"where clause must be a dict, got {type(clause).__name__}")
+    if not clause:
+        return ""
+    parts = []
+    for key, value in clause.items():
+        if key == "$and":
+            if not isinstance(value, list) or not value:
+                raise UnsupportedFilterError("$and requires a non-empty list of clauses")
+            nested = [_translate_clause(item) for item in value]
+            parts.append("(" + " and ".join(part for part in nested if part) + ")")
+        elif key == "$or":
+            if not isinstance(value, list) or not value:
+                raise UnsupportedFilterError("$or requires a non-empty list of clauses")
+            nested = [_translate_clause(item) for item in value]
+            parts.append("(" + " or ".join(part for part in nested if part) + ")")
+        elif key.startswith("$"):
+            raise UnsupportedFilterError(f"operator {key!r} not supported by milvus")
+        else:
+            parts.append(_translate_field(key, value))
+    return " and ".join(part for part in parts if part)
+
+
+def translate_where(where: Optional[dict]) -> str:
+    """Translate the portable metadata where DSL into a Milvus filter string."""
+    if not where:
+        return ""
+    return _translate_clause(where)
+
+
+def translate_where_document(where_document: Optional[dict]) -> str:
+    """Translate the portable document filter subset into a Milvus filter."""
+    if not where_document:
+        return ""
+    if not isinstance(where_document, dict):
+        raise UnsupportedFilterError("where_document must be a dict")
+    parts = []
+    for key, value in where_document.items():
+        if key == "$contains":
+            parts.append(f"{FIELD_DOCUMENT} like {_like_value(value)}")
+        elif key == "$and":
+            if not isinstance(value, list) or not value:
+                raise UnsupportedFilterError("$and requires a non-empty list of clauses")
+            nested = [translate_where_document(item) for item in value]
+            parts.append("(" + " and ".join(part for part in nested if part) + ")")
+        elif key == "$or":
+            if not isinstance(value, list) or not value:
+                raise UnsupportedFilterError("$or requires a non-empty list of clauses")
+            nested = [translate_where_document(item) for item in value]
+            parts.append("(" + " or ".join(part for part in nested if part) + ")")
+        else:
+            raise UnsupportedFilterError(f"where_document operator {key!r} not supported")
+    return " and ".join(part for part in parts if part)
+
+
+def _combine_filter(*filters: str) -> str:
+    present = [flt for flt in filters if flt]
+    if not present:
+        return ""
+    if len(present) == 1:
+        return present[0]
+    return "(" + ") and (".join(present) + ")"
+
+
+def _as_vector_array(vector: list[float]) -> np.ndarray:
+    arr = np.asarray(vector, dtype=np.float32)
+    if arr.ndim != 1 or arr.size == 0:
+        raise ValueError("embedding must be a non-empty 1D vector")
+    return arr
+
+
+def _normalize_vectors(embeddings: list[list[float]]) -> tuple[list[list[float]], int]:
+    vectors = []
+    dims = set()
+    for embedding in embeddings:
+        arr = _as_vector_array(embedding)
+        vectors.append(arr.astype(float).tolist())
+        dims.add(int(arr.size))
+    if len(dims) > 1:
+        raise DimensionMismatchError(f"milvus batch cannot mix embedding dimensions {sorted(dims)}")
+    return vectors, dims.pop() if dims else 0
+
+
+def _clean_text(value: Any) -> str:
+    text = "" if value is None else str(value)
+    return strip_lone_surrogates(text).replace("\x00", "")
+
+
+def _jsonable_metadata(meta: dict | None) -> dict:
+    cleaned = {}
+    for key, value in (meta or {}).items():
+        if key in RESERVED_FIELDS:
+            raise ValueError(f"metadata key {key!r} clashes with a reserved Milvus field")
+        try:
+            json.dumps(value, ensure_ascii=False)
+        except (TypeError, ValueError):
+            value = str(value)
+        cleaned[str(key)] = value
+    return cleaned
+
+
+def _tokenize(text: str) -> list[str]:
+    if not text:
+        return []
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _bm25_scores(query: str, documents: list[str], k1: float = 1.5, b: float = 0.75) -> list[float]:
+    query_terms = set(_tokenize(query))
+    n_docs = len(documents)
+    if not query_terms or n_docs == 0:
+        return [0.0] * n_docs
+    tokenized = [_tokenize(doc) for doc in documents]
+    lengths = [len(tokens) for tokens in tokenized]
+    if not any(lengths):
+        return [0.0] * n_docs
+    avgdl = sum(lengths) / n_docs or 1.0
+    df = {term: 0 for term in query_terms}
+    for tokens in tokenized:
+        for term in set(tokens) & query_terms:
+            df[term] += 1
+    idf = {
+        term: math.log((n_docs - count + 0.5) / (count + 0.5) + 1.0) for term, count in df.items()
+    }
+    scores = []
+    for tokens, length in zip(tokenized, lengths):
+        if length == 0:
+            scores.append(0.0)
+            continue
+        tf = {}
+        for token in tokens:
+            if token in query_terms:
+                tf[token] = tf.get(token, 0) + 1
+        score = 0.0
+        for term, freq in tf.items():
+            score += idf[term] * (freq * (k1 + 1)) / (freq + k1 * (1 - b + b * length / avgdl))
+        scores.append(score)
+    return scores
+
+
+def _slug(value: str, fallback: str = "collection") -> str:
+    safe = re.sub(r"[^A-Za-z0-9_]+", "_", value).strip("_")
+    if not safe or not re.match(r"^[A-Za-z_]", safe):
+        safe = f"{fallback}_{safe}" if safe else fallback
+    if len(safe) <= 120:
+        return safe
+    digest = sha256(value.encode("utf-8", errors="surrogatepass")).hexdigest()[:12]
+    return f"{safe[:107]}_{digest}"
+
+
+@dataclass(frozen=True)
+class _MilvusConfig:
+    uri: Optional[str] = None
+    token: Optional[str] = None
+    namespace: Optional[str] = None
+    db_filename: str = DEFAULT_DB_FILENAME
+
+    @classmethod
+    def from_options(cls, options: Optional[dict] = None) -> "_MilvusConfig":
+        options = options or {}
+        try:
+            from ..config import MempalaceConfig
+
+            cfg = MempalaceConfig()
+        except Exception:  # pragma: no cover - config import should be boring
+            cfg = None
+        uri = (
+            options.get("uri")
+            or os.environ.get("MEMPALACE_MILVUS_URI")
+            or getattr(cfg, "milvus_uri", None)
+        )
+        token = (
+            options.get("token")
+            or os.environ.get("MEMPALACE_MILVUS_TOKEN")
+            or getattr(cfg, "milvus_token", None)
+        )
+        namespace = (
+            options.get("namespace")
+            or os.environ.get("MEMPALACE_MILVUS_NAMESPACE")
+            or getattr(cfg, "milvus_namespace", None)
+        )
+        db_filename = options.get("db_filename") or DEFAULT_DB_FILENAME
+        return cls(
+            uri=str(uri).strip() if uri else None,
+            token=str(token) if token else None,
+            namespace=str(namespace).strip() if namespace else None,
+            db_filename=str(db_filename).strip() or DEFAULT_DB_FILENAME,
+        )
+
+
+class MilvusCollection(BaseCollection):
+    def __init__(
+        self,
+        *,
+        backend: "MilvusBackend",
+        client: Any,
+        config: _MilvusConfig,
+        palace: PalaceRef,
+        collection_name: str,
+        remote_collection: str,
+    ):
+        self._backend = backend
+        self._client = client
+        self._config = config
+        self._palace = palace
+        self._collection_name = collection_name
+        self._remote_collection = remote_collection
+        self._lock = threading.RLock()
+        self._closed = False
+        self._known_dimension: Optional[int] = None
+
+    def _ensure_open(self) -> None:
+        if self._closed or self._backend._closed:
+            raise BackendClosedError("MilvusCollection has been closed")
+
+    def _remote_exists(self) -> bool:
+        return bool(self._client.has_collection(self._remote_collection))
+
+    def _marker_exists(self) -> bool:
+        return self._backend._marker_exists(self._palace)
+
+    def get_stored_embedder_identity(self):
+        return self._backend._get_embedder_identity(self._palace, self._collection_name)
+
+    def set_embedder_identity(self, identity) -> None:
+        self._backend._set_embedder_identity(self._palace, self._collection_name, identity)
+
+    @property
+    def distance_metric(self) -> str:
+        return "cosine"
+
+    def _remote_dimension(self) -> Optional[int]:
+        if not self._remote_exists():
+            return None
+        try:
+            info = self._client.describe_collection(self._remote_collection)
+        except Exception:
+            logger.debug("Milvus describe_collection failed", exc_info=True)
+            return None
+        fields = []
+        if isinstance(info, dict):
+            fields = info.get("fields") or (info.get("schema") or {}).get("fields") or []
+        for field in fields:
+            name = field.get("name") or field.get("field_name")
+            if name != FIELD_VECTOR:
+                continue
+            params = field.get("params") or field.get("type_params") or {}
+            dim = field.get("dim") or params.get("dim")
+            try:
+                return int(dim)
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def _ensure_remote_collection(self, dimension: int) -> None:
+        if dimension <= 0:
+            raise ValueError("embedding dimension must be positive")
+        with self._lock:
+            self._ensure_open()
+            if self._known_dimension is not None:
+                if self._known_dimension != dimension:
+                    raise DimensionMismatchError(
+                        f"milvus collection {self._collection_name!r} expects "
+                        f"embedding dimension {self._known_dimension}, got {dimension}"
+                    )
+                return
+            if not self._remote_exists():
+                self._backend._create_remote_collection(
+                    self._client, self._remote_collection, dimension
+                )
+                self._backend._load_remote_collection(self._client, self._remote_collection)
+                self._known_dimension = dimension
+                self._backend._write_marker(self._palace, self._config)
+                return
+            remote_dim = self._remote_dimension()
+            if remote_dim is not None and remote_dim != dimension:
+                raise DimensionMismatchError(
+                    f"milvus collection {self._collection_name!r} expects "
+                    f"embedding dimension {remote_dim}, got {dimension}"
+                )
+            self._known_dimension = remote_dim or dimension
+
+    def _output_fields(self, spec: _IncludeSpec) -> list[str]:
+        fields = [FIELD_ID]
+        if spec.documents:
+            fields.append(FIELD_DOCUMENT)
+        if spec.embeddings:
+            fields.append(FIELD_VECTOR)
+        if spec.metadatas:
+            fields.append(FIELD_METADATA)
+        return list(dict.fromkeys(fields))
+
+    def _extract_metadata(self, row: dict) -> dict:
+        metadata = row.get(FIELD_METADATA)
+        if isinstance(metadata, dict):
+            return metadata
+        if isinstance(metadata, str):
+            try:
+                parsed = json.loads(metadata)
+            except json.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, dict):
+                return parsed
+        return {key: value for key, value in row.items() if key not in RESERVED_FIELDS}
+
+    def _row_from_search_hit(self, hit: Any) -> dict:
+        if isinstance(hit, dict):
+            entity = hit.get("entity") or hit
+            doc_id = hit.get(FIELD_ID) or hit.get("id") or entity.get(FIELD_ID)
+            score = hit.get("distance", hit.get("score", 0.0))
+        else:
+            entity = getattr(hit, "entity", None) or {}
+            doc_id = getattr(hit, "id", None) or entity.get(FIELD_ID)
+            score = getattr(hit, "distance", getattr(hit, "score", 0.0))
+        row = dict(entity or {})
+        row[FIELD_ID] = str(doc_id)
+        row["distance"] = float(score or 0.0)
+        return row
+
+    def _flush(self) -> None:
+        try:
+            self._client.flush(collection_name=self._remote_collection)
+        except Exception:
+            logger.debug("Milvus flush skipped", exc_info=True)
+
+    def _prepare_rows(
+        self,
+        *,
+        documents: list[str],
+        ids: list[str],
+        metadatas: Optional[list[dict]],
+        embeddings: list[list[float]],
+    ) -> tuple[list[dict], int]:
+        if len(documents) != len(ids):
+            raise ValueError(
+                f"documents length {len(documents)} does not match ids length {len(ids)}"
+            )
+        if metadatas is not None and len(metadatas) != len(ids):
+            raise ValueError(
+                f"metadatas length {len(metadatas)} does not match ids length {len(ids)}"
+            )
+        if len(embeddings) != len(ids):
+            raise ValueError(
+                f"embeddings length {len(embeddings)} does not match ids length {len(ids)}"
+            )
+        vectors, dimension = _normalize_vectors(embeddings)
+        metadatas = metadatas or [{} for _ in ids]
+        rows = []
+        for idx, (doc_id, document, metadata, vector) in enumerate(
+            zip(ids, documents, metadatas, vectors)
+        ):
+            if not isinstance(doc_id, str) or not doc_id:
+                raise ValueError(f"row {idx}: id must be a non-empty string")
+            if len(doc_id) > DRAWER_ID_MAX_LENGTH:
+                raise ValueError(
+                    f"row {idx}: id length {len(doc_id)} exceeds {DRAWER_ID_MAX_LENGTH}"
+                )
+            document = _clean_text(document)
+            if len(document) > DOCUMENT_MAX_LENGTH:
+                raise ValueError(
+                    f"row {idx}: document length {len(document)} exceeds "
+                    f"Milvus VARCHAR limit {DOCUMENT_MAX_LENGTH}; chunk before storing"
+                )
+            row = {
+                FIELD_ID: doc_id,
+                FIELD_DOCUMENT: document,
+                FIELD_METADATA: _jsonable_metadata(metadata),
+                FIELD_VECTOR: vector,
+            }
+            row.update(row[FIELD_METADATA])
+            rows.append(row)
+        return rows, dimension
+
+    def add(self, *, documents, ids, metadatas=None, embeddings=None):
+        if embeddings is None:
+            raise ValueError("milvus requires explicit embeddings")
+        if len(set(ids)) != len(ids):
+            raise ValueError("add ids must be unique")
+        rows, dimension = self._prepare_rows(
+            documents=documents,
+            ids=ids,
+            metadatas=metadatas,
+            embeddings=embeddings,
+        )
+        if not rows:
+            return
+        existing = self.get(ids=list(ids), include=[])
+        if existing.ids:
+            raise ValueError(f"ids already exist in milvus collection: {existing.ids}")
+        self._ensure_remote_collection(dimension)
+        self._client.insert(collection_name=self._remote_collection, data=rows)
+        self._flush()
+
+    def upsert(self, *, documents, ids, metadatas=None, embeddings=None):
+        if embeddings is None:
+            raise ValueError("milvus requires explicit embeddings")
+        rows, dimension = self._prepare_rows(
+            documents=documents,
+            ids=ids,
+            metadatas=metadatas,
+            embeddings=embeddings,
+        )
+        if not rows:
+            return
+        self._ensure_remote_collection(dimension)
+        self._client.upsert(collection_name=self._remote_collection, data=rows)
+        self._flush()
+
+    def update(self, *, ids, documents=None, metadatas=None, embeddings=None):
+        if documents is None and metadatas is None and embeddings is None:
+            raise ValueError("update requires at least one of documents, metadatas, embeddings")
+        n = len(ids)
+        for label, value in (
+            ("documents", documents),
+            ("metadatas", metadatas),
+            ("embeddings", embeddings),
+        ):
+            if value is not None and len(value) != n:
+                raise ValueError(f"{label} length {len(value)} does not match ids length {n}")
+        existing = self.get(ids=list(ids), include=["documents", "metadatas", "embeddings"])
+        by_id = {
+            rid: (existing.documents[i], existing.metadatas[i], existing.embeddings[i])
+            for i, rid in enumerate(existing.ids)
+            if existing.embeddings is not None
+        }
+        missing = [doc_id for doc_id in ids if doc_id not in by_id]
+        if missing:
+            raise KeyError(f"update: ids not found: {missing}")
+        out_docs = []
+        out_metas = []
+        out_embeddings = []
+        for idx, doc_id in enumerate(ids):
+            prev_doc, prev_meta, prev_embedding = by_id[doc_id]
+            out_docs.append(documents[idx] if documents is not None else prev_doc)
+            meta = dict(prev_meta or {})
+            if metadatas is not None:
+                meta.update(metadatas[idx] or {})
+            out_metas.append(meta)
+            out_embeddings.append(embeddings[idx] if embeddings is not None else prev_embedding)
+        self.upsert(
+            documents=out_docs, ids=list(ids), metadatas=out_metas, embeddings=out_embeddings
+        )
+
+    def query(
+        self,
+        *,
+        query_texts=None,
+        query_embeddings=None,
+        n_results=10,
+        where=None,
+        where_document=None,
+        include=None,
+    ) -> QueryResult:
+        if query_texts is not None:
+            raise ValueError("milvus requires query_embeddings; use palace.get_collection wrapper")
+        if query_embeddings is None:
+            raise ValueError("query requires query_embeddings")
+        if not query_embeddings:
+            return QueryResult.empty(
+                num_queries=0,
+                embeddings_requested=bool(include and "embeddings" in include),
+            )
+        if not self._remote_exists():
+            if self._marker_exists():
+                raise CollectionNotInitializedError(self._collection_name)
+            return QueryResult.empty(
+                num_queries=len(query_embeddings),
+                embeddings_requested=bool(include and "embeddings" in include),
+            )
+        spec = _IncludeSpec.resolve(include, default_distances=True)
+        output_fields = self._output_fields(spec)
+        filter_expr = _combine_filter(
+            translate_where(where), translate_where_document(where_document)
+        )
+        outer_ids: list[list[str]] = []
+        outer_docs: list[list[str]] = []
+        outer_metas: list[list[dict]] = []
+        outer_dists: list[list[float]] = []
+        outer_embeddings: list[list[list[float]]] = []
+        for query_vector in query_embeddings:
+            q = _as_vector_array(query_vector)
+            if self._known_dimension is None:
+                self._known_dimension = self._remote_dimension()
+            if self._known_dimension is not None and int(q.size) != self._known_dimension:
+                raise DimensionMismatchError(
+                    f"milvus collection {self._collection_name!r} expects "
+                    f"embedding dimension {self._known_dimension}, got {int(q.size)}"
+                )
+            kwargs = {
+                "collection_name": self._remote_collection,
+                "data": [q.astype(float).tolist()],
+                "limit": int(n_results),
+                "output_fields": output_fields,
+                "anns_field": FIELD_VECTOR,
+                "search_params": {"metric_type": "COSINE"},
+            }
+            if filter_expr:
+                kwargs["filter"] = filter_expr
+            raw = self._client.search(**kwargs)
+            hits = raw[0] if raw else []
+            rows = [self._row_from_search_hit(hit) for hit in hits]
+            outer_ids.append([row[FIELD_ID] for row in rows])
+            outer_docs.append(
+                [row.get(FIELD_DOCUMENT, "") for row in rows] if spec.documents else []
+            )
+            outer_metas.append(
+                [self._extract_metadata(row) for row in rows] if spec.metadatas else []
+            )
+            outer_dists.append(
+                [float(row.get("distance", 1.0)) for row in rows] if spec.distances else []
+            )
+            if spec.embeddings:
+                outer_embeddings.append([row.get(FIELD_VECTOR) or [] for row in rows])
+        return QueryResult(
+            ids=outer_ids,
+            documents=outer_docs,
+            metadatas=outer_metas,
+            distances=outer_dists,
+            embeddings=outer_embeddings if spec.embeddings else None,
+        )
+
+    def _collect_by_filter(
+        self,
+        *,
+        filter_expr: str = "",
+        output_fields: Optional[list[str]] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> list[dict]:
+        if not self._remote_exists():
+            if self._marker_exists():
+                raise CollectionNotInitializedError(self._collection_name)
+            return []
+        fields = output_fields or [FIELD_ID]
+        if limit is not None and offset + limit <= _MAX_QUERY_WINDOW:
+            kwargs = {
+                "collection_name": self._remote_collection,
+                "output_fields": fields,
+                "limit": int(limit),
+            }
+            if filter_expr:
+                kwargs["filter"] = filter_expr
+            if offset:
+                kwargs["offset"] = int(offset)
+            return list(self._client.query(**kwargs) or [])
+        batch_size = min(_MAX_QUERY_WINDOW, limit or 1000)
+        kwargs = {
+            "collection_name": self._remote_collection,
+            "output_fields": fields,
+            "batch_size": int(batch_size),
+        }
+        if filter_expr:
+            kwargs["filter"] = filter_expr
+        iterator = self._client.query_iterator(**kwargs)
+        skipped = 0
+        rows = []
+        try:
+            while True:
+                batch = iterator.next()
+                if not batch:
+                    break
+                for row in batch:
+                    if skipped < offset:
+                        skipped += 1
+                        continue
+                    rows.append(row)
+                    if limit is not None and len(rows) >= limit:
+                        return rows
+        finally:
+            try:
+                iterator.close()
+            except Exception:
+                pass
+        return rows
+
+    def get(
+        self,
+        *,
+        ids=None,
+        where=None,
+        where_document=None,
+        limit=None,
+        offset=None,
+        include=None,
+    ) -> GetResult:
+        spec = _IncludeSpec.resolve(include, default_distances=False)
+        output_fields = self._output_fields(spec)
+        if ids is not None:
+            if not ids:
+                return GetResult.empty()
+            if not self._remote_exists():
+                if self._marker_exists():
+                    raise CollectionNotInitializedError(self._collection_name)
+                return GetResult.empty()
+            records = self._client.get(
+                collection_name=self._remote_collection,
+                ids=list(ids),
+                output_fields=output_fields,
+            )
+            by_id = {str(row.get(FIELD_ID)): row for row in records or []}
+            rows = [by_id[str(doc_id)] for doc_id in ids if str(doc_id) in by_id]
+        else:
+            filter_expr = _combine_filter(
+                translate_where(where),
+                translate_where_document(where_document),
+            )
+            rows = self._collect_by_filter(
+                filter_expr=filter_expr,
+                output_fields=output_fields,
+                limit=limit,
+                offset=offset or 0,
+            )
+        return GetResult(
+            ids=[str(row.get(FIELD_ID, "")) for row in rows],
+            documents=[row.get(FIELD_DOCUMENT, "") for row in rows] if spec.documents else [],
+            metadatas=[self._extract_metadata(row) for row in rows] if spec.metadatas else [],
+            embeddings=[row.get(FIELD_VECTOR) or [] for row in rows] if spec.embeddings else None,
+        )
+
+    def get_all_metadata(self, where: Optional[dict] = None) -> list[dict]:
+        rows = self._collect_by_filter(
+            filter_expr=translate_where(where),
+            output_fields=[FIELD_ID, FIELD_METADATA],
+        )
+        return [self._extract_metadata(row) for row in rows]
+
+    def delete(self, *, ids=None, where=None):
+        filter_expr = translate_where(where)
+        if ids is None and where is None:
+            raise ValueError("delete requires either ids= or where=")
+        if not self._remote_exists():
+            if self._marker_exists():
+                raise CollectionNotInitializedError(self._collection_name)
+            return
+        if ids is not None and where is not None:
+            rows = self._collect_by_filter(
+                filter_expr=filter_expr,
+                output_fields=[FIELD_ID],
+            )
+            allowed = {row[FIELD_ID] for row in rows}
+            ids = [doc_id for doc_id in ids if doc_id in allowed]
+        if ids is not None:
+            if not ids:
+                return
+            self._client.delete(collection_name=self._remote_collection, ids=list(ids))
+        else:
+            self._client.delete(collection_name=self._remote_collection, filter=filter_expr)
+        self._flush()
+
+    def count(self) -> int:
+        if not self._remote_exists():
+            if self._marker_exists():
+                raise CollectionNotInitializedError(self._collection_name)
+            return 0
+        try:
+            rows = self._client.query(
+                collection_name=self._remote_collection,
+                filter="",
+                output_fields=["count(*)"],
+            )
+            if rows:
+                first = rows[0]
+                return int(first.get("count(*)", first.get("count", 0)))
+        except Exception:
+            logger.debug("Milvus count(*) query failed; falling back to stats", exc_info=True)
+        try:
+            stats = self._client.get_collection_stats(self._remote_collection)
+            return int(stats.get("row_count", stats.get("num_entities", 0)))
+        except Exception as exc:
+            raise BackendError(f"Milvus count failed: {exc}") from exc
+
+    def lexical_search(self, *, query: str, n_results: int = 10, where: Optional[dict] = None):
+        filter_expr = translate_where(where)
+        rows = self._collect_by_filter(
+            filter_expr=filter_expr,
+            output_fields=[FIELD_ID, FIELD_DOCUMENT, FIELD_METADATA],
+        )
+        scores = _bm25_scores(query, [row.get(FIELD_DOCUMENT, "") for row in rows])
+        hits = [
+            LexicalHit(
+                id=str(row.get(FIELD_ID, "")),
+                document=row.get(FIELD_DOCUMENT, ""),
+                metadata=self._extract_metadata(row),
+                score=score,
+            )
+            for row, score in zip(rows, scores)
+            if score > 0
+        ]
+        hits.sort(key=lambda hit: hit.score, reverse=True)
+        return LexicalResult(hits=hits[:n_results])
+
+    def close(self) -> None:
+        self._closed = True
+
+    def health(self) -> HealthStatus:
+        if self._closed or self._backend._closed:
+            return HealthStatus.unhealthy("collection closed")
+        try:
+            if not self._remote_exists():
+                return HealthStatus.unhealthy("milvus collection not found")
+        except Exception as exc:
+            return HealthStatus.unhealthy(str(exc))
+        return HealthStatus.healthy()
+
+
+class MilvusBackend(BaseBackend):
+    name = "milvus"
+    capabilities = frozenset(
+        {
+            "requires_explicit_embeddings",
+            "supports_embeddings_in",
+            "supports_embeddings_passthrough",
+            "supports_embeddings_out",
+            "supports_metadata_filters",
+            "supports_lexical_search",
+            "supports_namespace_isolation",
+            "server_mode",
+        }
+    )
+
+    def __init__(self):
+        self._clients: dict[_MilvusConfig, Any] = {}
+        self._collections_by_palace: dict[str, list[MilvusCollection]] = {}
+        self._lock = threading.RLock()
+        self._closed = False
+
+    @staticmethod
+    def _marker_path(palace_path: str) -> str:
+        return os.path.join(palace_path, _MARKER_FILENAME)
+
+    @staticmethod
+    def _palace_hash(palace: PalaceRef) -> str:
+        return sha256(palace.id.encode("utf-8", errors="surrogatepass")).hexdigest()[:16]
+
+    def _effective_config(self, palace: PalaceRef, options: Optional[dict]) -> _MilvusConfig:
+        config = _MilvusConfig.from_options(options)
+        namespace = palace.namespace or config.namespace
+        if config.uri:
+            return _MilvusConfig(
+                uri=config.uri,
+                token=config.token,
+                namespace=namespace,
+                db_filename=config.db_filename,
+            )
+        if not palace.local_path:
+            raise BackendError(
+                "milvus backend requires a local palace path when no URI is configured"
+            )
+        return _MilvusConfig(
+            uri=os.path.join(palace.local_path, config.db_filename),
+            token=config.token,
+            namespace=namespace,
+            db_filename=config.db_filename,
+        )
+
+    def _marker_target(self, palace: PalaceRef, config: _MilvusConfig) -> dict:
+        return {
+            "uri": config.uri,
+            "namespace": config.namespace,
+            "palace_hash": self._palace_hash(palace),
+            "remote_prefix": self._remote_collection_prefix(palace=palace, config=config),
+        }
+
+    def _remote_collection_prefix(self, *, palace: PalaceRef, config: _MilvusConfig) -> str:
+        parts = ["mempalace"]
+        if config.namespace:
+            parts.append(_slug(config.namespace, "namespace"))
+        parts.append(self._palace_hash(palace))
+        return "_".join(parts)
+
+    def _remote_collection_name(
+        self,
+        *,
+        palace: PalaceRef,
+        collection_name: str,
+        config: _MilvusConfig,
+    ) -> str:
+        if config.uri and not _is_server_uri(config.uri) and not config.namespace:
+            return _slug(collection_name)
+        prefix = self._remote_collection_prefix(palace=palace, config=config)
+        return f"{prefix}_{_slug(collection_name)}"
+
+    def _marker_exists(self, palace: PalaceRef) -> bool:
+        return bool(palace.local_path and os.path.isfile(self._marker_path(palace.local_path)))
+
+    def _read_marker(self, palace: PalaceRef) -> Optional[dict]:
+        if not palace.local_path:
+            return None
+        marker_path = self._marker_path(palace.local_path)
+        if not os.path.isfile(marker_path):
+            return None
+        try:
+            with open(marker_path, encoding="utf-8") as f:
+                marker = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise BackendMismatchError(f"milvus marker is unreadable: {marker_path}") from exc
+        return marker if isinstance(marker, dict) else {}
+
+    def _validate_marker_target(self, palace: PalaceRef, config: _MilvusConfig) -> None:
+        marker = self._read_marker(palace)
+        if marker is None:
+            return
+        if marker.get("backend") != self.name:
+            raise BackendMismatchError("milvus marker does not identify the milvus backend")
+        expected = self._marker_target(palace, config)
+        actual = marker.get("milvus")
+        if not isinstance(actual, dict):
+            raise BackendMismatchError("milvus marker is missing target metadata")
+        mismatched = [
+            key for key, expected_value in expected.items() if actual.get(key) != expected_value
+        ]
+        if mismatched:
+            raise BackendMismatchError(
+                "milvus marker target does not match current configuration "
+                f"({', '.join(mismatched)}); keep MEMPALACE_MILVUS_URI and "
+                "namespace consistent or use a fresh palace directory"
+            )
+
+    def _write_marker(self, palace: PalaceRef, config: _MilvusConfig) -> None:
+        if not palace.local_path:
+            return
+        os.makedirs(palace.local_path, exist_ok=True)
+        try:
+            os.chmod(palace.local_path, 0o700)
+        except (OSError, NotImplementedError):
+            pass
+        marker = {
+            "backend": self.name,
+            "schema_version": 1,
+            "created_at": _utcnow(),
+            "palace_id": palace.id,
+            "milvus": self._marker_target(palace, config),
+        }
+        marker_path = self._marker_path(palace.local_path)
+        with open(marker_path, "w", encoding="utf-8") as f:
+            json.dump(marker, f, indent=2, ensure_ascii=False)
+        try:
+            os.chmod(marker_path, 0o600)
+        except (OSError, NotImplementedError):
+            pass
+
+    @staticmethod
+    def _embedder_sidecar_path(palace: PalaceRef) -> Optional[str]:
+        if not palace.local_path:
+            return None
+        return os.path.join(palace.local_path, EMBEDDER_SIDECAR_FILENAME)
+
+    def _get_embedder_identity(self, palace: PalaceRef, collection_name: str):
+        return read_embedder_sidecar(self._embedder_sidecar_path(palace), collection_name)
+
+    def _set_embedder_identity(self, palace: PalaceRef, collection_name: str, identity) -> None:
+        write_embedder_sidecar(self._embedder_sidecar_path(palace), collection_name, identity)
+
+    def _client(self, config: _MilvusConfig):
+        if self._closed:
+            raise BackendClosedError("MilvusBackend has been closed")
+        with self._lock:
+            client = self._clients.get(config)
+            if client is not None:
+                return client
+            if config.uri and not _is_server_uri(config.uri):
+                parent = os.path.dirname(os.path.abspath(config.uri)) or "."
+                os.makedirs(parent, exist_ok=True)
+                try:
+                    os.chmod(parent, 0o700)
+                except (OSError, NotImplementedError):
+                    pass
+            from pymilvus import MilvusClient
+
+            kwargs = {"uri": config.uri or DEFAULT_DB_FILENAME}
+            if config.token:
+                kwargs["token"] = config.token
+            client = MilvusClient(**kwargs)
+            self._clients[config] = client
+            return client
+
+    def get_collection(self, *args, **kwargs) -> MilvusCollection:
+        palace, collection_name, create, options = self._normalize_args(args, kwargs)
+        config = self._effective_config(palace, options)
+        if palace.local_path:
+            if create:
+                os.makedirs(palace.local_path, exist_ok=True)
+                try:
+                    os.chmod(palace.local_path, 0o700)
+                except (OSError, NotImplementedError):
+                    pass
+            marker_path = self._marker_path(palace.local_path)
+            local_db_exists = bool(
+                config.uri and not _is_server_uri(config.uri) and os.path.exists(config.uri)
+            )
+            if os.path.isfile(marker_path):
+                self._validate_marker_target(palace, config)
+            elif not create and not local_db_exists:
+                raise PalaceNotFoundError(marker_path)
+        else:
+            raise BackendError(
+                "milvus backend requires a local palace path to anchor mismatch protection"
+            )
+        client = self._client(config)
+        remote_collection = self._remote_collection_name(
+            palace=palace,
+            collection_name=collection_name,
+            config=config,
+        )
+        if not create and not client.has_collection(remote_collection):
+            raise CollectionNotInitializedError(collection_name)
+        if client.has_collection(remote_collection):
+            self._load_remote_collection(client, remote_collection)
+        collection = MilvusCollection(
+            backend=self,
+            client=client,
+            config=config,
+            palace=palace,
+            collection_name=collection_name,
+            remote_collection=remote_collection,
+        )
+        with self._lock:
+            self._collections_by_palace.setdefault(palace.id, []).append(collection)
+        return collection
+
+    @staticmethod
+    def _normalize_args(args, kwargs):
+        if "palace" in kwargs:
+            palace = kwargs.pop("palace")
+            if not isinstance(palace, PalaceRef):
+                raise TypeError("palace= must be a PalaceRef instance")
+            collection_name = kwargs.pop("collection_name")
+            create = bool(kwargs.pop("create", False))
+            options = kwargs.pop("options", None)
+            if args or kwargs:
+                raise TypeError("unexpected arguments to get_collection")
+            return palace, collection_name, create, options
+        if args:
+            palace_path = args[0]
+            rest = list(args[1:])
+            collection_name = kwargs.pop("collection_name", None) or (rest.pop(0) if rest else None)
+            if collection_name is None:
+                raise TypeError("collection_name is required")
+            create = kwargs.pop("create", False)
+            if rest:
+                create = rest.pop(0)
+            options = kwargs.pop("options", None)
+            if rest or kwargs:
+                raise TypeError("unexpected arguments to get_collection")
+            return (
+                PalaceRef(id=palace_path, local_path=palace_path),
+                collection_name,
+                bool(create),
+                options,
+            )
+        if "palace_path" in kwargs:
+            palace_path = kwargs.pop("palace_path")
+            collection_name = kwargs.pop("collection_name")
+            create = bool(kwargs.pop("create", False))
+            options = kwargs.pop("options", None)
+            if kwargs:
+                raise TypeError("unexpected arguments to get_collection")
+            return (
+                PalaceRef(id=palace_path, local_path=palace_path),
+                collection_name,
+                create,
+                options,
+            )
+        raise TypeError("get_collection requires palace= or a positional palace_path")
+
+    def _create_remote_collection(self, client, collection_name: str, dimension: int) -> None:
+        from pymilvus import DataType
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=True)
+        schema.add_field(
+            field_name=FIELD_ID,
+            datatype=DataType.VARCHAR,
+            is_primary=True,
+            max_length=DRAWER_ID_MAX_LENGTH,
+        )
+        schema.add_field(
+            field_name=FIELD_DOCUMENT,
+            datatype=DataType.VARCHAR,
+            max_length=DOCUMENT_MAX_LENGTH,
+        )
+        schema.add_field(field_name=FIELD_METADATA, datatype=DataType.JSON)
+        schema.add_field(
+            field_name=FIELD_VECTOR,
+            datatype=DataType.FLOAT_VECTOR,
+            dim=int(dimension),
+        )
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name=FIELD_VECTOR,
+            index_type="AUTOINDEX",
+            metric_type="COSINE",
+        )
+        client.create_collection(
+            collection_name=collection_name,
+            schema=schema,
+            index_params=index_params,
+        )
+
+    def _load_remote_collection(self, client, collection_name: str) -> None:
+        try:
+            client.load_collection(collection_name)
+        except Exception:
+            logger.debug("Milvus load_collection skipped", exc_info=True)
+
+    def close_palace(self, palace: PalaceRef | str) -> None:
+        palace_id = palace.id if isinstance(palace, PalaceRef) else palace
+        with self._lock:
+            collections = self._collections_by_palace.pop(palace_id, [])
+        for collection in collections:
+            collection.close()
+
+    def close(self) -> None:
+        with self._lock:
+            collections = [
+                collection
+                for palace_collections in self._collections_by_palace.values()
+                for collection in palace_collections
+            ]
+            clients = list(self._clients.values())
+            self._collections_by_palace.clear()
+            self._clients.clear()
+            self._closed = True
+        for collection in collections:
+            collection.close()
+        for client in clients:
+            try:
+                client.close()
+            except Exception:
+                logger.debug("Milvus client close failed", exc_info=True)
+
+    def health(self, palace: Optional[PalaceRef] = None) -> HealthStatus:
+        if self._closed:
+            return HealthStatus.unhealthy("backend closed")
+        if palace and palace.local_path and not self._marker_exists(palace):
+            return HealthStatus.unhealthy("milvus marker not found")
+        try:
+            if palace is None:
+                config = _MilvusConfig.from_options()
+                if not config.uri:
+                    return HealthStatus.healthy("milvus lite uses per-palace local files")
+            else:
+                config = self._effective_config(palace, None)
+            client = self._client(config)
+            client.list_collections()
+        except Exception as exc:
+            return HealthStatus.unhealthy(str(exc))
+        return HealthStatus.healthy()
+
+    @classmethod
+    def detect(cls, path: str) -> bool:
+        return os.path.isfile(os.path.join(path, _MARKER_FILENAME)) or os.path.exists(
+            os.path.join(path, DEFAULT_DB_FILENAME)
+        )
+
+    def create_collection(self, palace_path: str, collection_name: str) -> MilvusCollection:
+        collection = self.get_collection(palace_path, collection_name, create=True)
+        if collection._remote_exists():
+            raise ValueError(f"collection {collection_name!r} already exists")
+        return collection
+
+    def get_or_create_collection(self, palace_path: str, collection_name: str):
+        return self.get_collection(palace_path, collection_name, create=True)
+
+    def delete_collection(self, palace_path: str, collection_name: str) -> None:
+        palace = PalaceRef(id=palace_path, local_path=palace_path)
+        config = self._effective_config(palace, None)
+        client = self._client(config)
+        remote_collection = self._remote_collection_name(
+            palace=palace,
+            collection_name=collection_name,
+            config=config,
+        )
+        if client.has_collection(remote_collection):
+            client.drop_collection(remote_collection)
+
+
+__all__ = [
+    "DEFAULT_DB_FILENAME",
+    "DOCUMENT_MAX_LENGTH",
+    "DRAWER_ID_MAX_LENGTH",
+    "MilvusBackend",
+    "MilvusCollection",
+    "translate_where",
+    "translate_where_document",
+]

--- a/mempalace/backends/milvus.py
+++ b/mempalace/backends/milvus.py
@@ -54,9 +54,18 @@ FIELD_ID = "id"
 FIELD_DOCUMENT = "document"
 FIELD_METADATA = "metadata"
 FIELD_VECTOR = "vector"
+FIELD_SPARSE = "sparse"
 DOCUMENT_MAX_LENGTH = 65535
 DRAWER_ID_MAX_LENGTH = 512
-RESERVED_FIELDS = {FIELD_ID, FIELD_DOCUMENT, FIELD_METADATA, FIELD_VECTOR, "distance", "score"}
+RESERVED_FIELDS = {
+    FIELD_ID,
+    FIELD_DOCUMENT,
+    FIELD_METADATA,
+    FIELD_VECTOR,
+    FIELD_SPARSE,
+    "distance",
+    "score",
+}
 
 _FIELD_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
@@ -339,6 +348,7 @@ class MilvusCollection(BaseCollection):
         self._lock = threading.RLock()
         self._closed = False
         self._known_dimension: Optional[int] = None
+        self._known_native_lexical: Optional[bool] = None
 
     def _ensure_open(self) -> None:
         if self._closed or self._backend._closed:
@@ -396,11 +406,15 @@ class MilvusCollection(BaseCollection):
                     )
                 return
             if not self._remote_exists():
-                self._backend._create_remote_collection(
-                    self._client, self._remote_collection, dimension
+                native_lexical = self._backend._create_remote_collection(
+                    self._client,
+                    self._remote_collection,
+                    dimension,
+                    enable_native_lexical=self._backend._enable_native_lexical(self._config),
                 )
                 self._backend._load_remote_collection(self._client, self._remote_collection)
                 self._known_dimension = dimension
+                self._known_native_lexical = native_lexical
                 self._backend._write_marker(self._palace, self._config)
                 return
             remote_dim = self._remote_dimension()
@@ -410,6 +424,26 @@ class MilvusCollection(BaseCollection):
                     f"embedding dimension {remote_dim}, got {dimension}"
                 )
             self._known_dimension = remote_dim or dimension
+
+    def _has_native_lexical(self) -> bool:
+        if self._known_native_lexical is not None:
+            return self._known_native_lexical
+        if not self._remote_exists():
+            self._known_native_lexical = False
+            return False
+        try:
+            info = self._client.describe_collection(self._remote_collection)
+        except Exception:
+            logger.debug("Milvus describe_collection failed", exc_info=True)
+            self._known_native_lexical = False
+            return False
+        fields = []
+        if isinstance(info, dict):
+            fields = info.get("fields") or (info.get("schema") or {}).get("fields") or []
+        self._known_native_lexical = any(
+            (field.get("name") or field.get("field_name")) == FIELD_SPARSE for field in fields
+        )
+        return self._known_native_lexical
 
     def _output_fields(self, spec: _IncludeSpec) -> list[str]:
         fields = [FIELD_ID]
@@ -515,9 +549,10 @@ class MilvusCollection(BaseCollection):
         )
         if not rows:
             return
-        existing = self.get(ids=list(ids), include=[])
-        if existing.ids:
-            raise ValueError(f"ids already exist in milvus collection: {existing.ids}")
+        if self._remote_exists():
+            existing = self.get(ids=list(ids), include=[])
+            if existing.ids:
+                raise ValueError(f"ids already exist in milvus collection: {existing.ids}")
         self._ensure_remote_collection(dimension)
         self._client.insert(collection_name=self._remote_collection, data=rows)
         self._flush()
@@ -802,6 +837,14 @@ class MilvusCollection(BaseCollection):
 
     def lexical_search(self, *, query: str, n_results: int = 10, where: Optional[dict] = None):
         filter_expr = translate_where(where)
+        if self._has_native_lexical():
+            native = self._native_lexical_search(
+                query=query,
+                n_results=n_results,
+                filter_expr=filter_expr,
+            )
+            if native is not None:
+                return native
         rows = self._collect_by_filter(
             filter_expr=filter_expr,
             output_fields=[FIELD_ID, FIELD_DOCUMENT, FIELD_METADATA],
@@ -819,6 +862,43 @@ class MilvusCollection(BaseCollection):
         ]
         hits.sort(key=lambda hit: hit.score, reverse=True)
         return LexicalResult(hits=hits[:n_results])
+
+    def _native_lexical_search(
+        self,
+        *,
+        query: str,
+        n_results: int,
+        filter_expr: str,
+    ) -> Optional[LexicalResult]:
+        try:
+            kwargs = {
+                "collection_name": self._remote_collection,
+                "data": [query],
+                "anns_field": FIELD_SPARSE,
+                "output_fields": [FIELD_ID, FIELD_DOCUMENT, FIELD_METADATA],
+                "limit": int(n_results),
+                "search_params": {"params": {}},
+            }
+            if filter_expr:
+                kwargs["filter"] = filter_expr
+            raw = self._client.search(**kwargs)
+        except Exception:
+            logger.debug(
+                "Milvus native BM25 search failed; using local BM25 fallback", exc_info=True
+            )
+            return None
+        rows = [self._row_from_search_hit(hit) for hit in (raw[0] if raw else [])]
+        return LexicalResult(
+            hits=[
+                LexicalHit(
+                    id=str(row.get(FIELD_ID, "")),
+                    document=row.get(FIELD_DOCUMENT, ""),
+                    metadata=self._extract_metadata(row),
+                    score=float(row.get("distance", row.get("score", 0.0)) or 0.0),
+                )
+                for row in rows
+            ]
+        )
 
     def close(self) -> None:
         self._closed = True
@@ -1005,6 +1085,10 @@ class MilvusBackend(BaseBackend):
             self._clients[config] = client
             return client
 
+    @staticmethod
+    def _enable_native_lexical(config: _MilvusConfig) -> bool:
+        return bool(config.uri and _is_server_uri(config.uri))
+
     def get_collection(self, *args, **kwargs) -> MilvusCollection:
         palace, collection_name, create, options = self._normalize_args(args, kwargs)
         config = self._effective_config(palace, options)
@@ -1094,7 +1178,44 @@ class MilvusBackend(BaseBackend):
             )
         raise TypeError("get_collection requires palace= or a positional palace_path")
 
-    def _create_remote_collection(self, client, collection_name: str, dimension: int) -> None:
+    def _create_remote_collection(
+        self,
+        client,
+        collection_name: str,
+        dimension: int,
+        *,
+        enable_native_lexical: bool,
+    ) -> bool:
+        if enable_native_lexical:
+            try:
+                self._create_remote_collection_schema(
+                    client,
+                    collection_name,
+                    dimension,
+                    enable_native_lexical=True,
+                )
+                return True
+            except Exception:
+                logger.debug(
+                    "Milvus native BM25 schema creation failed; retrying dense-only schema",
+                    exc_info=True,
+                )
+        self._create_remote_collection_schema(
+            client,
+            collection_name,
+            dimension,
+            enable_native_lexical=False,
+        )
+        return False
+
+    def _create_remote_collection_schema(
+        self,
+        client,
+        collection_name: str,
+        dimension: int,
+        *,
+        enable_native_lexical: bool,
+    ) -> None:
         from pymilvus import DataType
 
         schema = client.create_schema(auto_id=False, enable_dynamic_field=True)
@@ -1108,6 +1229,7 @@ class MilvusBackend(BaseBackend):
             field_name=FIELD_DOCUMENT,
             datatype=DataType.VARCHAR,
             max_length=DOCUMENT_MAX_LENGTH,
+            enable_analyzer=enable_native_lexical,
         )
         schema.add_field(field_name=FIELD_METADATA, datatype=DataType.JSON)
         schema.add_field(
@@ -1115,12 +1237,31 @@ class MilvusBackend(BaseBackend):
             datatype=DataType.FLOAT_VECTOR,
             dim=int(dimension),
         )
+        if enable_native_lexical:
+            from pymilvus import Function, FunctionType
+
+            schema.add_field(field_name=FIELD_SPARSE, datatype=DataType.SPARSE_FLOAT_VECTOR)
+            schema.add_function(
+                Function(
+                    name="document_bm25",
+                    input_field_names=[FIELD_DOCUMENT],
+                    output_field_names=[FIELD_SPARSE],
+                    function_type=FunctionType.BM25,
+                )
+            )
         index_params = client.prepare_index_params()
         index_params.add_index(
             field_name=FIELD_VECTOR,
             index_type="AUTOINDEX",
             metric_type="COSINE",
         )
+        if enable_native_lexical:
+            index_params.add_index(
+                field_name=FIELD_SPARSE,
+                index_type="SPARSE_INVERTED_INDEX",
+                metric_type="BM25",
+                params={"inverted_index_algo": "DAAT_MAXSCORE"},
+            )
         client.create_collection(
             collection_name=collection_name,
             schema=schema,

--- a/mempalace/backends/milvus.py
+++ b/mempalace/backends/milvus.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import os
 import re
 import threading
@@ -23,7 +22,7 @@ from typing import Any, Optional
 
 import numpy as np
 
-from ..config import strip_lone_surrogates
+from ..config import DEFAULT_MILVUS_CONSISTENCY_LEVEL, strip_lone_surrogates
 from ._sidecar import EMBEDDER_SIDECAR_FILENAME, read_embedder_sidecar, write_embedder_sidecar
 from .base import (
     BackendClosedError,
@@ -49,6 +48,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_DB_FILENAME = "milvus.db"
 _MARKER_FILENAME = "milvus_backend.json"
 _MAX_QUERY_WINDOW = 16384
+_MILVUS_CONSISTENCY_LEVELS = {
+    "strong": "Strong",
+    "session": "Session",
+    "bounded": "Bounded",
+    "eventually": "Eventually",
+}
 
 FIELD_ID = "id"
 FIELD_DOCUMENT = "document"
@@ -68,8 +73,6 @@ RESERVED_FIELDS = {
 }
 
 _FIELD_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
-
 
 def _utcnow() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -239,45 +242,6 @@ def _jsonable_metadata(meta: dict | None) -> dict:
     return cleaned
 
 
-def _tokenize(text: str) -> list[str]:
-    if not text:
-        return []
-    return _TOKEN_RE.findall(text.lower())
-
-
-def _bm25_scores(query: str, documents: list[str], k1: float = 1.5, b: float = 0.75) -> list[float]:
-    query_terms = set(_tokenize(query))
-    n_docs = len(documents)
-    if not query_terms or n_docs == 0:
-        return [0.0] * n_docs
-    tokenized = [_tokenize(doc) for doc in documents]
-    lengths = [len(tokens) for tokens in tokenized]
-    if not any(lengths):
-        return [0.0] * n_docs
-    avgdl = sum(lengths) / n_docs or 1.0
-    df = {term: 0 for term in query_terms}
-    for tokens in tokenized:
-        for term in set(tokens) & query_terms:
-            df[term] += 1
-    idf = {
-        term: math.log((n_docs - count + 0.5) / (count + 0.5) + 1.0) for term, count in df.items()
-    }
-    scores = []
-    for tokens, length in zip(tokenized, lengths):
-        if length == 0:
-            scores.append(0.0)
-            continue
-        tf = {}
-        for token in tokens:
-            if token in query_terms:
-                tf[token] = tf.get(token, 0) + 1
-        score = 0.0
-        for term, freq in tf.items():
-            score += idf[term] * (freq * (k1 + 1)) / (freq + k1 * (1 - b + b * length / avgdl))
-        scores.append(score)
-    return scores
-
-
 def _slug(value: str, fallback: str = "collection") -> str:
     safe = re.sub(r"[^A-Za-z0-9_]+", "_", value).strip("_")
     if not safe or not re.match(r"^[A-Za-z_]", safe):
@@ -288,12 +252,23 @@ def _slug(value: str, fallback: str = "collection") -> str:
     return f"{safe[:107]}_{digest}"
 
 
+def _normalize_consistency_level(value: Any) -> str:
+    raw = DEFAULT_MILVUS_CONSISTENCY_LEVEL if value is None else str(value).strip()
+    normalized = _MILVUS_CONSISTENCY_LEVELS.get(raw.lower())
+    if normalized:
+        return normalized
+    allowed = ", ".join(_MILVUS_CONSISTENCY_LEVELS.values())
+    raise BackendError(f"milvus consistency_level must be one of: {allowed}")
+
+
 @dataclass(frozen=True)
 class _MilvusConfig:
     uri: Optional[str] = None
     token: Optional[str] = None
+    db_name: Optional[str] = None
     namespace: Optional[str] = None
     db_filename: str = DEFAULT_DB_FILENAME
+    consistency_level: str = DEFAULT_MILVUS_CONSISTENCY_LEVEL
 
     @classmethod
     def from_options(cls, options: Optional[dict] = None) -> "_MilvusConfig":
@@ -314,17 +289,29 @@ class _MilvusConfig:
             or os.environ.get("MEMPALACE_MILVUS_TOKEN")
             or getattr(cfg, "milvus_token", None)
         )
+        db_name = (
+            options.get("db_name")
+            or os.environ.get("MEMPALACE_MILVUS_DB_NAME")
+            or getattr(cfg, "milvus_db_name", None)
+        )
         namespace = (
             options.get("namespace")
             or os.environ.get("MEMPALACE_MILVUS_NAMESPACE")
             or getattr(cfg, "milvus_namespace", None)
         )
+        consistency_level = (
+            options.get("consistency_level")
+            or os.environ.get("MEMPALACE_MILVUS_CONSISTENCY_LEVEL")
+            or getattr(cfg, "milvus_consistency_level", DEFAULT_MILVUS_CONSISTENCY_LEVEL)
+        )
         db_filename = options.get("db_filename") or DEFAULT_DB_FILENAME
         return cls(
             uri=str(uri).strip() if uri else None,
             token=str(token) if token else None,
+            db_name=str(db_name).strip() if db_name else None,
             namespace=str(namespace).strip() if namespace else None,
             db_filename=str(db_filename).strip() or DEFAULT_DB_FILENAME,
+            consistency_level=_normalize_consistency_level(consistency_level),
         )
 
 
@@ -406,15 +393,15 @@ class MilvusCollection(BaseCollection):
                     )
                 return
             if not self._remote_exists():
-                native_lexical = self._backend._create_remote_collection(
+                self._backend._create_remote_collection(
                     self._client,
                     self._remote_collection,
                     dimension,
-                    enable_native_lexical=True,
+                    consistency_level=self._config.consistency_level,
                 )
                 self._backend._load_remote_collection(self._client, self._remote_collection)
                 self._known_dimension = dimension
-                self._known_native_lexical = native_lexical
+                self._known_native_lexical = True
                 self._backend._write_marker(self._palace, self._config)
                 return
             remote_dim = self._remote_dimension()
@@ -481,12 +468,6 @@ class MilvusCollection(BaseCollection):
         row[FIELD_ID] = str(doc_id)
         row["distance"] = float(score or 0.0)
         return row
-
-    def _flush(self) -> None:
-        try:
-            self._client.flush(collection_name=self._remote_collection)
-        except Exception:
-            logger.debug("Milvus flush skipped", exc_info=True)
 
     def _prepare_rows(
         self,
@@ -555,7 +536,6 @@ class MilvusCollection(BaseCollection):
                 raise ValueError(f"ids already exist in milvus collection: {existing.ids}")
         self._ensure_remote_collection(dimension)
         self._client.insert(collection_name=self._remote_collection, data=rows)
-        self._flush()
 
     def upsert(self, *, documents, ids, metadatas=None, embeddings=None):
         if embeddings is None:
@@ -570,7 +550,6 @@ class MilvusCollection(BaseCollection):
             return
         self._ensure_remote_collection(dimension)
         self._client.upsert(collection_name=self._remote_collection, data=rows)
-        self._flush()
 
     def update(self, *, ids, documents=None, metadatas=None, embeddings=None):
         if documents is None and metadatas is None and embeddings is None:
@@ -659,6 +638,7 @@ class MilvusCollection(BaseCollection):
                 "output_fields": output_fields,
                 "anns_field": FIELD_VECTOR,
                 "search_params": {"metric_type": "COSINE"},
+                "consistency_level": self._config.consistency_level,
             }
             if filter_expr:
                 kwargs["filter"] = filter_expr
@@ -703,6 +683,7 @@ class MilvusCollection(BaseCollection):
                 "collection_name": self._remote_collection,
                 "output_fields": fields,
                 "limit": int(limit),
+                "consistency_level": self._config.consistency_level,
             }
             if filter_expr:
                 kwargs["filter"] = filter_expr
@@ -714,6 +695,7 @@ class MilvusCollection(BaseCollection):
             "collection_name": self._remote_collection,
             "output_fields": fields,
             "batch_size": int(batch_size),
+            "consistency_level": self._config.consistency_level,
         }
         if filter_expr:
             kwargs["filter"] = filter_expr
@@ -762,6 +744,7 @@ class MilvusCollection(BaseCollection):
                 collection_name=self._remote_collection,
                 ids=list(ids),
                 output_fields=output_fields,
+                consistency_level=self._config.consistency_level,
             )
             by_id = {str(row.get(FIELD_ID)): row for row in records or []}
             rows = [by_id[str(doc_id)] for doc_id in ids if str(doc_id) in by_id]
@@ -811,7 +794,6 @@ class MilvusCollection(BaseCollection):
             self._client.delete(collection_name=self._remote_collection, ids=list(ids))
         else:
             self._client.delete(collection_name=self._remote_collection, filter=filter_expr)
-        self._flush()
 
     def count(self) -> int:
         if not self._remote_exists():
@@ -823,6 +805,7 @@ class MilvusCollection(BaseCollection):
                 collection_name=self._remote_collection,
                 filter="",
                 output_fields=["count(*)"],
+                consistency_level=self._config.consistency_level,
             )
             if rows:
                 first = rows[0]
@@ -837,31 +820,19 @@ class MilvusCollection(BaseCollection):
 
     def lexical_search(self, *, query: str, n_results: int = 10, where: Optional[dict] = None):
         filter_expr = translate_where(where)
-        if self._has_native_lexical():
-            native = self._native_lexical_search(
-                query=query,
-                n_results=n_results,
-                filter_expr=filter_expr,
+        if not self._remote_exists():
+            if self._marker_exists():
+                raise CollectionNotInitializedError(self._collection_name)
+            return LexicalResult(hits=[])
+        if not self._has_native_lexical():
+            raise BackendError(
+                "milvus lexical search requires a collection created with native BM25 support"
             )
-            if native is not None:
-                return native
-        rows = self._collect_by_filter(
+        return self._native_lexical_search(
+            query=query,
+            n_results=n_results,
             filter_expr=filter_expr,
-            output_fields=[FIELD_ID, FIELD_DOCUMENT, FIELD_METADATA],
         )
-        scores = _bm25_scores(query, [row.get(FIELD_DOCUMENT, "") for row in rows])
-        hits = [
-            LexicalHit(
-                id=str(row.get(FIELD_ID, "")),
-                document=row.get(FIELD_DOCUMENT, ""),
-                metadata=self._extract_metadata(row),
-                score=score,
-            )
-            for row, score in zip(rows, scores)
-            if score > 0
-        ]
-        hits.sort(key=lambda hit: hit.score, reverse=True)
-        return LexicalResult(hits=hits[:n_results])
 
     def _native_lexical_search(
         self,
@@ -869,7 +840,7 @@ class MilvusCollection(BaseCollection):
         query: str,
         n_results: int,
         filter_expr: str,
-    ) -> Optional[LexicalResult]:
+    ) -> LexicalResult:
         try:
             kwargs = {
                 "collection_name": self._remote_collection,
@@ -878,15 +849,13 @@ class MilvusCollection(BaseCollection):
                 "output_fields": [FIELD_ID, FIELD_DOCUMENT, FIELD_METADATA],
                 "limit": int(n_results),
                 "search_params": {"params": {}},
+                "consistency_level": self._config.consistency_level,
             }
             if filter_expr:
                 kwargs["filter"] = filter_expr
             raw = self._client.search(**kwargs)
-        except Exception:
-            logger.debug(
-                "Milvus native BM25 search failed; using local BM25 fallback", exc_info=True
-            )
-            return None
+        except Exception as exc:
+            raise BackendError("Milvus native BM25 search failed") from exc
         rows = [self._row_from_search_hit(hit) for hit in (raw[0] if raw else [])]
         return LexicalResult(
             hits=[
@@ -950,8 +919,10 @@ class MilvusBackend(BaseBackend):
             return _MilvusConfig(
                 uri=config.uri,
                 token=config.token,
+                db_name=config.db_name,
                 namespace=namespace,
                 db_filename=config.db_filename,
+                consistency_level=config.consistency_level,
             )
         if not palace.local_path:
             raise BackendError(
@@ -960,13 +931,16 @@ class MilvusBackend(BaseBackend):
         return _MilvusConfig(
             uri=os.path.join(palace.local_path, config.db_filename),
             token=config.token,
+            db_name=config.db_name,
             namespace=namespace,
             db_filename=config.db_filename,
+            consistency_level=config.consistency_level,
         )
 
     def _marker_target(self, palace: PalaceRef, config: _MilvusConfig) -> dict:
         return {
             "uri": config.uri,
+            "db_name": config.db_name,
             "namespace": config.namespace,
             "palace_hash": self._palace_hash(palace),
             "remote_prefix": self._remote_collection_prefix(palace=palace, config=config),
@@ -1024,7 +998,7 @@ class MilvusBackend(BaseBackend):
             raise BackendMismatchError(
                 "milvus marker target does not match current configuration "
                 f"({', '.join(mismatched)}); keep MEMPALACE_MILVUS_URI and "
-                "namespace consistent or use a fresh palace directory"
+                "Milvus database/namespace settings consistent or use a fresh palace directory"
             )
 
     def _write_marker(self, palace: PalaceRef, config: _MilvusConfig) -> None:
@@ -1081,6 +1055,8 @@ class MilvusBackend(BaseBackend):
             kwargs = {"uri": config.uri or DEFAULT_DB_FILENAME}
             if config.token:
                 kwargs["token"] = config.token
+            if config.db_name:
+                kwargs["db_name"] = config.db_name
             client = MilvusClient(**kwargs)
             self._clients[config] = client
             return client
@@ -1180,29 +1156,14 @@ class MilvusBackend(BaseBackend):
         collection_name: str,
         dimension: int,
         *,
-        enable_native_lexical: bool,
-    ) -> bool:
-        if enable_native_lexical:
-            try:
-                self._create_remote_collection_schema(
-                    client,
-                    collection_name,
-                    dimension,
-                    enable_native_lexical=True,
-                )
-                return True
-            except Exception:
-                logger.debug(
-                    "Milvus native BM25 schema creation failed; retrying dense-only schema",
-                    exc_info=True,
-                )
+        consistency_level: str,
+    ) -> None:
         self._create_remote_collection_schema(
             client,
             collection_name,
             dimension,
-            enable_native_lexical=False,
+            consistency_level=consistency_level,
         )
-        return False
 
     def _create_remote_collection_schema(
         self,
@@ -1210,7 +1171,7 @@ class MilvusBackend(BaseBackend):
         collection_name: str,
         dimension: int,
         *,
-        enable_native_lexical: bool,
+        consistency_level: str,
     ) -> None:
         from pymilvus import DataType
 
@@ -1225,8 +1186,8 @@ class MilvusBackend(BaseBackend):
             field_name=FIELD_DOCUMENT,
             datatype=DataType.VARCHAR,
             max_length=DOCUMENT_MAX_LENGTH,
-            enable_analyzer=enable_native_lexical,
-            enable_match=enable_native_lexical,
+            enable_analyzer=True,
+            enable_match=True,
         )
         schema.add_field(field_name=FIELD_METADATA, datatype=DataType.JSON)
         schema.add_field(
@@ -1234,35 +1195,34 @@ class MilvusBackend(BaseBackend):
             datatype=DataType.FLOAT_VECTOR,
             dim=int(dimension),
         )
-        if enable_native_lexical:
-            from pymilvus import Function, FunctionType
+        from pymilvus import Function, FunctionType
 
-            schema.add_field(field_name=FIELD_SPARSE, datatype=DataType.SPARSE_FLOAT_VECTOR)
-            schema.add_function(
-                Function(
-                    name="document_bm25",
-                    input_field_names=[FIELD_DOCUMENT],
-                    output_field_names=[FIELD_SPARSE],
-                    function_type=FunctionType.BM25,
-                )
+        schema.add_field(field_name=FIELD_SPARSE, datatype=DataType.SPARSE_FLOAT_VECTOR)
+        schema.add_function(
+            Function(
+                name="document_bm25",
+                input_field_names=[FIELD_DOCUMENT],
+                output_field_names=[FIELD_SPARSE],
+                function_type=FunctionType.BM25,
             )
+        )
         index_params = client.prepare_index_params()
         index_params.add_index(
             field_name=FIELD_VECTOR,
             index_type="AUTOINDEX",
             metric_type="COSINE",
         )
-        if enable_native_lexical:
-            index_params.add_index(
-                field_name=FIELD_SPARSE,
-                index_type="SPARSE_INVERTED_INDEX",
-                metric_type="BM25",
-                params={"inverted_index_algo": "DAAT_MAXSCORE"},
-            )
+        index_params.add_index(
+            field_name=FIELD_SPARSE,
+            index_type="SPARSE_INVERTED_INDEX",
+            metric_type="BM25",
+            params={"inverted_index_algo": "DAAT_MAXSCORE"},
+        )
         client.create_collection(
             collection_name=collection_name,
             schema=schema,
             index_params=index_params,
+            consistency_level=consistency_level,
         )
 
     def _load_remote_collection(self, client, collection_name: str) -> None:

--- a/mempalace/backends/milvus.py
+++ b/mempalace/backends/milvus.py
@@ -410,7 +410,7 @@ class MilvusCollection(BaseCollection):
                     self._client,
                     self._remote_collection,
                     dimension,
-                    enable_native_lexical=self._backend._enable_native_lexical(self._config),
+                    enable_native_lexical=True,
                 )
                 self._backend._load_remote_collection(self._client, self._remote_collection)
                 self._known_dimension = dimension
@@ -1085,10 +1085,6 @@ class MilvusBackend(BaseBackend):
             self._clients[config] = client
             return client
 
-    @staticmethod
-    def _enable_native_lexical(config: _MilvusConfig) -> bool:
-        return bool(config.uri and _is_server_uri(config.uri))
-
     def get_collection(self, *args, **kwargs) -> MilvusCollection:
         palace, collection_name, create, options = self._normalize_args(args, kwargs)
         config = self._effective_config(palace, options)
@@ -1230,6 +1226,7 @@ class MilvusBackend(BaseBackend):
             datatype=DataType.VARCHAR,
             max_length=DOCUMENT_MAX_LENGTH,
             enable_analyzer=enable_native_lexical,
+            enable_match=enable_native_lexical,
         )
         schema.add_field(field_name=FIELD_METADATA, datatype=DataType.JSON)
         schema.add_field(

--- a/mempalace/backends/registry.py
+++ b/mempalace/backends/registry.py
@@ -207,6 +207,7 @@ def resolve_backend_for_palace(
 def _register_builtins() -> None:
     """Register chroma as the in-tree default."""
     from .chroma import ChromaBackend
+    from .milvus import MilvusBackend
     from .pgvector import PgVectorBackend
     from .qdrant import QdrantBackend
     from .sqlite_exact import SQLiteExactBackend
@@ -214,6 +215,8 @@ def _register_builtins() -> None:
     # Use setdefault semantics so a caller that pre-registered for tests wins.
     if "chroma" not in _registry:
         _registry["chroma"] = ChromaBackend
+    if "milvus" not in _registry:
+        _registry["milvus"] = MilvusBackend
     if "qdrant" not in _registry:
         _registry["qdrant"] = QdrantBackend
     if "sqlite_exact" not in _registry:

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -212,9 +212,13 @@ _MILVUS_CONSISTENCY_LEVELS = {
 DEFAULT_MAX_BACKUPS = 10
 
 
-def _normalize_milvus_consistency_config(value) -> str:
+def normalize_milvus_consistency_level(value) -> str:
     raw = str(value).strip() if value else DEFAULT_MILVUS_CONSISTENCY_LEVEL
-    return _MILVUS_CONSISTENCY_LEVELS.get(raw.lower(), raw)
+    normalized = _MILVUS_CONSISTENCY_LEVELS.get(raw.lower())
+    if normalized:
+        return normalized
+    allowed = ", ".join(_MILVUS_CONSISTENCY_LEVELS.values())
+    raise ValueError(f"milvus_consistency_level must be one of: {allowed}")
 
 
 def sqlite_read_uri(db_path: str) -> str:
@@ -479,9 +483,9 @@ class MempalaceConfig:
         """Milvus read consistency level for the opt-in ``milvus`` backend."""
         env_val = os.environ.get("MEMPALACE_MILVUS_CONSISTENCY_LEVEL")
         if env_val:
-            return _normalize_milvus_consistency_config(env_val)
+            return normalize_milvus_consistency_level(env_val)
         value = self._file_config.get("milvus_consistency_level")
-        return _normalize_milvus_consistency_config(value)
+        return normalize_milvus_consistency_level(value)
 
     @property
     def pgvector_dsn(self):

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -422,6 +422,38 @@ class MempalaceConfig:
         return timeout if timeout > 0 else 10.0
 
     @property
+    def milvus_uri(self):
+        """Milvus endpoint for the opt-in ``milvus`` backend.
+
+        Defaults to ``None`` so selecting Milvus uses per-palace Milvus Lite at
+        ``<palace>/milvus.db``. Set this only to deliberately use a shared
+        Milvus server, Zilliz Cloud, or a custom local Lite file.
+        """
+        env_val = os.environ.get("MEMPALACE_MILVUS_URI")
+        if env_val:
+            return env_val.strip()
+        value = self._file_config.get("milvus_uri")
+        return str(value).strip() if value else None
+
+    @property
+    def milvus_token(self):
+        """Token for the opt-in ``milvus`` backend, if configured."""
+        env_val = os.environ.get("MEMPALACE_MILVUS_TOKEN")
+        if env_val:
+            return env_val
+        value = self._file_config.get("milvus_token")
+        return str(value) if value else None
+
+    @property
+    def milvus_namespace(self):
+        """Optional Milvus collection namespace/prefix."""
+        env_val = os.environ.get("MEMPALACE_MILVUS_NAMESPACE")
+        if env_val:
+            return env_val.strip()
+        value = self._file_config.get("milvus_namespace")
+        return str(value).strip() if value else None
+
+    @property
     def pgvector_dsn(self):
         """Postgres DSN for the opt-in ``pgvector`` backend.
 

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -197,12 +197,24 @@ def sanitize_content(value: str, max_length: int = 100_000) -> str:
 DEFAULT_PALACE_PATH = os.path.expanduser("~/.mempalace/palace")
 DEFAULT_COLLECTION_NAME = "mempalace_drawers"
 DEFAULT_BACKEND = "chroma"
+DEFAULT_MILVUS_CONSISTENCY_LEVEL = "Strong"
+_MILVUS_CONSISTENCY_LEVELS = {
+    "strong": "Strong",
+    "session": "Session",
+    "bounded": "Bounded",
+    "eventually": "Eventually",
+}
 
 # How many timestamped palace backups to retain before the oldest are
 # pruned. Applies to the accumulating backups written by ``mempalace
 # migrate`` and ``mempalace repair max-seq-id`` — see
 # ``MempalaceConfig.max_backups``.
 DEFAULT_MAX_BACKUPS = 10
+
+
+def _normalize_milvus_consistency_config(value) -> str:
+    raw = str(value).strip() if value else DEFAULT_MILVUS_CONSISTENCY_LEVEL
+    return _MILVUS_CONSISTENCY_LEVELS.get(raw.lower(), raw)
 
 
 def sqlite_read_uri(db_path: str) -> str:
@@ -445,6 +457,15 @@ class MempalaceConfig:
         return str(value) if value else None
 
     @property
+    def milvus_db_name(self):
+        """Optional Milvus database name for the opt-in ``milvus`` backend."""
+        env_val = os.environ.get("MEMPALACE_MILVUS_DB_NAME")
+        if env_val:
+            return env_val.strip()
+        value = self._file_config.get("milvus_db_name")
+        return str(value).strip() if value else None
+
+    @property
     def milvus_namespace(self):
         """Optional Milvus collection namespace/prefix."""
         env_val = os.environ.get("MEMPALACE_MILVUS_NAMESPACE")
@@ -452,6 +473,15 @@ class MempalaceConfig:
             return env_val.strip()
         value = self._file_config.get("milvus_namespace")
         return str(value).strip() if value else None
+
+    @property
+    def milvus_consistency_level(self):
+        """Milvus read consistency level for the opt-in ``milvus`` backend."""
+        env_val = os.environ.get("MEMPALACE_MILVUS_CONSISTENCY_LEVEL")
+        if env_val:
+            return _normalize_milvus_consistency_config(env_val)
+        value = self._file_config.get("milvus_consistency_level")
+        return _normalize_milvus_consistency_config(value)
 
     @property
     def pgvector_dsn(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ mempalace-mcp = "mempalace.mcp_server:main"
 
 [project.entry-points."mempalace.backends"]
 chroma = "mempalace.backends.chroma:ChromaBackend"
+milvus = "mempalace.backends.milvus:MilvusBackend"
 pgvector = "mempalace.backends.pgvector:PgVectorBackend"
 qdrant = "mempalace.backends.qdrant:QdrantBackend"
 sqlite_exact = "mempalace.backends.sqlite_exact:SQLiteExactBackend"
@@ -99,6 +100,13 @@ dev = [
     "mypy>=1.0",
 ]
 spellcheck = ["autocorrect>=2.0"]
+# Opt-in Milvus backend. Defaults to per-palace Milvus Lite
+# (`<palace>/milvus.db`); set MEMPALACE_MILVUS_URI and
+# MEMPALACE_MILVUS_TOKEN to point at Milvus server or Zilliz Cloud.
+milvus = [
+    "pymilvus>=3.0.0",
+    "milvus-lite>=3.0; python_version >= '3.10' and sys_platform != 'win32'",
+]
 # Opt-in Postgres + pgvector backend. Only the psycopg driver is needed on the
 # client; the server must have the `vector` extension available. Selected via
 # MEMPALACE_BACKEND=pgvector / --backend pgvector; never required for the

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,6 +70,27 @@ def test_qdrant_config_from_env_and_file(tmp_path, monkeypatch):
     assert cfg.qdrant_timeout == 3.5
 
 
+def test_milvus_config_from_env_and_file(tmp_path, monkeypatch):
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump(
+            {
+                "milvus_uri": "https://config.example",
+                "milvus_token": "config-token",
+                "milvus_namespace": "config-ns",
+            },
+            f,
+        )
+    monkeypatch.setenv("MEMPALACE_MILVUS_URI", "https://env.example")
+    monkeypatch.setenv("MEMPALACE_MILVUS_TOKEN", "env-token")
+    monkeypatch.setenv("MEMPALACE_MILVUS_NAMESPACE", "env-ns")
+
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+
+    assert cfg.milvus_uri == "https://env.example"
+    assert cfg.milvus_token == "env-token"
+    assert cfg.milvus_namespace == "env-ns"
+
+
 def test_set_backend_persists_choice(tmp_path):
     cfg = MempalaceConfig(config_dir=str(tmp_path))
     cfg.set_backend("sqlite_exact")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,6 +97,14 @@ def test_milvus_config_from_env_and_file(tmp_path, monkeypatch):
     assert cfg.milvus_consistency_level == "Eventually"
 
 
+def test_milvus_config_rejects_invalid_consistency_level(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMPALACE_MILVUS_CONSISTENCY_LEVEL", "linearizable")
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+
+    with pytest.raises(ValueError, match="milvus_consistency_level"):
+        cfg.milvus_consistency_level
+
+
 def test_set_backend_persists_choice(tmp_path):
     cfg = MempalaceConfig(config_dir=str(tmp_path))
     cfg.set_backend("sqlite_exact")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,19 +76,25 @@ def test_milvus_config_from_env_and_file(tmp_path, monkeypatch):
             {
                 "milvus_uri": "https://config.example",
                 "milvus_token": "config-token",
+                "milvus_db_name": "config-db",
                 "milvus_namespace": "config-ns",
+                "milvus_consistency_level": "bounded",
             },
             f,
         )
     monkeypatch.setenv("MEMPALACE_MILVUS_URI", "https://env.example")
     monkeypatch.setenv("MEMPALACE_MILVUS_TOKEN", "env-token")
+    monkeypatch.setenv("MEMPALACE_MILVUS_DB_NAME", "env-db")
     monkeypatch.setenv("MEMPALACE_MILVUS_NAMESPACE", "env-ns")
+    monkeypatch.setenv("MEMPALACE_MILVUS_CONSISTENCY_LEVEL", "eventually")
 
     cfg = MempalaceConfig(config_dir=str(tmp_path))
 
     assert cfg.milvus_uri == "https://env.example"
     assert cfg.milvus_token == "env-token"
+    assert cfg.milvus_db_name == "env-db"
     assert cfg.milvus_namespace == "env-ns"
+    assert cfg.milvus_consistency_level == "Eventually"
 
 
 def test_set_backend_persists_choice(tmp_path):

--- a/tests/test_milvus_backend.py
+++ b/tests/test_milvus_backend.py
@@ -15,7 +15,12 @@ from mempalace.backends import (
     UnsupportedFilterError,
     available_backends,
 )
-from mempalace.backends.milvus import MilvusBackend, translate_where, translate_where_document
+from mempalace.backends.milvus import (
+    DOCUMENT_MAX_LENGTH,
+    MilvusBackend,
+    translate_where,
+    translate_where_document,
+)
 
 
 def _require_milvus_lite():
@@ -129,8 +134,9 @@ def test_milvus_lite_upsert_update_delete_get_order_and_multi_collection(tmp_pat
         assert got.ids == ["two", "one", "two"]
         assert got.documents == ["second document", "first document", "second document"]
 
-        drawers.update(ids=["one"], metadatas=[{"room": "updated"}])
+        drawers.update(ids=["one", "missing"], metadatas=[{"room": "updated"}, {"room": "skip"}])
         assert drawers.get(ids=["one"]).metadatas == [{"wing": "a", "room": "updated"}]
+        assert drawers.get(ids=["missing"]).ids == []
 
         drawers.delete(where={"wing": "b"})
         assert drawers.get().ids == ["one"]
@@ -192,10 +198,46 @@ def test_milvus_lite_dimension_and_validation_errors(tmp_path):
             col.add(ids=["reserved"], documents=["x"], metadatas=[{"id": "x"}], embeddings=[[1, 0]])
         with pytest.raises(ValueError, match="delete requires"):
             col.delete()
-        with pytest.raises(KeyError):
-            col.update(ids=["missing"], metadatas=[{"wing": "x"}])
+        with pytest.raises(ValueError, match="document byte length"):
+            col.add(
+                ids=["long"], documents=["你" * (DOCUMENT_MAX_LENGTH // 3 + 1)], embeddings=[[1, 0]]
+            )
     finally:
         backend.close()
+
+
+def test_milvus_writes_marker_when_upserting_existing_remote_collection(tmp_path):
+    _require_milvus_lite()
+    shared_uri = str(tmp_path / "shared.db")
+
+    backend_a = MilvusBackend()
+    palace_a = PalaceRef(id="palace-a", local_path=str(tmp_path / "palace-a"))
+    col_a = backend_a.get_collection(
+        palace=palace_a,
+        collection_name="drawers",
+        create=True,
+        options={"uri": shared_uri},
+    )
+    try:
+        col_a.upsert(ids=["a"], documents=["first"], embeddings=[[1, 0]])
+    finally:
+        backend_a.close()
+
+    backend_b = MilvusBackend()
+    palace_b = PalaceRef(id="palace-b", local_path=str(tmp_path / "palace-b"))
+    marker_b = os.path.join(palace_b.local_path, "milvus_backend.json")
+    col_b = backend_b.get_collection(
+        palace=palace_b,
+        collection_name="drawers",
+        create=True,
+        options={"uri": shared_uri},
+    )
+    try:
+        assert not os.path.exists(marker_b)
+        col_b.upsert(ids=["b"], documents=["second"], embeddings=[[0, 1]])
+        assert os.path.isfile(marker_b)
+    finally:
+        backend_b.close()
 
 
 def test_milvus_marker_rejects_remote_target_change(tmp_path, monkeypatch):
@@ -305,6 +347,14 @@ def test_milvus_zilliz_cloud_roundtrip_when_enabled(tmp_path):
             where={"wing": "live"},
         )
         assert result.ids == [["cloud-a"]]
+
+        ranked = col.query(
+            query_embeddings=[[1.0, 0.0]],
+            n_results=2,
+            include=["distances"],
+        )
+        assert ranked.ids == [["cloud-a", "cloud-b"]]
+        assert ranked.distances[0] == pytest.approx([0.0, 1.0])
 
         hits = col.lexical_search(query="rareterm", n_results=1).hits
         assert hits and hits[0].id == "cloud-a"

--- a/tests/test_milvus_backend.py
+++ b/tests/test_milvus_backend.py
@@ -1,0 +1,277 @@
+import os
+import sys
+import uuid
+
+import pytest
+
+from _backend_conformance import assert_partition_isolation
+
+from mempalace.backends import (
+    BackendMismatchError,
+    DimensionMismatchError,
+    PalaceRef,
+    UnsupportedFilterError,
+    available_backends,
+)
+from mempalace.backends.milvus import MilvusBackend, translate_where, translate_where_document
+
+
+def _require_milvus_lite():
+    pytest.importorskip("pymilvus")
+    if sys.platform == "win32":
+        pytest.skip("milvus-lite is not distributed on Windows")
+    pytest.importorskip("milvus_lite")
+
+
+def _new_lite_collection(tmp_path, name="drawers", namespace=None):
+    _require_milvus_lite()
+    backend = MilvusBackend()
+    palace_path = tmp_path / (namespace or "palace")
+    palace = PalaceRef(
+        id=str(palace_path),
+        local_path=str(palace_path),
+        namespace=namespace,
+    )
+    collection = backend.get_collection(palace=palace, collection_name=name, create=True)
+    return backend, palace, collection
+
+
+def test_registry_exposes_milvus():
+    assert "milvus" in available_backends()
+
+
+def test_translate_where_supports_portable_filter_subset():
+    assert translate_where(None) == ""
+    assert translate_where({"wing": "project"}) == 'wing == "project"'
+    assert translate_where({"rank": {"$gte": 2}}) == "rank >= 2"
+    assert translate_where({"wing": {"$in": ["a", "b"]}}) == 'wing in ["a", "b"]'
+    assert (
+        translate_where({"$and": [{"wing": "p"}, {"room": "r"}]}) == '(wing == "p" and room == "r")'
+    )
+    assert (
+        translate_where({"$or": [{"wing": "p"}, {"wing": "q"}]}) == '(wing == "p" or wing == "q")'
+    )
+    assert translate_where({"wing": "p", "room": "r"}) == 'wing == "p" and room == "r"'
+    assert translate_where_document({"$contains": "needle"}) == 'document like "%needle%"'
+
+
+def test_translate_where_rejects_unsafe_fields_and_operators():
+    with pytest.raises(UnsupportedFilterError):
+        translate_where({"bad field": "x"})
+    with pytest.raises(UnsupportedFilterError):
+        translate_where({"rank": {"$regex": "x"}})
+    with pytest.raises(UnsupportedFilterError):
+        translate_where({"$nor": [{"wing": "x"}]})
+
+
+def test_milvus_lite_add_query_filter_lexical_and_marker(tmp_path):
+    backend, palace, col = _new_lite_collection(tmp_path)
+    try:
+        col.add(
+            ids=["a", "b", "c"],
+            documents=[
+                "alpha backend note",
+                "rareterm milvus backend note",
+                "frontend design note",
+            ],
+            metadatas=[
+                {"wing": "project", "room": "backend", "rank": 1},
+                {"wing": "project", "room": "backend", "rank": 3},
+                {"wing": "project", "room": "frontend", "rank": 2},
+            ],
+            embeddings=[[1, 0], [0.9, 0.1], [0, 1]],
+        )
+
+        assert MilvusBackend.detect(palace.local_path)
+        assert os.path.isfile(os.path.join(palace.local_path, "milvus_backend.json"))
+        assert os.path.exists(os.path.join(palace.local_path, "milvus.db"))
+        assert col.count() == 3
+
+        result = col.query(
+            query_embeddings=[[1, 0]],
+            n_results=3,
+            where={"rank": {"$gte": 2}},
+            include=["documents", "metadatas", "distances", "embeddings"],
+        )
+        assert result.ids == [["b", "c"]]
+        assert result.documents[0][0] == "rareterm milvus backend note"
+        assert result.metadatas[0][0]["rank"] == 3
+        assert result.embeddings[0][0] == pytest.approx([0.9, 0.1])
+        assert result.distances[0] == sorted(result.distances[0])
+
+        hits = col.lexical_search(query="rareterm backend", n_results=2).hits
+        assert [hit.id for hit in hits] == ["b", "a"]
+    finally:
+        backend.close()
+
+
+def test_milvus_lite_upsert_update_delete_get_order_and_multi_collection(tmp_path):
+    backend, palace, drawers = _new_lite_collection(tmp_path, "drawers")
+    closets = backend.get_collection(palace=palace, collection_name="closets", create=True)
+    try:
+        drawers.upsert(
+            ids=["one", "two"],
+            documents=["first document", "second document"],
+            metadatas=[{"wing": "a"}, {"wing": "b"}],
+            embeddings=[[1, 0], [0, 1]],
+        )
+        closets.upsert(
+            ids=["one"],
+            documents=["closet document"],
+            metadatas=[{"wing": "closet"}],
+            embeddings=[[0.5, 0.5]],
+        )
+
+        got = drawers.get(ids=["two", "one", "two"], include=["documents", "metadatas"])
+        assert got.ids == ["two", "one", "two"]
+        assert got.documents == ["second document", "first document", "second document"]
+
+        drawers.update(ids=["one"], metadatas=[{"room": "updated"}])
+        assert drawers.get(ids=["one"]).metadatas == [{"wing": "a", "room": "updated"}]
+
+        drawers.delete(where={"wing": "b"})
+        assert drawers.get().ids == ["one"]
+        assert closets.get().ids == ["one"]
+    finally:
+        backend.close()
+
+
+def test_milvus_lite_dimension_and_validation_errors(tmp_path):
+    backend, _palace, col = _new_lite_collection(tmp_path)
+    try:
+        col.upsert(ids=["a"], documents=["one"], metadatas=[{}], embeddings=[[1, 0]])
+
+        with pytest.raises(DimensionMismatchError):
+            col.upsert(ids=["b"], documents=["two"], metadatas=[{}], embeddings=[[1, 0, 0]])
+        with pytest.raises(ValueError, match="unique"):
+            col.add(ids=["dup", "dup"], documents=["a", "b"], embeddings=[[1, 0], [0, 1]])
+        with pytest.raises(ValueError, match="reserved"):
+            col.add(ids=["reserved"], documents=["x"], metadatas=[{"id": "x"}], embeddings=[[1, 0]])
+        with pytest.raises(ValueError, match="delete requires"):
+            col.delete()
+        with pytest.raises(KeyError):
+            col.update(ids=["missing"], metadatas=[{"wing": "x"}])
+    finally:
+        backend.close()
+
+
+def test_milvus_marker_rejects_remote_target_change(tmp_path, monkeypatch):
+    backend, palace, col = _new_lite_collection(tmp_path)
+    try:
+        col.upsert(ids=["a"], documents=["one"], metadatas=[{}], embeddings=[[1, 0]])
+        backend.close()
+
+        monkeypatch.setenv("MEMPALACE_MILVUS_URI", str(tmp_path / "other.db"))
+        with pytest.raises(BackendMismatchError, match="target"):
+            MilvusBackend().get_collection(palace=palace, collection_name="drawers", create=False)
+    finally:
+        backend.close()
+
+
+def test_palace_wrapper_embeds_for_milvus(tmp_path, monkeypatch):
+    _require_milvus_lite()
+    import mempalace.backends.embedding_wrapper as embedding_wrapper
+    from mempalace import palace
+    from mempalace.backends import reset_backends
+
+    monkeypatch.setattr(
+        embedding_wrapper,
+        "_embed_texts",
+        lambda texts: [[1.0, 0.0] for _ in texts],
+    )
+    monkeypatch.setenv("MEMPALACE_BACKEND_EXPLICIT", "milvus")
+    monkeypatch.setenv("MEMPALACE_BACKEND", "milvus")
+    reset_backends()
+    try:
+        col = palace.get_collection(str(tmp_path / "wrapped"), "drawers", create=True)
+        col.add(documents=["wrapped milvus document"], ids=["wrapped"], metadatas=[{"wing": "w"}])
+        result = col.query(query_texts=["wrapped"], n_results=1)
+        assert result.ids == [["wrapped"]]
+    finally:
+        reset_backends()
+
+
+def test_milvus_cross_palace_isolation_conformance(tmp_path):
+    _require_milvus_lite()
+    backend = MilvusBackend()
+    cols = []
+    try:
+        for label in ("alpha", "beta"):
+            path = tmp_path / label
+            ref = PalaceRef(id=str(path), local_path=str(path))
+            cols.append(backend.get_collection(palace=ref, collection_name="drawers", create=True))
+        assert_partition_isolation(backend, cols[0], cols[1], embedding=[1.0, 0.0, 0.0, 0.0])
+    finally:
+        backend.close()
+
+
+def test_milvus_namespace_isolation_conformance(tmp_path):
+    _require_milvus_lite()
+    assert "supports_namespace_isolation" in MilvusBackend.capabilities
+    backend = MilvusBackend()
+    try:
+        ref_a = PalaceRef(
+            id=str(tmp_path / "tenant-a"),
+            local_path=str(tmp_path / "tenant-a"),
+            namespace="tenant-a",
+        )
+        ref_b = PalaceRef(
+            id=str(tmp_path / "tenant-b"),
+            local_path=str(tmp_path / "tenant-b"),
+            namespace="tenant-b",
+        )
+        col_a = backend.get_collection(palace=ref_a, collection_name="drawers", create=True)
+        col_b = backend.get_collection(palace=ref_b, collection_name="drawers", create=True)
+        assert col_a._remote_collection != col_b._remote_collection
+        assert_partition_isolation(backend, col_a, col_b, embedding=[1.0, 0.0, 0.0, 0.0])
+    finally:
+        backend.close()
+
+
+def test_milvus_zilliz_cloud_roundtrip_when_enabled(tmp_path):
+    pytest.importorskip("pymilvus")
+    uri = os.environ.get("MEMPALACE_MILVUS_URI")
+    token = os.environ.get("MEMPALACE_MILVUS_TOKEN")
+    if not uri or not token:
+        pytest.skip(
+            "set MEMPALACE_MILVUS_URI and MEMPALACE_MILVUS_TOKEN "
+            "to run live Milvus/Zilliz Cloud test"
+        )
+
+    backend = MilvusBackend()
+    namespace = f"live_{uuid.uuid4().hex}"
+    palace = PalaceRef(id=str(tmp_path), local_path=str(tmp_path), namespace=namespace)
+    col = backend.get_collection(
+        palace=palace,
+        collection_name="drawers",
+        create=True,
+        options={"uri": uri, "token": token, "namespace": namespace},
+    )
+    try:
+        col.upsert(
+            ids=["cloud-a", "cloud-b"],
+            documents=["rareterm live milvus backend", "other live document"],
+            metadatas=[{"wing": "live", "rank": 2}, {"wing": "other", "rank": 1}],
+            embeddings=[[1.0, 0.0], [0.0, 1.0]],
+        )
+        assert col.count() == 2
+
+        result = col.query(
+            query_embeddings=[[1.0, 0.0]],
+            n_results=2,
+            where={"wing": "live"},
+        )
+        assert result.ids == [["cloud-a"]]
+
+        hits = col.lexical_search(query="rareterm", n_results=1).hits
+        assert hits and hits[0].id == "cloud-a"
+
+        col.delete(ids=["cloud-a"])
+        assert col.get(ids=["cloud-a"]).ids == []
+    finally:
+        try:
+            if col._client.has_collection(col._remote_collection):
+                col._client.drop_collection(col._remote_collection)
+        except Exception:
+            pass
+        backend.close()

--- a/tests/test_milvus_backend.py
+++ b/tests/test_milvus_backend.py
@@ -115,7 +115,7 @@ def test_milvus_lite_upsert_update_delete_get_order_and_multi_collection(tmp_pat
             metadatas=[{"wing": "a"}, {"wing": "b"}],
             embeddings=[[1, 0], [0, 1]],
         )
-        closets.upsert(
+        closets.add(
             ids=["one"],
             documents=["closet document"],
             metadatas=[{"wing": "closet"}],

--- a/tests/test_milvus_backend.py
+++ b/tests/test_milvus_backend.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import uuid
@@ -7,6 +8,7 @@ import pytest
 from _backend_conformance import assert_partition_isolation
 
 from mempalace.backends import (
+    BackendError,
     BackendMismatchError,
     DimensionMismatchError,
     PalaceRef,
@@ -133,6 +135,46 @@ def test_milvus_lite_upsert_update_delete_get_order_and_multi_collection(tmp_pat
         drawers.delete(where={"wing": "b"})
         assert drawers.get().ids == ["one"]
         assert closets.get().ids == ["one"]
+    finally:
+        backend.close()
+
+
+def test_milvus_lite_db_name_and_consistency_options(tmp_path):
+    _require_milvus_lite()
+    backend = MilvusBackend()
+    palace = PalaceRef(id=str(tmp_path / "palace"), local_path=str(tmp_path / "palace"))
+    col = backend.get_collection(
+        palace=palace,
+        collection_name="drawers",
+        create=True,
+        options={"db_name": "mempalace_test", "consistency_level": "eventually"},
+    )
+    try:
+        assert col._config.db_name == "mempalace_test"
+        assert col._config.consistency_level == "Eventually"
+
+        col.upsert(ids=["a"], documents=["native bm25 document"], embeddings=[[1, 0]])
+
+        with open(os.path.join(palace.local_path, "milvus_backend.json"), encoding="utf-8") as f:
+            marker = json.load(f)
+        assert marker["milvus"]["db_name"] == "mempalace_test"
+        assert col.lexical_search(query="native", n_results=1).hits[0].id == "a"
+    finally:
+        backend.close()
+
+
+def test_milvus_rejects_invalid_consistency_level(tmp_path):
+    _require_milvus_lite()
+    backend = MilvusBackend()
+    palace = PalaceRef(id=str(tmp_path / "palace"), local_path=str(tmp_path / "palace"))
+    try:
+        with pytest.raises(BackendError, match="consistency_level"):
+            backend.get_collection(
+                palace=palace,
+                collection_name="drawers",
+                create=True,
+                options={"consistency_level": "linearizable"},
+            )
     finally:
         backend.close()
 

--- a/tests/test_milvus_backend.py
+++ b/tests/test_milvus_backend.py
@@ -85,6 +85,7 @@ def test_milvus_lite_add_query_filter_lexical_and_marker(tmp_path):
         assert MilvusBackend.detect(palace.local_path)
         assert os.path.isfile(os.path.join(palace.local_path, "milvus_backend.json"))
         assert os.path.exists(os.path.join(palace.local_path, "milvus.db"))
+        assert col._has_native_lexical()
         assert col.count() == 3
 
         result = col.query(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -2105,7 +2105,7 @@ requires-dist = [
     { name = "pytest-rerunfailures", marker = "extra == 'dev'", specifier = ">=12.0" },
     { name = "python-dateutil", specifier = ">=2.8" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.18" },
     { name = "striprtf", marker = "extra == 'extract'", specifier = ">=0.0.27" },
     { name = "tokenizers", specifier = ">=0.15" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
@@ -2121,7 +2121,7 @@ dev = [
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-cov", specifier = ">=4.0" },
     { name = "pytest-rerunfailures", specifier = ">=12.0" },
-    { name = "ruff", specifier = "==0.15.20" },
+    { name = "ruff", specifier = "==0.15.18" },
 ]
 
 [[package]]
@@ -3382,14 +3382,12 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
     "python_full_version == '3.10.*' and sys_platform != 'win32'",
-    "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version == '3.10.*'" },
+    { name = "pytz", marker = "python_full_version == '3.10.*'" },
+    { name = "tzdata", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -5219,27 +5217,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.20"
+version = "0.15.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
-    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
-    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
-    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
-    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
-    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
-    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
-    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -232,6 +232,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6c/1d/ab15c8ac57f4ee8778d7633bc6685f808ab414437b8644f555389cdc875e/build-1.4.2.tar.gz", hash = "sha256:35b14e1ee329c186d3f08466003521ed7685ec15ecffc07e68d706090bf161d1", size = 83433, upload-time = "2026-03-25T14:20:27.659Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/57/3b7d4dd193ade4641c865bc2b93aeeb71162e81fc348b8dad020215601ed/build-1.4.2-py3-none-any.whl", hash = "sha256:7a4d8651ea877cb2a89458b1b198f2e69f536c95e89129dbf5d448045d60db88", size = 24643, upload-time = "2026-03-25T14:20:26.568Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "6.2.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363, upload-time = "2026-01-27T20:32:59.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668, upload-time = "2026-01-27T20:32:58.527Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform == 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
 ]
 
 [[package]]
@@ -974,6 +1009,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "faiss-cpu"
+version = "1.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' and sys_platform != 'win32'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'win32'" },
+    { name = "packaging", marker = "python_full_version >= '3.10' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/34/6b04ef5bae3eada6b5a9457d7875cce041c040d53c890815cbd1e9821c65/faiss_cpu-1.14.3-cp310-abi3-macosx_15_0_x86_64.whl", hash = "sha256:f9d0e84d909194f63f027bbd3c1e35e905e48c9345c2db6e6f24da09a6bc5906", size = 6925734, upload-time = "2026-06-13T02:19:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/b451af4b3c6dd18749ecfb58ccb68503b77e49c9aa4a89d950e9d521e058/faiss_cpu-1.14.3-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d734cfa9ac90b6a5dfed3a27cb706d05f22824703dafc3969b4e2071877a31c", size = 9661210, upload-time = "2026-06-13T02:19:06.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ed/57335bc18c9e18677587bec9bf070c675b29c8e683e13f4def0440731ca0/faiss_cpu-1.14.3-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8780b526c06e57aad90a8c4655dfba2ff1b3195bd600ff4499752fc45159c9fc", size = 18506292, upload-time = "2026-06-13T02:19:09.621Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d3/c6ca8c44a63b909e78aa8a69e14501c79c89613e62261d58455ea603d710/faiss_cpu-1.14.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b28ba083e8c02f2c9be03783402537fd3f00d27e68799c44bf88931500ee12ec", size = 11238800, upload-time = "2026-06-13T02:19:12.821Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5f/b405692913a301251749cb175cb3f564ed257fdaa80a22c9a36444d0095d/faiss_cpu-1.14.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cdcb90850cb4b7c27d270839b37bcc0dc8d1fb6a62d1e13053e51ac95061ca25", size = 19237637, upload-time = "2026-06-13T02:19:15.531Z" },
 ]
 
 [[package]]
@@ -2001,6 +2054,10 @@ gpu = [
     { name = "onnxruntime-gpu", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "onnxruntime-gpu", version = "1.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
+milvus = [
+    { name = "milvus-lite", marker = "python_full_version >= '3.10' and sys_platform != 'win32'" },
+    { name = "pymilvus" },
+]
 pgvector = [
     { name = "psycopg", version = "3.2.13", source = { registry = "https://pypi.org/simple" }, extra = ["binary"], marker = "python_full_version < '3.10'" },
     { name = "psycopg", version = "3.3.4", source = { registry = "https://pypi.org/simple" }, extra = ["binary"], marker = "python_full_version >= '3.10'" },
@@ -2033,6 +2090,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=0.20" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "markitdown", extras = ["docx", "pdf", "pptx", "xlsx"], marker = "python_full_version >= '3.10' and extra == 'extract'", specifier = ">=0.1.5" },
+    { name = "milvus-lite", marker = "python_full_version >= '3.10' and sys_platform != 'win32' and extra == 'milvus'", specifier = ">=3.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "onnxruntime", marker = "extra == 'coreml'", specifier = ">=1.16" },
@@ -2041,17 +2099,18 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "psutil", marker = "extra == 'dev'", specifier = ">=5.9" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'pgvector'", specifier = ">=3.1" },
+    { name = "pymilvus", marker = "extra == 'milvus'", specifier = ">=3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest-rerunfailures", marker = "extra == 'dev'", specifier = ">=12.0" },
     { name = "python-dateutil", specifier = ">=2.8" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.18" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
     { name = "striprtf", marker = "extra == 'extract'", specifier = ">=0.0.27" },
     { name = "tokenizers", specifier = ">=0.15" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["dev", "spellcheck", "pgvector", "gpu", "dml", "coreml", "multilingual", "extract"]
+provides-extras = ["dev", "spellcheck", "milvus", "pgvector", "gpu", "dml", "coreml", "multilingual", "extract"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2062,7 +2121,24 @@ dev = [
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-cov", specifier = ">=4.0" },
     { name = "pytest-rerunfailures", specifier = ">=12.0" },
-    { name = "ruff", specifier = "==0.15.18" },
+    { name = "ruff", specifier = "==0.15.20" },
+]
+
+[[package]]
+name = "milvus-lite"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "faiss-cpu", marker = "python_full_version >= '3.10' and sys_platform != 'win32'" },
+    { name = "grpcio", marker = "python_full_version >= '3.10' and sys_platform != 'win32'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' and sys_platform != 'win32'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "python_full_version >= '3.10' and sys_platform != 'win32'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/9a/d80d260e6fe1246818a8ef782c374ba9c6ca46ca3b987c14eabe914ef805/milvus_lite-3.0.tar.gz", hash = "sha256:2c35d0d046b1faae3402cde1fb73d65f51ee8c6aba65f54de1dda46f7bb18b9b", size = 589749, upload-time = "2026-05-13T07:14:05.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/42/dee08ae3bfc1731572f193d00b248c9370b0b9dff12becb0ffd8b2ee8d56/milvus_lite-3.0-py3-none-any.whl", hash = "sha256:d9a094eab84bdaa4253da3721482282c939da1cce6f4e1759f947e8d3e53406e", size = 230490, upload-time = "2026-05-13T07:14:00.816Z" },
 ]
 
 [[package]]
@@ -3306,12 +3382,14 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
     "python_full_version == '3.10.*' and sys_platform != 'win32'",
+    "python_full_version < '3.10'",
 ]
 dependencies = [
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "python-dateutil", marker = "python_full_version == '3.10.*'" },
-    { name = "pytz", marker = "python_full_version == '3.10.*'" },
-    { name = "tzdata", marker = "python_full_version == '3.10.*'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -3909,6 +3987,56 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/bf/a34fee1d624152124fa8355c42f34195ad5fe5233ce5bb87946432047d52/pyarrow-24.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:7c2b98645d576a0b9616892ead22b64a83a5f043c5e2ca15ebcefcb5b70c80cb", size = 35076681, upload-time = "2026-04-21T08:51:46.845Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/41/64180033d7027afce12dc96d0fe1f504c6fa112190582b458acea2399530/pyarrow-24.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:644a246325b8c69c595ad1dd4b463eba4b0cdb731370e4a86137d433208d6147", size = 36684260, upload-time = "2026-04-21T08:51:53.642Z" },
+    { url = "https://files.pythonhosted.org/packages/57/02/9b9320e673dd8a99411fac78690f3df92f6dd6f59754c750110bca66d64e/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:3a577bd840ca83f646f0a625dbc571dba7044c43c2d1503afc378b570954345c", size = 45698566, upload-time = "2026-04-21T10:46:02.133Z" },
+    { url = "https://files.pythonhosted.org/packages/67/33/f75e91b9a64c3f33c787e263c93b871ad91b8a4a68c1d5cebddd9840e835/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e3268e43984d0b1a185c89b4cfff282a7ead12fc93f56cfd7088bdbcbe727041", size = 48835562, upload-time = "2026-04-21T10:46:10.278Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/63/097510448e47e4091faa41c43ba92f97cecaab8f4535b56a3d149578f634/pyarrow-24.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2392d954fcb920f42d230284b677605e4e2fbb11f2821e823e642abd67fbb491", size = 49394997, upload-time = "2026-04-21T10:46:18.08Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6b/c047d6222ab279024a062742d1807e2fbaf27bba88a98637299ff47b9236/pyarrow-24.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bec9373df11544592b0ba7ec2af0e35059e5f0e7647c6183a854dedd193298f1", size = 51911424, upload-time = "2026-04-21T10:46:25.347Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+]
+
+[[package]]
 name = "pybase64"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4313,6 +4441,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymilvus"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools", version = "6.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cachetools", version = "7.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "grpcio" },
+    { name = "orjson", version = "3.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "orjson", version = "3.11.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "protobuf" },
+    { name = "python-dotenv", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "python-dotenv", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "requests", version = "2.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/c1/01647e61f3a82fd881382746b6dde3401d65b88cd4f75bd059901fb2392b/pymilvus-3.0.0-1-py3-none-any.whl", hash = "sha256:57c8e7c87fbbf579f122b4df893949bc78e50bca2988527864891bd544817b05", size = 344817, upload-time = "2026-05-07T14:57:45.235Z" },
 ]
 
 [[package]]
@@ -5068,27 +5219,36 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.18"
+version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
-    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
-    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
-    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
-    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
-    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
-    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -28,13 +28,13 @@ pluggable backend contract, exercised across deliberately different substrates
 store) so the contract is never accidentally shaped around one vendor. Every
 non-default backend is opt-in.
 
-| Backend | Mode | Install | Namespaces | Lexical |
-| ------- | ---- | ------- | :--------: | :-----: |
-| `chroma` _(default)_ | Local (embedded) | bundled | – | ✓ |
-| `sqlite_exact` | Local (exact) | bundled | – | ✓ |
-| `milvus` | Local (Lite) · Server opt-in | `mempalace[milvus]` | ✓ | ✓ |
-| `qdrant` | Server (REST) | bundled | ✓ | ✓ |
-| `pgvector` | Server (Postgres) | `mempalace[pgvector]` | ✓ | ✓ |
+| Backend | Mode | Install | Namespaces | Lexical | Configure with |
+| ------- | ---- | ------- | :--------: | :-----: | -------------- |
+| `chroma` _(default)_ | Local (embedded) | bundled | – | ✓ | – |
+| `sqlite_exact` | Local (exact) | bundled | – | ✓ | – |
+| `milvus` | Local (Lite) · Server opt-in | `mempalace[milvus]` | ✓ | ✓ | `MEMPALACE_MILVUS_URI` |
+| `qdrant` | Server (REST) | bundled | ✓ | ✓ | `MEMPALACE_QDRANT_URL` |
+| `pgvector` | Server (Postgres) | `mempalace[pgvector]` | ✓ | ✓ | `MEMPALACE_PGVECTOR_DSN` |
 <!-- New backends add one row here and one `### <Backend>` subsection (with its connection variables) below; keep README's compatibility table in sync. -->
 
 Select a backend with `--backend <name>` on any `mempalace` / `mempalace-mcp`

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -32,6 +32,7 @@ non-default backend is opt-in.
 | ------- | ---- | ------- | :--------: | :-----: |
 | `chroma` _(default)_ | Local (embedded) | bundled | – | ✓ |
 | `sqlite_exact` | Local (exact) | bundled | – | ✓ |
+| `milvus` | Local (Lite) · Server opt-in | `mempalace[milvus]` | ✓ | ✓ |
 | `qdrant` | Server (REST) | bundled | ✓ | ✓ |
 | `pgvector` | Server (Postgres) | `mempalace[pgvector]` | ✓ | ✓ |
 <!-- New backends add one row here and one `### <Backend>` subsection (with its connection variables) below; keep README's compatibility table in sync. -->
@@ -61,6 +62,21 @@ The default. Local, embedded, no service to run. Drawers are stored at
 Local and built-in (no extra to install). Runs exact cosine over every row — no
 ANN index — so it is the reference for exact-vector correctness checks and small
 palaces. Select with `--backend sqlite_exact`; it has no connection settings.
+
+### Milvus
+
+A Milvus backend using `pymilvus`. Install the optional driver with
+`pip install mempalace[milvus]`. When `MEMPALACE_MILVUS_URI` is unset,
+MemPalace uses per-palace Milvus Lite at `<palace>/milvus.db`; set a server or
+Zilliz Cloud URI to use a shared Milvus deployment.
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `MEMPALACE_MILVUS_URI` | per-palace Milvus Lite | Milvus server / Zilliz Cloud URI |
+| `MEMPALACE_MILVUS_TOKEN` | _(none)_ | Token for Milvus server / Zilliz Cloud |
+| `MEMPALACE_MILVUS_DB_NAME` | _(none)_ | Optional Milvus database name |
+| `MEMPALACE_MILVUS_NAMESPACE` | _(none)_ | Collection namespace prefix (tenant isolation) |
+| `MEMPALACE_MILVUS_CONSISTENCY_LEVEL` | `Strong` | Milvus consistency level (`Strong`, `Session`, `Bounded`, `Eventually`) |
 
 ### Qdrant
 

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -15,8 +15,8 @@ Located at `~/.mempalace/config.json`:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `palace_path` | `~/.mempalace/palace` | Where ChromaDB stores your drawers |
-| `collection_name` | `mempalace_drawers` | ChromaDB collection name |
+| `palace_path` | `~/.mempalace/palace` | Where the default local palace stores your drawers |
+| `collection_name` | `mempalace_drawers` | Default backend collection name |
 | `people_map` | `{}` | Entity name → AAAK code mappings |
 | `max_backups` | `10` | How many timestamped palace backups to keep before the oldest are pruned. Applies to `mempalace migrate` (`<palace>.pre-migrate.*`) and `mempalace repair max-seq-id` (`chroma.sqlite3.max-seq-id-backup-*`), which each write a full copy every run. Set to `0` to keep every backup (e.g. when an external retention policy manages cleanup). |
 

--- a/website/guide/remote-server.md
+++ b/website/guide/remote-server.md
@@ -8,19 +8,20 @@ memory instead of a palace on each laptop.
 This is built from three pieces that already ship in MemPalace:
 
 - the **HTTP transport** for the MCP server (`mempalace-mcp --transport http`),
-- a **networked storage backend** ([Qdrant](https://qdrant.tech/) or
-  [Postgres + pgvector](/guide/configuration)),
+- a **networked storage backend** ([Milvus / Zilliz Cloud](https://milvus.io/),
+  [Qdrant](https://qdrant.tech/), or [Postgres + pgvector](/guide/configuration)),
 - optional **GPU embedding** on the server.
 
 ::: warning This is a deliberate step away from single-machine local-first
 By default MemPalace keeps everything on your own machine. A central server is
-still **your** infrastructure — no third-party API, no telemetry, nothing
-phones home — but your verbatim memory now lives on a server you operate and
-travels over your network. Run every component (Qdrant, the MCP host) on
-hardware you control, put it on a private network or VPN, and treat the
-bearer token and TLS setup below as mandatory, not optional. Embeddings are
-still produced locally on the server by MemPalace; only your own storage
-backend ever receives the vectors and text.
+still **your** infrastructure — no telemetry, nothing phones home — but your
+verbatim memory now lives on a server you operate and travels over your
+network. If you choose a managed backend such as Zilliz Cloud, that backend
+also receives the vectors and text by design. Run every self-hosted component
+(Milvus, Qdrant, Postgres, the MCP host) on hardware you control, put it on a
+private network or VPN, and treat the bearer token and TLS setup below as
+mandatory, not optional. Embeddings are still produced locally on the server by
+MemPalace.
 :::
 
 ## Architecture
@@ -32,14 +33,32 @@ backend ever receives the vectors and text.
                                       └─────────────┬───────────────
                                                     │ vectors + verbatim text
                                                     ▼
-                                              Qdrant / pgvector
+                                              Milvus / Qdrant / pgvector
                                               (central storage)
 ```
 
 ## 1. Central storage
 
-Pick a networked backend so all clients share one palace. **Qdrant** needs no
-extra Python package — MemPalace talks to its REST API directly.
+Pick a networked backend so all clients share one palace. **Milvus** can point
+at a self-hosted Milvus server or Zilliz Cloud. Milvus Lite is still local to
+one palace directory, so use a server URI for team mode.
+
+Install the optional Milvus driver on the server host:
+
+```bash
+pip install mempalace[milvus]
+```
+
+Point MemPalace at the shared Milvus endpoint:
+
+```bash
+export MEMPALACE_BACKEND=milvus
+export MEMPALACE_MILVUS_URI=https://your-cluster.api.region.zillizcloud.com
+export MEMPALACE_MILVUS_TOKEN=your-token
+```
+
+Prefer Qdrant? It needs no extra Python package — MemPalace talks to its REST
+API directly.
 
 Run Qdrant (Docker shown; use a managed/self-hosted instance you control):
 
@@ -59,14 +78,20 @@ export MEMPALACE_QDRANT_API_KEY=your-qdrant-api-key   # if your Qdrant requires 
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `MEMPALACE_BACKEND` | `chroma` | Set to `qdrant` (or `pgvector`) to select the backend |
+| `MEMPALACE_BACKEND` | `chroma` | Set to `milvus`, `qdrant`, or `pgvector` to select the backend |
+| `MEMPALACE_MILVUS_URI` | per-palace Milvus Lite | Milvus server / Zilliz Cloud URI |
+| `MEMPALACE_MILVUS_TOKEN` | _(none)_ | Token for Milvus server / Zilliz Cloud |
+| `MEMPALACE_MILVUS_DB_NAME` | _(none)_ | Optional Milvus database name |
+| `MEMPALACE_MILVUS_NAMESPACE` | _(none)_ | Optional Milvus collection namespace prefix |
+| `MEMPALACE_MILVUS_CONSISTENCY_LEVEL` | `Strong` | Milvus consistency level |
 | `MEMPALACE_QDRANT_URL` | `http://localhost:6333` | Qdrant REST endpoint |
 | `MEMPALACE_QDRANT_API_KEY` | _(none)_ | Sent as the `api-key` header when set |
 | `MEMPALACE_QDRANT_NAMESPACE` | _(none)_ | Optional collection namespace prefix |
 | `MEMPALACE_QDRANT_TIMEOUT` | backend default | REST request timeout (seconds) |
 
-The backend can also be set with `--backend qdrant` on any `mempalace` /
-`mempalace-mcp` command, or with `"backend": "qdrant"` in `config.json`.
+The backend can also be set with `--backend milvus` (or `qdrant` /
+`pgvector`) on any `mempalace` / `mempalace-mcp` command, or with
+`"backend": "milvus"` in `config.json`.
 
 Prefer Postgres? Install `pip install mempalace[pgvector]`, point
 `MEMPALACE_BACKEND=pgvector` at a database with the `vector` extension, and
@@ -96,7 +121,7 @@ ready-to-paste client config, and runs in the foreground so Docker/systemd own
 the lifecycle.
 
 ```bash
-mempalace serve --host 0.0.0.0 --port 8765 --backend qdrant
+mempalace serve --host 0.0.0.0 --port 8765 --backend milvus
 ```
 
 Output includes the token and the exact client command. Useful flags:
@@ -159,8 +184,9 @@ whole team.
   processes at the same backend collection.
 - **Health checks**: `GET /healthz` returns `200 ok` without a token, so it
   works as a load-balancer/Kubernetes liveness probe.
-- **Backups** are now your storage backend's responsibility (Qdrant snapshots
-  / Postgres backups) rather than a single laptop's palace directory.
+- **Backups** are now your storage backend's responsibility (Milvus / Zilliz
+  Cloud backups, Qdrant snapshots, or Postgres backups) rather than a single
+  laptop's palace directory.
 
 ## One-command deployments
 

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -1,6 +1,8 @@
 # CLI Commands
 
 All commands accept `--palace <path>` to override the default palace location.
+The top-level command also accepts `--backend <name>` to select a storage
+backend such as `milvus`, `qdrant`, or `pgvector`.
 
 ## `mempalace init`
 

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -2,7 +2,7 @@
 
 All commands accept `--palace <path>` to override the default palace location.
 The top-level command also accepts `--backend <name>` to select a storage
-backend such as `milvus`, `qdrant`, or `pgvector`.
+backend such as `sqlite_exact`, `milvus`, `qdrant`, or `pgvector`.
 
 ## `mempalace init`
 


### PR DESCRIPTION
## Summary

Adds an opt-in `milvus` storage backend using the `pymilvus.MilvusClient` API.

- defaults to per-palace Milvus Lite at `<palace>/milvus.db`
- supports Milvus server and Zilliz Cloud through `MEMPALACE_MILVUS_URI`, `MEMPALACE_MILVUS_TOKEN`, `MEMPALACE_MILVUS_DB_NAME`, `MEMPALACE_MILVUS_NAMESPACE`, and `MEMPALACE_MILVUS_CONSISTENCY_LEVEL`
- registers the backend through the built-in registry and entry point table
- stores explicit `id`, `document`, `metadata`, and `vector` fields with `AUTOINDEX` / COSINE vector search
- enables native Milvus BM25 lexical search for new Milvus Lite, Milvus server, and Zilliz Cloud collections; collections without a native sparse BM25 field report a backend error instead of falling back to local scoring
- adds marker-based target mismatch protection and namespace isolation
- documents the README compatibility table, backend configuration guide, CLI, and Remote / Team Server usage, and adds a `milvus` optional extra

## Testing

- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync pytest tests/test_config.py tests/test_milvus_backend.py -q` (`134 passed, 1 skipped`)
- `uv run --no-sync pytest tests/test_backend_conformance.py tests/test_qdrant_backend.py tests/test_config.py -q` (`146 passed, 1 skipped`)
- `MEMPALACE_MILVUS_URI=... MEMPALACE_MILVUS_TOKEN=... uv run --no-sync pytest tests/test_milvus_backend.py::test_milvus_zilliz_cloud_roundtrip_when_enabled -q` (`1 passed`)
- Verified Milvus Lite native BM25 lexical search through `lexical_search()`
- Verified a live Zilliz Cloud roundtrip with the Milvus backend
- `git diff --check`