### PR TITLE
fix(hooks): collapse hyphens in Cursor mempal_infer_wing to match normalize_wing_name

### DIFF
--- a/hooks/cursor/lib/common.sh
+++ b/hooks/cursor/lib/common.sh
@@ -444,12 +444,14 @@ mempal_infer_wing() {
     case "$base" in
         *\\*) base="${base##*\\}" ;;
     esac
-    # Lowercase + replace anything outside [a-z0-9_-] with underscore.
-    # Collapse runs of underscores so "foo  bar" doesn't become
-    # "foo__bar".
+    # Lowercase + collapse anything outside [a-z0-9_] (spaces, hyphens,
+    # other punctuation) to underscore, then squeeze runs so "foo  bar"
+    # doesn't become "foo__bar". Hyphens collapse too, matching
+    # config.normalize_wing_name, so the hook-derived wing equals the
+    # miner's canonical wing for a hyphenated repo dir (#1936).
     base="$(printf '%s' "$base" \
         | tr '[:upper:]' '[:lower:]' \
-        | tr -c 'a-z0-9_-' '_' \
+        | tr -c 'a-z0-9_' '_' \
         | tr -s '_' \
         | sed 's/^_//; s/_$//')"
     if [ -z "$base" ]; then

--- a/tests/test_cursor_hooks_shell.py
+++ b/tests/test_cursor_hooks_shell.py
@@ -616,6 +616,14 @@ class TestInferWing:
     def test_spaces_collapsed_to_underscore(self):
         assert _call_infer_wing("/Users/me/my project") == "my_project"
 
+    def test_hyphens_collapsed_to_underscore(self):
+        # Hyphens must collapse to "_" like spaces, so the hook-derived
+        # wing matches config.normalize_wing_name (which does the same).
+        # Otherwise a hyphenated repo dir like ~/code/my-proj yields wing
+        # "my-proj" from the hook but "my_proj" from the miners, and
+        # wing-filtered search misses the project's drawers (#1936).
+        assert _call_infer_wing("/Users/me/my-proj") == "my_proj"
+
     def test_lowercases_uppercase_basename(self):
         # Cursor on macOS often hands us /Users/<user>/Projects/MyApp.
         # The wing scoping in MemPalace's MCP tools is case-sensitive,


### PR DESCRIPTION
The Cursor wake/save hooks derive the wing via `mempal_infer_wing`, whose `tr -c 'a-z0-9_-'` kept hyphens, while `config.normalize_wing_name` (used by the miners) collapses `-` to `_`. A hyphenated repo dir (e.g. `my-proj`) then produced wing `my-proj` from the hooks but `my_proj` from the miners. Since the `mempalace_search` wing filter matches verbatim, wake-hook recall returned zero results, and save-hook checkpoints could fragment memory into a split wing.

Drop `-` from the kept set so hyphens collapse to `_`, matching the canonical normalizer. Adds a regression test in `TestInferWing`.

Fixes #1936

## What does this PR do?

Aligns the Cursor hook's `mempal_infer_wing` (`hooks/cursor/lib/common.sh`) with the canonical `config.normalize_wing_name` by collapsing hyphens to `_`, so the hook-derived wing matches the miner's wing for a hyphenated project directory. One-character change to the `tr` keep-set, plus a regression test. Scoped to the Cursor hook only; the Antigravity hook uses a different `wing_slug` scheme and is out of scope here.

## How to test

```
uv run pytest tests/test_cursor_hooks_shell.py -v
```

The new `TestInferWing::test_hyphens_collapsed_to_underscore` asserts `mempal_infer_wing "/Users/me/my-proj"` returns `my_proj`. Before the fix it returned `my-proj`.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

> Note: two pre-existing failures in `tests/test_repair.py` (FTS5 shadow-table corruption auto-heal) also fail on a clean `develop` checkout and are unrelated to this change. All Cursor hook shell tests pass.