### PR TITLE
[codex] fix status writer lease classification

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1693,9 +1693,6 @@ def tool_status():
     # is detected so status stays reachable.
     db_exists = _backend_db_exists()
     _refresh_vector_disabled_flag()
-    writer_ok, writer_reason = _acquire_mcp_writer_lock()
-    if not writer_ok:
-        logger.warning("%s; mutating MCP tools will run read-only", writer_reason)
 
     if _vector_disabled:
         return _tool_status_via_sqlite()

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -55,6 +55,7 @@ WRITE_TOOLS = frozenset(
     {
         "mempalace_add_drawer",
         "mempalace_checkpoint",
+        "mempalace_delete_by_source",
         "mempalace_delete_drawer",
         "mempalace_update_drawer",
         "mempalace_diary_write",

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -174,6 +174,7 @@ def test_service_tool_classification():
     assert service.classify_tool("mempalace_search") == "read"
     assert service.classify_tool("mempalace_add_drawer") == "write"
     assert service.classify_tool("mempalace_checkpoint") == "write"
+    assert service.classify_tool("mempalace_delete_by_source") == "write"
     assert service.classify_tool("mempalace_mine") == "maintenance"
     assert service.classify_tool("unknown") == "unknown"
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4832,6 +4832,27 @@ def test_peer_writer_guard_does_not_gate_read_tool(monkeypatch):
     assert '"ok": true' in response["result"]["content"][0]["text"]
 
 
+def test_status_tool_does_not_acquire_peer_writer_lock(monkeypatch):
+    from mempalace import mcp_server
+
+    def forbidden_lock():
+        raise AssertionError("status should not acquire the peer-writer lock")
+
+    monkeypatch.setattr(mcp_server, "_ensure_sqlite_integrity_status", lambda: None)
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_errors", None)
+    monkeypatch.setattr(mcp_server, "_backend_db_exists", lambda: True)
+    monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", lambda: None)
+    monkeypatch.setattr(mcp_server, "_vector_disabled", True)
+    monkeypatch.setattr(
+        mcp_server,
+        "_tool_status_via_sqlite",
+        lambda: {"total_drawers": 0, "wings": {}, "rooms": {}},
+    )
+    monkeypatch.setattr(mcp_server, "_acquire_mcp_writer_lock", forbidden_lock)
+
+    assert mcp_server.tool_status()["total_drawers"] == 0
+
+
 def test_peer_writer_lock_setup_failure_is_cached(monkeypatch):
     from mempalace import mcp_server, palace
 


### PR DESCRIPTION
## Summary

Fixes #1923 by keeping `mempalace_status` on the read side of the MCP peer-writer guard. `tool_status()` no longer calls `_acquire_mcp_writer_lock()`, so a status request cannot elect or steal the per-palace writer lease in multi-server setups.

This also aligns the daemon service classifier with the recently merged mutating-tool update by classifying `mempalace_delete_by_source` as a write tool.

## Why

The peer-writer lock is intentionally held for mutating MCP tools, but status is a read operation. Calling status should not cause later writers to be refused or force an otherwise read-only server to become the writer lease holder.

## Validation

- `uv run pytest tests/test_mcp_server.py -k "peer_writer or status_tool_does_not_acquire" -v`
- `uv run pytest tests/test_daemon.py -k "service_tool_classification" -v`
- `uv run pytest tests/test_mcp_server.py tests/test_daemon.py -v`
- `uv run ruff check .`
- `uv run ruff format --check .`

Note: `uv run` modified `uv.lock` in the local isolated worktree; that generated change was intentionally left unstaged and is not part of this PR.