### PR TITLE
fix: sanitize embedded NUL bytes before they reach ChromaDB

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1375,8 +1375,8 @@ class ChromaCollection(BaseCollection):
 
     @staticmethod
     def _sanitize_documents_for_chromadb(documents):
-        """Strip lone UTF-16 surrogates from every document before it reaches
-        the chromadb client.
+        """Strip lone UTF-16 surrogates and embedded NUL characters from every
+        document before it reaches the chromadb client.
 
         A single lone surrogate (U+D800–U+DFFF) raises ``UnicodeEncodeError``
         inside chromadb's encode path and aborts the *entire* add/upsert batch
@@ -1389,18 +1389,29 @@ class ChromaCollection(BaseCollection):
         directly. Sanitising here makes the chokepoint catch-all complete: the
         sibling :meth:`_sanitize_metadatas_for_chromadb` already guarantees this
         for metadata one method over; documents get the same guarantee.
+
+        A document containing an embedded NUL (U+0000) — routine in mined
+        Bash tool output — is well-formed UTF-8, unlike a lone surrogate, but
+        can corrupt the FTS5 inverted index for the whole collection rather
+        than just failing to store that one row (a ChromaDB-side bug; tracked
+        upstream). Stripping it here is the same defense-in-depth already
+        applied to surrogates: sanitize input we don't control before it
+        reaches a datastore we don't control.
         """
         if documents is None:
             return None
-        from ..config import strip_lone_surrogates
+        from ..config import strip_lone_surrogates, strip_nul_bytes
+
+        def _sanitize(d):
+            return strip_nul_bytes(strip_lone_surrogates(d))
 
         # chromadb accepts OneOrMany[Document]: a bare str is a single document,
         # not an iterable of characters. Handle it explicitly so we don't split
         # it into per-character documents — that would be exactly the kind of
         # silent corruption this method exists to prevent.
         if isinstance(documents, str):
-            return strip_lone_surrogates(documents)
-        return [strip_lone_surrogates(d) if isinstance(d, str) else d for d in documents]
+            return _sanitize(documents)
+        return [_sanitize(d) if isinstance(d, str) else d for d in documents]
 
     def add(self, *, documents, ids, metadatas=None, embeddings=None):
         kwargs: dict[str, Any] = {

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -31,6 +31,22 @@ def strip_lone_surrogates(text: str) -> str:
     return _LONE_SURROGATE_RE.sub("�", text)
 
 
+# Tool output mined from real transcripts routinely embeds a NUL character
+# (U+0000) — e.g. captured Bash output where a reader raced a background
+# writer, or genuine binary/NUL-delimited command output. A document
+# containing one is otherwise valid, well-formed text (unlike a lone
+# surrogate, which is invalid UTF-8), but handing it to ChromaDB's
+# SQLite/FTS5 layer can corrupt the FTS5 inverted index for the *whole*
+# collection (``PRAGMA quick_check`` reports "malformed inverted index for
+# FTS5 table"), not just fail to store that one document. Stripping it
+# before it reaches the chromadb client is the same defense-in-depth this
+# module already applies to lone surrogates (#1235) — sanitize input we
+# don't control before it reaches a datastore we don't control.
+def strip_nul_bytes(text: str) -> str:
+    """Replace embedded NUL characters with U+FFFD before ChromaDB storage."""
+    return text.replace("\x00", "�")
+
+
 def normalize_wing_name(name: str) -> str:
     """Lower-case + collapse separators (`-`, ` `) to `_` for wing slugs.
 

