### PR TITLE
[adam] Optimize Qdrant incremental mining metadata reads

### DIFF
--- a/mempalace/backends/qdrant.py
+++ b/mempalace/backends/qdrant.py
@@ -498,10 +498,11 @@ class _QdrantRESTClient:
         limit: int = _SCROLL_PAGE_SIZE,
         offset: Any = None,
         with_vector: bool = False,
+        with_payload: Any = True,
     ) -> tuple[list[dict], Any]:
         body: dict[str, Any] = {
             "limit": int(limit),
-            "with_payload": True,
+            "with_payload": with_payload,
             "with_vector": bool(with_vector),
         }
         if qdrant_filter:
@@ -751,6 +752,15 @@ class QdrantCollection(BaseCollection):
                 self._client.create_collection(self._remote_collection, dimension)
                 self._client.create_payload_index(
                     self._remote_collection, _PAYLOAD_DOCUMENT, "text"
+                )
+                self._client.create_payload_index(
+                    self._remote_collection, f"{_PAYLOAD_METADATA}.source_file", "keyword"
+                )
+                self._client.create_payload_index(
+                    self._remote_collection, f"{_PAYLOAD_METADATA}.wing", "keyword"
+                )
+                self._client.create_payload_index(
+                    self._remote_collection, f"{_PAYLOAD_METADATA}.room", "keyword"
                 )
                 self._known_dimension = dimension
                 return
@@ -1056,17 +1066,36 @@ class QdrantCollection(BaseCollection):
         loop would re-walk the entire collection from the start just to
         discard everything outside its slice (O(n^2) over collection size).
 
-        Delegates to self._rows(), the same single-scroll-plus-local-filter
-        helper that backs get()/delete(). With ids=None and
-        where_document=None, _rows() reduces to exactly one _scroll_all()
-        pass followed by an unconditional _matches_where() re-check on every
-        row -- the same filter logic get(), delete(), and lexical_search()
-        already use, so this can't independently drift from those call
-        sites. (Maintainer review on #1832: avoid duplicating the filter
-        dance inline.)
+        Uses Qdrant's payload selector to fetch only the metadata payload.
+        The full document text is not needed by callers that are building an
+        incremental source-file cache, and transferring it dominates runtime
+        for large local codebases.
         """
-        rows = self._rows(where=where)
-        return [row["metadata"] for row in rows]
+        _validate_where(where)
+        self._ensure_open()
+        if not self._remote_exists():
+            if self._marker_exists():
+                raise CollectionNotInitializedError(self._collection_name)
+            return []
+        q_filter = None if _requires_local_filter(where) else _qdrant_filter(where)
+        metadatas: list[dict] = []
+        offset = None
+        while True:
+            points, offset = self._client.scroll_points(
+                self._remote_collection,
+                qdrant_filter=q_filter,
+                limit=_SCROLL_PAGE_SIZE,
+                offset=offset,
+                with_vector=False,
+                with_payload=[_PAYLOAD_METADATA],
+            )
+            for point in points:
+                payload = point.get("payload") or {}
+                metadata = payload.get(_PAYLOAD_METADATA) or {}
+                if isinstance(metadata, dict) and _matches_where(metadata, where):
+                    metadatas.append(metadata)
+            if offset is None:
+                return metadatas
 
     def facet_counts(
         self,

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1359,6 +1359,7 @@ def process_file(
     chunk_overlap: int = None,
     min_chunk_size: int = None,
     max_chunks_per_file: Optional[int] = None,
+    mined_mtime_cache: Optional[dict[str, set[float]]] = None,
 ) -> tuple:
     """Read, chunk, route, and file one file.
 
