### PR TITLE
docs: note MiniLM is the default without onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ verbatim drawer per user/assistant message, idempotent and resume-safe.
 - Python 3.9+
 - A vector-store backend (ChromaDB by default)
 - ~300 MB disk for the embedding model. Onboarding (`python -m mempalace.onboarding`) offers `embeddinggemma-300m` (multilingual, 100+ languages, recommended) or `all-MiniLM-L6-v2` (English-only, ~30 MB). See the docstring at [`mempalace/embedding.py`](mempalace/embedding.py) for details and migration notes.
+  If you skip onboarding (e.g. after `uv tool install`), the first `mine` defaults to `all-MiniLM-L6-v2` (`minilm`).
+  For the multilingual model, set `MEMPALACE_EMBEDDING_MODEL=embeddinggemma` (or run onboarding) before the first `mine`.
+  To switch an existing palace after mining, set `MEMPALACE_EMBEDDING_MODEL=embeddinggemma` and run `mempalace repair rebuild-index` (the variable must be set for the rebuild, or it falls back to `minilm` again).
 
 No API key is required for the core benchmark path.
 


### PR DESCRIPTION
## What

The Requirements section lists `embeddinggemma` as the model onboarding
recommends, but doesn't mention what happens if onboarding is skipped. This
adds one sentence clarifying the fallback and how to switch.

## Why

Installing via `uv tool install` and running `mine` **without** onboarding
silently falls back to `all-MiniLM-L6-v2`, because `embedding_model` defaults
to `"minilm"` when `config.json` has no entry (see `config.py`
`embedding_model` property). A user expecting the documented multilingual
default gets an English-only index with no notice.

## Change

Documents the fallback and the two supported ways to get the multilingual
model:
- set `MEMPALACE_EMBEDDING_MODEL=embeddinggemma` (or run onboarding) **before**
  the first mine, and
- `mempalace repair rebuild-index` to switch an existing palace.

Docs-only; no code changes.
