### PR TITLE
fix(stdio): pin newline="\n" on Windows to keep JSON-RPC frames clean

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -5445,7 +5445,7 @@ def _run_stdio_loop() -> None:
         if hasattr(stream, "reconfigure"):
             try:
                 stream.reconfigure(encoding="utf-8", errors="replace", newline="\n")
-            except (AttributeError, OSError):
+            except (AttributeError, OSError, TypeError):
                 pass
 
     logger.info("MemPalace MCP Server starting...")

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -5439,10 +5439,12 @@ def _run_stdio_loop() -> None:
     # defaults stdin/stdout to the system codepage (e.g. cp1251), which
     # corrupts non-ASCII payloads and surfaces as generic -32000 errors on
     # Cyrillic/CJK content. See PEP 540.
+    # Also pin newline="\n": Windows text-mode stdout translates \n -> \r\n,
+    # injecting stray \r into the newline-framed JSON-RPC stream.
     for stream in (sys.stdin, sys.stdout):
         if hasattr(stream, "reconfigure"):
             try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
+                stream.reconfigure(encoding="utf-8", errors="replace", newline="\n")
             except (AttributeError, OSError):
                 pass
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5634,3 +5634,66 @@ def test_ensure_sqlite_integrity_status_joins_inflight_probe(monkeypatch):
         release_probe.set()
         background.join(5)
         consumer_thread.join(5)
+
+
+def test_stdio_loop_pins_utf8_and_lf_newlines(monkeypatch):
+    from mempalace import mcp_server
+
+    class FakeStream:
+        def __init__(self):
+            self.reconfigure_calls = []
+
+        def reconfigure(self, **kwargs):
+            self.reconfigure_calls.append(kwargs)
+
+        def readline(self):
+            return ""
+
+    class FakeThread:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def start(self):
+            pass
+
+    fake_stdin = FakeStream()
+    fake_stdout = FakeStream()
+    monkeypatch.setattr(mcp_server, "_restore_stdout", lambda: None)
+    monkeypatch.setattr(mcp_server.sys, "stdin", fake_stdin)
+    monkeypatch.setattr(mcp_server.sys, "stdout", fake_stdout)
+    monkeypatch.setattr(mcp_server.threading, "Thread", FakeThread)
+    monkeypatch.setattr(mcp_server, "_maybe_eager_warmup_embedder", lambda: None)
+    monkeypatch.setattr(mcp_server, "_start_idle_exit_watchdog", lambda: None)
+
+    mcp_server._run_stdio_loop()
+
+    expected = {"encoding": "utf-8", "errors": "replace", "newline": "\n"}
+    assert fake_stdin.reconfigure_calls == [expected]
+    assert fake_stdout.reconfigure_calls == [expected]
+
+
+def test_stdio_loop_tolerates_reconfigure_without_newline_support(monkeypatch):
+    from mempalace import mcp_server
+
+    class LegacyStream:
+        def reconfigure(self, **kwargs):
+            raise TypeError("newline is not supported")
+
+        def readline(self):
+            return ""
+
+    class FakeThread:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(mcp_server, "_restore_stdout", lambda: None)
+    monkeypatch.setattr(mcp_server.sys, "stdin", LegacyStream())
+    monkeypatch.setattr(mcp_server.sys, "stdout", LegacyStream())
+    monkeypatch.setattr(mcp_server.threading, "Thread", FakeThread)
+    monkeypatch.setattr(mcp_server, "_maybe_eager_warmup_embedder", lambda: None)
+    monkeypatch.setattr(mcp_server, "_start_idle_exit_watchdog", lambda: None)
+
+    mcp_server._run_stdio_loop()


### PR DESCRIPTION
## Problem

On Windows, `_run_stdio_loop()` reconfigures stdin/stdout to UTF-8 but leaves newline translation at the default. Python text-mode stdout can rewrite `\n` as `\r\n`, adding a stray carriage return to newline-framed JSON-RPC messages and causing intermittent MCP framing failures.

## Fix

- Pass `newline="\n"` to the existing stdin/stdout `reconfigure()` call so JSON-RPC frames use LF exactly.
- Catch `TypeError` as requested in review so custom or mock streams that expose `reconfigure()` without supporting `newline` continue to fail soft.
- Add focused regression tests for both LF pinning and legacy/mock-stream compatibility.
- Rebase the PR onto the v3.6.0 `main` release.

## Verification

- `pytest tests/test_mcp_server.py -q` → 279 passed, 3 skipped
- `ruff check mempalace/mcp_server.py tests/test_mcp_server.py` → passed
- `ruff format --check mempalace/mcp_server.py tests/test_mcp_server.py` → passed

## Checklist

- [x] Tests pass
- [x] Ruff check passes
- [x] Ruff formatting passes
- [x] No hardcoded paths