--- a/tests/test_clean_nul_bytes.py
+++ b/tests/test_clean_nul_bytes.py
@@ -1,0 +1,163 @@
+"""Tests for embedded-NUL sanitisation in the bulk-ingest write path.
+
+Mirrors ``test_clean_lone_surrogates.py`` (issue #1235) for a sibling class of
+bad input: a document containing an embedded NUL character (U+0000).
+
+Unlike a lone surrogate, a NUL-containing string is well-formed UTF-8 — it
+doesn't raise on ``.encode()``. But handing it to ChromaDB's SQLite/FTS5
+layer can corrupt the FTS5 inverted index for the *whole* collection
+(``PRAGMA quick_check`` reports "malformed inverted index for FTS5 table"),
+not just fail to store that one document. This is routine in mined Bash
+tool output — e.g. a reader racing a background writer, or genuine
+NUL-delimited/binary command output captured verbatim.
+
+``sanitize_content`` (the MCP write-tool path) already rejects NUL bytes
+outright (``ValueError``) — that behaviour is unchanged and still tested
+here for completeness. The bulk ingest paths (miner, convo_miner, sweeper,
+diary_ingest) build documents without routing through that helper and reach
+``ChromaCollection`` directly, exactly as #1235 found for surrogates. This
+file covers the chokepoint fix that closes that gap: replace, not reject, so
+a NUL-containing chunk doesn't abort or corrupt an otherwise-good mine.
+"""
+
+from mempalace.config import strip_nul_bytes
+
+
+# ── Unit tests ─────────────────────────────────────────────────────────────
+
+
+class TestStripNulBytes:
+    def test_passthrough_normal(self):
+        assert strip_nul_bytes("hello world") == "hello world"
+        assert strip_nul_bytes("你好世界") == "你好世界"
+
+    def test_empty_string(self):
+        assert strip_nul_bytes("") == ""
+
+    def test_replaces_single_nul(self):
+        assert strip_nul_bytes("hello\x00world") == "hello�world"
+
+    def test_replaces_multiple_nuls(self):
+        assert strip_nul_bytes("\x00\x00\x00") == "���"
+        assert strip_nul_bytes("a\x00b\x00c") == "a�b�c"
+
+    def test_replaces_large_nul_run(self):
+        """The reporter-shaped case: a large contiguous NUL run inside
+        otherwise-ordinary captured tool output."""
+        dirty = "before-nuls " + ("\x00" * 10291) + " after-nuls"
+        clean = strip_nul_bytes(dirty)
+        assert "\x00" not in clean
+        assert clean.startswith("before-nuls ")
+        assert clean.endswith(" after-nuls")
+        assert clean.count("�") == 10291
+
+    def test_preserves_real_content_around_nuls(self):
+        assert (
+            strip_nul_bytes("[scheduler] Registered job\x00\x00\x00next line")
+            == "[scheduler] Registered job���next line"
+        )
+
+
+# ── Existing sanitizer behavior (unchanged) ─────────────────────────────────
+
+
+class TestSanitizeContentStillRejectsNuls:
+    """sanitize_content (the MCP write-tool path) already guards against NUL
+    bytes by rejecting them outright — that's a reasonable choice for an
+    interactive tool call and is untouched by this fix. Verifies it still
+    holds now that a sibling path (the backend chokepoint) takes the
+    replace-not-reject approach instead, for the bulk-ingest paths where
+    rejecting one bad chunk would otherwise abort or corrupt a whole mine.
+    """
+
+    def test_sanitize_content_rejects_nul(self):
+        from mempalace.config import sanitize_content
+
+        import pytest
+
+        with pytest.raises(ValueError, match="null bytes"):
+            sanitize_content("hello\x00world")
+
+
+# ── Backend chokepoint (bulk ingest paths) ──────────────────────────────────
+
+
+class _CapturingCollection:
+    """Minimal chromadb.Collection stand-in that records the kwargs it receives,
+    so we can assert what actually reaches the chromadb client."""
+
+    def __init__(self):
+        self.calls = []
+
+    def add(self, **kwargs):
+        self.calls.append(("add", kwargs))
+
+    def upsert(self, **kwargs):
+        self.calls.append(("upsert", kwargs))
+
+    def update(self, **kwargs):
+        self.calls.append(("update", kwargs))
+
+
+class TestBackendChokepointStripsNulBytes:
+    """The bulk ingest paths (miner, convo_miner, sweeper, diary_ingest) build
+    documents without routing through ``sanitize_content`` and reach
+    ``ChromaCollection`` directly — the same gap #1235 found for surrogates.
+    A NUL byte in *document* text can corrupt the FTS5 inverted index for the
+    whole collection. The backend chokepoint must strip it, mirroring the
+    existing surrogate handling in the same method."""
+
+    @staticmethod
+    def _collection():
+        from mempalace.backends.chroma import ChromaCollection
+
+        fake = _CapturingCollection()
+        return fake, ChromaCollection(fake)
+
+    def test_add_strips_nul_in_document(self):
+        fake, col = self._collection()
+        col.add(documents=["clean\x00doc"], ids=["1"])
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == ["clean�doc"]
+
+    def test_upsert_strips_nul_in_document(self):
+        fake, col = self._collection()
+        col.upsert(documents=["a\x00b"], ids=["1"], metadatas=[{"wing": "w"}])
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == ["a�b"]
+
+    def test_update_strips_nul_in_document(self):
+        fake, col = self._collection()
+        col.update(ids=["1"], documents=["x\x00y"])
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == ["x�y"]
+
+    def test_one_nul_message_does_not_corrupt_the_batch(self):
+        """The reporter's shape: a single NUL-heavy row alongside ordinary
+        ones in the same batch. All rows survive, sanitised."""
+        fake, col = self._collection()
+        col.upsert(
+            documents=["ok one", "poison\x00row", "ok three"],
+            ids=["1", "2", "3"],
+        )
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == ["ok one", "poison�row", "ok three"]
+        assert len(kwargs["ids"]) == 3
+
+    def test_both_surrogates_and_nuls_in_same_document(self):
+        """Both sanitizers apply to the same document — order doesn't
+        leave either kind of bad character behind."""
+        fake, col = self._collection()
+        col.upsert(documents=["a\udc95b\x00c"], ids=["1"])
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == ["a�b�c"]
+
+    def test_single_string_document_is_not_split_into_chars(self):
+        """chromadb accepts a bare str as one document (OneOrMany[Document]).
+        The sanitiser must keep it whole and clean, not split it into
+        per-character documents."""
+        fake, col = self._collection()
+        col.upsert(documents="one\x00document", ids=["1"])
+        _, kwargs = fake.calls[0]
+        assert kwargs["documents"] == "one�document"
+        assert isinstance(kwargs["documents"], str)

