### PR TITLE
feat(miner): support .mempalaceignore as the mining ignore file

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1799,8 +1799,10 @@ def main():
     p_mine.add_argument("--wing", default=None, help="Wing name (default: directory name)")
     p_mine.add_argument(
         "--no-gitignore",
+        "--no-mempalaceignore",
+        dest="no_gitignore",
         action="store_true",
-        help="Don't respect .gitignore files when scanning project files",
+        help="Don't respect .mempalaceignore / .gitignore files when scanning project files",
     )
     p_mine.add_argument(
         "--include-ignored",

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -150,6 +150,7 @@ SKIP_FILENAMES = {
     "mempal.yaml",
     "mempal.yml",
     ".gitignore",
+    ".mempalaceignore",
     "package-lock.json",
     "pnpm-lock.yaml",
     "yarn.lock",
@@ -237,16 +238,52 @@ def _resolve_max_chunks_per_file(override: Optional[int] = None) -> int:
 # =============================================================================
 
 
+GITIGNORE = ".gitignore"
+MEMPALACEIGNORE = ".mempalaceignore"
+
+
+def detect_ignore_filename(project_root: Path) -> str:
+    """Return the ignore-file basename that applies to this project.
+
+    Project-scoped, decided once at the project root:
+
+    - If ``.mempalaceignore`` exists at the project root, the project is in
+      mempalace-mode: only ``.mempalaceignore`` files are consulted anywhere
+      in the tree, and ``.gitignore`` is never read.
+    - Otherwise the project is in git-mode: only ``.gitignore`` files are
+      consulted (the historical behaviour — fully backward compatible for
+      any project without a ``.mempalaceignore``).
+
+    Scoping the decision to the project root — rather than falling back
+    per-directory between the two files — keeps the contract obvious: one
+    ignore-file convention per project. A per-directory fallback lets a
+    single tree mix conventions in confusing ways (a root
+    ``.mempalaceignore`` masks the same-dir ``.gitignore`` but not a
+    sibling-dir ``.gitignore``), which is easy to misread when a directory
+    unexpectedly does or doesn't get pruned.
+    """
+    if (project_root / MEMPALACEIGNORE).is_file():
+        return MEMPALACEIGNORE
+    return GITIGNORE
+
+
 class GitignoreMatcher:
-    """Lightweight matcher for one directory's .gitignore patterns."""
+    """Lightweight matcher for one directory's ignore patterns.
+
+    Reads a single named ignore file per directory (``.gitignore`` by
+    default; ``.mempalaceignore`` when the caller passes ``filename``).
+    Never falls back between the two — the caller decides which convention
+    is active for the project, typically via :func:`detect_ignore_filename`
+    on the project root.
+    """
 
     def __init__(self, base_dir: Path, rules: list):
         self.base_dir = base_dir
         self.rules = rules
 
     @classmethod
-    def from_dir(cls, dir_path: Path):
-        gitignore_path = dir_path / ".gitignore"
+    def from_dir(cls, dir_path: Path, filename: str = GITIGNORE):
+        gitignore_path = dir_path / filename
         if not gitignore_path.is_file():
             return None
 
@@ -353,15 +390,16 @@ class GitignoreMatcher:
         return matches(0, 0)
 
 
-def load_gitignore_matcher(dir_path: Path, cache: dict):
-    """Load and cache one directory's .gitignore matcher."""
-    if dir_path not in cache:
-        cache[dir_path] = GitignoreMatcher.from_dir(dir_path)
-    return cache[dir_path]
+def load_gitignore_matcher(dir_path: Path, cache: dict, filename: str = GITIGNORE):
+    """Load and cache one directory's ignore matcher for the given filename."""
+    key = (dir_path, filename)
+    if key not in cache:
+        cache[key] = GitignoreMatcher.from_dir(dir_path, filename=filename)
+    return cache[key]
 
 
 def is_gitignored(path: Path, matchers: list, is_dir: bool = False) -> bool:
-    """Apply active .gitignore matchers in ancestor order; last match wins."""
+    """Apply active ignore matchers in ancestor order; last match wins."""
     ignored = False
     for matcher in matchers:
         decision = matcher.matches(path, is_dir=is_dir)
@@ -1543,6 +1581,9 @@ def scan_project(
     active_matchers = []
     matcher_cache = {}
     include_paths = normalize_include_paths(include_ignored)
+    # Decide the ignore convention once, at the project root: .mempalaceignore
+    # if present, else .gitignore (backward compatible).
+    ignore_filename = detect_ignore_filename(project_path)
 
     for root, dirs, filenames in os.walk(project_path):
         root_path = Path(root)
@@ -1553,7 +1594,9 @@ def scan_project(
                 for matcher in active_matchers
                 if root_path == matcher.base_dir or matcher.base_dir in root_path.parents
             ]
-            current_matcher = load_gitignore_matcher(root_path, matcher_cache)
+            current_matcher = load_gitignore_matcher(
+                root_path, matcher_cache, filename=ignore_filename
+            )
             if current_matcher is not None:
                 active_matchers.append(current_matcher)
 
@@ -1708,7 +1751,7 @@ def _mine_impl(
     if dry_run:
         print("  DRY RUN — nothing will be filed")
     if not respect_gitignore:
-        print("  .gitignore: DISABLED")
+        print("  .mempalaceignore / .gitignore: DISABLED")
     if include_ignored:
         print(f"  Include: {', '.join(sorted(normalize_include_paths(include_ignored)))}")
     print(f"{'-' * 55}\n")

--- a/mempalace/sync.py
+++ b/mempalace/sync.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Callable, Optional, TypedDict
 
-from .miner import is_gitignored, load_gitignore_matcher
+from .miner import detect_ignore_filename, is_gitignored, load_gitignore_matcher
 from .palace import (
     MineAlreadyRunning,
     get_closets_collection,
@@ -69,13 +69,16 @@ def _ancestor_matchers(source_file: Path, root: Path, matcher_cache: dict) -> li
         parts = source_file.relative_to(root).parts
     except ValueError:
         return matchers
+    # Prune with the same ignore convention the miner used on the way in:
+    # .mempalaceignore if the project declares one, else .gitignore.
+    ignore_filename = detect_ignore_filename(root)
     cursor = root
-    matcher = load_gitignore_matcher(cursor, matcher_cache)
+    matcher = load_gitignore_matcher(cursor, matcher_cache, filename=ignore_filename)
     if matcher is not None:
         matchers.append(matcher)
     for part in parts[:-1]:
         cursor = cursor / part
-        matcher = load_gitignore_matcher(cursor, matcher_cache)
+        matcher = load_gitignore_matcher(cursor, matcher_cache, filename=ignore_filename)
         if matcher is not None:
             matchers.append(matcher)
     return matchers

--- a/mempalace/sync.py
+++ b/mempalace/sync.py
@@ -71,7 +71,11 @@ def _ancestor_matchers(source_file: Path, root: Path, matcher_cache: dict) -> li
         return matchers
     # Prune with the same ignore convention the miner used on the way in:
     # .mempalaceignore if the project declares one, else .gitignore.
-    ignore_filename = detect_ignore_filename(root)
+    # Cache the detection to avoid redundant is_file() calls per source file.
+    cache_key = ("ignore_filename", root)
+    if cache_key not in matcher_cache:
+        matcher_cache[cache_key] = detect_ignore_filename(root)
+    ignore_filename = matcher_cache[cache_key]
     cursor = root
     matcher = load_gitignore_matcher(cursor, matcher_cache, filename=ignore_filename)
     if matcher is not None:

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -13,6 +13,7 @@ from mempalace.config import normalize_wing_name
 from mempalace.miner import (
     PHP_EXTENSIONS,
     READABLE_EXTENSIONS,
+    detect_ignore_filename,
     detect_room,
     load_config,
     mine,
@@ -443,6 +444,80 @@ def test_scan_project_can_disable_gitignore():
         project_root = Path(tmpdir).resolve()
 
         write_file(project_root / ".gitignore", "data/\n")
+        write_file(project_root / "data" / "stuff.csv", "a,b,c\n" * 20)
+
+        assert scanned_files(project_root, respect_gitignore=False) == ["data/stuff.csv"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_detect_ignore_filename_prefers_mempalaceignore(tmp_path):
+    project_root = tmp_path.resolve()
+    write_file(project_root / ".gitignore", "*.log\n")
+    # Git-mode until a .mempalaceignore appears at the root.
+    assert detect_ignore_filename(project_root) == ".gitignore"
+
+    write_file(project_root / ".mempalaceignore", "*.tmp\n")
+    assert detect_ignore_filename(project_root) == ".mempalaceignore"
+
+
+def test_scan_project_respects_mempalaceignore():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".mempalaceignore", "ignored.py\ngenerated/\n")
+        write_file(project_root / "src" / "app.py", "print('hello')\n" * 20)
+        write_file(project_root / "ignored.py", "print('ignore me')\n" * 20)
+        write_file(project_root / "generated" / "artifact.py", "print('artifact')\n" * 20)
+
+        assert scanned_files(project_root) == ["src/app.py"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_mempalaceignore_supersedes_gitignore_project_wide():
+    # Project-mode: once a root .mempalaceignore exists, .gitignore is never
+    # consulted anywhere in the tree — even a nested .gitignore is inert.
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".mempalaceignore", "*.tmp\n")
+        write_file(project_root / ".gitignore", "src/\n")
+        write_file(project_root / "sub" / ".gitignore", "keep.py\n")
+        write_file(project_root / "src" / "app.py", "print('app')\n" * 20)
+        write_file(project_root / "sub" / "keep.py", "print('keep')\n" * 20)
+        write_file(project_root / "scratch.tmp", "temp\n" * 20)
+
+        # src/ and sub/keep.py survive (their .gitignore rules are ignored);
+        # scratch.tmp is dropped by .mempalaceignore.
+        assert scanned_files(project_root) == ["src/app.py", "sub/keep.py"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_scan_project_falls_back_to_gitignore_without_mempalaceignore():
+    # Git-mode is fully preserved for any project without a .mempalaceignore.
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".gitignore", "data/\n")
+        write_file(project_root / "data" / "stuff.csv", "a,b,c\n" * 20)
+        write_file(project_root / "src" / "app.py", "print('app')\n" * 20)
+
+        assert scanned_files(project_root) == ["src/app.py"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_scan_project_can_disable_mempalaceignore():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".mempalaceignore", "data/\n")
         write_file(project_root / "data" / "stuff.csv", "a,b,c\n" * 20)
 
         assert scanned_files(project_root, respect_gitignore=False) == ["data/stuff.csv"]

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -2453,3 +2453,74 @@ def test_mine_limit_summary_counts(tmp_path, capsys):
     assert "Files processed: 2" in out
     assert "Drawers filed: 6" in out
     assert "(limit: 2 new)" in out
+
+
+# ── .mempalaceignore ───────────────────────────────────────────────────
+
+
+def test_detect_ignore_filename_prefers_mempalaceignore(tmp_path):
+    project_root = tmp_path.resolve()
+    write_file(project_root / ".gitignore", "*.log\n")
+    assert detect_ignore_filename(project_root) == ".gitignore"
+
+    write_file(project_root / ".mempalaceignore", "*.tmp\n")
+    assert detect_ignore_filename(project_root) == ".mempalaceignore"
+
+
+def test_scan_project_respects_mempalaceignore():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".mempalaceignore", "ignored.py\ngenerated/\n")
+        write_file(project_root / "src" / "app.py", "print('hello')\n" * 20)
+        write_file(project_root / "ignored.py", "print('ignore me')\n" * 20)
+        write_file(project_root / "generated" / "artifact.py", "print('artifact')\n" * 20)
+
+        assert scanned_files(project_root) == ["src/app.py"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_mempalaceignore_supersedes_gitignore_project_wide():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".mempalaceignore", "*.tmp\n")
+        write_file(project_root / ".gitignore", "src/\n")
+        write_file(project_root / "sub" / ".gitignore", "keep.py\n")
+        write_file(project_root / "src" / "app.py", "print('app')\n" * 20)
+        write_file(project_root / "sub" / "keep.py", "print('keep')\n" * 20)
+        write_file(project_root / "scratch.tmp", "temp\n" * 20)
+
+        assert scanned_files(project_root) == ["src/app.py", "sub/keep.py"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_scan_project_falls_back_to_gitignore_without_mempalaceignore():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".gitignore", "data/\n")
+        write_file(project_root / "data" / "stuff.csv", "a,b,c\n" * 20)
+        write_file(project_root / "src" / "app.py", "print('app')\n" * 20)
+
+        assert scanned_files(project_root) == ["src/app.py"]
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_scan_project_can_disable_mempalaceignore():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        project_root = Path(tmpdir).resolve()
+
+        write_file(project_root / ".mempalaceignore", "data/\n")
+        write_file(project_root / "data" / "stuff.csv", "a,b,c\n" * 20)
+
+        assert scanned_files(project_root, respect_gitignore=False) == ["data/stuff.csv"]
+    finally:
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION
## What

Adds a project-scoped `.mempalaceignore` convention to the miner. If a `.mempalaceignore` file exists at the project root, mining (and the sync/prune path) read `.mempalaceignore` throughout the tree and never consult `.gitignore`. Otherwise behavior is unchanged — `.gitignore` is used exactly as today.

## Why

Today the mining ignore source is hardcoded to git (`is_gitignored`, `load_gitignore_matcher`, `respect_gitignore`). "What should mining ignore?" and "what does git ignore?" are not always the same question:

- Mine a config/notes directory that git ignores.
- Exclude generated content from the palace that git tracks.

`.mempalaceignore` gives users an ignore surface that's independent of git, while costing nothing for anyone who doesn't use it.

## Design

- **Project-scoped, not per-directory.** `detect_ignore_filename(project_root)` decides the convention once at the root. A per-directory fallback (try `.mempalaceignore`, else `.gitignore` in each dir) was deliberately avoided — it lets one tree mix conventions confusingly (a root `.mempalaceignore` masks the same-dir `.gitignore` but not a sibling-dir one). One convention per project keeps the contract obvious.
- **Same matcher engine.** `.mempalaceignore` uses the identical gitignore-syntax matcher (`GitignoreMatcher`); only the filename read changes.
- **Ingest and prune agree.** `scan_project` and `sync._ancestor_matchers` both honor the detected filename, so a file blocked on the way in is also pruned on the way out.

## Backward compatibility

Fully additive — no behavior change for any project without a `.mempalaceignore`:

- `GitignoreMatcher.from_dir` / `load_gitignore_matcher` gained an optional `filename=` argument that **defaults to `.gitignore`**; existing callers are untouched.
- The public `respect_gitignore` parameter and the `--no-gitignore` CLI flag are preserved. `--no-mempalaceignore` is added as an alias of `--no-gitignore`.
- `.mempalaceignore` is added to `SKIP_FILENAMES` so it isn't itself ingested.

(Naming note: I kept the existing `is_gitignored` / `load_gitignore_matcher` / `respect_gitignore` names and the `GitignoreMatcher` class to avoid a breaking rename. If you'd prefer neutral names — `is_ignored` / `respect_ignore` — I'm happy to rename with back-compat aliases.)

## Tests

Adds coverage in `tests/test_miner.py`:

- `detect_ignore_filename` prefers `.mempalaceignore`, falls back to `.gitignore`
- `scan_project` respects `.mempalaceignore`
- project-mode: a root `.mempalaceignore` makes `.gitignore` (incl. nested) inert
- git-mode fallback preserved when no `.mempalaceignore`
- `respect_gitignore=False` still disables ignore matching

All new tests pass; ruff check + format clean.