@@ -1373,8 +1374,21 @@ def process_file(
 
     # Skip if already filed
     source_file = str(filepath)
-    if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
-        return 0, "general", None
+    if not dry_run:
+        try:
+            source_mtime = os.path.getmtime(source_file)
+        except OSError:
+            source_mtime = None
+        if (
+            mined_mtime_cache is not None
+            and source_mtime is not None
+            and source_mtime in mined_mtime_cache.get(source_file, set())
+        ):
+            return 0, "general", None
+        if mined_mtime_cache is None and file_already_mined(
+            collection, source_file, check_mtime=True
+        ):
+            return 0, "general", None
 
     content = _read_text_no_follow(filepath, project_path)
     if content is None:
@@ -1520,6 +1534,26 @@ def process_file(
             upsert_closet_lines(closets_col, closet_id_base, closet_lines, closet_meta)
 
     return drawers_added, room, None
+
+
+def _build_mined_mtime_cache(collection, wing: str) -> Optional[dict[str, set[float]]]:
+    """Build a per-wing source-file mtime cache for incremental mine skips."""
+    cache: dict[str, set[float]] = defaultdict(set)
+    try:
+        metadatas = collection.get_all_metadata(where={"wing": wing})
+    except Exception:
+        logger.debug("Bulk mined-file metadata cache failed; falling back per file", exc_info=True)
+        return None
+    for meta in metadatas:
+        if not isinstance(meta, dict):
+            continue
+        if meta.get("normalize_version") != NORMALIZE_VERSION:
+            continue
+        source_file = meta.get("source_file")
+        source_mtime = meta.get("source_mtime")
+        if isinstance(source_file, str) and isinstance(source_mtime, (int, float)):
+            cache[source_file].add(float(source_mtime))
+    return cache
 
 
 # =============================================================================
@@ -1747,6 +1781,10 @@ def _mine_impl(
     last_file = None
     room_counts = defaultdict(int)
     effective_chunk_cap = _resolve_max_chunks_per_file(max_chunks_per_file)
+    mined_mtime_cache: Optional[dict[str, set[float]]] = None
+
+    if not dry_run:
+        mined_mtime_cache = _build_mined_mtime_cache(collection, wing)
 
     try:
         for i, filepath in enumerate(files, 1):
@@ -1768,6 +1806,7 @@ def _mine_impl(
                     # otherwise a malformed env var would emit its warning
                     # per file.
                     max_chunks_per_file=effective_chunk_cap,
+                    mined_mtime_cache=mined_mtime_cache,
                 )
             except KeyboardInterrupt:
                 # Re-raise so the outer handler prints the summary; we
@@ -1794,7 +1833,7 @@ def _mine_impl(
                 if limit > 0 and files_mined >= limit:
                     break
 
-        if not dry_run:
+        if not dry_run and total_drawers > 0:
             # Cross-wing topic tunnels: after every file in this wing has been
             # processed, link this wing to any other wing that shares a
             # confirmed TOPIC label. Out of scope for v1: manifest-dependency

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -1107,6 +1107,40 @@ def test_process_file_uses_bounded_upsert_batches(tmp_path, monkeypatch):
     assert col.batch_sizes == [2, 2, 1]
 
 
+def test_process_file_uses_bulk_mtime_cache_before_reading(tmp_path, monkeypatch):
+    from mempalace import miner
+
+    source = tmp_path / "cached.py"
+    source.write_text("print('already indexed')\n", encoding="utf-8")
+    source_mtime = source.stat().st_mtime
+
+    monkeypatch.setattr(
+        miner,
+        "file_already_mined",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("per-file query used")),
+    )
+    monkeypatch.setattr(
+        miner,
+        "_read_text_no_follow",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("file was read")),
+    )
+
+    drawers, room, skip_reason = miner.process_file(
+        source,
+        tmp_path,
+        object(),
+        "wing",
+        [{"name": "general", "description": "General"}],
+        "agent",
+        False,
+        mined_mtime_cache={str(source): {source_mtime}},
+    )
+
+    assert drawers == 0
+    assert room == "general"
+    assert skip_reason is None
+
+
 # ── normalize_version schema gate ───────────────────────────────────────
 #
 # When the normalization pipeline changes shape (e.g., strip_noise lands),

--- a/tests/test_qdrant_backend.py
+++ b/tests/test_qdrant_backend.py
@@ -148,8 +148,11 @@ class _FakeQdrantClient:
         limit=256,
         offset=None,
         with_vector=False,
+        with_payload=True,
     ):
-        self.scroll_calls.append(qdrant_filter)
+        self.scroll_calls.append(
+            {"filter": qdrant_filter, "with_vector": with_vector, "with_payload": with_payload}
+        )
         points = list(self.collections.get(collection, {"points": {}})["points"].values())
         points = [point for point in points if _fake_match_filter(point, qdrant_filter)]
         start = int(offset or 0)
@@ -157,7 +160,13 @@ class _FakeQdrantClient:
         next_offset = start + limit if start + limit < len(points) else None
         out = []
         for point in selected:
-            item = {"id": point["id"], "payload": point["payload"]}
+            if with_payload is True:
+                payload = point["payload"]
+            elif with_payload is False:
+                payload = {}
+            else:
+                payload = {key: point["payload"][key] for key in with_payload if key in point["payload"]}
+            item = {"id": point["id"], "payload": payload}
             if with_vector:
                 item["vector"] = point["vector"]
             out.append(item)
@@ -265,7 +274,12 @@ def test_qdrant_add_query_filters_lexical_and_marker(tmp_path, fake_qdrant):
 
     hits = col.lexical_search(query="rareterm backend", n_results=2, where={"wing": "project"}).hits
     assert [hit.id for hit in hits] == ["b", "a"]
-    assert fake_qdrant.instances[0].created_indexes[0][1:] == ("document", "text")
+    assert [index[1:] for index in fake_qdrant.instances[0].created_indexes] == [
+        ("document", "text"),
+        ("metadata.source_file", "keyword"),
+        ("metadata.wing", "keyword"),
+        ("metadata.room", "keyword"),
+    ]
 
     backend.close_palace(str(tmp_path))
     with pytest.raises(Exception):

--- a/tests/test_qdrant_bulk_metadata_scroll.py
+++ b/tests/test_qdrant_bulk_metadata_scroll.py
@@ -187,9 +187,23 @@ def _make_qdrant_collection(monkeypatch, scroll_pages):
     call_log = []
 
     def fake_scroll_points(
-        collection, *, qdrant_filter=None, limit=4096, offset=None, with_vector=False
+        collection,
+        *,
+        qdrant_filter=None,
+        limit=4096,
+        offset=None,
+        with_vector=False,
+        with_payload=True,
     ):
-        call_log.append({"limit": limit, "offset": offset, "filter": qdrant_filter})
+        call_log.append(
+            {
+                "limit": limit,
+                "offset": offset,
+                "filter": qdrant_filter,
+                "with_vector": with_vector,
+                "with_payload": with_payload,
+            }
+        )
         idx = len([c for c in call_log]) - 1
         return scroll_pages[idx]
 
@@ -252,6 +266,8 @@ class TestQdrantGetAllMetadataSingleScroll:
         assert len(call_log) == 2, (
             f"Expected exactly 2 scroll_points() calls (one full pass), got {len(call_log)}"
         )
+        assert all(call["with_payload"] == [qdrant_mod._PAYLOAD_METADATA] for call in call_log)
+        assert all(call["with_vector"] is False for call in call_log)
 
     def test_does_not_call_get_internally(self, monkeypatch):
         """


### PR DESCRIPTION
## Summary

This PR optimizes Qdrant-backed incremental mining for large local codebases.

The issue observed locally was that repeated no-change `mempalace mine` runs still spent most of their time fetching existing metadata and recomputing derived graph data, even when zero files needed to be re-indexed.

## Root Cause

- `QdrantCollection.get_all_metadata()` avoided the default O(n^2) offset loop, but still delegated through `_rows()`, which materialized full payload rows including the `document` text.
- The Qdrant REST scroll helper always requested full payloads, so metadata-only callers could not avoid document transfer.
- `mine` checked already-indexed files one file at a time unless the backend-specific bulk metadata path was fast enough to use as a cache.
- No-change mining still recomputed topic tunnels, hallways, and entity tunnels even when `total_drawers == 0`.

## Changes

- Add `with_payload` support to Qdrant REST scroll requests.
- Make `QdrantCollection.get_all_metadata()` use a single metadata-only scroll cursor.
- Create Qdrant payload indexes for `metadata.source_file`, `metadata.wing`, and `metadata.room` on new collections, in addition to the existing document text index.
- Build a per-wing source-file mtime cache once per `mine` run and use it before reading unchanged files.
- Skip derived tunnel/hallway recomputation when a mine run files zero new drawers.
- Add regression tests for metadata-only scroll, payload index creation, and the bulk mtime cache short-circuit.

## Local Impact Observed

On a local Qdrant collection with 50,038 drawers and 3,721 source files:

- `get_all_metadata(where={"wing": "dirextalk"})`: about 53s -> about 0.68s after the metadata-only/forwarded path.
- No-change `mempalace --backend qdrant mine C:\Users\84960\Desktop\dirextalk`: about 58s -> about 4.1s in the installed local tool after applying the same fixes.
- This branch, run through `uv run` from the PR checkout, completed a no-change mine in about 10.2s with 0 files processed and 3,721 files skipped. That run used CPU because the dev venv did not install `mempalace[gpu]`, but no embeddings were computed because no files changed.
- Search still works after the changes; `mempalace --backend qdrant search "dirextalk message server" --wing dirextalk` returned matching results from the existing index.

## Validation

- `python -m pytest --basetemp .pytest-tmp tests/test_qdrant_backend.py tests/test_qdrant_bulk_metadata_scroll.py tests/test_embedding_wrapper.py tests/test_miner.py::test_process_file_uses_bounded_upsert_batches tests/test_miner.py::test_process_file_uses_bulk_mtime_cache_before_reading`
  - 52 passed, 1 skipped
- `ruff check mempalace/backends/qdrant.py mempalace/miner.py tests/test_qdrant_backend.py tests/test_qdrant_bulk_metadata_scroll.py tests/test_miner.py`
  - All checks passed
- Real local Qdrant mine/search smoke tests as described above.