--- a/tests/test_clean_nul_bytes.py
+++ b/tests/test_clean_nul_bytes.py
@@ -53,8 +53,8 @@ class TestStripNulBytes:
 
     def test_preserves_real_content_around_nuls(self):
         assert (
-            strip_nul_bytes("[scheduler] Registered job\x00\x00\x00next line")
-            == "[scheduler] Registered job���next line"
+            strip_nul_bytes("ordinary log line one\x00\x00\x00ordinary log line two")
+            == "ordinary log line one���ordinary log line two"
         )
 
 


### PR DESCRIPTION
Fixes #1927

## Summary

`mempalace/backends/chroma.py::_sanitize_documents_for_chromadb` already strips lone UTF-16 surrogates from every document before it reaches the chromadb client (#1235) — but it doesn't do the same for embedded NUL characters (U+0000). A NUL-containing document is well-formed UTF-8 (unlike a lone surrogate, it doesn't raise on `.encode()`), but handing it to ChromaDB's SQLite/FTS5 layer can corrupt the FTS5 inverted index for the *whole collection*, not just fail to store that one document. Reported upstream at [chroma-core/chroma#7388](https://github.com/chroma-core/chroma/issues/7388), with a minimal reproduction fully independent of mempalace.

This is routine input, not a contrived edge case: a Bash tool_result whose output was captured via a backgrounded process (`command > logfile 2>&1 &`) can end up with a contiguous run of NUL bytes if the reader races the writer, or from genuine NUL-delimited/binary command output. Mining real Claude Code session transcripts will hit this.

## The gap, precisely

`config.py::sanitize_content` (the MCP write-tool path) already guards against this — `if "\x00" in value: raise ValueError("content contains null bytes")`. But per the existing `_sanitize_documents_for_chromadb` docstring (added for #1235):

> #1235 fixed this for the MCP write tools via `sanitize_content`, but the bulk ingest paths (miner, convo_miner, sweeper, diary_ingest) build documents without routing through that helper and reach this backend directly.

The exact same gap applies to NUL bytes: the bulk-ingest paths never call `sanitize_content`, so its NUL check never runs for mined content.

## Fix

Adds `strip_nul_bytes` alongside `strip_lone_surrogates` in `config.py`, and chains both at the same `_sanitize_documents_for_chromadb` chokepoint — mirroring #1235's exact pattern (replace with U+FFFD, don't reject), since rejecting would abort or partially corrupt an entire mine batch over one bad chunk. `sanitize_content`'s reject-outright behavior for the interactive MCP tool path is unchanged.

## Verification

- Reproduced the corruption against real content (a real transcript slice that reliably corrupted `PRAGMA quick_check`), confirmed this patch resolves it: mine completes cleanly, and the previously-NUL-containing content remains fully indexed and searchable (verified via `mempalace search` returning correct results from the sanitized chunk).
- Independently confirmed with a minimal, mempalace-free script (bare `chromadb.PersistentClient`, one `upsert()` call) that the corruption is a pure ChromaDB-level issue — filed upstream as chroma-core/chroma#7388. This fix is the defense-in-depth mempalace can apply on its own regardless of that upstream fix's timeline.
- New test file `tests/test_clean_nul_bytes.py` (13 tests) mirrors `test_clean_lone_surrogates.py`'s structure: unit tests for `strip_nul_bytes`, a test confirming `sanitize_content`'s existing reject-behavior is unchanged, and backend-chokepoint tests for `add`/`upsert`/`update` covering single documents, batches with one poisoned row, and documents containing both a surrogate and a NUL together.
- Full test suite: `3227 passed, 20 skipped` (3214 + 13 new) — no new failures. Same two pre-existing unrelated failures as always (see #1925).
- `ruff check` and `ruff format --check` clean on all changed files.

## Test plan
- [x] `pytest tests/test_clean_nul_bytes.py` — 13 passed
- [x] `pytest tests/` (full suite) — 3227 passed, 20 skipped, 2 pre-existing unrelated failures (see #1925)
- [x] Manual: reproduced against real transcript content, confirmed clean mine + full searchability after the fix
- [x] `ruff check` / `ruff format --check` — clean
