### PR TITLE
feat: add LaTeX (.tex, .bib) to readable and prose extensions

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -215,6 +215,8 @@ PROSE_EXTENSIONS = {
     ".md",
     ".rst",
     ".csv",
+    ".tex",
+    ".bib",
 }
 
 READABLE_EXTENSIONS = {

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -133,6 +133,8 @@ READABLE_EXTENSIONS = {
     ".csv",
     ".sql",
     ".toml",
+    ".tex",
+    ".bib",
     # C# / .NET
     ".cs",
     ".csproj",

--- a/tests/test_entity_detector.py
+++ b/tests/test_entity_detector.py
@@ -531,6 +531,24 @@ def test_scan_for_detection_skips_git_dir(tmp_path):
     assert not any(".git" in f for f in file_strs)
 
 
+def test_scan_for_detection_includes_latex_prose(tmp_path):
+    # .tex and .bib are prose-heavy (author names, abstracts, citations) and
+    # belong in the preferred PROSE_EXTENSIONS bucket alongside .md / .rst,
+    # not the code-file fallback. .bib in particular is almost entirely
+    # author names — high entity density per byte.
+    (tmp_path / "paper.tex").write_text(
+        "\\documentclass{article}\\author{Leslie Lamport}\\begin{document}Body.\\end{document}"
+    )
+    (tmp_path / "refs.bib").write_text(
+        "@article{l86, author={Leslie Lamport}, title={LaTeX}, year={1986}}"
+    )
+    (tmp_path / "code.py").write_text("import os")
+    files = scan_for_detection(str(tmp_path))
+    extensions = {os.path.splitext(str(f))[1] for f in files}
+    assert ".tex" in extensions
+    assert ".bib" in extensions
+
+
 # ── module-level constants ──────────────────────────────────────────────
 
 
@@ -543,6 +561,8 @@ def test_stopwords_contains_common_words():
 def test_prose_extensions():
     assert ".txt" in PROSE_EXTENSIONS
     assert ".md" in PROSE_EXTENSIONS
+    assert ".tex" in PROSE_EXTENSIONS
+    assert ".bib" in PROSE_EXTENSIONS
 
 
 # ── _print_entity_list ─────────────────────────────────────────────────

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -349,6 +349,20 @@ def test_scan_project_includes_kotlin_files():
         ]
 
 
+def test_scan_project_includes_latex_files():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_root = Path(tmpdir).resolve()
+        write_file(
+            project_root / "main.tex",
+            "\\documentclass{article}\n\\begin{document}\nHello, world.\n\\end{document}\n" * 20,
+        )
+        write_file(
+            project_root / "refs.bib",
+            "@article{lamport1986, author={Leslie Lamport}, title={LaTeX}, year={1986}}\n" * 20,
+        )
+        assert scanned_files(project_root) == ["main.tex", "refs.bib"]
+
+
 def test_scan_project_respects_gitignore():
     tmpdir = tempfile.mkdtemp()
     try:


### PR DESCRIPTION
## What does this PR do?

Adds `.tex` and `.bib` to the file-extension allowlists so LaTeX projects are mineable into the palace AND surface correctly during entity detection.

- `mempalace/miner.py:READABLE_EXTENSIONS` — both extensions join the mining allowlist
- `mempalace/entity_detector.py:PROSE_EXTENSIONS` — both extensions also join the *preferred* entity-detection bucket (alongside `.md`, `.rst`, `.csv`), not the code-file fallback

## Why touch entity_detector too?

Prior extension PRs (#1368 Swift/Kotlin, #1819 PHP) touched only `miner.py`. The reason `PROSE_EXTENSIONS` exists separately from `READABLE_EXTENSIONS` in `entity_detector.py` is documented in-code: programming-language files have lots of capitalized identifiers (class names, function names) that produce false-positive person matches.

LaTeX/BibTeX are different in kind — they're typesetting languages for prose documents:
- `.tex` files contain abstracts, paragraphs of natural-language content, `\author{}` declarations, and citations referencing real people.
- `.bib` files are *almost entirely* author names (one `author = {...}` per entry, often dozens per file).

Without the `entity_detector.py` change, mining LaTeX projects works (post this PR) but `mempalace init` on a thesis or paper project would either find few prose files and fall back to all-readable, or treat `.tex`/`.bib` as part of the code-file fallback bucket alongside any actual code. Putting them in `PROSE_EXTENSIONS` is the correct placement.

## How to test

```
uv run pytest tests/test_miner.py::test_scan_project_includes_latex_files \
              tests/test_entity_detector.py::test_scan_for_detection_includes_latex_prose -v
```

Both new tests + the existing `test_prose_extensions` (extended to assert the new entries) pass. Full env-cleared suite: **3216 passed, 20 skipped, 0 failed**. `ruff check .` and `ruff format --check .` both clean.

## Checklist
- [x] Tests pass (`uv run pytest tests/ --ignore=tests/benchmarks`)
- [x] No hardcoded paths
- [x] Linter passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)