### PR TITLE
fix: read-only mode misses checkpoint and delete_by_source in _MUTATING_TOOLS

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -373,6 +373,8 @@ _MUTATING_TOOLS = frozenset(
         "mempalace_delete_hallway",
         "mempalace_add_drawer",
         "mempalace_delete_drawer",
+        "mempalace_checkpoint",
+        "mempalace_delete_by_source",
         "mempalace_mine",
         "mempalace_sync",
         "mempalace_update_drawer",


### PR DESCRIPTION
﻿## Summary
`mempalace_checkpoint` and `mempalace_delete_by_source` (both added in 3.5.0) are missing from `_MUTATING_TOOLS` in `mcp_server.py`. As a result, a server started with `--read-only` / `MEMPALACE_MCP_READ_ONLY=1` still allows writing drawers (checkpoint) and bulk-deleting them (`delete_by_source` with `dry_run=false`). The peer-writer lock gate uses the same frozenset, so it is affected as well.

## Fix
Add both tool names to the `_MUTATING_TOOLS` frozenset (2 lines, no behavior change outside read-only/peer-writer gating).

## Context
Found during a security review of the codebase before adopting MemPalace as a hardened read-only recall layer for a personal memory system. Thanks for the project, the defensive engineering elsewhere (restricted unpickler, sanitizers, loopback-anchored HTTP) is genuinely impressive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
