### PR TITLE
fix(docs): wide-table layout — stop clipping, fit backend table

### DIFF
--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -165,8 +165,11 @@
 /* ── Tables ─────────────────────────────────────────────────────────── */
 
 .vp-doc table {
+  display: block;
+  /* Keep VitePress's horizontal scroll for wide tables; `overflow: hidden`
+     here would clip columns that don't fit the content column instead. */
+  overflow-x: auto;
   border-radius: 8px;
-  overflow: hidden;
 }
 
 .vp-doc th {

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -172,6 +172,21 @@
   border-radius: 8px;
 }
 
+/* Slightly denser cells so comparison tables fit the content column without a
+   horizontal scrollbar (VitePress default is 8px 16px). */
+.vp-doc td,
+.vp-doc th {
+  padding: 8px 12px;
+}
+
+/* Break only inline-code tokens that genuinely can't fit their column (long
+   description strings), while leaving natural column sizing intact so short
+   identifiers like `palace_path` stay on one line. `overflow-x: auto` above is
+   the safety net for any table still wider than the content column. */
+.vp-doc td code {
+  overflow-wrap: break-word;
+}
+
 .vp-doc th {
   background: rgba(56, 189, 248, 0.06);
   font-weight: 600;

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -28,8 +28,8 @@ pluggable backend contract, exercised across deliberately different substrates
 store) so the contract is never accidentally shaped around one vendor. Every
 non-default backend is opt-in.
 
-| Backend | Mode | Install | Namespace isolation | Lexical search | Configure with |
-| ------- | ---- | ------- | :-----------------: | :------------: | -------------- |
+| Backend | Mode | Install | Namespaces | Lexical | Configure with |
+| ------- | ---- | ------- | :--------: | :-----: | -------------- |
 | `chroma` _(default)_ | Local (embedded) | bundled | – | ✓ | `palace_path` |
 | `sqlite_exact` | Local (exact cosine) | bundled | – | ✓ | `palace_path` |
 | `qdrant` | Server (REST) | bundled | ✓ | ✓ | `MEMPALACE_QDRANT_URL` |

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -28,13 +28,13 @@ pluggable backend contract, exercised across deliberately different substrates
 store) so the contract is never accidentally shaped around one vendor. Every
 non-default backend is opt-in.
 
-| Backend | Mode | Install | Namespaces | Lexical | Configure with |
-| ------- | ---- | ------- | :--------: | :-----: | -------------- |
-| `chroma` _(default)_ | Local (embedded) | bundled | – | ✓ | `palace_path` |
-| `sqlite_exact` | Local (exact cosine) | bundled | – | ✓ | `palace_path` |
-| `qdrant` | Server (REST) | bundled | ✓ | ✓ | `MEMPALACE_QDRANT_URL` |
-| `pgvector` | Server (Postgres) | `mempalace[pgvector]` | ✓ | ✓ | `MEMPALACE_PGVECTOR_DSN` |
-<!-- New backends add one row here and one `### <Backend>` subsection below; keep README's compatibility table in sync. -->
+| Backend | Mode | Install | Namespaces | Lexical |
+| ------- | ---- | ------- | :--------: | :-----: |
+| `chroma` _(default)_ | Local (embedded) | bundled | – | ✓ |
+| `sqlite_exact` | Local (exact) | bundled | – | ✓ |
+| `qdrant` | Server (REST) | bundled | ✓ | ✓ |
+| `pgvector` | Server (Postgres) | `mempalace[pgvector]` | ✓ | ✓ |
+<!-- New backends add one row here and one `### <Backend>` subsection (with its connection variables) below; keep README's compatibility table in sync. -->
 
 Select a backend with `--backend <name>` on any `mempalace` / `mempalace-mcp`
 command, `MEMPALACE_BACKEND=<name>` in the environment, or `"backend": "<name>"`


### PR DESCRIPTION
## Summary

Batched, browser-validated frontend fixes for wide tables in the docs.

The docs theme **clipped** any table wider than the content column instead of
letting it scroll — visible on the storage-backends compatibility table, whose
right-most columns were cut off and unreachable.

**Root cause:** the custom theme set `.vp-doc table { overflow: hidden }` to clip
the rounded corners, which also overrode VitePress's default `overflow-x: auto`.
With overflow hidden, columns that don't fit are simply unreachable.

## Changes

`.vitepress/theme/style.css` (site-wide):
- `.vp-doc table` → `overflow-x: auto` (keeps rounded corners, restores
  horizontal scroll for any wide table — fixes clipping everywhere, not just one
  page).
- Denser table cells (`8px 16px` → `8px 12px`) so comparison tables fit the
  content column without a scrollbar.
- `overflow-wrap: break-word` on table-cell code so only genuinely long values
  (e.g. a Postgres DSN) wrap, while short identifiers like `palace_path` keep
  natural column sizing and stay on one line.

`guide/configuration.md`:
- Drop the redundant `Configure with` column from the storage-backends table
  (each backend's connection variables are documented in full in its own
  subsection right below), shorten the capability headers, and
  `Local (exact cosine)` → `Local (exact)`. The comparison table is now five
  columns and fits cleanly.

## Validation (Playwright, dev server)

Measured `scrollWidth`/`clientWidth` and page overflow, plus visual screenshots,
at **1280px** and **375px**:
- No element clipping and **no page-level horizontal overflow** on the
  configuration, remote-server, reference (cli / mcp-tools / python-api),
  claude-code, and knowledge-graph pages.
- The storage-backends comparison table now fits the content column with no
  scroll at desktop; on mobile it scrolls within its own container.
- One subsection table (pgvector, long Postgres DSN) scrolls ~36px gracefully —
  reachable, never clipped.
- `bun run docs:build` — clean, no dead links.