### PR TITLE
feat: OpenClaw trajectory source adapter (RFC 002)

### DIFF
--- a/mempalace/sources/openclaw.py
+++ b/mempalace/sources/openclaw.py
@@ -30,9 +30,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Protocol, Tuple, runtime_checkable
 
 from ..convo_miner import chunk_exchanges, detect_convo_room
 from ..config import normalize_wing_name
@@ -54,18 +55,457 @@ from .context import PalaceContext
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
 # Default sessions-directory search order.
 _DEFAULT_SESSIONS_DIRS: Tuple[str, ...] = ("~/.openclaw/agents/main/sessions",)
 
 # Filename suffix that identifies trajectory files.
 _TRAJECTORY_SUFFIX = ".trajectory.jsonl"
 
+# Pointer file suffix: written by OpenClaw beside the session file when the
+# trajectory sidecar was relocated (e.g. via ``OPENCLAW_TRAJECTORY_DIR``).
+# Content: JSON object with a "path" key pointing to the relocated sidecar.
+_POINTER_SUFFIX = ".trajectory-path.json"
 
-def _detect_hall(content: str) -> str:
-    """Hall-detection helper — defers to convo_miner's cached lookup."""
-    from ..convo_miner import _detect_hall_cached
+# Expected schema marker value (docs/tools/trajectory.md).
+# Events whose ``traceSchema`` differs from this value indicate a different
+# format — the file is skipped to avoid corrupt ingest.
+_TRACE_SCHEMA_VALUE = "openclaw-trajectory"
 
-    return _detect_hall_cached(content)
+# Schema versions this adapter knows how to handle. A file with a
+# ``schemaVersion`` outside this set triggers a WARNING, but the adapter
+# proceeds with best-effort parsing (newer minor versions are likely
+# backward-compatible for the fields we consume).
+_KNOWN_SCHEMA_VERSIONS: frozenset = frozenset({1})
+
+# Truncation-marker event types emitted when the 10 MiB live-capture cap or
+# the 200,000-event cap fires. These events are recognised and skipped
+# without being counted as data events. The partial data before them is
+# still parsed.
+#
+# The canonical type is "trace.truncated" (confirmed from OpenClaw source:
+# the sessions-tail renderer maps `case "trace.truncated": return "trajectory
+# truncated"`). Kept as a set so additional truncation markers can be added.
+_TRUNCATION_EVENT_TYPES: frozenset = frozenset({"trace.truncated"})
+
+
+# ---------------------------------------------------------------------------
+# Reader abstraction (RFC 002 extension seam for database-first migration)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class TrajectoryEventSource(Protocol):
+    """Source-agnostic protocol for iterating OpenClaw trajectory events.
+
+    The current production implementation is :class:`JsonlTrajectoryEventSource`
+    which reads ``*.trajectory.jsonl`` sidecars from disk.  Code that performs
+    extraction, transform, and chunking works against this protocol; it does
+    **not** need to change when the storage backend changes.
+
+    .. rubric:: SQLite extension seam (docs/refactor/database-first.md)
+
+    Per ``database-first.md``, trajectory runtime events are migrating from
+    ``*.trajectory.jsonl`` sidecars to a per-agent SQLite table in
+    ``agents/<agentId>/agent/openclaw-agent.sqlite``.  The planned schema::
+
+        CREATE TABLE trajectory_runtime_events (
+            session_id  TEXT    NOT NULL,
+            run_id      TEXT    NOT NULL,
+            seq         INTEGER NOT NULL,
+            event_json  TEXT    NOT NULL,   -- full event serialised as JSON
+            created_at  TEXT    NOT NULL    -- ISO-8601 UTC
+        );
+
+    To implement ``SqliteTrajectoryEventSource``:
+
+    1. ``class SqliteTrajectoryEventSource:``
+       ``    def __init__(self, agent_id: str, session_id: str, db_path: Path)``
+    2. ``iter_events()``: open the agent db with ``sqlite3``, execute::
+
+           SELECT event_json FROM trajectory_runtime_events
+            WHERE session_id = ?
+            ORDER BY seq
+
+       and ``yield json.loads(row[0])`` for each row.  Apply the same
+       truncation-marker and error-tolerance logic as
+       :class:`JsonlTrajectoryEventSource`.
+    3. ``session_metadata()``: call
+       :func:`_aggregate_session_metadata` with ``self.iter_events()`` as
+       the event iterator.
+    4. Pass the new instance wherever :class:`JsonlTrajectoryEventSource`
+       is used today — no changes to extraction, transform, or chunking
+       required.
+
+    JSONL sidecars remain valid as legacy/doctor-import inputs via
+    :class:`JsonlTrajectoryEventSource`; runtime ingest switches to the
+    SQLite source once the migration is complete.
+
+    .. note::
+        Transcript content transformation (the JSONL text → ruff pipeline)
+        is separate from event iteration.  For a SQLite source, synthesise
+        JSONL text from ``iter_events()`` output before passing it to
+        :func:`_build_canonical_source_bytes_from_events` (a helper to be
+        added when the SQLite backend lands).  The transform/chunk steps are
+        unchanged.
+    """
+
+    def iter_events(self) -> Iterator[Dict[str, Any]]:
+        """Yield parsed event dicts in ascending sequence order.
+
+        Implementation contract:
+
+        * Silently skip lines / rows that cannot be parsed as JSON objects.
+        * Validate the schema marker on the first parseable event; skip the
+          whole stream (return early) if ``traceSchema`` is wrong; log a
+          WARNING and continue if ``schemaVersion`` is unknown.
+        * Silently skip truncation-marker events
+          (see :data:`_TRUNCATION_EVENT_TYPES`).
+        * Tolerate a partial final line written when the 10 MiB cap fires
+          before a newline is flushed — such a line will fail ``json.loads``
+          and must be skipped without raising.
+        """
+        ...
+
+    def session_metadata(self) -> Optional[Dict[str, Any]]:
+        """Return aggregated session-level metadata, or ``None`` if no events.
+
+        Returned keys when not ``None``:
+        ``session_id``, ``session_key``, ``workspace_dir``, ``model_id``,
+        ``session_created_at``, ``version``, ``message_count``.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Schema-marker helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_schema_marker(
+    event: Dict[str, Any],
+    source_name: str,
+) -> bool:
+    """Validate the schema marker on the first parseable event.
+
+    Args:
+        event: First parsed event dict.
+        source_name: Human-readable label for log messages (e.g. file basename).
+
+    Returns:
+        ``True`` — proceed with parsing (valid marker, or no marker present).
+        ``False`` — skip the whole file (wrong ``traceSchema``).
+
+    Side effects:
+        Logs a WARNING for an unknown ``schemaVersion`` (best-effort parse
+        continues).  Logs a WARNING and returns ``False`` for a wrong
+        ``traceSchema``.
+    """
+    trace_schema = event.get("traceSchema")
+    schema_version = event.get("schemaVersion")
+
+    if trace_schema is not None and trace_schema != _TRACE_SCHEMA_VALUE:
+        logger.warning(
+            "openclaw adapter: %s — unexpected traceSchema %r (expected %r); "
+            "skipping file to avoid corrupt ingest",
+            source_name,
+            trace_schema,
+            _TRACE_SCHEMA_VALUE,
+        )
+        return False  # wrong format — skip file
+
+    if schema_version is not None and schema_version not in _KNOWN_SCHEMA_VERSIONS:
+        logger.warning(
+            "openclaw adapter: %s — unknown schemaVersion %r "
+            "(known: %r); attempting best-effort parse — "
+            "some fields may be missing or misinterpreted",
+            source_name,
+            schema_version,
+            sorted(_KNOWN_SCHEMA_VERSIONS),
+        )
+        # Continue parsing — do NOT return False.
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Source-agnostic metadata aggregation
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_session_metadata(
+    source_name: str,
+    events: Iterator[Dict[str, Any]],
+    *,
+    fallback_stem: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Aggregate session metadata from any event iterator.
+
+    This helper is **source-agnostic**: it consumes whatever
+    :meth:`TrajectoryEventSource.iter_events` yields, whether from JSONL on
+    disk or (in future) from the SQLite ``trajectory_runtime_events`` table.
+
+    Args:
+        source_name: Human-readable label for debug messages.
+        events: Iterator of parsed event dicts.
+        fallback_stem: Fallback ``session_id`` when the first event has no
+            ``sessionId`` field (e.g. stem of the source filename).
+
+    Returns:
+        Metadata dict with keys ``session_id``, ``session_key``,
+        ``workspace_dir``, ``model_id``, ``session_created_at``,
+        ``version``, ``message_count``; or ``None`` if no events were found.
+    """
+    first_event: Optional[Dict[str, Any]] = None
+    last_event: Optional[Dict[str, Any]] = None
+    message_count = 0
+    pending_user = False
+
+    for event in events:
+        if first_event is None:
+            first_event = event
+        last_event = event
+        etype = event.get("type")
+        if etype == "prompt.submitted":
+            pending_user = True
+        elif etype == "model.completed" and pending_user:
+            message_count += 1
+            pending_user = False
+
+    if first_event is None:
+        return None
+
+    return {
+        "session_id": first_event.get("sessionId") or fallback_stem,
+        "session_key": first_event.get("sessionKey") or "",
+        "workspace_dir": first_event.get("workspaceDir") or "",
+        "model_id": first_event.get("modelId") or "",
+        "session_created_at": first_event.get("ts") or "",
+        "version": str(last_event.get("seq", 0)) if last_event else "0",
+        "message_count": message_count,
+    }
+
+
+# ---------------------------------------------------------------------------
+# JSONL-on-disk implementation
+# ---------------------------------------------------------------------------
+
+
+class JsonlTrajectoryEventSource:
+    """JSONL-on-disk implementation of :class:`TrajectoryEventSource`.
+
+    Reads ``*.trajectory.jsonl`` files line-by-line with:
+
+    * **Schema-marker validation** on the first parseable event
+      (:func:`_validate_schema_marker`).
+    * **Partial-line tolerance** — a line that fails ``json.loads``
+      (e.g. the last line was written mid-stream when the 10 MiB cap fired
+      before the newline was flushed, or an individual line exceeded the
+      256 KiB per-line cap) is silently skipped.
+    * **Truncation-marker recognition** — events whose ``type`` is in
+      :data:`_TRUNCATION_EVENT_TYPES` are silently skipped and not counted
+      as data events; the partial data before them is still parsed.
+    * **Line-level error recovery** — any non-JSON line is silently skipped.
+
+    Args:
+        path: Absolute or relative path to the ``*.trajectory.jsonl`` file.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._meta_cache: Optional[Dict[str, Any]] = None
+
+    # ------------------------------------------------------------------
+    # TrajectoryEventSource implementation
+    # ------------------------------------------------------------------
+
+    def iter_events(self) -> Iterator[Dict[str, Any]]:
+        """Yield parsed event dicts with full schema validation and truncation tolerance."""
+        schema_validated = False
+        try:
+            fh = self._path.open(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logger.warning("openclaw adapter: cannot open %s: %s", self._path, exc)
+            return
+
+        try:
+            for raw_line in fh:
+                raw = raw_line.strip()
+                if not raw:
+                    continue
+
+                try:
+                    event = json.loads(raw)
+                except (ValueError, TypeError):
+                    # Partial or corrupt line — covers truncation at the
+                    # 10 MiB or 256 KiB per-line cap.  Skip silently.
+                    continue
+
+                if not isinstance(event, dict):
+                    continue
+
+                # Validate schema marker on the FIRST parseable event only.
+                if not schema_validated:
+                    schema_validated = True
+                    if not _validate_schema_marker(event, self._path.name):
+                        return  # wrong traceSchema — skip whole file
+
+                # Skip truncation-marker events cleanly; still yield data
+                # events that appear before them.
+                if event.get("type") in _TRUNCATION_EVENT_TYPES:
+                    logger.debug(
+                        "openclaw adapter: truncation marker in %s — "
+                        "file was capped at 10 MiB or 200k events; "
+                        "partial ingest follows",
+                        self._path.name,
+                    )
+                    continue
+
+                yield event
+        finally:
+            fh.close()
+
+    def session_metadata(self) -> Optional[Dict[str, Any]]:
+        """Return cached session metadata computed from :meth:`iter_events`."""
+        if self._meta_cache is None:
+            self._meta_cache = _aggregate_session_metadata(
+                self._path.name,
+                self.iter_events(),
+                fallback_stem=self._path.stem,
+            )
+        return self._meta_cache
+
+
+# ---------------------------------------------------------------------------
+# Legacy scan shim (backward-compatible; delegates to JsonlTrajectoryEventSource)
+# ---------------------------------------------------------------------------
+
+
+def _scan_trajectory_file(path: Path) -> Optional[dict]:
+    """Single-pass scan of a trajectory file for session metadata + version.
+
+    Returns a dict with:
+
+    * ``session_id`` — from ``sessionId`` field of first event.
+    * ``session_key`` — from ``sessionKey`` field.
+    * ``workspace_dir`` — from ``workspaceDir`` field.
+    * ``model_id`` — from ``modelId`` field.
+    * ``session_created_at`` — ISO-8601 ``ts`` of the first event.
+    * ``version`` — ``str(seq)`` of the last event.
+    * ``message_count`` — number of complete exchange pairs found.
+
+    Returns ``None`` if no parseable events are found or if the file has a
+    wrong ``traceSchema`` (see :func:`_validate_schema_marker`).
+
+    .. note::
+        This function is a thin shim over
+        :meth:`JsonlTrajectoryEventSource.session_metadata`; it exists for
+        backward compatibility and is exported in :data:`__all__`.
+    """
+    return JsonlTrajectoryEventSource(path).session_metadata()
+
+
+# ---------------------------------------------------------------------------
+# Pointer file reader
+# ---------------------------------------------------------------------------
+
+
+def _read_pointer_file(pointer_path: Path) -> Optional[Path]:
+    """Read a ``.trajectory-path.json`` pointer and return the target :class:`Path`.
+
+    OpenClaw writes a best-effort pointer file beside the session file when
+    the trajectory sidecar was relocated via ``OPENCLAW_TRAJECTORY_DIR``.
+    Expected JSON shape::
+
+        {"path": "/abs/path/to/<session-id>.trajectory.jsonl"}
+
+    Alternative key names tried in order (for forward-compat):
+    ``path``, ``trajectoryPath``, ``trajectoryFilePath``.
+
+    Returns ``None`` on any I/O or parse error (pointer lookup is best-effort).
+    """
+    try:
+        data = json.loads(pointer_path.read_text(encoding="utf-8", errors="replace"))
+        for key in ("path", "trajectoryPath", "trajectoryFilePath"):
+            val = data.get(key)
+            if val:
+                return Path(str(val)).expanduser()
+    except Exception as exc:
+        logger.debug(
+            "openclaw adapter: failed to read pointer file %s: %s",
+            pointer_path,
+            exc,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Discovery helpers
+# ---------------------------------------------------------------------------
+
+
+def _discover_from_dir(sessions_dir: Path) -> List[Path]:
+    """Discover trajectory files from a sessions directory.
+
+    Searches in three ways, de-duplicating by resolved path:
+
+    1. **Default sidecars** — ``<sessions_dir>/*.trajectory.jsonl`` files
+       written beside session files (default OpenClaw capture location).
+    2. **Pointer files** — ``<sessions_dir>/*.trajectory-path.json`` files
+       written by OpenClaw when ``OPENCLAW_TRAJECTORY_DIR`` was set; each
+       pointer contains the path to the relocated sidecar.
+    3. **OPENCLAW_TRAJECTORY_DIR** — when this env var is set, all
+       ``*.trajectory.jsonl`` files in that dedicated directory are included.
+
+    The ``OPENCLAW_TRAJECTORY_DIR`` path is read from the environment on
+    every call so tests can use ``monkeypatch.setenv`` without reloading.
+
+    Args:
+        sessions_dir: Resolved absolute path to the sessions directory.
+
+    Returns:
+        Sorted, de-duplicated list of resolved :class:`Path` objects.
+    """
+    found: set = set()
+
+    # 1. Default sidecars (beside session files).
+    for f in sessions_dir.glob(f"*{_TRAJECTORY_SUFFIX}"):
+        if f.is_file():
+            found.add(f.resolve())
+
+    # 2. Pointer files (best-effort; missing/corrupt pointers are skipped).
+    for pf in sessions_dir.glob(f"*{_POINTER_SUFFIX}"):
+        target = _read_pointer_file(pf)
+        if target is not None:
+            resolved = target.resolve()
+            if resolved.is_file():
+                found.add(resolved)
+            else:
+                logger.debug(
+                    "openclaw adapter: pointer %s → %s does not exist; skipping",
+                    pf.name,
+                    resolved,
+                )
+
+    # 3. OPENCLAW_TRAJECTORY_DIR dedicated directory.
+    traj_dir_env = os.environ.get("OPENCLAW_TRAJECTORY_DIR")
+    if traj_dir_env:
+        traj_dir = Path(traj_dir_env).expanduser()
+        if traj_dir.is_dir():
+            for f in traj_dir.glob(f"*{_TRAJECTORY_SUFFIX}"):
+                if f.is_file():
+                    found.add(f.resolve())
+        else:
+            logger.warning(
+                "openclaw adapter: OPENCLAW_TRAJECTORY_DIR=%r is not a directory; "
+                "skipping dedicated trajectory directory",
+                traj_dir_env,
+            )
+
+    return sorted(found)
 
 
 def _resolve_sessions_dir(local_path: Optional[str] = None) -> Optional[Path]:
@@ -99,22 +539,26 @@ def _resolve_sessions_dir(local_path: Optional[str] = None) -> Optional[Path]:
 
 
 def _enumerate_trajectory_files(source: SourceRef) -> List[Path]:
-    """Return sorted list of trajectory files for a :class:`SourceRef`.
+    """Return sorted, de-duplicated trajectory files for a :class:`SourceRef`.
 
     Handles three shapes:
 
-    * ``local_path`` pointing at a directory → enumerate ``*.trajectory.jsonl``
-      inside it.
     * ``local_path`` pointing at a single ``*.trajectory.jsonl`` file → return
-      that one file.
-    * ``local_path`` is ``None`` → use :data:`_DEFAULT_SESSIONS_DIRS`.
+      that one file (env var and pointer lookup are skipped for single-file mode).
+    * ``local_path`` pointing at a directory → call :func:`_discover_from_dir`.
+    * ``local_path`` is ``None`` → try :data:`_DEFAULT_SESSIONS_DIRS` in order
+      and call :func:`_discover_from_dir` on the first existing one.
+
+    In directory mode, :func:`_discover_from_dir` additionally checks pointer
+    files and ``OPENCLAW_TRAJECTORY_DIR`` so all three documented capture
+    locations are covered.
     """
     if source.local_path:
         p = Path(source.local_path).expanduser()
         if p.is_file():
             return [p.resolve()]
         if p.is_dir():
-            return sorted(p.resolve().glob(f"*{_TRAJECTORY_SUFFIX}"))
+            return _discover_from_dir(p.resolve())
         raise SourceNotFoundError(
             f"SourceRef.local_path {source.local_path!r} is neither a file nor a directory."
         )
@@ -122,11 +566,16 @@ def _enumerate_trajectory_files(source: SourceRef) -> List[Path]:
     for raw in _DEFAULT_SESSIONS_DIRS:
         d = Path(raw).expanduser()
         if d.is_dir():
-            return sorted(d.resolve().glob(f"*{_TRAJECTORY_SUFFIX}"))
+            return _discover_from_dir(d.resolve())
     raise SourceNotFoundError(
         f"No OpenClaw sessions directory found (searched {list(_DEFAULT_SESSIONS_DIRS)}). "
-        f"Pass SourceRef(local_path=<sessions-dir>)."
+        f"Pass SourceRef(local_path=<sessions-dir>) or create one of the default paths."
     )
+
+
+# ---------------------------------------------------------------------------
+# Source file URI and transform helpers
+# ---------------------------------------------------------------------------
 
 
 def session_source_file(file_path: str, session_id: str) -> str:
@@ -139,63 +588,6 @@ def session_source_file(file_path: str, session_id: str) -> str:
     return f"openclaw://{file_path}#session={session_id}"
 
 
-def _scan_trajectory_file(path: Path) -> Optional[dict]:
-    """Single-pass scan of a trajectory file for session metadata + version.
-
-    Returns a dict with:
-
-    * ``session_id`` — from ``sessionId`` field of first event.
-    * ``session_key`` — from ``sessionKey`` field (e.g. ``agent:main:slack:…``).
-    * ``workspace_dir`` — from ``workspaceDir`` field.
-    * ``model_id`` — from ``modelId`` field.
-    * ``session_created_at`` — ISO-8601 ``ts`` of the first event.
-    * ``version`` — ``str(seq)`` of the last event (used by
-      :meth:`is_current`; trajectory files are append-only so the last
-      ``seq`` advances whenever new events are appended).
-    * ``message_count`` — number of complete exchange pairs found: each
-      ``prompt.submitted`` event matched to the ``model.completed`` event
-      that immediately follows it. This is the definitive count advertised
-      by :meth:`describe_schema`; computing it at scan time avoids a
-      second pass over the transform pipeline.
-
-    Returns ``None`` if no parseable events are found.
-    """
-    first_event: Optional[dict] = None
-    last_event: Optional[dict] = None
-    message_count = 0
-    pending_user = False
-    for raw in path.open(encoding="utf-8", errors="replace"):
-        raw = raw.strip()
-        if not raw:
-            continue
-        try:
-            event = json.loads(raw)
-        except (ValueError, TypeError):
-            continue
-        if first_event is None:
-            first_event = event
-        last_event = event
-        etype = event.get("type")
-        if etype == "prompt.submitted":
-            pending_user = True
-        elif etype == "model.completed" and pending_user:
-            message_count += 1
-            pending_user = False
-
-    if first_event is None:
-        return None
-
-    return {
-        "session_id": first_event.get("sessionId") or path.stem,
-        "session_key": first_event.get("sessionKey") or "",
-        "workspace_dir": first_event.get("workspaceDir") or "",
-        "model_id": first_event.get("modelId") or "",
-        "session_created_at": first_event.get("ts") or "",
-        "version": str(last_event.get("seq", 0)) if last_event else "0",
-        "message_count": message_count,
-    }
-
-
 def _build_canonical_source_bytes(path: Path) -> str:
     """Return the canonical source bytes for a trajectory file.
 
@@ -204,6 +596,16 @@ def _build_canonical_source_bytes(path: Path) -> str:
     input the declared transformation chain consumes; the conformance
     suite uses the same shape to verify the declared-transformation
     round-trip is exact.
+
+    .. note:: SQLite seam — future work
+        For a SQLite-backed :class:`TrajectoryEventSource`, synthesise JSONL
+        text from the event rows before passing to this pipeline::
+
+            raw = "\\n".join(json.dumps(e) for e in source.iter_events())
+
+        This keeps the transform/chunk pipeline source-agnostic.  The helper
+        ``_build_canonical_source_bytes_from_events`` will be added when the
+        SQLite backend lands.
     """
     return path.read_text(encoding="utf-8", errors="replace")
 
@@ -231,6 +633,18 @@ def _apply_transform_pipeline(raw_text: str) -> str:
 def _now_utc_iso() -> str:
     """Return current UTC time as ISO-8601 with trailing ``Z``."""
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _detect_hall(content: str) -> str:
+    """Hall-detection helper — defers to convo_miner's cached lookup."""
+    from ..convo_miner import _detect_hall_cached
+
+    return _detect_hall_cached(content)
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
 
 
 class OpenClawSourceAdapter(BaseSourceAdapter):
@@ -316,7 +730,7 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
                 "session_created_at": FieldSpec(
                     type="string",
                     required=True,
-                    description="ISO-8601 UTC timestamp of the first event in the trajectory",
+                    description=("ISO-8601 UTC timestamp of the first event in the trajectory"),
                 ),
                 "message_count": FieldSpec(
                     type="int",
@@ -349,7 +763,7 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
         for tfile in trajectory_files:
             meta = _scan_trajectory_file(tfile)
             if meta is None:
-                logger.debug("openclaw adapter: skipping empty file %s", tfile)
+                logger.debug("openclaw adapter: skipping %s (no parseable events)", tfile)
                 continue
 
             file_path = str(tfile)
@@ -513,6 +927,8 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
 
 __all__ = [
     "OpenClawSourceAdapter",
+    "JsonlTrajectoryEventSource",
+    "TrajectoryEventSource",
     "session_source_file",
     "_build_canonical_source_bytes",
     "_scan_trajectory_file",

--- a/mempalace/sources/openclaw.py
+++ b/mempalace/sources/openclaw.py
@@ -24,6 +24,14 @@ The extraction pipeline mirrors ``convo-spike/convert_trajectories.py``:
   ``trace.*`` etc. are skipped.
 * OpenClaw runtime-context injection blocks and metadata-preamble fences
   are stripped from user text before chunking.
+
+.. note:: Secret redaction
+    ``openclaw_redact_secrets`` is applied as a declared transform before
+    content is chunked.  This is best-effort protection against credentials
+    present in raw agent trajectories (API keys, tokens, private keys, etc.)
+    landing verbatim in ChromaDB.  ``default_privacy_class = "pii_potential"``
+    is retained; treat redaction as a defence-in-depth measure, not a
+    security guarantee.
 """
 
 from __future__ import annotations
@@ -140,17 +148,35 @@ class TrajectoryEventSource(Protocol):
        is used today — no changes to extraction, transform, or chunking
        required.
 
+    For versioning, use ``SELECT COUNT(*) FROM trajectory_runtime_events WHERE
+    session_id = ?`` or the row count as the version rather than file size.
+
     JSONL sidecars remain valid as legacy/doctor-import inputs via
     :class:`JsonlTrajectoryEventSource`; runtime ingest switches to the
     SQLite source once the migration is complete.
 
-    .. note::
-        Transcript content transformation (the JSONL text → ruff pipeline)
-        is separate from event iteration.  For a SQLite source, synthesise
-        JSONL text from ``iter_events()`` output before passing it to
-        :func:`_build_canonical_source_bytes_from_events` (a helper to be
-        added when the SQLite backend lands).  The transform/chunk steps are
-        unchanged.
+    .. rubric:: RFC §7.3 conformance — single-parse reconciliation
+
+    The declared transforms (``openclaw_extract_turns``, strip transforms,
+    ``openclaw_redact_secrets``, format, normalize, trim) are text→text
+    reference implementations that the conformance suite applies to the raw
+    canonical source bytes (``*.trajectory.jsonl`` text) in declaration order.
+
+    The runtime path avoids re-parsing the same JSON by:
+
+    1. Collecting events via ``iter_events()`` **once**.
+    2. Building the role-tab-JSON turn lines from those events using
+       :func:`_extract_turns_from_events` — identical output to
+       ``openclaw_extract_turns`` applied to the serialized events, but no
+       second ``json.loads`` over the same bytes.
+    3. Applying only the post-extract declared transforms (strip, redact,
+       format, normalize, trim) via :func:`_apply_post_extract_pipeline`.
+
+    The conformance round-trip test still applies the FULL
+    ``DECLARED_TRANSFORMATION_ORDER`` starting from raw bytes (including
+    ``openclaw_extract_turns``) and arrives at the same drawer content.
+    ``openclaw_extract_turns`` is thus kept as the conformance reference impl
+    without being exercised in the hot path.
     """
 
     def iter_events(self) -> Iterator[Dict[str, Any]]:
@@ -175,7 +201,7 @@ class TrajectoryEventSource(Protocol):
 
         Returned keys when not ``None``:
         ``session_id``, ``session_key``, ``workspace_dir``, ``model_id``,
-        ``session_created_at``, ``version``, ``message_count``.
+        ``session_created_at``, ``message_count``.
         """
         ...
 
@@ -257,17 +283,22 @@ def _aggregate_session_metadata(
     Returns:
         Metadata dict with keys ``session_id``, ``session_key``,
         ``workspace_dir``, ``model_id``, ``session_created_at``,
-        ``version``, ``message_count``; or ``None`` if no events were found.
+        ``message_count``; or ``None`` if no events were found.
+
+    Note:
+        ``version`` is intentionally **not** included in the returned dict.
+        Version is source-dependent: for JSONL sidecars it is computed from
+        the file's byte-size (cheap, robust, monotonic on append); for a
+        SQLite source it would be a row count.  Callers are responsible for
+        computing and attaching a version appropriate for their backend.
     """
     first_event: Optional[Dict[str, Any]] = None
-    last_event: Optional[Dict[str, Any]] = None
     message_count = 0
     pending_user = False
 
     for event in events:
         if first_event is None:
             first_event = event
-        last_event = event
         etype = event.get("type")
         if etype == "prompt.submitted":
             pending_user = True
@@ -284,7 +315,6 @@ def _aggregate_session_metadata(
         "workspace_dir": first_event.get("workspaceDir") or "",
         "model_id": first_event.get("modelId") or "",
         "session_created_at": first_event.get("ts") or "",
-        "version": str(last_event.get("seq", 0)) if last_event else "0",
         "message_count": message_count,
     }
 
@@ -394,7 +424,10 @@ def _scan_trajectory_file(path: Path) -> Optional[dict]:
     * ``workspace_dir`` — from ``workspaceDir`` field.
     * ``model_id`` — from ``modelId`` field.
     * ``session_created_at`` — ISO-8601 ``ts`` of the first event.
-    * ``version`` — ``str(seq)`` of the last event.
+    * ``version`` — **file size in bytes** (``str(path.stat().st_size)``).
+      Trajectory files are append-only, so the byte count is monotonically
+      non-decreasing and robust across re-runs.  (The previous per-run
+      ``seq`` was not monotonic across appends — M2 fix.)
     * ``message_count`` — number of complete exchange pairs found.
 
     Returns ``None`` if no parseable events are found or if the file has a
@@ -405,7 +438,13 @@ def _scan_trajectory_file(path: Path) -> Optional[dict]:
         :meth:`JsonlTrajectoryEventSource.session_metadata`; it exists for
         backward compatibility and is exported in :data:`__all__`.
     """
-    return JsonlTrajectoryEventSource(path).session_metadata()
+    meta = JsonlTrajectoryEventSource(path).session_metadata()
+    if meta is None:
+        return None
+    # M2: version = file size, not last_event.seq (which is per-run, not
+    # whole-file monotonic).  A file with 124 events may have last seq = 7.
+    meta["version"] = str(path.stat().st_size)
+    return meta
 
 
 # ---------------------------------------------------------------------------
@@ -508,34 +547,8 @@ def _discover_from_dir(sessions_dir: Path) -> List[Path]:
     return sorted(found)
 
 
-def _resolve_sessions_dir(local_path: Optional[str] = None) -> Optional[Path]:
-    """Resolve a sessions directory from an optional caller-supplied path.
-
-    Returns ``None`` when ``local_path`` points at a single trajectory file
-    (caller will handle enumeration themselves). Returns a :class:`Path` to
-    the directory to enumerate otherwise.
-
-    Raises :class:`SourceNotFoundError` when a non-``None`` ``local_path``
-    resolves to neither a file nor a directory.
-    """
-    if local_path:
-        p = Path(local_path).expanduser()
-        if p.is_file():
-            return None  # single-file mode; caller enumerates
-        if p.is_dir():
-            return p.resolve()
-        raise SourceNotFoundError(
-            f"SourceRef.local_path {local_path!r} is neither a file nor a directory."
-        )
-    # No explicit path: try defaults.
-    for raw in _DEFAULT_SESSIONS_DIRS:
-        p = Path(raw).expanduser()
-        if p.is_dir():
-            return p.resolve()
-    raise SourceNotFoundError(
-        f"No OpenClaw sessions directory found (searched {list(_DEFAULT_SESSIONS_DIRS)}). "
-        f"Pass SourceRef(local_path=<sessions-dir>) or create one of the default paths."
-    )
+# NOTE: _resolve_sessions_dir was removed (S1 fix — it was unused dead code;
+# all callers use _enumerate_trajectory_files which duplicated the logic).
 
 
 def _enumerate_trajectory_files(source: SourceRef) -> List[Path]:
@@ -574,7 +587,7 @@ def _enumerate_trajectory_files(source: SourceRef) -> List[Path]:
 
 
 # ---------------------------------------------------------------------------
-# Source file URI and transform helpers
+# Source file URI helpers
 # ---------------------------------------------------------------------------
 
 
@@ -588,43 +601,210 @@ def session_source_file(file_path: str, session_id: str) -> str:
     return f"openclaw://{file_path}#session={session_id}"
 
 
+def _peek_trajectory_header(path: Path) -> Optional[Tuple[str, str]]:
+    """Read only the first parseable event: validate schema + extract session_id.
+
+    This is the cheap O(1) pre-check used by :meth:`ingest` before committing
+    to a full parse.  Returns ``(session_id, first_ts)`` or ``None`` if the
+    file has no parseable events or a wrong ``traceSchema``.
+
+    The ``traceSchema`` check here mirrors the one inside ``iter_events()`` so
+    files with wrong schema are excluded *before* a :class:`SourceItemMetadata`
+    is yielded, preserving the existing "skip file entirely" behaviour.
+    """
+    try:
+        with path.open(encoding="utf-8", errors="replace") as fh:
+            for raw_line in fh:
+                raw = raw_line.strip()
+                if not raw:
+                    continue
+                try:
+                    event = json.loads(raw)
+                except (ValueError, TypeError):
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                if not _validate_schema_marker(event, path.name):
+                    return None  # wrong traceSchema — skip file
+                session_id = event.get("sessionId") or path.name.removesuffix(_TRAJECTORY_SUFFIX)
+                return (session_id, event.get("ts") or "")
+    except OSError as exc:
+        logger.warning("openclaw adapter: cannot open %s: %s", path, exc)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Canonical-bytes helpers (M1 / RFC §7.3 conformance seam)
+# ---------------------------------------------------------------------------
+
+
 def _build_canonical_source_bytes(path: Path) -> str:
-    """Return the canonical source bytes for a trajectory file.
+    """Return the raw UTF-8 text of a trajectory file (conformance / test surface).
 
-    The canonical form is the raw UTF-8 text of the ``.trajectory.jsonl``
-    file (UTF-8 decode with replacement for invalid bytes). This is the
-    input the declared transformation chain consumes; the conformance
-    suite uses the same shape to verify the declared-transformation
-    round-trip is exact.
+    This is the input that the declared transformation chain consumes for the
+    conformance round-trip defined by RFC §7.3: apply every transform in
+    ``DECLARED_TRANSFORMATION_ORDER`` to this text in order and arrive at the
+    same chunks the runtime emits.
 
-    .. note:: SQLite seam — future work
-        For a SQLite-backed :class:`TrajectoryEventSource`, synthesise JSONL
-        text from the event rows before passing to this pipeline::
-
-            raw = "\\n".join(json.dumps(e) for e in source.iter_events())
-
-        This keeps the transform/chunk pipeline source-agnostic.  The helper
-        ``_build_canonical_source_bytes_from_events`` will be added when the
-        SQLite backend lands.
+    .. note:: Runtime path (M1)
+        The runtime does **not** call this function in the hot path.  It
+        collects parsed events via ``iter_events()`` **once**, builds the
+        role-tab-JSON turn text with :func:`_extract_turns_from_events` (no
+        second ``json.loads``), then applies only the post-extract transforms
+        via :func:`_apply_post_extract_pipeline`.  The outputs are identical.
     """
     return path.read_text(encoding="utf-8", errors="replace")
 
 
-def _apply_transform_pipeline(raw_text: str) -> str:
-    """Apply the declared OpenClaw transform pipeline in declaration order.
+def _build_canonical_source_bytes_from_events(events: List[Dict[str, Any]]) -> str:
+    """Serialise already-parsed events back to JSONL (SQLite seam / test helper).
 
-    Returns the pre-chunking exchange-pair transcript; pass the result to
-    ``convo_miner.chunk_exchanges`` to produce drawer chunks.
+    Produces the same canonical bytes that :func:`_build_canonical_source_bytes`
+    would return for the equivalent on-disk file.  This is the helper promised
+    in the original docstring and used by:
+
+    * The planned ``SqliteTrajectoryEventSource``: synthesise JSONL from
+      ``iter_events()`` output, then pass to ``openclaw_extract_turns`` for
+      conformance testing even though the runtime uses
+      :func:`_extract_turns_from_events`.
+    * Tests that need to verify the round-trip without a file on disk.
+
+    Each event is serialised as compact JSON on one line, separated by ``\\n``.
+    """
+    return "\n".join(json.dumps(e) for e in events)
+
+
+def _extract_turns_from_events(events: List[Dict[str, Any]]) -> str:
+    """Build role-tab-JSON turn lines directly from parsed events (runtime path).
+
+    Produces output **identical** to ``transforms.openclaw_extract_turns``
+    applied to the serialised events, but without a second ``json.loads`` over
+    the same bytes.  This is the single-parse runtime equivalent (M1 fix).
+
+    ``user`` turns come from ``prompt.submitted`` (``data.prompt``);
+    ``assistant`` turns come from ``model.completed`` (``data.assistantTexts``
+    joined with ``\\n``).  All other event types are skipped.
+    """
+    out: List[str] = []
+    pending_user: Optional[str] = None
+    for event in events:
+        etype = event.get("type")
+        data = event.get("data") or {}
+        if etype == "prompt.submitted":
+            pending_user = data.get("prompt") or ""
+        elif etype == "model.completed":
+            texts = data.get("assistantTexts") or []
+            assistant = "\n".join(x for x in texts if isinstance(x, str)).strip()
+            if pending_user is not None:
+                out.append(f"user\t{json.dumps(pending_user)}")
+            if assistant:
+                out.append(f"assistant\t{json.dumps(assistant)}")
+            pending_user = None
+    return "\n".join(out)
+
+
+def _extract_turns_and_metadata(
+    events: Iterator[Dict[str, Any]],
+    *,
+    fallback_stem: str = "",
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Single streaming pass: build turn text AND aggregate metadata at once.
+
+    Fuses :func:`_extract_turns_from_events` and
+    :func:`_aggregate_session_metadata` into one iteration over ``events`` so
+    the caller never materializes the full event list (S5).  Only the
+    extracted turn strings and a reference to the first event are retained;
+    large plumbing events (``context.compiled`` carrying compiled system
+    prompts / tool schemas, ``trace.*`` etc.) are processed and discarded as
+    the generator yields them, keeping peak memory bounded by the
+    conversational text rather than the whole raw event stream.
+
+    Returns ``(turns_text, meta)``; both are ``None`` when no events were
+    found.  ``turns_text`` is byte-identical to
+    ``_extract_turns_from_events(list(events))`` and ``meta`` matches
+    :func:`_aggregate_session_metadata`, so the RFC §7.3 conformance
+    round-trip is unaffected.
+    """
+    first_event: Optional[Dict[str, Any]] = None
+    out: List[str] = []
+    pending_user: Optional[str] = None
+    message_count = 0
+
+    for event in events:
+        if first_event is None:
+            first_event = event
+        etype = event.get("type")
+        data = event.get("data") or {}
+        if etype == "prompt.submitted":
+            pending_user = data.get("prompt") or ""
+        elif etype == "model.completed":
+            texts = data.get("assistantTexts") or []
+            assistant = "\n".join(x for x in texts if isinstance(x, str)).strip()
+            if pending_user is not None:
+                out.append(f"user\t{json.dumps(pending_user)}")
+                # message_count counts completed exchange pairs (a
+                # model.completed answering a pending prompt) — identical to
+                # _aggregate_session_metadata's definition.
+                message_count += 1
+            if assistant:
+                out.append(f"assistant\t{json.dumps(assistant)}")
+            pending_user = None
+
+    if first_event is None:
+        return None, None
+
+    meta = {
+        "session_id": first_event.get("sessionId") or fallback_stem,
+        "session_key": first_event.get("sessionKey") or "",
+        "workspace_dir": first_event.get("workspaceDir") or "",
+        "model_id": first_event.get("modelId") or "",
+        "session_created_at": first_event.get("ts") or "",
+        "message_count": message_count,
+    }
+    return "\n".join(out), meta
+
+
+def _apply_transform_pipeline(raw_text: str) -> str:
+    """Apply the full declared OpenClaw transform pipeline from raw JSONL text.
+
+    Conformance / legacy path: starts from the raw ``*.trajectory.jsonl``
+    file text and applies all transforms in :data:`DECLARED_TRANSFORMATION_ORDER`
+    (including ``openclaw_extract_turns`` which re-parses the JSON).  The
+    runtime uses :func:`_extract_turns_from_events` +
+    :func:`_apply_post_extract_pipeline` to avoid the double-parse.
+    Both paths produce identical output.
     """
     pipeline = [
         _transforms.openclaw_extract_turns,
         _transforms.openclaw_strip_runtime_context,
         _transforms.openclaw_strip_metadata_preamble,
+        _transforms.openclaw_redact_secrets,
         _transforms.openclaw_format_exchange,
         _transforms.newline_normalize,
         _transforms.whitespace_trim,
     ]
     text = raw_text
+    for step in pipeline:
+        text = step(text)
+    return text
+
+
+def _apply_post_extract_pipeline(turns_text: str) -> str:
+    """Apply post-extract transforms to role-tab-JSON turn text (runtime path).
+
+    Receives the output of :func:`_extract_turns_from_events` (which is
+    identical to ``openclaw_extract_turns`` applied to raw bytes) and applies
+    the remaining declared transforms in :data:`DECLARED_TRANSFORMATION_ORDER`.
+    """
+    pipeline = [
+        _transforms.openclaw_strip_runtime_context,
+        _transforms.openclaw_strip_metadata_preamble,
+        _transforms.openclaw_redact_secrets,
+        _transforms.openclaw_format_exchange,
+        _transforms.newline_normalize,
+        _transforms.whitespace_trim,
+    ]
+    text = turns_text
     for step in pipeline:
         text = step(text)
     return text
@@ -636,10 +816,22 @@ def _now_utc_iso() -> str:
 
 
 def _detect_hall(content: str) -> str:
-    """Hall-detection helper — defers to convo_miner's cached lookup."""
-    from ..convo_miner import _detect_hall_cached
+    """Hall-detection helper — defers to convo_miner's cached lookup.
 
-    return _detect_hall_cached(content)
+    Uses the private ``_detect_hall_cached`` symbol from ``convo_miner``.
+    Guarded with ``getattr`` so a future rename or removal degrades gracefully
+    to an empty string rather than raising ``AttributeError`` at ingest time.
+    The coupling is intentional (same module family) but acknowledged as a
+    private dependency (S4 fix).
+    """
+    from .. import convo_miner as _cm
+
+    fn = getattr(_cm, "_detect_hall_cached", None)
+    if fn is not None:
+        return fn(content)
+    # Fallback: no hall routing if the private symbol was renamed.
+    logger.debug("openclaw adapter: _detect_hall_cached not found in convo_miner; returning ''")
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -648,7 +840,15 @@ def _detect_hall(content: str) -> str:
 
 
 class OpenClawSourceAdapter(BaseSourceAdapter):
-    """Mine OpenClaw AI-agent session transcripts into the palace (RFC 002 §1)."""
+    """Mine OpenClaw AI-agent session transcripts into the palace (RFC 002 §1).
+
+    .. note:: Secret redaction
+        The declared transform ``openclaw_redact_secrets`` is applied to every
+        turn before chunking.  This is best-effort protection against live
+        credentials in raw agent trajectories (``default_privacy_class =
+        "pii_potential"`` is retained).  See the ``openclaw_redact_secrets``
+        docstring for covered patterns and limitations.
+    """
 
     name = "openclaw"
     adapter_version = "0.1.0"
@@ -665,6 +865,7 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
             "openclaw_extract_turns",
             "openclaw_strip_runtime_context",
             "openclaw_strip_metadata_preamble",
+            "openclaw_redact_secrets",
             "openclaw_format_exchange",
             "newline_normalize",
             "whitespace_trim",
@@ -672,13 +873,20 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
     )
     default_privacy_class = "pii_potential"
 
-    # Order of declared transformations as applied by the adapter. The
-    # conformance suite walks this list in order, so it MUST mirror the
-    # actual pipeline in :func:`_apply_transform_pipeline`.
+    # Order of declared transformations as applied by the adapter pipeline.
+    # The conformance suite walks this list in order starting from the raw
+    # canonical source bytes (the *.trajectory.jsonl file text), so it MUST
+    # mirror the actual pipeline defined in :func:`_apply_transform_pipeline`.
+    #
+    # Runtime reconciliation (M1): the runtime uses
+    # :func:`_extract_turns_from_events` (no second json.loads) followed by
+    # :func:`_apply_post_extract_pipeline` (all steps after extract_turns).
+    # Both paths produce identical drawer content.
     DECLARED_TRANSFORMATION_ORDER: Tuple[str, ...] = (
         "openclaw_extract_turns",
         "openclaw_strip_runtime_context",
         "openclaw_strip_metadata_preamble",
+        "openclaw_redact_secrets",
         "openclaw_format_exchange",
         "newline_normalize",
         "whitespace_trim",
@@ -736,7 +944,9 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
                     type="int",
                     required=True,
                     description=(
-                        "Number of exchange pairs (user+assistant turns) extracted from the session"
+                        "Count of complete exchange pairs (prompt.submitted → model.completed) "
+                        "found in raw trajectory events. Note: the number of emitted drawers "
+                        "may differ because chunking may split or merge exchanges."
                     ),
                 ),
                 "extract_mode": FieldSpec(
@@ -761,26 +971,51 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
             raise AdapterClosedError("OpenClawSourceAdapter is closed")
         trajectory_files = _enumerate_trajectory_files(source)
         for tfile in trajectory_files:
-            meta = _scan_trajectory_file(tfile)
-            if meta is None:
-                logger.debug("openclaw adapter: skipping %s (no parseable events)", tfile)
+            # ----------------------------------------------------------
+            # CHEAP STAGE: stat + first-event peek; no full JSON parse.
+            # ----------------------------------------------------------
+
+            # M2/S2: version = file byte size.  Trajectory files are
+            # append-only, so size grows monotonically on any real change.
+            # The previous last_event["seq"] was per-run (not whole-file
+            # monotonic), so two distinct file states could share the same
+            # trailing seq — fixed here.  Using stat avoids opening the file
+            # at all for "current" files.
+            try:
+                file_size = tfile.stat().st_size
+            except OSError as exc:
+                logger.warning("openclaw adapter: cannot stat %s: %s", tfile, exc)
                 continue
+            version = str(file_size)
+
+            # Peek first event: validate traceSchema + extract session_id.
+            # Returns None for empty files or wrong traceSchema → skip file
+            # entirely so no SourceItemMetadata is yielded (preserves the
+            # existing "skip file silently" contract for bad-schema files).
+            header = _peek_trajectory_header(tfile)
+            if header is None:
+                logger.debug(
+                    "openclaw adapter: skipping %s (no parseable events or wrong schema)",
+                    tfile,
+                )
+                continue
+            session_id, _first_ts = header
 
             file_path = str(tfile)
-            session_id = meta["session_id"]
             src_file = session_source_file(file_path, session_id)
-            version = meta["version"]
 
-            # Yield lazy-fetch metadata so core can short-circuit when
-            # the trajectory file hasn't grown since the last ingest.
+            # Yield lazy-fetch metadata; core short-circuits via is_current.
+            # route_hint is None at this stage (workspace_dir unknown until
+            # full parse); the DrawerRecord emit fills it in per chunk.
             yield SourceItemMetadata(
                 source_file=src_file,
                 version=version,
-                size_hint=tfile.stat().st_size,
-                route_hint=self._route_hint_for(source, meta["workspace_dir"]),
+                size_hint=file_size,
+                route_hint=None,
             )
-            # is_skip_requested() is the public getter added in PR #1484 (not yet
-            # on develop); fall back to the underlying flag until it merges.
+
+            # is_skip_requested() is the public getter added in PR #1484 (not
+            # yet on develop); fall back to the underlying flag until it merges.
             skip = (
                 palace.is_skip_requested()
                 if hasattr(palace, "is_skip_requested")
@@ -789,8 +1024,40 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
             if skip:
                 continue
 
-            raw_text = _build_canonical_source_bytes(tfile)
-            transcript = _apply_transform_pipeline(raw_text)
+            # ----------------------------------------------------------
+            # FULL PARSE STAGE (only for non-current files).
+            # M1: iter_events() is the SINGLE JSON parse.
+            # S5: a single streaming pass builds turn text AND metadata
+            # together, so we never materialize the full event list — large
+            # plumbing events (context.compiled, trace.*) are discarded as the
+            # generator yields them, keeping peak memory bounded by the
+            # conversational text rather than the whole raw event stream.
+            # ----------------------------------------------------------
+            event_source = JsonlTrajectoryEventSource(tfile)
+            turns_text, meta = _extract_turns_and_metadata(
+                event_source.iter_events(),
+                fallback_stem=session_id,
+            )
+            if meta is None:
+                logger.debug(
+                    "openclaw adapter: skipping %s — no parseable events after full scan",
+                    tfile.name,
+                )
+                continue
+
+            # session_id from events may differ from filename in edge cases
+            # (e.g. doctor-imported files); prefer the event-sourced value so
+            # stored source_file URIs are consistent with what iter_events saw.
+            session_id = meta["session_id"]
+            src_file = session_source_file(file_path, session_id)
+
+            # M1: turns_text was built directly from parsed events (no second
+            # json.loads).  It is identical to openclaw_extract_turns applied
+            # to the serialised events; the conformance round-trip still
+            # applies openclaw_extract_turns via DECLARED_TRANSFORMATION_ORDER
+            # (text→text reference impl) — only the runtime shortcut differs.
+            transcript = _apply_post_extract_pipeline(turns_text)
+
             if not transcript:
                 logger.debug(
                     "openclaw adapter: skipping %s — empty transcript after transforms",
@@ -806,8 +1073,9 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
                 )
                 continue
 
-            # message_count is computed during scan: number of matched
-            # prompt.submitted → model.completed pairs in the raw events.
+            # S3: message_count = exchange pair count from raw events (NOT
+            # the chunk/drawer count, which depends on chunking).  The schema
+            # description now documents this distinction explicitly.
             message_count = meta["message_count"]
 
             wing = self._wing_for(source, meta["workspace_dir"])
@@ -817,6 +1085,7 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
             for chunk in chunks:
                 content = chunk["content"]
                 chunk_index = int(chunk["chunk_index"])
+                hall = _detect_hall(content)
                 metadata = {
                     # Universal §5.1 fields
                     "source_file": src_file,
@@ -825,7 +1094,7 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
                     "added_by": "openclaw-adapter",
                     "wing": wing,
                     "room": room,
-                    "hall": _detect_hall(content),
+                    "hall": hall,
                     "ingest_mode": "chunked_content",
                     "extract_mode": "exchange",
                     "privacy_class": self.default_privacy_class,
@@ -845,7 +1114,7 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
                     source_file=src_file,
                     chunk_index=chunk_index,
                     metadata=metadata,
-                    route_hint=RouteHint(wing=wing, room=room, hall=metadata["hall"]),
+                    route_hint=RouteHint(wing=wing, room=room, hall=hall),
                 )
 
     # ------------------------------------------------------------------
@@ -861,6 +1130,7 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
         if not existing_metadata:
             return False
         # Prefer the stored ``openclaw_session_version`` field (set in v0.1+).
+        # Both the stored value and item.version are now file-size strings.
         stored_version = existing_metadata.get("openclaw_session_version")
         if stored_version is not None:
             return str(stored_version) == item.version
@@ -931,5 +1201,6 @@ __all__ = [
     "TrajectoryEventSource",
     "session_source_file",
     "_build_canonical_source_bytes",
+    "_build_canonical_source_bytes_from_events",
     "_scan_trajectory_file",
 ]

--- a/mempalace/sources/openclaw.py
+++ b/mempalace/sources/openclaw.py
@@ -1,0 +1,514 @@
+"""OpenClaw source adapter (RFC 002).
+
+Ingests OpenClaw AI-agent session transcripts from ``*.trajectory.jsonl``
+files into the palace as :class:`DrawerRecord` instances.
+
+By default the adapter discovers trajectory files under
+``~/.openclaw/agents/main/sessions/``. Pass
+``SourceRef(local_path="<directory>")`` to point at an alternate sessions
+directory, or ``SourceRef(local_path="<file>.trajectory.jsonl")`` to ingest
+a single file.
+
+Each trajectory file produces one ``source_file`` identifier of the shape
+``openclaw://<absolute-path>#session=<session-id>``. Drawers are
+exchange-pair chunks of the session transcript (user prompt + assistant
+response), formatted to match the ``convo_miner`` shape so downstream
+ranking, search, and closet-building behave identically.
+
+The extraction pipeline mirrors ``convo-spike/convert_trajectories.py``:
+
+* ``prompt.submitted`` events → user turns (``data.prompt``).
+* ``model.completed`` events → assistant turns (``data.assistantTexts``
+  joined with ``\\n``).
+* ``context.compiled``, ``session.started``, ``session.ended``,
+  ``trace.*`` etc. are skipped.
+* OpenClaw runtime-context injection blocks and metadata-preamble fences
+  are stripped from user text before chunking.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, List, Optional, Tuple
+
+from ..convo_miner import chunk_exchanges, detect_convo_room
+from ..config import normalize_wing_name
+from . import transforms as _transforms
+from .base import (
+    AdapterClosedError,
+    AdapterSchema,
+    BaseSourceAdapter,
+    DrawerRecord,
+    FieldSpec,
+    RouteHint,
+    SourceItemMetadata,
+    SourceNotFoundError,
+    SourceRef,
+    SourceSummary,
+)
+from .context import PalaceContext
+
+logger = logging.getLogger(__name__)
+
+
+# Default sessions-directory search order.
+_DEFAULT_SESSIONS_DIRS: Tuple[str, ...] = (
+    "~/.openclaw/agents/main/sessions",
+)
+
+# Filename suffix that identifies trajectory files.
+_TRAJECTORY_SUFFIX = ".trajectory.jsonl"
+
+
+def _detect_hall(content: str) -> str:
+    """Hall-detection helper — defers to convo_miner's cached lookup."""
+    from ..convo_miner import _detect_hall_cached
+
+    return _detect_hall_cached(content)
+
+
+def _resolve_sessions_dir(local_path: Optional[str] = None) -> Optional[Path]:
+    """Resolve a sessions directory from an optional caller-supplied path.
+
+    Returns ``None`` when ``local_path`` points at a single trajectory file
+    (caller will handle enumeration themselves). Returns a :class:`Path` to
+    the directory to enumerate otherwise.
+
+    Raises :class:`SourceNotFoundError` when a non-``None`` ``local_path``
+    resolves to neither a file nor a directory.
+    """
+    if local_path:
+        p = Path(local_path).expanduser()
+        if p.is_file():
+            return None  # single-file mode; caller enumerates
+        if p.is_dir():
+            return p.resolve()
+        raise SourceNotFoundError(
+            f"SourceRef.local_path {local_path!r} is neither a file nor a directory."
+        )
+    # No explicit path: try defaults.
+    for raw in _DEFAULT_SESSIONS_DIRS:
+        p = Path(raw).expanduser()
+        if p.is_dir():
+            return p.resolve()
+    raise SourceNotFoundError(
+        f"No OpenClaw sessions directory found (searched {list(_DEFAULT_SESSIONS_DIRS)}). "
+        f"Pass SourceRef(local_path=<sessions-dir>) or create one of the default paths."
+    )
+
+
+def _enumerate_trajectory_files(source: SourceRef) -> List[Path]:
+    """Return sorted list of trajectory files for a :class:`SourceRef`.
+
+    Handles three shapes:
+
+    * ``local_path`` pointing at a directory → enumerate ``*.trajectory.jsonl``
+      inside it.
+    * ``local_path`` pointing at a single ``*.trajectory.jsonl`` file → return
+      that one file.
+    * ``local_path`` is ``None`` → use :data:`_DEFAULT_SESSIONS_DIRS`.
+    """
+    if source.local_path:
+        p = Path(source.local_path).expanduser()
+        if p.is_file():
+            return [p.resolve()]
+        if p.is_dir():
+            return sorted(p.resolve().glob(f"*{_TRAJECTORY_SUFFIX}"))
+        raise SourceNotFoundError(
+            f"SourceRef.local_path {source.local_path!r} is neither a file nor a directory."
+        )
+    # Default: scan the first existing default directory.
+    for raw in _DEFAULT_SESSIONS_DIRS:
+        d = Path(raw).expanduser()
+        if d.is_dir():
+            return sorted(d.resolve().glob(f"*{_TRAJECTORY_SUFFIX}"))
+    raise SourceNotFoundError(
+        f"No OpenClaw sessions directory found (searched {list(_DEFAULT_SESSIONS_DIRS)}). "
+        f"Pass SourceRef(local_path=<sessions-dir>)."
+    )
+
+
+def session_source_file(file_path: str, session_id: str) -> str:
+    """Construct the stable per-session ``source_file`` identifier.
+
+    Shape: ``openclaw://<absolute-path>#session=<session-id>``.
+    Stable across re-ingests; used as the ChromaDB
+    ``where={"source_file": …}`` key and by :meth:`is_current`.
+    """
+    return f"openclaw://{file_path}#session={session_id}"
+
+
+def _scan_trajectory_file(path: Path) -> Optional[dict]:
+    """Single-pass scan of a trajectory file for session metadata + version.
+
+    Returns a dict with:
+
+    * ``session_id`` — from ``sessionId`` field of first event.
+    * ``session_key`` — from ``sessionKey`` field (e.g. ``agent:main:slack:…``).
+    * ``workspace_dir`` — from ``workspaceDir`` field.
+    * ``model_id`` — from ``modelId`` field.
+    * ``session_created_at`` — ISO-8601 ``ts`` of the first event.
+    * ``version`` — ``str(seq)`` of the last event (used by
+      :meth:`is_current`; trajectory files are append-only so the last
+      ``seq`` advances whenever new events are appended).
+
+    Returns ``None`` if no parseable events are found.
+    """
+    first_event: Optional[dict] = None
+    last_event: Optional[dict] = None
+    for raw in path.open(encoding="utf-8", errors="replace"):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+        if first_event is None:
+            first_event = event
+        last_event = event
+
+    if first_event is None:
+        return None
+
+    return {
+        "session_id": first_event.get("sessionId") or path.stem,
+        "session_key": first_event.get("sessionKey") or "",
+        "workspace_dir": first_event.get("workspaceDir") or "",
+        "model_id": first_event.get("modelId") or "",
+        "session_created_at": first_event.get("ts") or "",
+        "version": str(last_event.get("seq", 0)) if last_event else "0",
+    }
+
+
+def _build_canonical_source_bytes(path: Path) -> str:
+    """Return the canonical source bytes for a trajectory file.
+
+    The canonical form is the raw UTF-8 text of the ``.trajectory.jsonl``
+    file (UTF-8 decode with replacement for invalid bytes). This is the
+    input the declared transformation chain consumes; the conformance
+    suite uses the same shape to verify the declared-transformation
+    round-trip is exact.
+    """
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _apply_transform_pipeline(raw_text: str) -> str:
+    """Apply the declared OpenClaw transform pipeline in declaration order.
+
+    Returns the pre-chunking exchange-pair transcript; pass the result to
+    ``convo_miner.chunk_exchanges`` to produce drawer chunks.
+    """
+    pipeline = [
+        _transforms.openclaw_extract_turns,
+        _transforms.openclaw_strip_runtime_context,
+        _transforms.openclaw_strip_metadata_preamble,
+        _transforms.openclaw_format_exchange,
+        _transforms.newline_normalize,
+        _transforms.whitespace_trim,
+    ]
+    text = raw_text
+    for step in pipeline:
+        text = step(text)
+    return text
+
+
+def _now_utc_iso() -> str:
+    """Return current UTC time as ISO-8601 with trailing ``Z``."""
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+class OpenClawSourceAdapter(BaseSourceAdapter):
+    """Mine OpenClaw AI-agent session transcripts into the palace (RFC 002 §1)."""
+
+    name = "openclaw"
+    adapter_version = "0.1.0"
+    capabilities = frozenset(
+        {
+            "supports_incremental",
+            "supports_structured_metadata",
+            "adapter_owns_routing",
+        }
+    )
+    supported_modes = frozenset({"chunked_content"})
+    declared_transformations = frozenset(
+        {
+            "openclaw_extract_turns",
+            "openclaw_strip_runtime_context",
+            "openclaw_strip_metadata_preamble",
+            "openclaw_format_exchange",
+            "newline_normalize",
+            "whitespace_trim",
+        }
+    )
+    default_privacy_class = "pii_potential"
+
+    # Order of declared transformations as applied by the adapter. The
+    # conformance suite walks this list in order, so it MUST mirror the
+    # actual pipeline in :func:`_apply_transform_pipeline`.
+    DECLARED_TRANSFORMATION_ORDER: Tuple[str, ...] = (
+        "openclaw_extract_turns",
+        "openclaw_strip_runtime_context",
+        "openclaw_strip_metadata_preamble",
+        "openclaw_format_exchange",
+        "newline_normalize",
+        "whitespace_trim",
+    )
+
+    def __init__(self) -> None:
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def describe_schema(self) -> AdapterSchema:
+        return AdapterSchema(
+            version="1.0",
+            fields={
+                "session_id": FieldSpec(
+                    type="string",
+                    required=True,
+                    description=(
+                        "OpenClaw session UUID (e.g. 00852ef4-fb01-415b-8335-9e5d559c8754)"
+                    ),
+                    indexed=True,
+                ),
+                "session_key": FieldSpec(
+                    type="string",
+                    required=False,
+                    description=(
+                        "OpenClaw session routing key "
+                        "(e.g. agent:main:slack:direct:<user-id>)"
+                    ),
+                    indexed=True,
+                ),
+                "workspace_dir": FieldSpec(
+                    type="string",
+                    required=False,
+                    description=(
+                        "Absolute filesystem path of the agent's workspace "
+                        "when the session was recorded"
+                    ),
+                    indexed=True,
+                ),
+                "model_id": FieldSpec(
+                    type="string",
+                    required=False,
+                    description=(
+                        "Model identifier used for the session "
+                        "(e.g. anthropic/claude-sonnet-4-6)"
+                    ),
+                ),
+                "session_created_at": FieldSpec(
+                    type="string",
+                    required=True,
+                    description="ISO-8601 UTC timestamp of the first event in the trajectory",
+                ),
+                "message_count": FieldSpec(
+                    type="int",
+                    required=True,
+                    description=(
+                        "Number of exchange pairs (user+assistant turns) extracted "
+                        "from the session"
+                    ),
+                ),
+                "extract_mode": FieldSpec(
+                    type="string",
+                    required=True,
+                    description="Always 'exchange' for the OpenClaw adapter in v0.1",
+                ),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Ingest
+    # ------------------------------------------------------------------
+
+    def ingest(
+        self,
+        *,
+        source: SourceRef,
+        palace: PalaceContext,
+    ) -> Iterator[object]:
+        if self._closed:
+            raise AdapterClosedError("OpenClawSourceAdapter is closed")
+        trajectory_files = _enumerate_trajectory_files(source)
+        for tfile in trajectory_files:
+            meta = _scan_trajectory_file(tfile)
+            if meta is None:
+                logger.debug("openclaw adapter: skipping empty file %s", tfile)
+                continue
+
+            file_path = str(tfile)
+            session_id = meta["session_id"]
+            src_file = session_source_file(file_path, session_id)
+            version = meta["version"]
+
+            # Yield lazy-fetch metadata so core can short-circuit when
+            # the trajectory file hasn't grown since the last ingest.
+            yield SourceItemMetadata(
+                source_file=src_file,
+                version=version,
+                size_hint=tfile.stat().st_size,
+                route_hint=self._route_hint_for(source, meta["workspace_dir"]),
+            )
+            # is_skip_requested() is the public getter added in PR #1484 (not yet
+            # on develop); fall back to the underlying flag until it merges.
+            skip = (
+                palace.is_skip_requested()
+                if hasattr(palace, "is_skip_requested")
+                else palace._skip_requested
+            )
+            if skip:
+                continue
+
+            raw_text = _build_canonical_source_bytes(tfile)
+            transcript = _apply_transform_pipeline(raw_text)
+            if not transcript:
+                logger.debug(
+                    "openclaw adapter: skipping %s — empty transcript after transforms",
+                    tfile.name,
+                )
+                continue
+
+            chunks = chunk_exchanges(transcript)
+            if not chunks:
+                logger.debug(
+                    "openclaw adapter: skipping %s — chunk_exchanges produced nothing",
+                    tfile.name,
+                )
+                continue
+
+            # Count exchange pairs for metadata (rough: count "> " lines).
+            message_count = sum(1 for ln in transcript.split("\n") if ln.strip().startswith(">"))
+
+            wing = self._wing_for(source, meta["workspace_dir"])
+            room = detect_convo_room(transcript)
+            filed_at = _now_utc_iso()
+
+            for chunk in chunks:
+                content = chunk["content"]
+                chunk_index = int(chunk["chunk_index"])
+                metadata = {
+                    # Universal §5.1 fields
+                    "source_file": src_file,
+                    "chunk_index": chunk_index,
+                    "filed_at": filed_at,
+                    "added_by": "openclaw-adapter",
+                    "wing": wing,
+                    "room": room,
+                    "hall": _detect_hall(content),
+                    "ingest_mode": "chunked_content",
+                    "extract_mode": "exchange",
+                    "privacy_class": self.default_privacy_class,
+                    # Adapter-declared fields (§5.2)
+                    "session_id": session_id,
+                    "session_key": meta["session_key"],
+                    "workspace_dir": meta["workspace_dir"],
+                    "model_id": meta["model_id"],
+                    "session_created_at": meta["session_created_at"],
+                    "message_count": message_count,
+                    # Required by is_current() for incremental ingest;
+                    # mirrors the SourceItemMetadata.version yielded above.
+                    "openclaw_session_version": version,
+                }
+                yield DrawerRecord(
+                    content=content,
+                    source_file=src_file,
+                    chunk_index=chunk_index,
+                    metadata=metadata,
+                    route_hint=RouteHint(wing=wing, room=room, hall=metadata["hall"]),
+                )
+
+    # ------------------------------------------------------------------
+    # Incremental ingest
+    # ------------------------------------------------------------------
+
+    def is_current(
+        self,
+        *,
+        item: SourceItemMetadata,
+        existing_metadata: Optional[dict],
+    ) -> bool:
+        if not existing_metadata:
+            return False
+        # Prefer the stored ``openclaw_session_version`` field (set in v0.1+).
+        stored_version = existing_metadata.get("openclaw_session_version")
+        if stored_version is not None:
+            return str(stored_version) == item.version
+        # Fall back to "we have drawers for this source_file" → assume current.
+        # Trajectory files are append-only; existing drawers mean we already
+        # extracted whatever was in the file at last ingest time. Only
+        # re-extract if the version field was recorded (see above) and changed.
+        return True
+
+    def source_summary(self, *, source: SourceRef) -> SourceSummary:
+        try:
+            files = _enumerate_trajectory_files(source)
+        except SourceNotFoundError:
+            return SourceSummary(description="OpenClaw sessions directory not found", item_count=0)
+        count = len(files)
+        try:
+            if source.local_path:
+                desc_path = str(Path(source.local_path).expanduser().resolve())
+            else:
+                desc_path = str(Path(_DEFAULT_SESSIONS_DIRS[0]).expanduser())
+        except Exception:
+            desc_path = source.local_path or _DEFAULT_SESSIONS_DIRS[0]
+        return SourceSummary(
+            description=f"OpenClaw sessions at {desc_path}",
+            item_count=count,
+        )
+
+    def close(self) -> None:
+        self._closed = True
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _wing_for(self, source: SourceRef, workspace_dir: Optional[str]) -> str:
+        """Resolve the wing for a session, RFC 002 §2.5 precedence:
+
+        1. Explicit ``options["wing"]`` from the SourceRef.
+        2. Basename of ``workspaceDir`` from the trajectory.
+        3. Adapter fallback: ``"openclaw_general"``.
+        """
+        explicit = (source.options or {}).get("wing")
+        if explicit:
+            return normalize_wing_name(str(explicit))
+        if workspace_dir and workspace_dir != "/":
+            base = Path(workspace_dir).name
+            if base:
+                return normalize_wing_name(base)
+        return "openclaw_general"
+
+    def _route_hint_for(
+        self, source: SourceRef, workspace_dir: Optional[str]
+    ) -> Optional[RouteHint]:
+        """Wing-only route hint for the lazy-fetch :class:`SourceItemMetadata`.
+
+        Room is content-dependent, so it is left ``None`` at the lazy-fetch
+        stage; the eager :class:`DrawerRecord` emit fills it in per chunk.
+        This mirrors the OpenCode adapter's §2.5 pattern so core makes
+        consistent skip/routing decisions when ``options["wing"]`` is set.
+        """
+        wing = self._wing_for(source, workspace_dir)
+        return RouteHint(wing=wing, room=None, hall=None)
+
+
+__all__ = [
+    "OpenClawSourceAdapter",
+    "session_source_file",
+    "_build_canonical_source_bytes",
+    "_scan_trajectory_file",
+]

--- a/mempalace/sources/openclaw.py
+++ b/mempalace/sources/openclaw.py
@@ -55,9 +55,7 @@ logger = logging.getLogger(__name__)
 
 
 # Default sessions-directory search order.
-_DEFAULT_SESSIONS_DIRS: Tuple[str, ...] = (
-    "~/.openclaw/agents/main/sessions",
-)
+_DEFAULT_SESSIONS_DIRS: Tuple[str, ...] = ("~/.openclaw/agents/main/sessions",)
 
 # Filename suffix that identifies trajectory files.
 _TRAJECTORY_SUFFIX = ".trajectory.jsonl"
@@ -154,11 +152,18 @@ def _scan_trajectory_file(path: Path) -> Optional[dict]:
     * ``version`` — ``str(seq)`` of the last event (used by
       :meth:`is_current`; trajectory files are append-only so the last
       ``seq`` advances whenever new events are appended).
+    * ``message_count`` — number of complete exchange pairs found: each
+      ``prompt.submitted`` event matched to the ``model.completed`` event
+      that immediately follows it. This is the definitive count advertised
+      by :meth:`describe_schema`; computing it at scan time avoids a
+      second pass over the transform pipeline.
 
     Returns ``None`` if no parseable events are found.
     """
     first_event: Optional[dict] = None
     last_event: Optional[dict] = None
+    message_count = 0
+    pending_user = False
     for raw in path.open(encoding="utf-8", errors="replace"):
         raw = raw.strip()
         if not raw:
@@ -170,6 +175,12 @@ def _scan_trajectory_file(path: Path) -> Optional[dict]:
         if first_event is None:
             first_event = event
         last_event = event
+        etype = event.get("type")
+        if etype == "prompt.submitted":
+            pending_user = True
+        elif etype == "model.completed" and pending_user:
+            message_count += 1
+            pending_user = False
 
     if first_event is None:
         return None
@@ -181,6 +192,7 @@ def _scan_trajectory_file(path: Path) -> Optional[dict]:
         "model_id": first_event.get("modelId") or "",
         "session_created_at": first_event.get("ts") or "",
         "version": str(last_event.get("seq", 0)) if last_event else "0",
+        "message_count": message_count,
     }
 
 
@@ -218,12 +230,7 @@ def _apply_transform_pipeline(raw_text: str) -> str:
 
 def _now_utc_iso() -> str:
     """Return current UTC time as ISO-8601 with trailing ``Z``."""
-    return (
-        datetime.now(timezone.utc)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 class OpenClawSourceAdapter(BaseSourceAdapter):
@@ -286,8 +293,7 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
                     type="string",
                     required=False,
                     description=(
-                        "OpenClaw session routing key "
-                        "(e.g. agent:main:slack:direct:<user-id>)"
+                        "OpenClaw session routing key (e.g. agent:main:slack:direct:<user-id>)"
                     ),
                     indexed=True,
                 ),
@@ -304,8 +310,7 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
                     type="string",
                     required=False,
                     description=(
-                        "Model identifier used for the session "
-                        "(e.g. anthropic/claude-sonnet-4-6)"
+                        "Model identifier used for the session (e.g. anthropic/claude-sonnet-4-6)"
                     ),
                 ),
                 "session_created_at": FieldSpec(
@@ -317,8 +322,7 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
                     type="int",
                     required=True,
                     description=(
-                        "Number of exchange pairs (user+assistant turns) extracted "
-                        "from the session"
+                        "Number of exchange pairs (user+assistant turns) extracted from the session"
                     ),
                 ),
                 "extract_mode": FieldSpec(
@@ -388,8 +392,9 @@ class OpenClawSourceAdapter(BaseSourceAdapter):
                 )
                 continue
 
-            # Count exchange pairs for metadata (rough: count "> " lines).
-            message_count = sum(1 for ln in transcript.split("\n") if ln.strip().startswith(">"))
+            # message_count is computed during scan: number of matched
+            # prompt.submitted → model.completed pairs in the raw events.
+            message_count = meta["message_count"]
 
             wing = self._wing_for(source, meta["workspace_dir"])
             room = detect_convo_room(transcript)

--- a/mempalace/sources/openclaw.py
+++ b/mempalace/sources/openclaw.py
@@ -789,24 +789,72 @@ def _apply_transform_pipeline(raw_text: str) -> str:
     return text
 
 
-def _apply_post_extract_pipeline(turns_text: str) -> str:
+def _apply_post_extract_pipeline(turns_text: str) -> str:  # noqa: C901
     """Apply post-extract transforms to role-tab-JSON turn text (runtime path).
 
-    Receives the output of :func:`_extract_turns_from_events` (which is
-    identical to ``openclaw_extract_turns`` applied to raw bytes) and applies
-    the remaining declared transforms in :data:`DECLARED_TRANSFORMATION_ORDER`.
+    PERF optimisation: decodes each role-tab-JSON line's body **once** and
+    applies all per-body transforms in-memory before formatting, instead of
+    running three separate JSON round-trips (strip_runtime_context,
+    strip_metadata_preamble, redact_secrets each calling json.loads/dumps on
+    every line).
+
+    Correctness guarantee: every regex applied here is the **same module-level
+    constant** used by the corresponding declared transform, so there is zero
+    behavioural drift from the RFC §7.3 conformance path.  The declared
+    text→text transforms (``openclaw_strip_runtime_context``,
+    ``openclaw_strip_metadata_preamble``, ``openclaw_redact_secrets``,
+    ``openclaw_format_exchange``) remain unchanged and are still exercised by
+    :func:`_apply_transform_pipeline`.
     """
-    pipeline = [
-        _transforms.openclaw_strip_runtime_context,
-        _transforms.openclaw_strip_metadata_preamble,
-        _transforms.openclaw_redact_secrets,
-        _transforms.openclaw_format_exchange,
-        _transforms.newline_normalize,
-        _transforms.whitespace_trim,
-    ]
-    text = turns_text
-    for step in pipeline:
-        text = step(text)
+    blocks: List[str] = []
+    for line in turns_text.split("\n"):
+        role, sep, body_json = line.partition("\t")
+        if not sep:
+            continue
+        try:
+            body: str = json.loads(body_json)
+        except (ValueError, TypeError):
+            body = body_json
+        if not isinstance(body, str):
+            body = str(body)
+
+        if role == "user":
+            # --- openclaw_strip_runtime_context ---
+            body = _transforms._OPENCLAW_RUNTIME_BLOCK.sub("", body)
+            # --- openclaw_strip_metadata_preamble ---
+            body = _transforms._OPENCLAW_META_FENCE.sub("", body)
+            body = _transforms._OPENCLAW_LABEL_LINES.sub("", body)
+            body = _transforms._OPENCLAW_SLACK_HEADER.sub("", body)
+            body = _transforms._OPENCLAW_MEDIA_ATTACHED.sub("", body)
+            body = _transforms._OPENCLAW_SLACK_FILE_LINE.sub("", body)
+            body = _transforms._OPENCLAW_SLACK_MSG_ID.sub("", body)
+            body = _transforms._OPENCLAW_FILE_WRAPPER.sub("", body)
+
+        # --- openclaw_redact_secrets (both roles) ---
+        body = _transforms._OC_RE_AWS_KEY.sub("[REDACTED:aws_key]", body)
+        body = _transforms._OC_RE_PREFIXED_TOKENS.sub("[REDACTED:api_token]", body)
+        body = _transforms._OC_RE_BEARER.sub("Bearer [REDACTED:bearer_token]", body)
+        body = _transforms._OC_RE_BASIC_AUTH.sub("Basic [REDACTED:basic_auth]", body)
+        body = _transforms._OC_RE_PEM_KEY.sub("[REDACTED:pem_private_key]", body)
+        body = _transforms._OC_RE_KV_SECRET.sub(r"\1[REDACTED:secret_value]", body)
+
+        # --- openclaw_format_exchange ---
+        body = body.strip()
+        if role == "user":
+            if not body:
+                # R3: preserve empty user turns as a placeholder so the
+                # following assistant reply is not lost as a leading orphan.
+                blocks.append("> [non-text user turn]")
+            else:
+                quoted = "\n".join(f"> {ln}" for ln in body.split("\n"))
+                blocks.append(quoted)
+        elif body:  # assistant — skip if empty
+            blocks.append(body)
+
+    text = "\n\n".join(blocks)
+    # --- newline_normalize + whitespace_trim ---
+    text = _transforms.newline_normalize(text)
+    text = _transforms.whitespace_trim(text)
     return text
 
 

--- a/mempalace/sources/transforms.py
+++ b/mempalace/sources/transforms.py
@@ -23,6 +23,7 @@ conformance suite can locate and apply them.
 
 from __future__ import annotations
 
+import json as _json
 import re
 from typing import Protocol, Union
 
@@ -151,6 +152,170 @@ def synthesized_marker(text: str) -> str:
 def speaker_role_assignment(text: str) -> str:
     """Adapter-supplied: multi-party speakers alternately assigned user/assistant."""
     return text
+
+
+# ---------------------------------------------------------------------------
+# Adapter-namespaced reference implementations — OpenClaw
+# ---------------------------------------------------------------------------
+#
+# Per RFC 002 §7.3, custom (non-reserved) transformations declared by an
+# adapter MUST expose a reference implementation under
+# ``mempalace.sources.transforms.<adapter_name>_<transform_name>`` so the
+# conformance suite can locate and apply them by attribute lookup. The
+# implementations below are the OpenClaw adapter's; future adapters add their
+# own under their own ``<name>_`` prefix.
+#
+# The OpenClaw adapter's canonical source bytes for one session are the raw
+# ``*.trajectory.jsonl`` file contents: one JSON event object per line. The
+# transformation chain below converts that into chunked exchange-pair markdown
+# compatible with ``mempalace.convo_miner.chunk_exchanges``.
+
+
+# Regex patterns for user-text cleanup — compiled once at module load.
+_OPENCLAW_RUNTIME_BLOCK = re.compile(
+    r"OpenClaw runtime context.*?END_OPENCLAW_INTERNAL_CONTEXT>>>",
+    re.DOTALL,
+)
+_OPENCLAW_META_FENCE = re.compile(
+    r"```[a-zA-Z]*\s*\n.*?(?:chat_id|inbound_event_kind|sender_id|\"label\").*?```",
+    re.DOTALL,
+)
+_OPENCLAW_LABEL_LINES = re.compile(
+    r"^\s*(?:Conversation info \(untrusted metadata\):"
+    r"|Sender \(untrusted metadata\):"
+    r"|Conversation info.*:"
+    r"|.*untrusted metadata.*:)\s*$",
+    re.MULTILINE,
+)
+
+
+def openclaw_extract_turns(text: str) -> str:  # noqa: D401
+    """Parse JSONL trajectory events and emit one role-tab-JSON line per turn.
+
+    Input: newline-separated JSON event objects (raw ``*.trajectory.jsonl``
+    file contents).
+
+    Output: lines of the form ``<role>\\t<json_body>`` where ``<json_body>``
+    is the JSON-encoded turn text. ``user`` turns come from
+    ``prompt.submitted`` (``data.prompt``); ``assistant`` turns come from
+    ``model.completed`` (``data.assistantTexts`` joined with ``\\n``).
+    All other event types — ``context.compiled``, ``session.started``,
+    ``session.ended``, ``trace.*`` etc. — are skipped.
+
+    The JSON encoding of the body means embedded newlines are escaped and
+    downstream transforms can split on ``\\n`` without ambiguity.
+    """
+    out: list[str] = []
+    pending_user: str | None = None
+    for raw_line in text.split("\n"):
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        try:
+            event = _json.loads(raw_line)
+        except (ValueError, TypeError):
+            continue
+        etype = event.get("type")
+        data = event.get("data") or {}
+        if etype == "prompt.submitted":
+            pending_user = data.get("prompt") or ""
+        elif etype == "model.completed":
+            texts = data.get("assistantTexts") or []
+            assistant = "\n".join(x for x in texts if isinstance(x, str)).strip()
+            if pending_user is not None:
+                out.append(f"user\t{_json.dumps(pending_user)}")
+            if assistant:
+                out.append(f"assistant\t{_json.dumps(assistant)}")
+            pending_user = None
+    return "\n".join(out)
+
+
+def openclaw_strip_runtime_context(text: str) -> str:  # noqa: D401
+    """Strip OpenClaw runtime-context injection blocks from user turns.
+
+    Operates on the role-tab-JSON line format produced by
+    :func:`openclaw_extract_turns`. For each ``user`` line, JSON-decodes the
+    body, removes the ``OpenClaw runtime context … END_OPENCLAW_INTERNAL_CONTEXT>>>``
+    block (inserted by the agent runtime before every prompt), then re-encodes.
+    Assistant lines are passed through unchanged.
+    """
+    out: list[str] = []
+    for line in text.split("\n"):
+        role, sep, body_json = line.partition("\t")
+        if not sep:
+            out.append(line)
+            continue
+        if role == "user":
+            try:
+                body = _json.loads(body_json)
+                body = _OPENCLAW_RUNTIME_BLOCK.sub("", body)
+                body_json = _json.dumps(body)
+            except (ValueError, TypeError):
+                pass
+        out.append(f"{role}\t{body_json}")
+    return "\n".join(out)
+
+
+def openclaw_strip_metadata_preamble(text: str) -> str:  # noqa: D401
+    """Strip OpenClaw metadata fences and header label lines from user turns.
+
+    Operates on the role-tab-JSON line format produced by
+    :func:`openclaw_extract_turns`. For each ``user`` line, JSON-decodes the
+    body, removes:
+
+    * Fenced code blocks containing OpenClaw metadata JSON (``chat_id``,
+      ``sender_id``, ``inbound_event_kind``, ``label`` keys).
+    * Bare label lines such as ``Conversation info (untrusted metadata):``.
+
+    Assistant lines are passed through unchanged.
+    """
+    out: list[str] = []
+    for line in text.split("\n"):
+        role, sep, body_json = line.partition("\t")
+        if not sep:
+            out.append(line)
+            continue
+        if role == "user":
+            try:
+                body = _json.loads(body_json)
+                body = _OPENCLAW_META_FENCE.sub("", body)
+                body = _OPENCLAW_LABEL_LINES.sub("", body)
+                body_json = _json.dumps(body)
+            except (ValueError, TypeError):
+                pass
+        out.append(f"{role}\t{body_json}")
+    return "\n".join(out)
+
+
+def openclaw_format_exchange(text: str) -> str:  # noqa: D401
+    """Reformat role-tab-JSON lines as ``convo_miner`` exchange-pair markdown.
+
+    Mirrors :func:`opencode_format_exchange` but JSON-decodes the body first.
+    ``user`` lines become ``> <body>``; ``assistant`` lines become the body on
+    its own paragraph. Pairs are separated by blank lines. The output is what
+    ``mempalace.convo_miner.chunk_exchanges`` recognises as an exchange
+    transcript.
+    """
+    blocks: list[str] = []
+    for line in text.split("\n"):
+        role, sep, body_json = line.partition("\t")
+        if not sep:
+            continue
+        try:
+            body = _json.loads(body_json)
+        except (ValueError, TypeError):
+            body = body_json
+        if not isinstance(body, str):
+            body = str(body)
+        body = body.strip()
+        if not body:
+            continue
+        if role == "user":
+            quoted = "\n".join(f"> {ln}" for ln in body.split("\n"))
+            blocks.append(quoted)
+        else:
+            blocks.append(body)
+    return "\n\n".join(blocks)
 
 
 # ---------------------------------------------------------------------------

--- a/mempalace/sources/transforms.py
+++ b/mempalace/sources/transforms.py
@@ -179,9 +179,13 @@ _OPENCLAW_RUNTIME_BLOCK = re.compile(
     re.DOTALL,
 )
 # Strip fenced code blocks whose body contains OpenClaw routing metadata keys.
+# R4 / ReDoS hardening: replaced the two DOTALL .*? spans with [^`]*? so the
+# pattern is bounded by backtick characters and cannot span ``` delimiters.
+# [^`] matches any character except a backtick — including newlines — so
+# re.DOTALL is not needed.  Behavior on well-formed OpenClaw metadata fences
+# (JSON bodies without inline backticks) is identical to the original.
 _OPENCLAW_META_FENCE = re.compile(
-    r"```[a-zA-Z]*\s*\n.*?(?:chat_id|inbound_event_kind|sender_id|\"label\").*?```",
-    re.DOTALL,
+    r'```[a-zA-Z]*[^\n]*\n[^`]*?(?:chat_id|inbound_event_kind|sender_id|"label")[^`]*?```',
 )
 # Strip bare label header lines injected above the metadata fences.
 _OPENCLAW_LABEL_LINES = re.compile(
@@ -355,12 +359,17 @@ def openclaw_format_exchange(text: str) -> str:  # noqa: D401
         if not isinstance(body, str):
             body = str(body)
         body = body.strip()
-        if not body:
-            continue
+        # R3: empty user bodies are emitted as a stable placeholder so the
+        # following assistant turn stays paired and is not lost as a leading
+        # orphan by _chunk_by_exchange.  Empty assistant turns are still
+        # silently skipped (they carry no useful content).
         if role == "user":
-            quoted = "\n".join(f"> {ln}" for ln in body.split("\n"))
-            blocks.append(quoted)
-        else:
+            if not body:
+                blocks.append("> [non-text user turn]")
+            else:
+                quoted = "\n".join(f"> {ln}" for ln in body.split("\n"))
+                blocks.append(quoted)
+        elif body:  # assistant — skip if empty
             blocks.append(body)
     return "\n\n".join(blocks)
 
@@ -386,14 +395,20 @@ def openclaw_format_exchange(text: str) -> str:  # noqa: D401
 _OC_RE_AWS_KEY = re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")
 
 # Well-known token prefixes with variable-length alphanumeric tails.
+# R1: broadened to cover dashed/newer OpenAI formats (sk-proj-*, sk-svcacct-*)
+# and additional GitHub token prefixes (gho_, ghu_, ghr_, github_pat_).
 _OC_RE_PREFIXED_TOKENS = re.compile(
     r"\b(?:"
-    r"ghp_[A-Za-z0-9_]{36,}"  # GitHub personal access token
+    r"ghp_[A-Za-z0-9_]{36,}"  # GitHub personal access token (classic)
     r"|ghs_[A-Za-z0-9_]{36,}"  # GitHub server-to-server token
+    r"|gho_[A-Za-z0-9_]{36,}"  # GitHub OAuth app token
+    r"|ghu_[A-Za-z0-9_]{36,}"  # GitHub user-to-server token
+    r"|ghr_[A-Za-z0-9_]{36,}"  # GitHub refresh token
+    r"|github_pat_[A-Za-z0-9_]{22,}"  # GitHub fine-grained PAT
     r"|lin_api_[A-Za-z0-9_]{30,}"  # Linear API key
     r"|xoxb-[A-Za-z0-9\-]{20,}"  # Slack bot token
     r"|xoxp-[A-Za-z0-9\-]{20,}"  # Slack user token
-    r"|sk-[A-Za-z0-9]{20,}"  # OpenAI / generic sk- token
+    r"|sk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{20,}"  # OpenAI / generic sk- token
     r"|clh_[A-Za-z0-9_\-]{20,}"  # ClawHub token
     r"|ATATT[A-Za-z0-9+=/\-_]{30,}"  # Atlassian (Jira) personal access token
     r")"
@@ -413,6 +428,11 @@ _OC_RE_PEM_KEY = re.compile(
 
 # Common key=value / key: value assignment patterns.
 # Group 1 = the key prefix (preserved); group 2 = the value (redacted).
+# R2 — known limitation (accepted, best-effort): the value pattern
+# [^\s,'"`\n>{]{8,} matches any non-whitespace run of ≥8 chars, so a
+# single prose word after a secret-like key (e.g. "password: yesterday")
+# can be over-redacted.  Eliminating these false positives would require
+# entropy-based heuristics and risks introducing false negatives.
 _OC_RE_KV_SECRET = re.compile(
     r"(?i)"
     r"((?:api[_-]?key|api[_-]?token|auth[_-]?token|access[_-]?token"

--- a/mempalace/sources/transforms.py
+++ b/mempalace/sources/transforms.py
@@ -366,6 +366,110 @@ def openclaw_format_exchange(text: str) -> str:  # noqa: D401
 
 
 # ---------------------------------------------------------------------------
+# Adapter-namespaced reference implementations — OpenClaw (continued)
+# ---------------------------------------------------------------------------
+#
+# M3: Secret redaction (RFC 002 §7.3 declared transform).
+#
+# ``openclaw_redact_secrets`` applies best-effort regex redaction to role-tab-
+# JSON turn lines (the format produced by ``openclaw_extract_turns``).  It
+# operates on the decoded body of every turn (both user and assistant) before
+# content is chunked into drawers.  This reduces the risk of vacuuming live
+# credentials from raw agent trajectories into ChromaDB.
+#
+# .. warning::
+#     This is BEST-EFFORT redaction only — it covers known prefixes and common
+#     key=value patterns, not every possible secret format.  Do not rely on it
+#     as the sole credential-protection mechanism.
+
+# AWS access key IDs: AKIA... (long-term) or ASIA... (assumed-role)
+_OC_RE_AWS_KEY = re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")
+
+# Well-known token prefixes with variable-length alphanumeric tails.
+_OC_RE_PREFIXED_TOKENS = re.compile(
+    r"\b(?:"
+    r"ghp_[A-Za-z0-9_]{36,}"  # GitHub personal access token
+    r"|ghs_[A-Za-z0-9_]{36,}"  # GitHub server-to-server token
+    r"|lin_api_[A-Za-z0-9_]{30,}"  # Linear API key
+    r"|xoxb-[A-Za-z0-9\-]{20,}"  # Slack bot token
+    r"|xoxp-[A-Za-z0-9\-]{20,}"  # Slack user token
+    r"|sk-[A-Za-z0-9]{20,}"  # OpenAI / generic sk- token
+    r"|clh_[A-Za-z0-9_\-]{20,}"  # ClawHub token
+    r"|ATATT[A-Za-z0-9+=/\-_]{30,}"  # Atlassian (Jira) personal access token
+    r")"
+)
+
+# Bearer token in an Authorization header.
+_OC_RE_BEARER = re.compile(r"(?i)\bBearer\s+([A-Za-z0-9\-._~+/]{16,}=*)")
+
+# HTTP Basic Auth base64 blob.
+_OC_RE_BASIC_AUTH = re.compile(r"(?i)\bBasic\s+([A-Za-z0-9+/]{8,}={0,2})\b")
+
+# PEM private key blocks.
+_OC_RE_PEM_KEY = re.compile(
+    r"-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----.*?-----END (?:[A-Z ]+ )?PRIVATE KEY-----",
+    re.DOTALL,
+)
+
+# Common key=value / key: value assignment patterns.
+# Group 1 = the key prefix (preserved); group 2 = the value (redacted).
+_OC_RE_KV_SECRET = re.compile(
+    r"(?i)"
+    r"((?:api[_-]?key|api[_-]?token|auth[_-]?token|access[_-]?token"
+    r"|secret[_-]?key|secret[_-]?token|secret|password|passwd|private[_-]?key)"
+    r"\s*[:=]\s*)"
+    r"([^\s,'\"\n>{]{8,})"
+)
+
+
+def openclaw_redact_secrets(text: str) -> str:  # noqa: D401
+    """Redact common secret patterns from role-tab-JSON turn lines (best-effort).
+
+    Operates on the role-tab-JSON line format produced by
+    :func:`openclaw_extract_turns`.  JSON-decodes the body of every turn (both
+    ``user`` and ``assistant``), applies the regex suite below, then re-encodes.
+
+    Patterns covered:
+
+    * AWS access key IDs — ``AKIA\u2026`` / ``ASIA\u2026`` + 16 alphanumeric chars.
+    * Well-known token prefixes — ``ghp_``, ``ghs_``, ``lin_api_``, ``xoxb-``,
+      ``xoxp-``, ``sk-``, ``clh_``, ``ATATT``.
+    * ``Bearer <token>`` Authorization header values.
+    * ``Basic <base64>`` Authorization header values.
+    * PEM ``-----BEGIN \u2026 PRIVATE KEY-----`` blocks.
+    * ``key = value`` / ``token: value`` / ``secret = value`` assignment pairs.
+
+    Redacted values are replaced by stable placeholders of the form
+    ``[REDACTED:<kind>]`` so the sanitised content is still human-readable.
+
+    .. warning::
+        BEST-EFFORT only.  This transform reduces the risk of credentials
+        landing in ChromaDB but is **not a security guarantee**.  It cannot
+        detect every possible secret format.
+    """
+    out: list[str] = []
+    for line in text.split("\n"):
+        role, sep, body_json = line.partition("\t")
+        if not sep:
+            out.append(line)
+            continue
+        try:
+            body = _json.loads(body_json)
+            if isinstance(body, str):
+                body = _OC_RE_AWS_KEY.sub("[REDACTED:aws_key]", body)
+                body = _OC_RE_PREFIXED_TOKENS.sub("[REDACTED:api_token]", body)
+                body = _OC_RE_BEARER.sub("Bearer [REDACTED:bearer_token]", body)
+                body = _OC_RE_BASIC_AUTH.sub("Basic [REDACTED:basic_auth]", body)
+                body = _OC_RE_PEM_KEY.sub("[REDACTED:pem_private_key]", body)
+                body = _OC_RE_KV_SECRET.sub(r"\1[REDACTED:secret_value]", body)
+            body_json = _json.dumps(body)
+        except (ValueError, TypeError):
+            pass
+        out.append(f"{role}\t{body_json}")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 

--- a/mempalace/sources/transforms.py
+++ b/mempalace/sources/transforms.py
@@ -172,20 +172,54 @@ def speaker_role_assignment(text: str) -> str:
 
 
 # Regex patterns for user-text cleanup — compiled once at module load.
+
+# Strip the OpenClaw internal context injection block inserted before every prompt.
 _OPENCLAW_RUNTIME_BLOCK = re.compile(
     r"OpenClaw runtime context.*?END_OPENCLAW_INTERNAL_CONTEXT>>>",
     re.DOTALL,
 )
+# Strip fenced code blocks whose body contains OpenClaw routing metadata keys.
 _OPENCLAW_META_FENCE = re.compile(
     r"```[a-zA-Z]*\s*\n.*?(?:chat_id|inbound_event_kind|sender_id|\"label\").*?```",
     re.DOTALL,
 )
+# Strip bare label header lines injected above the metadata fences.
 _OPENCLAW_LABEL_LINES = re.compile(
     r"^\s*(?:Conversation info \(untrusted metadata\):"
     r"|Sender \(untrusted metadata\):"
     r"|Conversation info.*:"
     r"|.*untrusted metadata.*:)\s*$",
     re.MULTILINE,
+)
+# Strip Slack routing header prepended to each Slack-delivered message:
+# "[Slack <name> +Nm Mon YYYY-MM-DD HH:MM:SS UTC] <name>: "
+# Uses [ \t]+ (not \s+) between ] and the display name so the pattern cannot
+# cross line boundaries and accidentally consume the next line's content.
+_OPENCLAW_SLACK_HEADER = re.compile(
+    r"^\[Slack [^\]]+\][ \t]+[^:\n]+:\s*",
+    re.MULTILINE,
+)
+# Strip [media attached: media://... (mime/type)] annotation lines.
+_OPENCLAW_MEDIA_ATTACHED = re.compile(
+    r"^\[media attached:[^\]]*\][ \t]*$",
+    re.MULTILINE,
+)
+# Strip [Slack file: <name> (fileId: <id>)] provenance lines.
+_OPENCLAW_SLACK_FILE_LINE = re.compile(
+    r"^\[Slack file:[^\]]*\][ \t]*$",
+    re.MULTILINE,
+)
+# Strip [slack message id: <ts> channel: <id>] provenance lines.
+_OPENCLAW_SLACK_MSG_ID = re.compile(
+    r"^\[slack message id:[^\]]*\][ \t]*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+# Strip <file name="..." mime="...">...</file> wrapper blocks including any
+# <<<EXTERNAL_UNTRUSTED_CONTENT>>> / SECURITY NOTICE scaffolding inside.
+# Inner content is tool-injected file data, not human conversation text.
+_OPENCLAW_FILE_WRAPPER = re.compile(
+    r"<file\b[^>]*>.*?</file>",
+    re.DOTALL | re.IGNORECASE,
 )
 
 
@@ -257,15 +291,23 @@ def openclaw_strip_runtime_context(text: str) -> str:  # noqa: D401
 
 
 def openclaw_strip_metadata_preamble(text: str) -> str:  # noqa: D401
-    """Strip OpenClaw metadata fences and header label lines from user turns.
+    """Strip OpenClaw metadata fences and all Slack/media envelope annotations.
 
     Operates on the role-tab-JSON line format produced by
     :func:`openclaw_extract_turns`. For each ``user`` line, JSON-decodes the
-    body, removes:
+    body and removes:
 
-    * Fenced code blocks containing OpenClaw metadata JSON (``chat_id``,
-      ``sender_id``, ``inbound_event_kind``, ``label`` keys).
-    * Bare label lines such as ``Conversation info (untrusted metadata):``.
+    * Fenced code blocks whose body contains OpenClaw routing metadata keys
+      (``chat_id``, ``sender_id``, ``inbound_event_kind``, ``label``).
+    * Bare label lines such as ``Conversation info (untrusted metadata):``
+      and ``Sender (untrusted metadata):``.
+    * Slack routing header prefix: ``[Slack <name> +Nm ...] <name>:``.
+    * ``[media attached: media://... (mime)]`` file-attachment annotation lines.
+    * ``[Slack file: <name> (fileId: <id>)]`` file provenance lines.
+    * ``[slack message id: <ts> channel: <id>]`` message provenance lines.
+    * ``<file name="..." mime="...">...</file>`` wrapper blocks; inner content
+      is tool-injected file data (with ``<<<EXTERNAL_UNTRUSTED_CONTENT>>>``
+      scaffolding) and is dropped entirely — it is not human conversation text.
 
     Assistant lines are passed through unchanged.
     """
@@ -280,6 +322,11 @@ def openclaw_strip_metadata_preamble(text: str) -> str:  # noqa: D401
                 body = _json.loads(body_json)
                 body = _OPENCLAW_META_FENCE.sub("", body)
                 body = _OPENCLAW_LABEL_LINES.sub("", body)
+                body = _OPENCLAW_SLACK_HEADER.sub("", body)
+                body = _OPENCLAW_MEDIA_ATTACHED.sub("", body)
+                body = _OPENCLAW_SLACK_FILE_LINE.sub("", body)
+                body = _OPENCLAW_SLACK_MSG_ID.sub("", body)
+                body = _OPENCLAW_FILE_WRAPPER.sub("", body)
                 body_json = _json.dumps(body)
             except (ValueError, TypeError):
                 pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ sqlite_exact = "mempalace.backends.sqlite_exact:SQLiteExactBackend"
 # onto ``BaseSourceAdapter`` in a follow-up PR. Third-party adapter packages
 # (``mempalace-source-cursor``, ``mempalace-source-git``, …) register here.
 [project.entry-points."mempalace.sources"]
+openclaw = "mempalace.sources.openclaw:OpenClawSourceAdapter"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_sources_openclaw.py
+++ b/tests/test_sources_openclaw.py
@@ -506,14 +506,93 @@ def test_scan_trajectory_file_returns_none_for_empty_file(tmp_path):
     assert _scan_trajectory_file(empty) is None
 
 
-def test_scan_trajectory_file_version_is_last_seq(sessions_dir):
-    """Version must be the seq of the last event (append-only growth check)."""
+def test_scan_trajectory_file_version_is_size_based(sessions_dir):
+    """Version must be the file byte-size (append-only monotonic — M2 fix)."""
     tfile = sessions_dir / f"{_SESSION_SIMPLE}.trajectory.jsonl"
     meta = _scan_trajectory_file(tfile)
-    # Read the last non-empty line to confirm the seq matches
-    events = [json.loads(ln) for ln in tfile.read_text().splitlines() if ln.strip()]
-    last_seq = str(events[-1]["seq"])
-    assert meta["version"] == last_seq
+    assert meta is not None
+    assert meta["version"] == str(tfile.stat().st_size)
+
+
+def test_version_is_stable_when_file_unchanged(sessions_dir):
+    """Re-scanning the same unchanged file must return the same version."""
+    tfile = sessions_dir / f"{_SESSION_SIMPLE}.trajectory.jsonl"
+    meta1 = _scan_trajectory_file(tfile)
+    meta2 = _scan_trajectory_file(tfile)
+    assert meta1 is not None
+    assert meta2 is not None
+    assert meta1["version"] == meta2["version"]
+
+
+def test_version_grows_on_append(tmp_path):
+    """Appending bytes to a file must increase its version (M2: size-based)."""
+    tfile = tmp_path / "sess-grow.trajectory.jsonl"
+    build_trajectory_fixture(
+        tfile,
+        "sess-grow",
+        [("Initial question that forms a complete chunk.", ["Initial answer."])],
+        workspace_dir="/tmp/test",
+    )
+    meta1 = _scan_trajectory_file(tfile)
+    assert meta1 is not None
+
+    # Append a benign non-event line (version check only cares about byte count).
+    extra = {
+        "type": "trace.ping",
+        "seq": 99,
+        "sessionId": "sess-grow",
+        "traceSchema": "openclaw-trajectory",
+        "schemaVersion": 1,
+        "ts": "2026-01-02T00:00:00.000Z",
+        "data": {},
+    }
+    with tfile.open("a") as fh:
+        fh.write(json.dumps(extra) + "\n")
+
+    meta2 = _scan_trajectory_file(tfile)
+    assert meta2 is not None
+    assert int(meta2["version"]) > int(meta1["version"]), (
+        "appending to a file must increase the size-based version"
+    )
+
+
+def test_per_run_seq_no_longer_used_as_version(tmp_path):
+    """Confirm version is NOT the last event's seq (which would break M2)."""
+    tfile = tmp_path / "sess-seq-check.trajectory.jsonl"
+    # Write a tiny file where last seq is 7 (mirrors the real-data finding).
+    events = [
+        {
+            "traceSchema": "openclaw-trajectory",
+            "schemaVersion": 1,
+            "type": "session.started",
+            "seq": 1,
+            "sessionId": "sess-seq-check",
+            "sessionKey": "k",
+            "workspaceDir": "/tmp",
+            "modelId": "m",
+            "ts": "2026-01-01T00:00:00.000Z",
+            "data": {},
+        },
+        {
+            "traceSchema": "openclaw-trajectory",
+            "schemaVersion": 1,
+            "type": "model.completed",
+            "seq": 7,  # seq resets per-run
+            "sessionId": "sess-seq-check",
+            "sessionKey": "k",
+            "workspaceDir": "/tmp",
+            "modelId": "m",
+            "ts": "2026-01-01T00:00:01.000Z",
+            "data": {"assistantTexts": ["answer"]},
+        },
+    ]
+    with tfile.open("w") as fh:
+        for e in events:
+            fh.write(json.dumps(e) + "\n")
+    meta = _scan_trajectory_file(tfile)
+    assert meta is not None
+    assert meta["version"] != "7", "version must not be last_event.seq (per-run, not monotonic)"
+    assert meta["version"] == str(tfile.stat().st_size)
 
 
 # ===========================================================================
@@ -681,6 +760,90 @@ def test_is_current_falls_back_to_presence_when_version_missing(adapter):
 
 
 # ===========================================================================
+# M1: No-double-parse — runtime path identical to conformance path
+# ===========================================================================
+
+
+def test_extract_turns_from_events_matches_openclaw_extract_turns(sessions_dir):
+    """_extract_turns_from_events must produce identical output to openclaw_extract_turns."""
+    from mempalace.sources.openclaw import (
+        JsonlTrajectoryEventSource,
+        _build_canonical_source_bytes_from_events,
+        _extract_turns_from_events,
+    )
+
+    tfile = sessions_dir / f"{_SESSION_SIMPLE}.trajectory.jsonl"
+    src = JsonlTrajectoryEventSource(tfile)
+    events = list(src.iter_events())
+
+    # Runtime path (single parse).
+    runtime_turns = _extract_turns_from_events(events)
+
+    # Conformance path (re-serialise events, then run declared extract transform).
+    canon_bytes = _build_canonical_source_bytes_from_events(events)
+    conformance_turns = src_transforms.openclaw_extract_turns(canon_bytes)
+
+    assert runtime_turns == conformance_turns, (
+        "_extract_turns_from_events must produce identical output to "
+        "openclaw_extract_turns applied to serialised events"
+    )
+
+
+def test_extract_turns_and_metadata_matches_split_helpers(sessions_dir):
+    """S5: the fused single-pass runtime path must be byte-identical to the two
+    original helpers it replaces (so it can't silently drift from the RFC
+    conformance reference impls)."""
+    from mempalace.sources.openclaw import (
+        JsonlTrajectoryEventSource,
+        _aggregate_session_metadata,
+        _extract_turns_and_metadata,
+        _extract_turns_from_events,
+    )
+
+    tfile = sessions_dir / f"{_SESSION_SIMPLE}.trajectory.jsonl"
+    events = list(JsonlTrajectoryEventSource(tfile).iter_events())
+
+    turns_split = _extract_turns_from_events(events)
+    meta_split = _aggregate_session_metadata(tfile.name, iter(events), fallback_stem=tfile.stem)
+
+    # Fused pass consumes a fresh generator (never materializes the list).
+    turns_fused, meta_fused = _extract_turns_and_metadata(
+        JsonlTrajectoryEventSource(tfile).iter_events(),
+        fallback_stem=tfile.stem,
+    )
+
+    assert turns_fused == turns_split
+    assert meta_fused == meta_split
+
+
+def test_extract_turns_and_metadata_empty_returns_none():
+    """S5: no events → (None, None), matching the split helpers' empty contract."""
+    from mempalace.sources.openclaw import _extract_turns_and_metadata
+
+    turns, meta = _extract_turns_and_metadata(iter([]), fallback_stem="stem")
+    assert turns is None and meta is None
+
+
+def test_build_canonical_source_bytes_from_events_round_trips(sessions_dir):
+    """Serialise → extract should reproduce the same turns as direct extract."""
+    from mempalace.sources.openclaw import (
+        JsonlTrajectoryEventSource,
+        _build_canonical_source_bytes_from_events,
+    )
+
+    tfile = sessions_dir / f"{_SESSION_METADATA}.trajectory.jsonl"
+    src = JsonlTrajectoryEventSource(tfile)
+    events = list(src.iter_events())
+
+    canon = _build_canonical_source_bytes_from_events(events)
+    # Every line must be valid JSON.
+    for i, line in enumerate(canon.split("\n")):
+        if line.strip():
+            parsed = json.loads(line)
+            assert isinstance(parsed, dict), f"line {i} not a dict after round-trip"
+
+
+# ===========================================================================
 # Transform unit tests
 # ===========================================================================
 
@@ -808,8 +971,15 @@ def test_openclaw_format_exchange_handles_multiline_user():
 def test_declared_transformation_round_trip_reproduces_drawer_content(
     adapter, palace_ctx, sessions_dir
 ):
-    """Applying the declared transforms in order to canonical source bytes
-    then chunking MUST reproduce the drawer content."""
+    """Applying declared transforms in order to canonical source bytes then
+    chunking MUST reproduce the drawer content (RFC 002 §7.3 conformance).
+
+    This test verifies both:
+    (a) The conformance path: raw bytes → full DECLARED_TRANSFORMATION_ORDER → chunks.
+    (b) Implicitly, the runtime path (_extract_turns_from_events +
+        _apply_post_extract_pipeline) produces identical results since both
+        paths converge on the same transcript text.
+    """
     results = list(
         adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
     )
@@ -1711,18 +1881,25 @@ def test_jsonl_source_iter_events_yields_dicts(sessions_dir):
 
 
 def test_jsonl_source_session_metadata_is_consistent_with_scan(sessions_dir):
-    """JsonlTrajectoryEventSource.session_metadata must match _scan_trajectory_file."""
+    """JsonlTrajectoryEventSource.session_metadata must match _scan_trajectory_file.
+
+    _scan_trajectory_file adds 'version' (size-based) on top of the base metadata;
+    all other keys must agree.
+    """
     for sid in (_SESSION_SIMPLE, _SESSION_METADATA, _SESSION_UNICODE):
         tfile = sessions_dir / f"{sid}.trajectory.jsonl"
         src = JsonlTrajectoryEventSource(tfile)
         meta_src = src.session_metadata()
         meta_scan = _scan_trajectory_file(tfile)
-        # Both paths should agree (scan delegates to the source anyway, but
-        # this double-checks the contract is stable).
-        assert meta_src == meta_scan, (
-            f"JsonlTrajectoryEventSource.session_metadata() and _scan_trajectory_file() "
-            f"must agree for {sid}"
+        assert meta_src is not None
+        assert meta_scan is not None
+        # scan adds 'version'; strip it before comparing.
+        scan_without_version = {k: v for k, v in meta_scan.items() if k != "version"}
+        assert meta_src == scan_without_version, (
+            f"session_metadata() and _scan_trajectory_file() (minus 'version') must agree for {sid}"
         )
+        # version must be the file size.
+        assert meta_scan["version"] == str(tfile.stat().st_size)
 
 
 def test_jsonl_source_metadata_cache_is_stable(sessions_dir):
@@ -1743,4 +1920,247 @@ def test_reader_abstraction_seam_docstring_present():
     )
     assert "SqliteTrajectoryEventSource" in doc, (
         "TrajectoryEventSource docstring must name the expected SQLite implementation"
+    )
+
+
+# ===========================================================================
+# M3: Secret redaction — transform unit tests + end-to-end
+# ===========================================================================
+
+# Fake (non-real) secret values used exclusively in test fixtures.
+# These are intentionally synthetic — they follow the prefix format but are
+# not (and have never been) real credentials.
+_FAKE_AWS_KEY = "AKIAFAKEKEY1234ABCDE"
+_FAKE_GH_TOKEN = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+_FAKE_LIN_API = "lin_api_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+_FAKE_BEARER = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.AAAAAAAAAAAAAAAAAA"
+_FAKE_ATATT = "ATATT3xFfGF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+_FAKE_CLH = "clh_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+_FAKE_PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIEowIBAAKCAQEA0000000000000000000000000000000000000000000000\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+
+
+def test_openclaw_redact_secrets_removes_aws_key():
+    """AWS access key IDs must be redacted."""
+    role_tab = f"user\t{json.dumps(f'My key is {_FAKE_AWS_KEY} thanks')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert _FAKE_AWS_KEY not in body
+    assert "[REDACTED:aws_key]" in body
+
+
+def test_openclaw_redact_secrets_removes_github_token():
+    """GitHub personal access tokens (ghp_...) must be redacted."""
+    role_tab = f"assistant\t{json.dumps(f'Token: {_FAKE_GH_TOKEN}')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert _FAKE_GH_TOKEN not in body
+    assert "[REDACTED:api_token]" in body
+
+
+def test_openclaw_redact_secrets_removes_linear_api_key():
+    """Linear API keys (lin_api_...) must be redacted."""
+    role_tab = f"user\t{json.dumps(f'API key: {_FAKE_LIN_API}')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert _FAKE_LIN_API not in body
+    assert "[REDACTED:api_token]" in body
+
+
+def test_openclaw_redact_secrets_removes_bearer_token():
+    """Bearer tokens in Authorization headers must be redacted."""
+    role_tab = f"user\t{json.dumps(f'Authorization: Bearer {_FAKE_BEARER}')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert _FAKE_BEARER not in body
+    assert "Bearer [REDACTED:bearer_token]" in body
+
+
+def test_openclaw_redact_secrets_removes_kv_password():
+    """key=value password patterns must be redacted."""
+    role_tab = f"user\t{json.dumps('password=SuperSecretPass123!')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert "SuperSecretPass123!" not in body
+    assert "[REDACTED:secret_value]" in body
+
+
+def test_openclaw_redact_secrets_removes_pem_private_key():
+    """PEM private key blocks must be redacted."""
+    role_tab = f"user\t{json.dumps(f'Key: {_FAKE_PEM}')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert "-----BEGIN RSA PRIVATE KEY-----" not in body
+    assert "[REDACTED:pem_private_key]" in body
+
+
+def test_openclaw_redact_secrets_is_noop_for_clean_content():
+    """Clean content (no secrets) must pass through unchanged."""
+    clean = "How do I use Python decorators effectively in production code?"
+    role_tab = f"user\t{json.dumps(clean)}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert body == clean
+
+
+def test_openclaw_redact_secrets_redacts_assistant_turns():
+    """Redaction must apply to assistant turns as well as user turns."""
+    role_tab = f"assistant\t{json.dumps(f'Here is your token: {_FAKE_GH_TOKEN}')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert _FAKE_GH_TOKEN not in body
+
+
+def test_redaction_end_to_end_drawer_content(adapter, palace_ctx, tmp_path):
+    """Seeded fake secrets must NOT appear in emitted drawer content (M3).
+
+    Uses only synthetic/fake credentials — no real tokens.
+    """
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+
+    # Embed fake credentials into the user prompts.
+    user_text_with_secrets = (
+        f"My AWS key is {_FAKE_AWS_KEY} and my GitHub token is {_FAKE_GH_TOKEN}. "
+        f"Also the Linear key is {_FAKE_LIN_API} and Atlassian is {_FAKE_ATATT}. "
+        f"Please help me set up access. This text is long enough to form a chunk."
+    )
+    assistant_text = (
+        "I can help you set up access. Please rotate those credentials first — "
+        "sharing them in chat is insecure. This answer is long enough to chunk."
+    )
+
+    build_trajectory_fixture(
+        sdir / "sess-redact-e2e.trajectory.jsonl",
+        "sess-redact-e2e",
+        [(user_text_with_secrets, [assistant_text])],
+        workspace_dir="/home/user/projects/redact-test",
+    )
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert drawers, "expected at least one drawer"
+
+    joined = "\n".join(d.content for d in drawers)
+
+    # None of the fake secrets should appear in drawer content.
+    assert _FAKE_AWS_KEY not in joined, "AWS key survived redaction"
+    assert _FAKE_GH_TOKEN not in joined, "GitHub token survived redaction"
+    assert _FAKE_LIN_API not in joined, "Linear API key survived redaction"
+    assert _FAKE_ATATT not in joined, "Atlassian token survived redaction"
+
+    # Legitimate content must still be present.
+    assert "set up access" in joined or "rotate" in joined, (
+        "legitimate content was stripped by over-aggressive redaction"
+    )
+
+
+def test_redaction_round_trip_still_matches_declared_transforms(adapter, palace_ctx, tmp_path):
+    """Conformance: declared-transform round-trip must match runtime even with redaction.
+
+    Seeded secrets are redacted in BOTH the conformance path and the runtime path,
+    so the outputs must remain identical.
+    """
+    from mempalace.convo_miner import chunk_exchanges
+
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+
+    user_text = (
+        f"Token for CI: {_FAKE_GH_TOKEN}. "
+        f"Please confirm the deployment pipeline is set up. "
+        f"This message is intentionally long enough to form a chunk for testing."
+    )
+    assistant_text = (
+        "Deployment confirmed. The CI pipeline is configured. "
+        "This response is also long enough to be chunked properly."
+    )
+
+    tfile = sdir / "sess-redact-roundtrip.trajectory.jsonl"
+    build_trajectory_fixture(
+        tfile,
+        "sess-redact-roundtrip",
+        [(user_text, [assistant_text])],
+        workspace_dir="/home/user/projects/roundtrip",
+    )
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    if not drawers:
+        pytest.skip("no drawers — nothing to verify")
+
+    # Apply conformance path.
+    raw = _build_canonical_source_bytes(tfile)
+    transformed = raw
+    for name in adapter.DECLARED_TRANSFORMATION_ORDER:
+        fn = getattr(src_transforms, name)
+        transformed = fn(transformed)
+    expected_chunks = chunk_exchanges(transformed)
+
+    ds_sorted = sorted(drawers, key=lambda d: d.chunk_index)
+    assert len(expected_chunks) == len(ds_sorted)
+    for c, d in zip(expected_chunks, ds_sorted):
+        assert c["content"] == d.content, (
+            f"round-trip mismatch at chunk_index={d.chunk_index} after redaction"
+        )
+
+
+# ===========================================================================
+# S3: message_count definition — drawer count vs exchange-pair count
+# ===========================================================================
+
+
+def test_message_count_reflects_exchange_pairs_not_drawer_count(adapter, palace_ctx, tmp_path):
+    """message_count must equal exchange pairs, NOT drawer count (S3 fix).
+
+    The schema description now explicitly states this — verify the field value
+    is the exchange pair count for a session where chunking might produce a
+    different number of drawers.
+    """
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+
+    # Build a 3-exchange session.
+    exchanges = [
+        (
+            f"Question {i}: explain concept {i} in enough detail to fill a chunk properly.",
+            [f"Answer {i}: here is a thorough explanation of concept {i} that fills a chunk."],
+        )
+        for i in range(3)
+    ]
+    build_trajectory_fixture(
+        sdir / "sess-msgcount.trajectory.jsonl",
+        "sess-msgcount",
+        exchanges,
+        workspace_dir="/home/user/projects/msgcount",
+    )
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert drawers
+
+    # All drawers from one session share the same message_count.
+    mc_values = {d.metadata["message_count"] for d in drawers}
+    assert len(mc_values) == 1, "all drawers from one session must have the same message_count"
+    mc = mc_values.pop()
+
+    # message_count must equal the number of exchange pairs (3), not drawer count.
+    assert mc == 3, f"expected message_count == 3 (exchange pairs), got {mc}"
+
+    # Document that it may differ from drawer count (S3 contract).
+    # (We don't assert equality — the spec says they CAN differ.)
+    drawer_count = len(drawers)
+    _ = drawer_count  # number of drawers is chunk-dependent; not required to equal mc
+
+
+def test_schema_description_documents_message_count_definition(adapter):
+    """describe_schema message_count description must mention 'drawer' or 'chunking'."""
+    schema = adapter.describe_schema()
+    desc = schema.fields["message_count"].description
+    assert any(word in desc.lower() for word in ("drawer", "chunk", "emitted", "differ")), (
+        "message_count schema description must clarify it counts exchange pairs, "
+        f"not drawers (got: {desc!r})"
     )

--- a/tests/test_sources_openclaw.py
+++ b/tests/test_sources_openclaw.py
@@ -379,7 +379,7 @@ def test_adapter_identity():
 
 
 def test_declared_transformations_have_reference_impls():
-    """Every declared transformation MUST resolve to a callable on transforms (RFC 002 §7.3)."""
+    """Every declared transformation MUST resolve to a callable on transforms (RFC 002 section 7.3)."""
     for name in OpenClawSourceAdapter.declared_transformations:
         impl = getattr(src_transforms, name, None)
         assert callable(impl), (
@@ -964,7 +964,7 @@ def test_openclaw_format_exchange_handles_multiline_user():
 
 
 # ===========================================================================
-# Declared-transformation round-trip (RFC 002 §7.3)
+# Declared-transformation round-trip (RFC 002 section 7.3)
 # ===========================================================================
 
 
@@ -972,7 +972,7 @@ def test_declared_transformation_round_trip_reproduces_drawer_content(
     adapter, palace_ctx, sessions_dir
 ):
     """Applying declared transforms in order to canonical source bytes then
-    chunking MUST reproduce the drawer content (RFC 002 §7.3 conformance).
+    chunking MUST reproduce the drawer content (RFC 002 section 7.3 conformance).
 
     This test verifies both:
     (a) The conformance path: raw bytes → full DECLARED_TRANSFORMATION_ORDER → chunks.

--- a/tests/test_sources_openclaw.py
+++ b/tests/test_sources_openclaw.py
@@ -213,16 +213,16 @@ _SESSION_SINGLE_TURN = "sess-aa11bb22-0000-0000-0000-000000000004"
 def _make_metadata_prompt(user_request: str) -> str:
     """Wrap a user request with the OpenClaw metadata preamble."""
     return (
-        'Conversation info (untrusted metadata):\n'
-        '```json\n'
-        '{\n'
+        "Conversation info (untrusted metadata):\n"
+        "```json\n"
+        "{\n"
         '  "chat_id": "user:UTEST123",\n'
         '  "message_id": "1234567890.123456",\n'
         '  "sender_id": "UTEST123",\n'
         '  "sender": "Test User"\n'
-        '}\n'
-        '```\n'
-        '\n' + user_request
+        "}\n"
+        "```\n"
+        "\n" + user_request
     )
 
 
@@ -259,11 +259,15 @@ def sessions_dir(tmp_path) -> Path:
         [
             (
                 "How do I use TanStack Query for data fetching?",
-                ["Use the useQuery hook with a queryFn. For example: useQuery({ queryKey: ['todos'], queryFn: fetchTodos })"],
+                [
+                    "Use the useQuery hook with a queryFn. For example: useQuery({ queryKey: ['todos'], queryFn: fetchTodos })"
+                ],
             ),
             (
                 "How do I invalidate the cache after a mutation?",
-                ["Call queryClient.invalidateQueries({ queryKey: ['todos'] }) inside the onSuccess callback of useMutation."],
+                [
+                    "Call queryClient.invalidateQueries({ queryKey: ['todos'] }) inside the onSuccess callback of useMutation."
+                ],
             ),
         ],
         workspace_dir="/home/user/projects/myproject",
@@ -280,7 +284,9 @@ def sessions_dir(tmp_path) -> Path:
             ),
             (
                 "Here is the traceback: AttributeError: NoneType has no attribute 'split'",
-                ["That error means you're calling .split() on a None value. Check where the variable is assigned."],
+                [
+                    "That error means you're calling .split() on a None value. Check where the variable is assigned."
+                ],
             ),
         ],
         workspace_dir="/home/user/projects/backend",
@@ -293,7 +299,9 @@ def sessions_dir(tmp_path) -> Path:
         [
             (
                 "日本語で説明してください: how does async/await work in Python?",
-                ["async/await は非同期処理のための構文です。asyncキーワードをコルーチン関数の前に付けます。"],
+                [
+                    "async/await は非同期処理のための構文です。asyncキーワードをコルーチン関数の前に付けます。"
+                ],
             ),
         ],
         workspace_dir="/home/user/projects/docs",
@@ -404,7 +412,9 @@ def test_session_source_file_is_stable():
 
 
 def test_session_source_file_has_expected_shape():
-    sf = session_source_file("/home/user/.openclaw/agents/main/sessions/abc.trajectory.jsonl", "abc")
+    sf = session_source_file(
+        "/home/user/.openclaw/agents/main/sessions/abc.trajectory.jsonl", "abc"
+    )
     assert sf.startswith("openclaw://")
     assert "#session=" in sf
 
@@ -468,6 +478,18 @@ def test_scan_trajectory_file_extracts_metadata(sessions_dir):
     assert meta["model_id"] == "anthropic/claude-test-model"
     assert meta["session_created_at"]  # non-empty ISO timestamp
     assert meta["version"]  # non-empty version string
+    # Defect 1 fix: message_count must be an integer, not absent or None.
+    assert isinstance(meta["message_count"], int)
+    assert meta["message_count"] == 2  # _SESSION_SIMPLE has exactly 2 exchanges
+
+
+def test_scan_trajectory_file_message_count_empty_session(sessions_dir):
+    """A session with zero exchange pairs must report message_count == 0."""
+    tfile = sessions_dir / f"{_SESSION_SINGLE_TURN}.trajectory.jsonl"
+    meta = _scan_trajectory_file(tfile)
+    assert meta is not None
+    assert isinstance(meta["message_count"], int)
+    assert meta["message_count"] == 0
 
 
 def test_scan_trajectory_file_returns_none_for_empty_file(tmp_path):
@@ -492,7 +514,9 @@ def test_scan_trajectory_file_version_is_last_seq(sessions_dir):
 
 
 def test_ingest_yields_metadata_then_drawers(adapter, palace_ctx, sessions_dir):
-    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
     metas = [r for r in results if isinstance(r, SourceItemMetadata)]
     drawers = [r for r in results if isinstance(r, DrawerRecord)]
     # 4 files → 4 SourceItemMetadata
@@ -507,7 +531,9 @@ def test_ingest_yields_metadata_then_drawers(adapter, palace_ctx, sessions_dir):
 
 def test_ingest_empty_session_produces_no_drawers(adapter, palace_ctx, sessions_dir):
     """The single-turn (0-exchange) session should yield metadata but no drawers."""
-    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
     drawers = [r for r in results if isinstance(r, DrawerRecord)]
     src_files_with_drawers = {d.source_file for d in drawers}
     assert all(_SESSION_SINGLE_TURN not in sf for sf in src_files_with_drawers), (
@@ -516,7 +542,9 @@ def test_ingest_empty_session_produces_no_drawers(adapter, palace_ctx, sessions_
 
 
 def test_drawer_metadata_has_all_universal_and_schema_fields(adapter, palace_ctx, sessions_dir):
-    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
     drawers = [r for r in results if isinstance(r, DrawerRecord)]
     assert drawers, "expected at least one drawer"
     schema_keys = set(adapter.describe_schema().fields.keys())
@@ -548,14 +576,18 @@ def test_drawer_metadata_has_all_universal_and_schema_fields(adapter, palace_ctx
 
 
 def test_drawer_extract_mode_is_exchange(adapter, palace_ctx, sessions_dir):
-    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
     for r in results:
         if isinstance(r, DrawerRecord):
             assert r.metadata["extract_mode"] == "exchange"
 
 
 def test_drawer_route_hint_carries_wing_and_room(adapter, palace_ctx, sessions_dir):
-    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
     drawers = [r for r in results if isinstance(r, DrawerRecord)]
     for d in drawers:
         assert d.route_hint is not None
@@ -569,12 +601,12 @@ def test_drawer_route_hint_carries_wing_and_room(adapter, palace_ctx, sessions_d
 
 
 def test_wing_derived_from_workspace_dir_basename(adapter, palace_ctx, sessions_dir):
-    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
     drawers = [r for r in results if isinstance(r, DrawerRecord)]
     # _SESSION_SIMPLE has workspace_dir="/home/user/projects/myproject" → wing="myproject"
-    myproject_drawers = [
-        d for d in drawers if _SESSION_SIMPLE in d.source_file
-    ]
+    myproject_drawers = [d for d in drawers if _SESSION_SIMPLE in d.source_file]
     assert myproject_drawers, "expected drawers for simple session"
     assert all(d.metadata["wing"] == "myproject" for d in myproject_drawers)
 
@@ -620,8 +652,12 @@ def test_is_current_uses_stored_version_when_present(adapter):
         source_file="openclaw:///tmp/x.trajectory.jsonl#session=sess-abc",
         version="42",
     )
-    assert adapter.is_current(item=item, existing_metadata={"openclaw_session_version": "42"}) is True
-    assert adapter.is_current(item=item, existing_metadata={"openclaw_session_version": "99"}) is False
+    assert (
+        adapter.is_current(item=item, existing_metadata={"openclaw_session_version": "42"}) is True
+    )
+    assert (
+        adapter.is_current(item=item, existing_metadata={"openclaw_session_version": "99"}) is False
+    )
 
 
 def test_is_current_falls_back_to_presence_when_version_missing(adapter):
@@ -683,7 +719,10 @@ def test_openclaw_extract_turns_multiple_assistant_texts():
     """Multiple assistantTexts entries are joined with newline."""
     events = [
         {"type": "prompt.submitted", "data": {"prompt": "Give me two answers."}},
-        {"type": "model.completed", "data": {"assistantTexts": ["First answer.", "Second answer."]}},
+        {
+            "type": "model.completed",
+            "data": {"assistantTexts": ["First answer.", "Second answer."]},
+        },
     ]
     raw = "\n".join(json.dumps(e) for e in events)
     result = src_transforms.openclaw_extract_turns(raw)
@@ -695,9 +734,7 @@ def test_openclaw_extract_turns_multiple_assistant_texts():
 
 def test_openclaw_strip_runtime_context_removes_block():
     """Runtime context block must be removed from user turns."""
-    raw_prompt = (
-        "<<<OpenClaw runtime context\nSome internal info.\nEND_OPENCLAW_INTERNAL_CONTEXT>>>\n\nActual question"
-    )
+    raw_prompt = "<<<OpenClaw runtime context\nSome internal info.\nEND_OPENCLAW_INTERNAL_CONTEXT>>>\n\nActual question"
     role_tab = f"user\t{json.dumps(raw_prompt)}"
     result = src_transforms.openclaw_strip_runtime_context(role_tab)
     body = json.loads(result.partition("\t")[2])
@@ -716,11 +753,11 @@ def test_openclaw_strip_runtime_context_preserves_assistant_turns():
 def test_openclaw_strip_metadata_preamble_removes_fence():
     """Metadata JSON fences must be stripped from user prompts."""
     preamble_prompt = (
-        'Conversation info (untrusted metadata):\n'
-        '```json\n'
+        "Conversation info (untrusted metadata):\n"
+        "```json\n"
         '{"chat_id": "user:U123", "sender_id": "U123"}\n'
-        '```\n'
-        '\nReal user request here'
+        "```\n"
+        "\nReal user request here"
     )
     role_tab = f"user\t{json.dumps(preamble_prompt)}"
     result = src_transforms.openclaw_strip_metadata_preamble(role_tab)
@@ -730,10 +767,7 @@ def test_openclaw_strip_metadata_preamble_removes_fence():
 
 
 def test_openclaw_strip_metadata_preamble_removes_label_lines():
-    prompt_with_label = (
-        "Conversation info (untrusted metadata):\n"
-        "Real content below"
-    )
+    prompt_with_label = "Conversation info (untrusted metadata):\nReal content below"
     role_tab = f"user\t{json.dumps(prompt_with_label)}"
     result = src_transforms.openclaw_strip_metadata_preamble(role_tab)
     body = json.loads(result.partition("\t")[2])
@@ -807,6 +841,144 @@ def test_declared_transformation_round_trip_reproduces_drawer_content(
 
 
 # ===========================================================================
+# Realistic Slack + media input — strips all envelope cruft
+# ===========================================================================
+
+_SESSION_SLACK_REALISTIC = "sess-aa11bb22-0000-0000-0000-000000000099"
+
+
+def _make_slack_user_prompt(core_message: str) -> str:
+    """Build a realistic Slack-delivered prompt as the runtime injects it.
+
+    Includes every pattern the Defect 2 fix must strip:
+    * Two OpenClaw metadata fences (Conversation info + Sender).
+    * A ``[media attached: ...]`` annotation line.
+    * A Slack routing header prefix ``[Slack <name> ...] <name>:``.
+    * A ``[Slack file: ...]`` file provenance line.
+    * A ``[slack message id: ...]`` message provenance line.
+    * A ``<file ...>...</file>`` wrapper block containing
+      ``<<<EXTERNAL_UNTRUSTED_CONTENT>>>`` scaffolding.
+    """
+    return (
+        "Conversation info (untrusted metadata):\n"
+        "```json\n"
+        "{\n"
+        '  "chat_id": "user:UREALISTIC",\n'
+        '  "message_id": "1783366572.599909",\n'
+        '  "sender_id": "UREALISTIC",\n'
+        '  "sender": "Grace",\n'
+        '  "inbound_event_kind": "user_request"\n'
+        "}\n"
+        "```\n"
+        "\n"
+        "Sender (untrusted metadata):\n"
+        "```json\n"
+        "{\n"
+        '  "label": "Grace (UREALISTIC)",\n'
+        '  "id": "UREALISTIC",\n'
+        '  "name": "Grace"\n'
+        "}\n"
+        "```\n"
+        "\n"
+        "[media attached: media://inbound/abc-def-123 (application/force-download)]\n"
+        "[Slack Grace +1m Mon 2026-07-06 19:36:12 UTC] Grace: " + core_message + "\n"
+        "[Slack file: notes.txt (fileId: F0BGBN9QG9E)]\n"
+        "[slack message id: 1783366572.599909 channel: D0AM196D2P6]\n"
+        "\n"
+        '<file name="abc-def-123" mime="text/plain">\n'
+        "\n"
+        '<<<EXTERNAL_UNTRUSTED_CONTENT id="deadbeef0001">\n'
+        "Source: External\n"
+        "---\n"
+        "This is injected file content that must be stripped entirely.\n"
+        '<<<END_EXTERNAL_UNTRUSTED_CONTENT id="deadbeef0001">\n'
+        "</file>\n"
+    )
+
+
+def test_realistic_slack_media_cruft_stripped(adapter, palace_ctx, tmp_path):
+    """Realistic Slack-delivered input: all envelope annotations must be stripped.
+
+    Asserts (per task spec):
+    (a) All envelope cruft is absent from drawer content.
+    (b) message_count is an int and equals the number of exchange pairs.
+    (c) All describe_schema fields appear in every emitted DrawerRecord.metadata.
+    """
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+
+    core_msg_1 = (
+        "Can you summarize the attached Slack transcript? "
+        "It is long enough to form a complete chunk."
+    )
+    core_msg_2 = "Thanks! Now list the three main decisions."
+
+    build_trajectory_fixture(
+        sdir / f"{_SESSION_SLACK_REALISTIC}.trajectory.jsonl",
+        _SESSION_SLACK_REALISTIC,
+        [
+            (
+                _make_slack_user_prompt(core_msg_1),
+                [
+                    "Sure — the Slack transcript covers three topics: "
+                    "memory routing, the RFC 002 adapter spike, and palace cleanup. "
+                    "I'll summarize each in turn."
+                ],
+            ),
+            (
+                _make_slack_user_prompt(core_msg_2),
+                [
+                    "The three main decisions were: "
+                    "(1) use declared-transformation round-trip tests, "
+                    "(2) adopt the wing/room/hall routing hierarchy, "
+                    "(3) keep ChromaDB as the vector backend for v4."
+                ],
+            ),
+        ],
+        workspace_dir="/home/user/projects/slack-test",
+    )
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert drawers, "expected at least one drawer from the realistic session"
+
+    joined = "\n".join(d.content for d in drawers)
+
+    # (a) All Slack/media envelope patterns must be gone from drawer content.
+    assert "media attached:" not in joined, "[media attached:] survived transform"
+    assert "[Slack Grace" not in joined, "Slack header prefix survived transform"
+    assert "[Slack file:" not in joined, "[Slack file:] survived transform"
+    assert "slack message id:" not in joined.lower(), "[slack message id:] survived"
+    assert "<file name=" not in joined, "<file> wrapper survived transform"
+    assert "EXTERNAL_UNTRUSTED_CONTENT" not in joined, "file content survived transform"
+    assert "chat_id" not in joined, "metadata fence content survived transform"
+    assert "sender_id" not in joined, "sender fence content survived transform"
+
+    # Actual user content must survive.
+    assert "summarize" in joined or "decisions" in joined, (
+        "core user message was stripped alongside the cruft"
+    )
+
+    # (b) message_count must be a populated int equal to the pair count.
+    meta_values = [d.metadata.get("message_count") for d in drawers]
+    assert all(isinstance(v, int) for v in meta_values), (
+        f"message_count is not int in some drawers: {meta_values!r}"
+    )
+    # All chunks of the same session share the same message_count.
+    assert all(v == 2 for v in meta_values), (
+        f"expected message_count == 2 (2 exchanges), got: {set(meta_values)}"
+    )
+
+    # (c) All describe_schema fields must appear in each DrawerRecord.metadata.
+    schema_keys = set(adapter.describe_schema().fields.keys())
+    for drawer in drawers:
+        missing = schema_keys - set(drawer.metadata.keys())
+        assert not missing, (
+            f"drawer metadata missing schema fields: {missing}; source_file={drawer.source_file!r}"
+        )
+
+
+# ===========================================================================
 # Edge cases
 # ===========================================================================
 
@@ -823,10 +995,11 @@ def test_ingest_single_file_via_local_path(adapter, palace_ctx, sessions_dir):
 
 def test_unicode_content_preserved_end_to_end(adapter, palace_ctx, sessions_dir):
     """BMP + emoji Unicode must survive the full transform pipeline to drawer.content."""
-    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
     drawers = [
-        d for d in results
-        if isinstance(d, DrawerRecord) and _SESSION_UNICODE in d.source_file
+        d for d in results if isinstance(d, DrawerRecord) and _SESSION_UNICODE in d.source_file
     ]
     assert drawers, "expected at least one drawer for the unicode session"
     joined = "\n".join(d.content for d in drawers)
@@ -863,10 +1036,11 @@ def test_runtime_context_stripped_from_drawers(adapter, palace_ctx, tmp_path):
 
 def test_metadata_preamble_stripped_from_drawers(adapter, palace_ctx, sessions_dir):
     """Metadata JSON fences must not appear in drawer content."""
-    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
     drawers = [
-        d for d in results
-        if isinstance(d, DrawerRecord) and _SESSION_METADATA in d.source_file
+        d for d in results if isinstance(d, DrawerRecord) and _SESSION_METADATA in d.source_file
     ]
     assert drawers, "expected drawers for metadata-preamble session"
     joined = "\n".join(d.content for d in drawers)
@@ -882,17 +1056,40 @@ def test_malformed_jsonl_lines_are_skipped(adapter, palace_ctx, tmp_path):
     sdir.mkdir()
     tfile = sdir / "malformed.trajectory.jsonl"
     events = [
-        {"type": "session.started", "data": {}, "sessionId": "sess-mal",
-         "sessionKey": "k", "workspaceDir": "/tmp", "modelId": "m",
-         "ts": "2026-01-01T00:00:00.000Z", "seq": 1},
+        {
+            "type": "session.started",
+            "data": {},
+            "sessionId": "sess-mal",
+            "sessionKey": "k",
+            "workspaceDir": "/tmp",
+            "modelId": "m",
+            "ts": "2026-01-01T00:00:00.000Z",
+            "seq": 1,
+        },
         "THIS IS NOT JSON",
-        {"type": "prompt.submitted", "data": {"prompt": "Valid question that is long enough to pass chunking threshold"},
-         "sessionId": "sess-mal", "sessionKey": "k", "workspaceDir": "/tmp",
-         "modelId": "m", "ts": "2026-01-01T00:00:01.000Z", "seq": 2},
+        {
+            "type": "prompt.submitted",
+            "data": {"prompt": "Valid question that is long enough to pass chunking threshold"},
+            "sessionId": "sess-mal",
+            "sessionKey": "k",
+            "workspaceDir": "/tmp",
+            "modelId": "m",
+            "ts": "2026-01-01T00:00:01.000Z",
+            "seq": 2,
+        },
         "ANOTHER GARBAGE LINE",
-        {"type": "model.completed", "data": {"assistantTexts": ["Valid answer that is also long enough to make a proper chunk"]},
-         "sessionId": "sess-mal", "sessionKey": "k", "workspaceDir": "/tmp",
-         "modelId": "m", "ts": "2026-01-01T00:00:02.000Z", "seq": 3},
+        {
+            "type": "model.completed",
+            "data": {
+                "assistantTexts": ["Valid answer that is also long enough to make a proper chunk"]
+            },
+            "sessionId": "sess-mal",
+            "sessionKey": "k",
+            "workspaceDir": "/tmp",
+            "modelId": "m",
+            "ts": "2026-01-01T00:00:02.000Z",
+            "seq": 3,
+        },
     ]
     with tfile.open("w") as fh:
         for e in events:

--- a/tests/test_sources_openclaw.py
+++ b/tests/test_sources_openclaw.py
@@ -7,6 +7,11 @@ Covers:
     * Unit tests for JSONL extraction, runtime-context strip, metadata-preamble
       strip, exchange formatting, and chunked-exchange emit via
       ``convo_miner.chunk_exchanges``.
+    * Second-pass hardening (improvement 1-4):
+      - Schema-marker validation (valid, wrong traceSchema, unknown schemaVersion).
+      - Discovery across OPENCLAW_TRAJECTORY_DIR, pointer files, and default.
+      - Truncation tolerance (partial final line, truncation-marker event).
+      - TrajectoryEventSource / JsonlTrajectoryEventSource abstraction seam.
     * Edge cases: empty file, file with no exchange pairs, single-turn
       sessions, unicode content, explicit wing override.
 
@@ -35,8 +40,11 @@ from mempalace.sources.base import (
 )
 from mempalace.sources.context import PalaceContext
 from mempalace.sources.openclaw import (
+    JsonlTrajectoryEventSource,
     OpenClawSourceAdapter,
+    TrajectoryEventSource,
     _build_canonical_source_bytes,
+    _read_pointer_file,
     _scan_trajectory_file,
     session_source_file,
 )
@@ -1098,3 +1106,641 @@ def test_malformed_jsonl_lines_are_skipped(adapter, palace_ctx, tmp_path):
     results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
     drawers = [r for r in results if isinstance(r, DrawerRecord)]
     assert len(drawers) >= 1, "malformed lines should be skipped, not crash"
+
+
+# ===========================================================================
+# Second-pass hardening: 1 — Schema-marker validation
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Helpers for schema-marker tests
+# ---------------------------------------------------------------------------
+
+
+def _write_events(path: Path, events: list) -> None:
+    """Write a list of event dicts (or raw strings) as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for e in events:
+            fh.write((json.dumps(e) if isinstance(e, dict) else str(e)) + "\n")
+
+
+def _make_minimal_event(
+    event_type: str,
+    seq: int,
+    *,
+    trace_schema: str = "openclaw-trajectory",
+    schema_version: int = 1,
+    session_id: str = "sess-schema-test",
+) -> dict:
+    """Build a minimal event with explicit schema marker fields."""
+    return {
+        "traceSchema": trace_schema,
+        "schemaVersion": schema_version,
+        "type": event_type,
+        "ts": "2026-01-01T00:00:00.000Z",
+        "seq": seq,
+        "sessionId": session_id,
+        "sessionKey": "agent:main:slack:direct:UTEST",
+        "workspaceDir": "/home/user/projects/schematest",
+        "modelId": "anthropic/claude-test",
+        "data": {},
+    }
+
+
+def _make_exchange_events(
+    session_id: str,
+    seq_start: int,
+    user_text: str,
+    assistant_text: str,
+    *,
+    trace_schema: str = "openclaw-trajectory",
+    schema_version: int = 1,
+) -> list:
+    """Build prompt.submitted + model.completed events with explicit schema fields."""
+    kwargs = dict(
+        trace_schema=trace_schema,
+        schema_version=schema_version,
+        session_id=session_id,
+    )
+    return [
+        _make_minimal_event("session.started", seq_start, **kwargs),
+        {
+            **_make_minimal_event("prompt.submitted", seq_start + 1, **kwargs),
+            "data": {"prompt": user_text},
+        },
+        {
+            **_make_minimal_event("model.completed", seq_start + 2, **kwargs),
+            "data": {"assistantTexts": [assistant_text]},
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Test: valid traceSchema parses normally
+# ---------------------------------------------------------------------------
+
+
+def test_valid_trace_schema_parses_normally(adapter, palace_ctx, tmp_path):
+    """A file with the correct traceSchema and schemaVersion 1 ingests cleanly."""
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    tfile = sdir / "sess-valid-schema.trajectory.jsonl"
+    events = _make_exchange_events(
+        "sess-valid-schema",
+        1,
+        "What is the capital of France? This question is long enough to chunk.",
+        "The capital of France is Paris, a major European city with rich culture.",
+    )
+    _write_events(tfile, events)
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+    assert len(metas) == 1, "expected one SourceItemMetadata for valid schema"
+    assert drawers, "valid traceSchema should produce drawers"
+
+
+# ---------------------------------------------------------------------------
+# Test: wrong traceSchema causes file to be skipped
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_trace_schema_causes_file_to_be_skipped(adapter, palace_ctx, tmp_path):
+    """A file with traceSchema != 'openclaw-trajectory' must be silently skipped."""
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    tfile = sdir / "sess-wrong-schema.trajectory.jsonl"
+    events = _make_exchange_events(
+        "sess-wrong-schema",
+        1,
+        "Ignored user text because the schema is wrong.",
+        "Ignored assistant text.",
+        trace_schema="some-other-format",
+    )
+    _write_events(tfile, events)
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    # Wrong schema → _scan_trajectory_file returns None → file skipped entirely
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert len(metas) == 0, (
+        "wrong traceSchema must suppress SourceItemMetadata; adapter should skip the file entirely"
+    )
+    assert len(drawers) == 0, "wrong traceSchema must suppress all drawers"
+
+
+def test_wrong_trace_schema_logs_warning(tmp_path, caplog):
+    """Wrong traceSchema must emit a WARNING log."""
+    import logging
+
+    tfile = tmp_path / "sess-warn.trajectory.jsonl"
+    events = _make_exchange_events(
+        "sess-warn", 1, "user text", "assistant text", trace_schema="bad-schema"
+    )
+    _write_events(tfile, events)
+
+    src = JsonlTrajectoryEventSource(tfile)
+    with caplog.at_level(logging.WARNING, logger="mempalace.sources.openclaw"):
+        result = src.session_metadata()
+
+    assert result is None, "wrong traceSchema should return None metadata"
+    assert any("traceSchema" in rec.message for rec in caplog.records), (
+        "expected a WARNING mentioning traceSchema"
+    )
+
+
+def test_missing_trace_schema_is_tolerated(adapter, palace_ctx, tmp_path):
+    """Events without any traceSchema marker (legacy files) must be parsed normally."""
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    tfile = sdir / "sess-no-schema.trajectory.jsonl"
+
+    # Build events without schema marker fields at all.
+    events = [
+        {
+            "type": "session.started",
+            "ts": "2026-01-01T00:00:00.000Z",
+            "seq": 1,
+            "sessionId": "sess-no-schema",
+            "sessionKey": "k",
+            "workspaceDir": "/home/user/projects/noschema",
+            "modelId": "m",
+            "data": {},
+        },
+        {
+            "type": "prompt.submitted",
+            "ts": "2026-01-01T00:00:01.000Z",
+            "seq": 2,
+            "sessionId": "sess-no-schema",
+            "sessionKey": "k",
+            "workspaceDir": "/home/user/projects/noschema",
+            "modelId": "m",
+            "data": {
+                "prompt": (
+                    "How do I use context managers in Python? "
+                    "This is long enough to form a complete chunk in the test."
+                )
+            },
+        },
+        {
+            "type": "model.completed",
+            "ts": "2026-01-01T00:00:02.000Z",
+            "seq": 3,
+            "sessionId": "sess-no-schema",
+            "sessionKey": "k",
+            "workspaceDir": "/home/user/projects/noschema",
+            "modelId": "m",
+            "data": {
+                "assistantTexts": [
+                    "Use the 'with' statement. It calls __enter__ and __exit__ "
+                    "automatically, ensuring cleanup even if an exception occurs."
+                ]
+            },
+        },
+    ]
+    _write_events(tfile, events)
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert drawers, "events without schema marker (legacy) must parse normally"
+
+
+# ---------------------------------------------------------------------------
+# Test: unknown schemaVersion warns but still parses
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_schema_version_warns_and_still_parses(adapter, palace_ctx, tmp_path, caplog):
+    """An unknown schemaVersion must emit a WARNING but still produce drawers."""
+    import logging
+
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    tfile = sdir / "sess-future-schema.trajectory.jsonl"
+    events = _make_exchange_events(
+        "sess-future-schema",
+        1,
+        (
+            "How does the new v99 trajectory format work? "
+            "This question is long enough to produce a chunk."
+        ),
+        (
+            "The v99 format is hypothetical. Best-effort parse should still "
+            "extract user and assistant turns from known fields."
+        ),
+        schema_version=99,  # future/unknown version
+    )
+    _write_events(tfile, events)
+
+    with caplog.at_level(logging.WARNING, logger="mempalace.sources.openclaw"):
+        results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert drawers, "unknown schemaVersion should still produce drawers (best-effort parse)"
+    assert any("schemaVersion" in rec.message for rec in caplog.records), (
+        "expected a WARNING mentioning schemaVersion"
+    )
+
+
+def test_jsonl_source_scan_unknown_schema_version_not_none(tmp_path):
+    """JsonlTrajectoryEventSource must return non-None metadata for future schemaVersion."""
+    tfile = tmp_path / "future.trajectory.jsonl"
+    events = _make_exchange_events(
+        "sess-future",
+        1,
+        "user text for future schema",
+        "assistant text for future schema",
+        schema_version=42,
+    )
+    _write_events(tfile, events)
+
+    src = JsonlTrajectoryEventSource(tfile)
+    meta = src.session_metadata()
+    assert meta is not None, "best-effort parse of future schemaVersion must return metadata"
+    assert meta["message_count"] == 1
+
+
+# ===========================================================================
+# Second-pass hardening: 2 — Discovery across all documented capture locations
+# ===========================================================================
+
+
+def test_discovery_finds_files_in_openclaw_trajectory_dir(
+    adapter, palace_ctx, tmp_path, monkeypatch
+):
+    """OPENCLAW_TRAJECTORY_DIR env var must be scanned for trajectory files."""
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    traj_dir = tmp_path / "trajectories"
+    traj_dir.mkdir()
+
+    session_id = "sess-traj-dir-0001"
+    build_trajectory_fixture(
+        traj_dir / f"{session_id}.trajectory.jsonl",
+        session_id,
+        [
+            (
+                "Question in the trajectory dir — long enough to chunk properly.",
+                ["Answer from the trajectory dir — also long enough for chunking."],
+            )
+        ],
+        workspace_dir="/home/user/projects/trajdir",
+    )
+
+    monkeypatch.setenv("OPENCLAW_TRAJECTORY_DIR", str(traj_dir))
+
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+    # The file is only in traj_dir, not in sessions_dir — must still be found.
+    assert len(metas) == 1, f"expected 1 file from OPENCLAW_TRAJECTORY_DIR, got {len(metas)}"
+    assert any(session_id in m.source_file for m in metas)
+
+
+def test_discovery_follows_pointer_files(adapter, palace_ctx, tmp_path):
+    """Pointer files (*.trajectory-path.json) beside sessions must be followed."""
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    relocated_dir = tmp_path / "relocated"
+    relocated_dir.mkdir()
+
+    session_id = "sess-pointer-0001"
+    tfile = relocated_dir / f"{session_id}.trajectory.jsonl"
+    build_trajectory_fixture(
+        tfile,
+        session_id,
+        [
+            (
+                "Pointer-relocated question — long enough to form a chunk.",
+                ["Pointer-relocated answer — long enough to form a chunk."],
+            )
+        ],
+        workspace_dir="/home/user/projects/pointed",
+    )
+
+    # Write pointer file beside a (non-existent) session file in sessions_dir.
+    pointer_path = sessions_dir / f"{session_id}.trajectory-path.json"
+    pointer_path.write_text(json.dumps({"path": str(tfile)}), encoding="utf-8")
+
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+    assert len(metas) == 1, f"pointer file must resolve to 1 trajectory file; got {len(metas)}"
+    assert any(session_id in m.source_file for m in metas)
+
+
+def test_discovery_deduplicates_when_pointer_and_direct(adapter, palace_ctx, tmp_path, monkeypatch):
+    """If a file is reachable via both direct sidecar AND pointer, count it once."""
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    traj_dir = tmp_path / "trajectories"
+    traj_dir.mkdir()
+
+    session_id = "sess-dedup-0001"
+    tfile = sessions_dir / f"{session_id}.trajectory.jsonl"
+    build_trajectory_fixture(
+        tfile,
+        session_id,
+        [
+            (
+                "Deduplicated question — must appear exactly once.",
+                ["Deduplicated answer — must appear exactly once."],
+            )
+        ],
+        workspace_dir="/home/user/projects/dedup",
+    )
+
+    # Pointer points to the SAME file that already exists as a sidecar.
+    pointer_path = sessions_dir / f"{session_id}.trajectory-path.json"
+    pointer_path.write_text(json.dumps({"path": str(tfile)}), encoding="utf-8")
+
+    # OPENCLAW_TRAJECTORY_DIR also has a symlink to the same file (extra dup).
+    import shutil
+
+    shutil.copy(str(tfile), str(traj_dir / f"{session_id}.trajectory.jsonl"))
+
+    monkeypatch.setenv("OPENCLAW_TRAJECTORY_DIR", str(traj_dir))
+
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+    # All three sources point to files with the same resolved content/session;
+    # the traj_dir copy is a different inode so may produce 2 metas — but
+    # the sidecar + pointer MUST deduplicate to 1.
+    # traj_dir copy has same session_id embedded in source_file but different
+    # file path, so they are distinct source_files. What we verify is that the
+    # sessions_dir sidecar + pointer do NOT duplicate.
+    assert len(metas) <= 2, (
+        "sidecar + pointer referencing the same file must deduplicate; "
+        f"got {len(metas)} SourceItemMetadata records"
+    )
+
+
+def test_discovery_invalid_openclaw_trajectory_dir_logs_warning(tmp_path, caplog, monkeypatch):
+    """OPENCLAW_TRAJECTORY_DIR pointing at a non-dir emits a WARNING, no crash."""
+    import logging
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    nonexistent = tmp_path / "nosuchdir"
+
+    monkeypatch.setenv("OPENCLAW_TRAJECTORY_DIR", str(nonexistent))
+
+    from mempalace.sources.openclaw import _discover_from_dir
+
+    with caplog.at_level(logging.WARNING, logger="mempalace.sources.openclaw"):
+        result = _discover_from_dir(sessions_dir)
+
+    assert isinstance(result, list), "must return a list even on bad env var"
+    assert any("OPENCLAW_TRAJECTORY_DIR" in rec.message for rec in caplog.records), (
+        "expected a WARNING about OPENCLAW_TRAJECTORY_DIR"
+    )
+
+
+def test_read_pointer_file_returns_path_from_valid_json(tmp_path):
+    """_read_pointer_file must return the target Path for a valid JSON pointer."""
+    pointer = tmp_path / "sess.trajectory-path.json"
+    target_path = "/abs/path/to/sess.trajectory.jsonl"
+    pointer.write_text(json.dumps({"path": target_path}), encoding="utf-8")
+
+    result = _read_pointer_file(pointer)
+    assert result is not None
+    assert str(result) == target_path
+
+
+def test_read_pointer_file_returns_none_for_corrupt_json(tmp_path):
+    """_read_pointer_file must return None for corrupt / unreadable pointer files."""
+    pointer = tmp_path / "sess.trajectory-path.json"
+    pointer.write_text("THIS IS NOT JSON", encoding="utf-8")
+
+    result = _read_pointer_file(pointer)
+    assert result is None
+
+
+def test_read_pointer_file_returns_none_for_missing_key(tmp_path):
+    """_read_pointer_file must return None if no recognised path key is present."""
+    pointer = tmp_path / "sess.trajectory-path.json"
+    pointer.write_text(json.dumps({"unknown_key": "/some/path"}), encoding="utf-8")
+
+    result = _read_pointer_file(pointer)
+    assert result is None
+
+
+# ===========================================================================
+# Second-pass hardening: 3 — Truncation tolerance
+# ===========================================================================
+
+
+def test_partial_final_line_does_not_crash(adapter, palace_ctx, tmp_path):
+    """A file ending with a partial (un-terminated) JSON line must not crash."""
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    tfile = sdir / "sess-partial.trajectory.jsonl"
+
+    # Write a valid session with two events, then append a partial line (no newline).
+    events = _make_exchange_events(
+        "sess-partial",
+        1,
+        "Question before truncation — long enough to form a proper chunk.",
+        "Answer before truncation — long enough to form a proper chunk here.",
+    )
+    lines = [json.dumps(e) + "\n" for e in events]
+    lines.append('{"type": "model.completed", "seq": 99, "data": {"assistantTe')  # partial!
+
+    with tfile.open("w", encoding="utf-8") as fh:
+        fh.writelines(lines)
+
+    # Must not raise; should produce the drawer from the complete exchange.
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert len(metas) == 1, "partial final line must not suppress SourceItemMetadata"
+    assert len(drawers) >= 1, "complete exchange before partial line must produce a drawer"
+
+
+def test_partial_final_line_scan_does_not_crash(tmp_path):
+    """_scan_trajectory_file must not crash on a partial final line."""
+    tfile = tmp_path / "sess-partial-scan.trajectory.jsonl"
+    events = _make_exchange_events(
+        "sess-partial-scan",
+        1,
+        "Question before truncation.",
+        "Answer before truncation.",
+    )
+    lines = [json.dumps(e) + "\n" for e in events]
+    lines.append('{"type": "broken_json": ')  # partial line, also invalid JSON
+
+    with tfile.open("w", encoding="utf-8") as fh:
+        fh.writelines(lines)
+
+    # Must not raise; should return valid metadata for the events that parsed.
+    meta = _scan_trajectory_file(tfile)
+    assert meta is not None, "partial final line must not prevent metadata extraction"
+    assert isinstance(meta["message_count"], int)
+    assert meta["message_count"] == 1
+
+
+def test_truncation_marker_event_is_skipped_and_data_preserved(adapter, palace_ctx, tmp_path):
+    """A truncation-marker event must be skipped; data before it must survive."""
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    tfile = sdir / "sess-truncated.trajectory.jsonl"
+
+    # Build a normal exchange followed by the truncation marker.
+    events = _make_exchange_events(
+        "sess-truncated",
+        1,
+        "Question captured before the 10 MiB cap fired — long enough to chunk.",
+        "Answer captured before the 10 MiB cap fired — long enough to chunk.",
+    )
+    truncation_marker = {
+        "type": "trace.truncated",
+        "ts": "2026-01-01T00:00:10.000Z",
+        "seq": 20,
+        "sessionId": "sess-truncated",
+        "traceSchema": "openclaw-trajectory",
+        "schemaVersion": 1,
+        "data": {"reason": "size_cap", "bytesWritten": 10485760},
+    }
+    _write_events(tfile, events + [truncation_marker])
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+
+    # The truncation marker must not become a drawer.
+    assert len(metas) == 1, "expected one SourceItemMetadata"
+    assert len(drawers) >= 1, "data before truncation marker must still produce drawers"
+    # The truncation marker event must not appear in any drawer content.
+    joined = "\n".join(d.content for d in drawers)
+    assert "size_cap" not in joined, "truncation marker data must not appear in drawer content"
+    assert "trace.truncated" not in joined
+
+
+def test_truncation_marker_not_counted_in_message_count(tmp_path):
+    """Truncation-marker events must not be counted in message_count."""
+    tfile = tmp_path / "sess-tc-count.trajectory.jsonl"
+    events = _make_exchange_events(
+        "sess-tc-count",
+        1,
+        "Real exchange before truncation.",
+        "Real answer before truncation.",
+    )
+    truncation = {
+        "type": "trace.truncated",
+        "seq": 99,
+        "sessionId": "sess-tc-count",
+        "traceSchema": "openclaw-trajectory",
+        "schemaVersion": 1,
+        "ts": "2026-01-01T00:00:10.000Z",
+        "data": {},
+    }
+    _write_events(tfile, events + [truncation])
+
+    src = JsonlTrajectoryEventSource(tfile)
+    meta = src.session_metadata()
+    assert meta is not None
+    assert meta["message_count"] == 1, "truncation marker must not increment message_count"
+
+
+def test_file_all_corrupt_returns_none_scan(tmp_path):
+    """A file containing only unparseable lines must return None from scan."""
+    tfile = tmp_path / "corrupt.trajectory.jsonl"
+    tfile.write_text("NOT JSON\nALSO NOT JSON\n{broken\n", encoding="utf-8")
+    assert _scan_trajectory_file(tfile) is None
+
+
+def test_jsonl_source_iter_events_empty_lines_skipped(tmp_path):
+    """Blank lines in a JSONL file must be silently skipped."""
+    tfile = tmp_path / "blanks.trajectory.jsonl"
+    events = _make_exchange_events("sess-blanks", 1, "user text", "assistant text")
+    # Interleave blank lines.
+    lines = []
+    for e in events:
+        lines.append(json.dumps(e))
+        lines.append("")  # blank
+        lines.append("   ")  # whitespace-only
+    tfile.write_text("\n".join(lines), encoding="utf-8")
+
+    src = JsonlTrajectoryEventSource(tfile)
+    collected = list(src.iter_events())
+    assert len(collected) == len(events), "blank lines must be skipped without altering event count"
+
+
+# ===========================================================================
+# Second-pass hardening: 4 — Reader abstraction seam
+# ===========================================================================
+
+
+def test_jsonl_source_is_trajectory_event_source(tmp_path):
+    """JsonlTrajectoryEventSource must satisfy the TrajectoryEventSource Protocol."""
+    tfile = tmp_path / "proto-check.trajectory.jsonl"
+    tfile.write_text("")
+    src = JsonlTrajectoryEventSource(tfile)
+    assert isinstance(src, TrajectoryEventSource), (
+        "JsonlTrajectoryEventSource must pass isinstance check against "
+        "TrajectoryEventSource Protocol"
+    )
+
+
+def test_trajectory_event_source_protocol_has_required_methods():
+    """TrajectoryEventSource must declare iter_events and session_metadata."""
+    # Protocol attributes are accessible via its __protocol_attrs__ in Python 3.12+
+    # or via dir() for all versions.
+    attrs = set(dir(TrajectoryEventSource))
+    assert "iter_events" in attrs
+    assert "session_metadata" in attrs
+
+
+def test_jsonl_source_iter_events_yields_dicts(sessions_dir):
+    """iter_events must yield dicts with expected event fields."""
+    tfile = sessions_dir / f"{_SESSION_SIMPLE}.trajectory.jsonl"
+    src = JsonlTrajectoryEventSource(tfile)
+    events = list(src.iter_events())
+    assert events, "expected at least one event from a non-empty fixture"
+    for event in events:
+        assert isinstance(event, dict), f"iter_events must yield dicts; got {type(event)}"
+    # At least one prompt.submitted and one model.completed.
+    types = {e.get("type") for e in events}
+    assert "prompt.submitted" in types
+    assert "model.completed" in types
+
+
+def test_jsonl_source_session_metadata_is_consistent_with_scan(sessions_dir):
+    """JsonlTrajectoryEventSource.session_metadata must match _scan_trajectory_file."""
+    for sid in (_SESSION_SIMPLE, _SESSION_METADATA, _SESSION_UNICODE):
+        tfile = sessions_dir / f"{sid}.trajectory.jsonl"
+        src = JsonlTrajectoryEventSource(tfile)
+        meta_src = src.session_metadata()
+        meta_scan = _scan_trajectory_file(tfile)
+        # Both paths should agree (scan delegates to the source anyway, but
+        # this double-checks the contract is stable).
+        assert meta_src == meta_scan, (
+            f"JsonlTrajectoryEventSource.session_metadata() and _scan_trajectory_file() "
+            f"must agree for {sid}"
+        )
+
+
+def test_jsonl_source_metadata_cache_is_stable(sessions_dir):
+    """Calling session_metadata() twice must return the same dict (caching)."""
+    tfile = sessions_dir / f"{_SESSION_SIMPLE}.trajectory.jsonl"
+    src = JsonlTrajectoryEventSource(tfile)
+    first = src.session_metadata()
+    second = src.session_metadata()
+    assert first is second, "session_metadata must return the same cached object"
+
+
+def test_reader_abstraction_seam_docstring_present():
+    """TrajectoryEventSource must have a docstring describing the SQLite seam."""
+    doc = TrajectoryEventSource.__doc__ or ""
+    assert "trajectory_runtime_events" in doc, (
+        "TrajectoryEventSource docstring must describe the SQLite seam "
+        "with the trajectory_runtime_events table name"
+    )
+    assert "SqliteTrajectoryEventSource" in doc, (
+        "TrajectoryEventSource docstring must name the expected SQLite implementation"
+    )

--- a/tests/test_sources_openclaw.py
+++ b/tests/test_sources_openclaw.py
@@ -2164,3 +2164,353 @@ def test_schema_description_documents_message_count_definition(adapter):
         "message_count schema description must clarify it counts exchange pairs, "
         f"not drawers (got: {desc!r})"
     )
+
+
+# ===========================================================================
+# R1: Broader token redaction — sk-proj-*, sk-svcacct-*, github_pat_, gho_, etc.
+# ===========================================================================
+
+# Fake tokens in the new formats — never real credentials.
+_FAKE_SK_PROJ = "sk-proj-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+_FAKE_SK_SVCACCT = "sk-svcacct-BBBBBBBBBBBBBBBBBBBBBB"
+_FAKE_GITHUB_PAT = "github_pat_CCCCCCCCCCCCCCCCCCCCCC"
+_FAKE_GHO = "gho_DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
+_FAKE_GHU = "ghu_EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
+_FAKE_GHR = "ghr_FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+
+
+def test_r1_sk_proj_token_is_redacted():
+    """R1: sk-proj-... tokens must be redacted (dashes in tail broke old pattern)."""
+    role_tab = f"user\t{json.dumps(f'Token: {_FAKE_SK_PROJ}')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert _FAKE_SK_PROJ not in body, "sk-proj-... token survived redaction"
+    assert "[REDACTED:api_token]" in body
+
+
+def test_r1_sk_svcacct_token_is_redacted():
+    """R1: sk-svcacct-... tokens must be redacted."""
+    role_tab = f"user\t{json.dumps(f'Key: {_FAKE_SK_SVCACCT}')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert _FAKE_SK_SVCACCT not in body, "sk-svcacct-... token survived redaction"
+    assert "[REDACTED:api_token]" in body
+
+
+def test_r1_github_pat_is_redacted():
+    """R1: github_pat_... fine-grained PATs must be redacted."""
+    role_tab = f"user\t{json.dumps(f'PAT: {_FAKE_GITHUB_PAT}')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert _FAKE_GITHUB_PAT not in body, "github_pat_... token survived redaction"
+    assert "[REDACTED:api_token]" in body
+
+
+def test_r1_gho_token_is_redacted():
+    """R1: gho_... GitHub OAuth tokens must be redacted."""
+    role_tab = f"user\t{json.dumps(f'OAuth token: {_FAKE_GHO}')}"
+    result = src_transforms.openclaw_redact_secrets(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert _FAKE_GHO not in body, "gho_... token survived redaction"
+    assert "[REDACTED:api_token]" in body
+
+
+def test_r1_ghu_ghr_tokens_are_redacted():
+    """R1: ghu_... and ghr_... GitHub tokens must be redacted."""
+    for tok in (_FAKE_GHU, _FAKE_GHR):
+        role_tab = f"user\t{json.dumps(f'Token {tok}')}"
+        result = src_transforms.openclaw_redact_secrets(role_tab)
+        body = json.loads(result.partition("\t")[2])
+        assert tok not in body, f"{tok[:10]}... token survived redaction"
+        assert "[REDACTED:api_token]" in body
+
+
+def test_r1_new_tokens_redacted_end_to_end(adapter, palace_ctx, tmp_path):
+    """R1: sk-proj- and github_pat_ tokens must not appear in drawer content."""
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+
+    user_text = (
+        f"Here is my OpenAI key: {_FAKE_SK_PROJ}. "
+        f"And my GitHub PAT: {_FAKE_GITHUB_PAT}. "
+        f"Please help me configure the CI. This message is long enough to chunk."
+    )
+    assistant_text = (
+        "Please rotate those credentials immediately — they are now compromised. "
+        "This answer is also long enough to form a complete chunk for testing."
+    )
+    build_trajectory_fixture(
+        sdir / "sess-r1-tokens.trajectory.jsonl",
+        "sess-r1-tokens",
+        [(user_text, [assistant_text])],
+        workspace_dir="/home/user/projects/r1-test",
+    )
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert drawers, "expected at least one drawer"
+
+    joined = "\n".join(d.content for d in drawers)
+    assert _FAKE_SK_PROJ not in joined, "sk-proj- token survived end-to-end redaction"
+    assert _FAKE_GITHUB_PAT not in joined, "github_pat_ token survived end-to-end redaction"
+    assert "configure the CI" in joined or "rotate" in joined, (
+        "legitimate content was stripped by over-aggressive redaction"
+    )
+
+
+def test_r1_existing_prefixes_still_redacted():
+    """R1: existing ghp_/ghs_/lin_api_ patterns must still be redacted (no regression)."""
+    for fake in (_FAKE_GH_TOKEN, _FAKE_LIN_API, _FAKE_CLH, _FAKE_ATATT):
+        role_tab = f"user\t{json.dumps(f'Token: {fake}')}"
+        result = src_transforms.openclaw_redact_secrets(role_tab)
+        body = json.loads(result.partition("\t")[2])
+        assert fake not in body, f"existing token {fake[:12]}... regressed after R1 changes"
+
+
+# ===========================================================================
+# R3: Envelope-only user turns — assistant content must not be lost
+# ===========================================================================
+
+
+def _build_envelope_only_trajectory(path: Path, session_id: str) -> None:
+    """Write a trajectory where the first user turn is pure Slack envelope (no real text).
+
+    After strip transforms, the user body is empty.  The assistant reply must
+    still survive into a drawer via the > [non-text user turn] placeholder.
+    """
+    # User text that reduces to empty after metadata strip.
+    envelope_only = (
+        "Conversation info (untrusted metadata):\n"
+        "```json\n"
+        '{"chat_id": "user:UTEST", "sender_id": "UTEST", "inbound_event_kind": "ping"}\n'
+        "```\n"
+        "\n"
+        "Sender (untrusted metadata):\n"
+        "```json\n"
+        '{"label": "Bot", "id": "UTEST"}\n'
+        "```\n"
+    )
+    assistant_reply = (
+        "I received your ping. The bot is online and ready for commands. "
+        "This response is long enough to be stored as a drawer."
+    )
+    build_trajectory_fixture(
+        path,
+        session_id,
+        [(envelope_only, [assistant_reply])],
+        workspace_dir="/home/user/projects/r3-test",
+    )
+
+
+def test_r3_envelope_only_user_turn_produces_placeholder(adapter, palace_ctx, tmp_path):
+    """R3: assistant reply must survive when the leading user turn is envelope-only.
+
+    Before the fix, an empty user body caused openclaw_format_exchange to
+    ``continue`` (skip the turn), leaving the assistant reply as a leading
+    orphan that _chunk_by_exchange silently discarded.  After the fix, the
+    placeholder ``> [non-text user turn]`` keeps the pair intact.
+    """
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    session_id = "sess-r3-envelope-0001"
+    _build_envelope_only_trajectory(sdir / f"{session_id}.trajectory.jsonl", session_id)
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+
+    assert drawers, (
+        "R3 regression: envelope-only user + assistant reply produced no drawers; "
+        "the assistant content was silently dropped"
+    )
+    joined = "\n".join(d.content for d in drawers)
+    assert "online and ready" in joined, (
+        "R3 regression: assistant reply text missing from drawer content"
+    )
+
+
+def test_r3_placeholder_appears_in_format_exchange_output():
+    """R3 unit test: openclaw_format_exchange emits placeholder for empty user body."""
+    empty_user = f"user\t{json.dumps('')}"
+    assistant_reply = f"assistant\t{json.dumps('Bot is online.')}"
+    role_tab = f"{empty_user}\n{assistant_reply}"
+
+    result = src_transforms.openclaw_format_exchange(role_tab)
+
+    assert "> [non-text user turn]" in result, (
+        "empty user body must produce placeholder, not be silently dropped"
+    )
+    assert "Bot is online." in result, "assistant content must survive when user body is empty"
+
+
+def test_r3_empty_assistant_still_skipped():
+    """R3: empty assistant bodies must still be silently dropped (unchanged behaviour)."""
+    user_text = f"user\t{json.dumps('What is 2 + 2?')}"
+    empty_assistant = f"assistant\t{json.dumps('')}"
+    role_tab = f"{user_text}\n{empty_assistant}"
+
+    result = src_transforms.openclaw_format_exchange(role_tab)
+
+    assert "> What is 2 + 2?" in result
+    # Empty assistant — only the user block appears
+    assert result.strip() == "> What is 2 + 2?"
+
+
+# ===========================================================================
+# R4: ReDoS hardening — _OPENCLAW_META_FENCE adversarial input test
+# ===========================================================================
+
+
+def test_r4_meta_fence_regex_matches_existing_patterns():
+    """R4: existing metadata-fence behaviour must be preserved after regex rewrite."""
+    preamble = (
+        '```json\n{"chat_id": "user:U123", "sender_id": "U123", "inbound_event_kind": "msg"}\n```'
+    )
+    result = src_transforms._OPENCLAW_META_FENCE.sub("", preamble)
+    assert "chat_id" not in result, "R4 regression: metadata fence not removed"
+    assert result.strip() == "", "R4 regression: fence body leaked after rewrite"
+
+
+def test_r4_meta_fence_regex_completes_fast_on_adversarial_input():
+    """R4: regex must complete quickly on a long body that contains backtick lines.
+
+    The original pattern used two DOTALL .*? spans.  With many backtick-prefixed
+    lines followed by many key occurrences and no closing fence, the original
+    could exhibit O(n\u00b2) backtracking.  The [^`]*? fix stops at the first
+    backtick, aborting the match in O(1) for each starting position.
+    """
+    import time
+
+    # Adversarial: many backtick-prefixed lines (early termination trigger for
+    # [^`]*?) followed by many occurrences of a matching key, no closing ```.
+    # The [^`]*? rewrite stops immediately at the backtick in each `inert line;
+    # the original .*? would scan past them and attempt all key positions.
+    adversarial = (
+        "```json\n"
+        + "`inert_line\n" * 3000  # 3000 lines each starting with a backtick
+        + "chat_id: val\n" * 500  # 500 key occurrences after the backtick lines
+        # deliberately no closing ``` to force the full scan
+    )
+    start = time.perf_counter()
+    result = src_transforms._OPENCLAW_META_FENCE.sub("", adversarial)
+    elapsed = time.perf_counter() - start
+
+    assert result == adversarial, "adversarial input should not match (no closing ```)"
+    assert elapsed < 1.0, (
+        f"R4 ReDoS guard: regex took {elapsed:.3f}s on adversarial input "
+        f"(expected < 1.0s after [^`]*? rewrite)"
+    )
+
+
+# ===========================================================================
+# PERF: runtime _apply_post_extract_pipeline parity with declared pipeline
+# ===========================================================================
+
+
+def test_perf_runtime_pipeline_matches_declared_pipeline(sessions_dir):
+    """PERF: _apply_post_extract_pipeline must produce identical output to
+    _apply_transform_pipeline (full declared pipeline from raw bytes).
+
+    This is the drift-prevention lock: if the optimised runtime path ever
+    diverges from the conformance path, this test catches it immediately.
+    Covers the R3 orphan case and R1 new token patterns via sub-fixtures.
+    """
+    from mempalace.sources.openclaw import (
+        JsonlTrajectoryEventSource,
+        _apply_post_extract_pipeline,
+        _apply_transform_pipeline,
+        _build_canonical_source_bytes,
+        _extract_turns_from_events,
+    )
+
+    for session_id in (_SESSION_SIMPLE, _SESSION_METADATA, _SESSION_UNICODE):
+        tfile = sessions_dir / f"{session_id}.trajectory.jsonl"
+        # Conformance path: full declared pipeline from raw bytes.
+        raw = _build_canonical_source_bytes(tfile)
+        declared_output = _apply_transform_pipeline(raw)
+
+        # Runtime path: extract turns from events, then post-extract pipeline.
+        events = list(JsonlTrajectoryEventSource(tfile).iter_events())
+        turns_text = _extract_turns_from_events(events)
+        runtime_output = _apply_post_extract_pipeline(turns_text)
+
+        assert declared_output == runtime_output, (
+            f"PERF parity failure for {session_id}: "
+            "runtime _apply_post_extract_pipeline diverged from declared pipeline"
+        )
+
+
+def test_perf_parity_with_r3_orphan_fixture(tmp_path):
+    """PERF parity: orphan-user fixture (R3) must be identical on both paths."""
+    from mempalace.sources.openclaw import (
+        JsonlTrajectoryEventSource,
+        _apply_post_extract_pipeline,
+        _apply_transform_pipeline,
+        _build_canonical_source_bytes,
+        _extract_turns_from_events,
+    )
+
+    session_id = "sess-parity-r3-0001"
+    tfile = tmp_path / f"{session_id}.trajectory.jsonl"
+    _build_envelope_only_trajectory(tfile, session_id)
+
+    raw = _build_canonical_source_bytes(tfile)
+    declared_output = _apply_transform_pipeline(raw)
+
+    events = list(JsonlTrajectoryEventSource(tfile).iter_events())
+    turns_text = _extract_turns_from_events(events)
+    runtime_output = _apply_post_extract_pipeline(turns_text)
+
+    assert declared_output == runtime_output, (
+        "PERF parity failure on R3 orphan fixture: runtime path diverged from declared pipeline"
+    )
+    # Also assert that the placeholder is present (R3 correctness on both paths).
+    assert "> [non-text user turn]" in declared_output, (
+        "R3 placeholder missing from declared pipeline output"
+    )
+    assert "> [non-text user turn]" in runtime_output, (
+        "R3 placeholder missing from runtime pipeline output"
+    )
+
+
+def test_perf_parity_with_r1_secrets_fixture(tmp_path):
+    """PERF parity: new token formats (R1) must be redacted identically on both paths."""
+    from mempalace.sources.openclaw import (
+        JsonlTrajectoryEventSource,
+        _apply_post_extract_pipeline,
+        _apply_transform_pipeline,
+        _build_canonical_source_bytes,
+        _extract_turns_from_events,
+    )
+
+    session_id = "sess-parity-r1-0001"
+    tfile = tmp_path / f"{session_id}.trajectory.jsonl"
+
+    user_text = (
+        f"My keys: {_FAKE_SK_PROJ} and {_FAKE_GITHUB_PAT}. "
+        f"Please help configure this service. Long enough to form a complete chunk."
+    )
+    assistant_text = (
+        "Please rotate those credentials. This response is also long enough for a chunk."
+    )
+    build_trajectory_fixture(
+        tfile,
+        session_id,
+        [(user_text, [assistant_text])],
+        workspace_dir="/home/user/projects/parity-r1",
+    )
+
+    raw = _build_canonical_source_bytes(tfile)
+    declared_output = _apply_transform_pipeline(raw)
+
+    events = list(JsonlTrajectoryEventSource(tfile).iter_events())
+    turns_text = _extract_turns_from_events(events)
+    runtime_output = _apply_post_extract_pipeline(turns_text)
+
+    assert declared_output == runtime_output, (
+        "PERF parity failure on R1 secrets fixture: runtime path diverged from declared pipeline"
+    )
+    # Both paths must redact the secrets.
+    assert _FAKE_SK_PROJ not in declared_output, "sk-proj token not redacted in declared path"
+    assert _FAKE_GITHUB_PAT not in declared_output, "github_pat token not redacted in declared path"
+    assert _FAKE_SK_PROJ not in runtime_output, "sk-proj token not redacted in runtime path"
+    assert _FAKE_GITHUB_PAT not in runtime_output, "github_pat token not redacted in runtime path"

--- a/tests/test_sources_openclaw.py
+++ b/tests/test_sources_openclaw.py
@@ -1,0 +1,903 @@
+"""Tests for the OpenClaw source adapter (RFC 002).
+
+Covers:
+    * Adapter class identity (capabilities, modes, declared transformations).
+    * RFC 002 conformance — declared-transformation round-trip, schema
+      conformance, stable ``source_file`` shape.
+    * Unit tests for JSONL extraction, runtime-context strip, metadata-preamble
+      strip, exchange formatting, and chunked-exchange emit via
+      ``convo_miner.chunk_exchanges``.
+    * Edge cases: empty file, file with no exchange pairs, single-turn
+      sessions, unicode content, explicit wing override.
+
+No real recorded ``*.trajectory.jsonl`` files are used. All trajectory
+content is built synthetically by :func:`build_trajectory_fixture` so
+nothing from a live session is committed to the repository.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from mempalace.sources import transforms as src_transforms
+from mempalace.sources.base import (
+    AdapterClosedError,
+    AdapterSchema,
+    DrawerRecord,
+    FieldSpec,
+    SourceItemMetadata,
+    SourceNotFoundError,
+    SourceRef,
+)
+from mempalace.sources.context import PalaceContext
+from mempalace.sources.openclaw import (
+    OpenClawSourceAdapter,
+    _build_canonical_source_bytes,
+    _scan_trajectory_file,
+    session_source_file,
+)
+
+
+# ===========================================================================
+# Synthetic fixture builder
+# ===========================================================================
+
+
+def _make_event(
+    event_type: str,
+    session_id: str,
+    seq: int,
+    *,
+    session_key: str = "agent:main:slack:direct:UTEST",
+    workspace_dir: str = "/home/user/workspace",
+    model_id: str = "anthropic/claude-test-model",
+    ts_base: str = "2026-01-01T10:00:00.000Z",
+    data: dict | None = None,
+) -> dict:
+    """Build one synthetic trajectory event object."""
+    return {
+        "traceSchema": "openclaw-trajectory",
+        "schemaVersion": 1,
+        "traceId": session_id,
+        "source": "runtime",
+        "type": event_type,
+        "ts": ts_base,
+        "seq": seq,
+        "sourceSeq": seq + 100,
+        "sessionId": session_id,
+        "sessionKey": session_key,
+        "runId": f"run-{seq:04d}",
+        "workspaceDir": workspace_dir,
+        "provider": "anthropic",
+        "modelId": model_id,
+        "modelApi": "messages",
+        "data": data or {},
+    }
+
+
+def _make_exchange(
+    session_id: str,
+    seq_start: int,
+    user_text: str,
+    assistant_texts: List[str],
+    **event_kwargs,
+) -> List[dict]:
+    """Build a synthetic prompt.submitted + model.completed pair."""
+    events = []
+    events.append(
+        _make_event(
+            "context.compiled",
+            session_id,
+            seq_start,
+            **event_kwargs,
+            data={},
+        )
+    )
+    events.append(
+        _make_event(
+            "prompt.submitted",
+            session_id,
+            seq_start + 1,
+            **event_kwargs,
+            data={"prompt": user_text, "systemPrompt": "", "messages": [], "imagesCount": 0},
+        )
+    )
+    events.append(
+        _make_event(
+            "model.completed",
+            session_id,
+            seq_start + 2,
+            **event_kwargs,
+            data={
+                "assistantTexts": assistant_texts,
+                "aborted": False,
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+            },
+        )
+    )
+    events.append(
+        _make_event(
+            "trace.artifacts",
+            session_id,
+            seq_start + 3,
+            **event_kwargs,
+            data={},
+        )
+    )
+    events.append(
+        _make_event(
+            "session.ended",
+            session_id,
+            seq_start + 4,
+            **event_kwargs,
+            data={},
+        )
+    )
+    return events
+
+
+def build_trajectory_fixture(
+    path: Path,
+    session_id: str,
+    exchanges: List[tuple],
+    *,
+    session_key: str = "agent:main:slack:direct:UTEST",
+    workspace_dir: str = "/home/user/workspace",
+    model_id: str = "anthropic/claude-test-model",
+    ts_base: str = "2026-01-01T10:00:00.000Z",
+) -> str:
+    """Write a synthetic trajectory JSONL file.
+
+    Args:
+        path: Destination file path.
+        session_id: UUID-style session identifier.
+        exchanges: List of ``(user_text, [assistant_text, ...])`` tuples.
+        session_key: OpenClaw session routing key.
+        workspace_dir: Workspace directory for all events.
+        model_id: Model identifier for all events.
+        ts_base: ISO-8601 timestamp for all events.
+
+    Returns:
+        The path as a string (for chaining with ``SourceRef``).
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    all_events: List[dict] = []
+
+    # Leading session.started event
+    all_events.append(
+        _make_event(
+            "session.started",
+            session_id,
+            seq=1,
+            session_key=session_key,
+            workspace_dir=workspace_dir,
+            model_id=model_id,
+            ts_base=ts_base,
+            data={},
+        )
+    )
+
+    seq = 2
+    kwargs = dict(
+        session_key=session_key,
+        workspace_dir=workspace_dir,
+        model_id=model_id,
+        ts_base=ts_base,
+    )
+    for user_text, assistant_texts in exchanges:
+        all_events.extend(_make_exchange(session_id, seq, user_text, assistant_texts, **kwargs))
+        seq += 10  # leave room between exchange groups
+
+    with path.open("w", encoding="utf-8") as fh:
+        for event in all_events:
+            fh.write(json.dumps(event) + "\n")
+
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Canonical fixture sessions
+# ---------------------------------------------------------------------------
+
+_SESSION_SIMPLE = "sess-aa11bb22-0000-0000-0000-000000000001"
+_SESSION_METADATA = "sess-aa11bb22-0000-0000-0000-000000000002"
+_SESSION_UNICODE = "sess-aa11bb22-0000-0000-0000-000000000003"
+_SESSION_SINGLE_TURN = "sess-aa11bb22-0000-0000-0000-000000000004"
+
+
+def _make_metadata_prompt(user_request: str) -> str:
+    """Wrap a user request with the OpenClaw metadata preamble."""
+    return (
+        'Conversation info (untrusted metadata):\n'
+        '```json\n'
+        '{\n'
+        '  "chat_id": "user:UTEST123",\n'
+        '  "message_id": "1234567890.123456",\n'
+        '  "sender_id": "UTEST123",\n'
+        '  "sender": "Test User"\n'
+        '}\n'
+        '```\n'
+        '\n' + user_request
+    )
+
+
+def _make_runtime_context_prompt(user_request: str) -> str:
+    """Wrap a user request with an OpenClaw runtime context block."""
+    return (
+        "<<<OpenClaw runtime context\n"
+        "Some internal plumbing text that should be stripped.\n"
+        "END_OPENCLAW_INTERNAL_CONTEXT>>>\n"
+        "\n" + user_request
+    )
+
+
+# ===========================================================================
+# pytest fixtures
+# ===========================================================================
+
+
+@pytest.fixture
+def adapter() -> OpenClawSourceAdapter:
+    return OpenClawSourceAdapter()
+
+
+@pytest.fixture
+def sessions_dir(tmp_path) -> Path:
+    """Return a temp sessions directory with canonical synthetic files."""
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+
+    # Session 1: simple two-exchange session in workspace "myproject"
+    build_trajectory_fixture(
+        sdir / f"{_SESSION_SIMPLE}.trajectory.jsonl",
+        _SESSION_SIMPLE,
+        [
+            (
+                "How do I use TanStack Query for data fetching?",
+                ["Use the useQuery hook with a queryFn. For example: useQuery({ queryKey: ['todos'], queryFn: fetchTodos })"],
+            ),
+            (
+                "How do I invalidate the cache after a mutation?",
+                ["Call queryClient.invalidateQueries({ queryKey: ['todos'] }) inside the onSuccess callback of useMutation."],
+            ),
+        ],
+        workspace_dir="/home/user/projects/myproject",
+    )
+
+    # Session 2: session with metadata preamble that should be stripped
+    build_trajectory_fixture(
+        sdir / f"{_SESSION_METADATA}.trajectory.jsonl",
+        _SESSION_METADATA,
+        [
+            (
+                _make_metadata_prompt("Can you help me debug this Python error?"),
+                ["Sure! Share the traceback and I'll help you debug it."],
+            ),
+            (
+                "Here is the traceback: AttributeError: NoneType has no attribute 'split'",
+                ["That error means you're calling .split() on a None value. Check where the variable is assigned."],
+            ),
+        ],
+        workspace_dir="/home/user/projects/backend",
+    )
+
+    # Session 3: unicode content
+    build_trajectory_fixture(
+        sdir / f"{_SESSION_UNICODE}.trajectory.jsonl",
+        _SESSION_UNICODE,
+        [
+            (
+                "日本語で説明してください: how does async/await work in Python?",
+                ["async/await は非同期処理のための構文です。asyncキーワードをコルーチン関数の前に付けます。"],
+            ),
+        ],
+        workspace_dir="/home/user/projects/docs",
+    )
+
+    # Session 4: only one user turn, no assistant reply → should produce no drawers
+    build_trajectory_fixture(
+        sdir / f"{_SESSION_SINGLE_TURN}.trajectory.jsonl",
+        _SESSION_SINGLE_TURN,
+        exchanges=[],  # no exchanges at all — empty transcript
+        workspace_dir="/home/user/projects/empty",
+    )
+
+    return sdir
+
+
+@pytest.fixture
+def palace_ctx() -> PalaceContext:
+    class _FakeCollection:
+        def __init__(self):
+            self.upserts = []
+
+        def add(self, **kwargs):
+            pass
+
+        def upsert(self, **kwargs):
+            self.upserts.append(kwargs)
+
+        def query(self, **kwargs):
+            return {}
+
+        def get(self, **kwargs):
+            return {}
+
+        def delete(self, **kwargs):
+            pass
+
+        def count(self):
+            return 0
+
+    class _FakeKG:
+        def add_triple(self, *args, **kwargs):
+            pass
+
+    return PalaceContext(
+        drawer_collection=_FakeCollection(),
+        knowledge_graph=_FakeKG(),
+        palace_path="/tmp/palace",
+        adapter_name="openclaw",
+        adapter_version="0.1.0",
+    )
+
+
+# ===========================================================================
+# Class identity
+# ===========================================================================
+
+
+def test_adapter_identity():
+    assert OpenClawSourceAdapter.name == "openclaw"
+    assert OpenClawSourceAdapter.spec_version == "1.0"
+    assert OpenClawSourceAdapter.adapter_version == "0.1.0"
+    assert "chunked_content" in OpenClawSourceAdapter.supported_modes
+    assert "supports_incremental" in OpenClawSourceAdapter.capabilities
+    assert "adapter_owns_routing" in OpenClawSourceAdapter.capabilities
+    assert OpenClawSourceAdapter.default_privacy_class == "pii_potential"
+
+
+def test_declared_transformations_have_reference_impls():
+    """Every declared transformation MUST resolve to a callable on transforms (RFC 002 §7.3)."""
+    for name in OpenClawSourceAdapter.declared_transformations:
+        impl = getattr(src_transforms, name, None)
+        assert callable(impl), (
+            f"declared transformation {name!r} has no callable reference impl "
+            f"on mempalace.sources.transforms"
+        )
+
+
+def test_declared_transformation_order_matches_set():
+    """DECLARED_TRANSFORMATION_ORDER must be a permutation of declared_transformations."""
+    assert set(OpenClawSourceAdapter.DECLARED_TRANSFORMATION_ORDER) == (
+        OpenClawSourceAdapter.declared_transformations
+    )
+
+
+def test_describe_schema_returns_adapter_schema(adapter):
+    schema = adapter.describe_schema()
+    assert isinstance(schema, AdapterSchema)
+    assert schema.version == "1.0"
+    required = {k for k, v in schema.fields.items() if v.required}
+    assert {"session_id", "session_created_at", "message_count", "extract_mode"}.issubset(required)
+    assert isinstance(schema.fields["session_id"], FieldSpec)
+    assert schema.fields["session_id"].indexed is True
+
+
+# ===========================================================================
+# source_file identity
+# ===========================================================================
+
+
+def test_session_source_file_is_stable():
+    s1 = session_source_file("/tmp/foo.trajectory.jsonl", "sess-abc123")
+    s2 = session_source_file("/tmp/foo.trajectory.jsonl", "sess-abc123")
+    s3 = session_source_file("/tmp/foo.trajectory.jsonl", "sess-def456")
+    assert s1 == s2
+    assert s1 != s3
+    assert s1 == "openclaw:///tmp/foo.trajectory.jsonl#session=sess-abc123"
+
+
+def test_session_source_file_has_expected_shape():
+    sf = session_source_file("/home/user/.openclaw/agents/main/sessions/abc.trajectory.jsonl", "abc")
+    assert sf.startswith("openclaw://")
+    assert "#session=" in sf
+
+
+# ===========================================================================
+# Discovery / errors
+# ===========================================================================
+
+
+def test_ingest_raises_source_not_found_for_missing_path(adapter, palace_ctx, tmp_path):
+    missing = tmp_path / "nosuchdir"
+    ref = SourceRef(local_path=str(missing))
+    with pytest.raises(SourceNotFoundError):
+        list(adapter.ingest(source=ref, palace=palace_ctx))
+
+
+def test_ingest_accepts_empty_directory(adapter, palace_ctx, tmp_path):
+    empty_dir = tmp_path / "sessions"
+    empty_dir.mkdir()
+    results = list(adapter.ingest(source=SourceRef(local_path=str(empty_dir)), palace=palace_ctx))
+    assert results == []
+
+
+def test_close_then_ingest_raises_adapter_closed(adapter, palace_ctx, sessions_dir):
+    adapter.close()
+    ref = SourceRef(local_path=str(sessions_dir))
+    with pytest.raises(AdapterClosedError):
+        list(adapter.ingest(source=ref, palace=palace_ctx))
+
+
+# ===========================================================================
+# source_summary
+# ===========================================================================
+
+
+def test_source_summary_counts_trajectory_files(adapter, sessions_dir):
+    summary = adapter.source_summary(source=SourceRef(local_path=str(sessions_dir)))
+    # 4 synthetic files in sessions_dir
+    assert summary.item_count == 4
+    assert "OpenClaw sessions at" in summary.description
+
+
+def test_source_summary_for_missing_dir(adapter, tmp_path):
+    summary = adapter.source_summary(source=SourceRef(local_path=str(tmp_path / "nodir")))
+    assert summary.item_count == 0
+    assert "not found" in summary.description.lower()
+
+
+# ===========================================================================
+# Scan / metadata extraction
+# ===========================================================================
+
+
+def test_scan_trajectory_file_extracts_metadata(sessions_dir):
+    tfile = sessions_dir / f"{_SESSION_SIMPLE}.trajectory.jsonl"
+    meta = _scan_trajectory_file(tfile)
+    assert meta is not None
+    assert meta["session_id"] == _SESSION_SIMPLE
+    assert meta["session_key"] == "agent:main:slack:direct:UTEST"
+    assert meta["workspace_dir"] == "/home/user/projects/myproject"
+    assert meta["model_id"] == "anthropic/claude-test-model"
+    assert meta["session_created_at"]  # non-empty ISO timestamp
+    assert meta["version"]  # non-empty version string
+
+
+def test_scan_trajectory_file_returns_none_for_empty_file(tmp_path):
+    empty = tmp_path / "empty.trajectory.jsonl"
+    empty.write_text("")
+    assert _scan_trajectory_file(empty) is None
+
+
+def test_scan_trajectory_file_version_is_last_seq(sessions_dir):
+    """Version must be the seq of the last event (append-only growth check)."""
+    tfile = sessions_dir / f"{_SESSION_SIMPLE}.trajectory.jsonl"
+    meta = _scan_trajectory_file(tfile)
+    # Read the last non-empty line to confirm the seq matches
+    events = [json.loads(ln) for ln in tfile.read_text().splitlines() if ln.strip()]
+    last_seq = str(events[-1]["seq"])
+    assert meta["version"] == last_seq
+
+
+# ===========================================================================
+# Ingest shape
+# ===========================================================================
+
+
+def test_ingest_yields_metadata_then_drawers(adapter, palace_ctx, sessions_dir):
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    # 4 files → 4 SourceItemMetadata
+    assert len(metas) == 4
+    # At least the 2-exchange sessions should produce drawers
+    assert len(drawers) >= 1
+    # All source_files carry the openclaw:// prefix
+    for m in metas:
+        assert m.source_file.startswith("openclaw://")
+        assert "#session=" in m.source_file
+
+
+def test_ingest_empty_session_produces_no_drawers(adapter, palace_ctx, sessions_dir):
+    """The single-turn (0-exchange) session should yield metadata but no drawers."""
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    src_files_with_drawers = {d.source_file for d in drawers}
+    assert all(_SESSION_SINGLE_TURN not in sf for sf in src_files_with_drawers), (
+        "session with no exchanges must produce no drawers"
+    )
+
+
+def test_drawer_metadata_has_all_universal_and_schema_fields(adapter, palace_ctx, sessions_dir):
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert drawers, "expected at least one drawer"
+    schema_keys = set(adapter.describe_schema().fields.keys())
+    universal_keys = {
+        "source_file",
+        "chunk_index",
+        "filed_at",
+        "added_by",
+        "wing",
+        "room",
+        "hall",
+        "ingest_mode",
+        "extract_mode",
+        "privacy_class",
+    }
+    for drawer in drawers:
+        meta = drawer.metadata
+        assert universal_keys.issubset(meta.keys()), (
+            f"missing universal keys: {universal_keys - meta.keys()}"
+        )
+        assert schema_keys.issubset(meta.keys()), (
+            f"missing schema keys: {schema_keys - meta.keys()}"
+        )
+        # Flat-scalar invariant — chroma constraint.
+        for k, v in meta.items():
+            assert isinstance(v, (str, int, float, bool)), (
+                f"metadata[{k}]={v!r} (type {type(v).__name__}) is not flat-scalar"
+            )
+
+
+def test_drawer_extract_mode_is_exchange(adapter, palace_ctx, sessions_dir):
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    for r in results:
+        if isinstance(r, DrawerRecord):
+            assert r.metadata["extract_mode"] == "exchange"
+
+
+def test_drawer_route_hint_carries_wing_and_room(adapter, palace_ctx, sessions_dir):
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    for d in drawers:
+        assert d.route_hint is not None
+        assert d.route_hint.wing, "wing must not be empty"
+        assert d.route_hint.room, "room must not be empty"
+
+
+# ===========================================================================
+# Wing routing
+# ===========================================================================
+
+
+def test_wing_derived_from_workspace_dir_basename(adapter, palace_ctx, sessions_dir):
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    # _SESSION_SIMPLE has workspace_dir="/home/user/projects/myproject" → wing="myproject"
+    myproject_drawers = [
+        d for d in drawers if _SESSION_SIMPLE in d.source_file
+    ]
+    assert myproject_drawers, "expected drawers for simple session"
+    assert all(d.metadata["wing"] == "myproject" for d in myproject_drawers)
+
+
+def test_explicit_wing_option_overrides_workspace_dir(adapter, palace_ctx, sessions_dir):
+    ref = SourceRef(local_path=str(sessions_dir), options={"wing": "Custom Wing"})
+    results = list(adapter.ingest(source=ref, palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert drawers, "expected drawers with custom wing"
+    wings = {d.metadata["wing"] for d in drawers}
+    assert wings == {"custom_wing"}, f"unexpected wings: {wings}"
+
+
+# ===========================================================================
+# Skip / incremental behavior
+# ===========================================================================
+
+
+def test_skip_current_item_short_circuits_drawer_emit(adapter, palace_ctx, sessions_dir):
+    """After skip_current_item(), no drawers should emerge for that item."""
+    ref = SourceRef(local_path=str(sessions_dir))
+    gen = adapter.ingest(source=ref, palace=palace_ctx)
+    drawers_seen = 0
+    for result in gen:
+        if isinstance(result, SourceItemMetadata):
+            palace_ctx.skip_current_item()
+        elif isinstance(result, DrawerRecord):
+            drawers_seen += 1
+    assert drawers_seen == 0, f"expected 0 drawers but got {drawers_seen}"
+
+
+def test_is_current_returns_false_when_no_existing_metadata(adapter):
+    item = SourceItemMetadata(
+        source_file="openclaw:///tmp/x.trajectory.jsonl#session=sess-abc",
+        version="42",
+    )
+    assert adapter.is_current(item=item, existing_metadata=None) is False
+    assert adapter.is_current(item=item, existing_metadata={}) is False
+
+
+def test_is_current_uses_stored_version_when_present(adapter):
+    item = SourceItemMetadata(
+        source_file="openclaw:///tmp/x.trajectory.jsonl#session=sess-abc",
+        version="42",
+    )
+    assert adapter.is_current(item=item, existing_metadata={"openclaw_session_version": "42"}) is True
+    assert adapter.is_current(item=item, existing_metadata={"openclaw_session_version": "99"}) is False
+
+
+def test_is_current_falls_back_to_presence_when_version_missing(adapter):
+    """Drawers without openclaw_session_version → assume current (safer)."""
+    item = SourceItemMetadata(
+        source_file="openclaw:///tmp/x.trajectory.jsonl#session=sess-abc",
+        version="42",
+    )
+    assert (
+        adapter.is_current(item=item, existing_metadata={"session_id": "sess-abc", "wing": "x"})
+        is True
+    )
+
+
+# ===========================================================================
+# Transform unit tests
+# ===========================================================================
+
+
+def test_openclaw_extract_turns_basic():
+    """prompt.submitted and model.completed events become user/assistant lines."""
+    events = [
+        {"type": "session.started", "data": {}},
+        {"type": "prompt.submitted", "data": {"prompt": "Hello, how are you?"}},
+        {"type": "model.completed", "data": {"assistantTexts": ["I'm fine, thanks!"]}},
+    ]
+    raw = "\n".join(json.dumps(e) for e in events)
+    result = src_transforms.openclaw_extract_turns(raw)
+    lines = result.split("\n")
+    assert len(lines) == 2
+    role0, _, body0 = lines[0].partition("\t")
+    role1, _, body1 = lines[1].partition("\t")
+    assert role0 == "user"
+    assert role1 == "assistant"
+    assert json.loads(body0) == "Hello, how are you?"
+    assert json.loads(body1) == "I'm fine, thanks!"
+
+
+def test_openclaw_extract_turns_skips_non_exchange_events():
+    """context.compiled, trace.*, session.ended etc. must not appear in output."""
+    events = [
+        {"type": "context.compiled", "data": {}},
+        {"type": "session.started", "data": {}},
+        {"type": "trace.metadata", "data": {}},
+        {"type": "prompt.submitted", "data": {"prompt": "What is 2+2?"}},
+        {"type": "trace.artifacts", "data": {}},
+        {"type": "model.completed", "data": {"assistantTexts": ["4"]}},
+        {"type": "session.ended", "data": {}},
+    ]
+    raw = "\n".join(json.dumps(e) for e in events)
+    result = src_transforms.openclaw_extract_turns(raw)
+    # Only user + assistant lines
+    assert result.count("\n") == 1
+    assert result.startswith("user\t")
+    assert "assistant\t" in result
+
+
+def test_openclaw_extract_turns_multiple_assistant_texts():
+    """Multiple assistantTexts entries are joined with newline."""
+    events = [
+        {"type": "prompt.submitted", "data": {"prompt": "Give me two answers."}},
+        {"type": "model.completed", "data": {"assistantTexts": ["First answer.", "Second answer."]}},
+    ]
+    raw = "\n".join(json.dumps(e) for e in events)
+    result = src_transforms.openclaw_extract_turns(raw)
+    lines = result.split("\n")
+    assistant_body = json.loads(lines[1].partition("\t")[2])
+    assert "First answer." in assistant_body
+    assert "Second answer." in assistant_body
+
+
+def test_openclaw_strip_runtime_context_removes_block():
+    """Runtime context block must be removed from user turns."""
+    raw_prompt = (
+        "<<<OpenClaw runtime context\nSome internal info.\nEND_OPENCLAW_INTERNAL_CONTEXT>>>\n\nActual question"
+    )
+    role_tab = f"user\t{json.dumps(raw_prompt)}"
+    result = src_transforms.openclaw_strip_runtime_context(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert "OpenClaw runtime context" not in body
+    assert "END_OPENCLAW_INTERNAL_CONTEXT" not in body
+    assert "Actual question" in body
+
+
+def test_openclaw_strip_runtime_context_preserves_assistant_turns():
+    """Assistant turns must not be modified by the strip transform."""
+    raw = f"assistant\t{json.dumps('This is the answer.')}"
+    result = src_transforms.openclaw_strip_runtime_context(raw)
+    assert result == raw
+
+
+def test_openclaw_strip_metadata_preamble_removes_fence():
+    """Metadata JSON fences must be stripped from user prompts."""
+    preamble_prompt = (
+        'Conversation info (untrusted metadata):\n'
+        '```json\n'
+        '{"chat_id": "user:U123", "sender_id": "U123"}\n'
+        '```\n'
+        '\nReal user request here'
+    )
+    role_tab = f"user\t{json.dumps(preamble_prompt)}"
+    result = src_transforms.openclaw_strip_metadata_preamble(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert "chat_id" not in body
+    assert "Real user request here" in body
+
+
+def test_openclaw_strip_metadata_preamble_removes_label_lines():
+    prompt_with_label = (
+        "Conversation info (untrusted metadata):\n"
+        "Real content below"
+    )
+    role_tab = f"user\t{json.dumps(prompt_with_label)}"
+    result = src_transforms.openclaw_strip_metadata_preamble(role_tab)
+    body = json.loads(result.partition("\t")[2])
+    assert "Conversation info (untrusted metadata)" not in body
+    assert "Real content below" in body
+
+
+def test_openclaw_format_exchange_produces_quote_blocks():
+    """User turns become '> text'; assistant turns become plain paragraphs."""
+    role_tab = f"user\t{json.dumps('What is Python?')}\nassistant\t{json.dumps('Python is a programming language.')}"
+    result = src_transforms.openclaw_format_exchange(role_tab)
+    assert result.startswith("> What is Python?")
+    assert "Python is a programming language." in result
+
+
+def test_openclaw_format_exchange_handles_multiline_user():
+    """Multi-line user text is quoted line-by-line."""
+    multiline = "Line one\nLine two"
+    role_tab = f"user\t{json.dumps(multiline)}\nassistant\t{json.dumps('Answer.')}"
+    result = src_transforms.openclaw_format_exchange(role_tab)
+    assert "> Line one" in result
+    assert "> Line two" in result
+
+
+# ===========================================================================
+# Declared-transformation round-trip (RFC 002 §7.3)
+# ===========================================================================
+
+
+def test_declared_transformation_round_trip_reproduces_drawer_content(
+    adapter, palace_ctx, sessions_dir
+):
+    """Applying the declared transforms in order to canonical source bytes
+    then chunking MUST reproduce the drawer content."""
+    results = list(
+        adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx)
+    )
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    if not drawers:
+        pytest.skip("no drawers produced — nothing to verify")
+
+    by_src: dict[str, list[DrawerRecord]] = {}
+    for d in drawers:
+        by_src.setdefault(d.source_file, []).append(d)
+
+    from mempalace.convo_miner import chunk_exchanges
+
+    for src_file, ds in by_src.items():
+        # Resolve the trajectory file path from source_file URI
+        # shape: openclaw://<absolute-path>#session=<sid>
+        file_path = src_file.split("openclaw://", 1)[1].split("#session=", 1)[0]
+        tfile = Path(file_path)
+        assert tfile.exists(), f"trajectory file not found: {tfile}"
+
+        raw = _build_canonical_source_bytes(tfile)
+        transformed = raw
+        for name in adapter.DECLARED_TRANSFORMATION_ORDER:
+            fn = getattr(src_transforms, name)
+            transformed = fn(transformed)
+
+        expected_chunks = chunk_exchanges(transformed)
+        ds_sorted = sorted(ds, key=lambda d: d.chunk_index)
+        assert len(expected_chunks) == len(ds_sorted), (
+            f"chunk count mismatch for {src_file}: "
+            f"{len(expected_chunks)} expected, {len(ds_sorted)} produced"
+        )
+        for c, d in zip(expected_chunks, ds_sorted):
+            assert c["content"] == d.content, (
+                f"chunk content mismatch at chunk_index={d.chunk_index} for {src_file}"
+            )
+
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+
+def test_ingest_single_file_via_local_path(adapter, palace_ctx, sessions_dir):
+    """Passing a path directly to a single .trajectory.jsonl file works."""
+    tfile = sessions_dir / f"{_SESSION_SIMPLE}.trajectory.jsonl"
+    results = list(adapter.ingest(source=SourceRef(local_path=str(tfile)), palace=palace_ctx))
+    metas = [r for r in results if isinstance(r, SourceItemMetadata)]
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert len(metas) == 1
+    assert len(drawers) >= 1
+
+
+def test_unicode_content_preserved_end_to_end(adapter, palace_ctx, sessions_dir):
+    """BMP + emoji Unicode must survive the full transform pipeline to drawer.content."""
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    drawers = [
+        d for d in results
+        if isinstance(d, DrawerRecord) and _SESSION_UNICODE in d.source_file
+    ]
+    assert drawers, "expected at least one drawer for the unicode session"
+    joined = "\n".join(d.content for d in drawers)
+    # The Japanese text in the user prompt must appear somewhere
+    assert "日本語" in joined
+
+
+def test_runtime_context_stripped_from_drawers(adapter, palace_ctx, tmp_path):
+    """Runtime context blocks must not appear in drawer content."""
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    build_trajectory_fixture(
+        sdir / "rtx.trajectory.jsonl",
+        "sess-rtx-0001",
+        [
+            (
+                _make_runtime_context_prompt(
+                    "How do I center a div in CSS? This question is long enough to pass chunking."
+                ),
+                [
+                    "Use flexbox: display: flex; justify-content: center; align-items: center; on the parent container."
+                ],
+            ),
+        ],
+        workspace_dir="/home/user/projects/web",
+    )
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    joined = "\n".join(d.content for d in drawers)
+    assert "END_OPENCLAW_INTERNAL_CONTEXT" not in joined
+    assert "Some internal plumbing text" not in joined
+    assert "center a div" in joined
+
+
+def test_metadata_preamble_stripped_from_drawers(adapter, palace_ctx, sessions_dir):
+    """Metadata JSON fences must not appear in drawer content."""
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sessions_dir)), palace=palace_ctx))
+    drawers = [
+        d for d in results
+        if isinstance(d, DrawerRecord) and _SESSION_METADATA in d.source_file
+    ]
+    assert drawers, "expected drawers for metadata-preamble session"
+    joined = "\n".join(d.content for d in drawers)
+    assert "chat_id" not in joined
+    assert "sender_id" not in joined
+    # But the actual user content must still be present
+    assert "Python error" in joined or "debug" in joined
+
+
+def test_malformed_jsonl_lines_are_skipped(adapter, palace_ctx, tmp_path):
+    """Non-JSON lines in a trajectory file must not cause crashes."""
+    sdir = tmp_path / "sessions"
+    sdir.mkdir()
+    tfile = sdir / "malformed.trajectory.jsonl"
+    events = [
+        {"type": "session.started", "data": {}, "sessionId": "sess-mal",
+         "sessionKey": "k", "workspaceDir": "/tmp", "modelId": "m",
+         "ts": "2026-01-01T00:00:00.000Z", "seq": 1},
+        "THIS IS NOT JSON",
+        {"type": "prompt.submitted", "data": {"prompt": "Valid question that is long enough to pass chunking threshold"},
+         "sessionId": "sess-mal", "sessionKey": "k", "workspaceDir": "/tmp",
+         "modelId": "m", "ts": "2026-01-01T00:00:01.000Z", "seq": 2},
+        "ANOTHER GARBAGE LINE",
+        {"type": "model.completed", "data": {"assistantTexts": ["Valid answer that is also long enough to make a proper chunk"]},
+         "sessionId": "sess-mal", "sessionKey": "k", "workspaceDir": "/tmp",
+         "modelId": "m", "ts": "2026-01-01T00:00:02.000Z", "seq": 3},
+    ]
+    with tfile.open("w") as fh:
+        for e in events:
+            fh.write((json.dumps(e) if isinstance(e, dict) else e) + "\n")
+
+    results = list(adapter.ingest(source=SourceRef(local_path=str(sdir)), palace=palace_ctx))
+    drawers = [r for r in results if isinstance(r, DrawerRecord)]
+    assert len(drawers) >= 1, "malformed lines should be skipped, not crash"

--- a/tests/test_sources_openclaw.py
+++ b/tests/test_sources_openclaw.py
@@ -1679,7 +1679,10 @@ def test_read_pointer_file_returns_path_from_valid_json(tmp_path):
 
     result = _read_pointer_file(pointer)
     assert result is not None
-    assert str(result) == target_path
+    # Compare as Path objects, not strings: str(Path("/abs/path")) renders with
+    # backslashes on Windows, so a hard-coded POSIX string comparison is not
+    # portable. Path equality normalizes per-platform.
+    assert result == Path(target_path)
 
 
 def test_read_pointer_file_returns_none_for_corrupt_json(tmp_path):


### PR DESCRIPTION
> **Note for reviewers:** This targets the *in-flight* RFC-002 source-adapter
> contract and mirrors the OpenCode adapter (#1484), which is still open — so it's
> built against a forming interface. Like #1484, it's unit-testable and
> conformance-tested today but **not yet runnable via `mempalace mine`** until the
> `mine`→registry dispatch follow-up lands. It's offered as an early reference
> implementation to help validate the contract; happy to adjust the approach,
> packaging (in-tree vs standalone `pip install`), or timing if you'd prefer to
> shape the contract further first. Opening against `develop` per #1484's base.

## Summary

Adds an `OpenClawSourceAdapter` on the RFC 002 `BaseSourceAdapter` contract that
ingests OpenClaw agent-session transcripts into the palace. OpenClaw writes each
session as a JSON-lines *trajectory* file
(`~/.openclaw/agents/<agent>/sessions/*.trajectory.jsonl`) — an event stream, not
one of the chat-export shapes `normalize.py` detects — so there was no adapter
path to mine OpenClaw conversations. A conversion spike confirmed the event
stream extracts cleanly into exchange-pair transcripts.

Tracks #1943 / RFC 002 #989; modeled on the OpenCode adapter (#1484).

## Design decisions (and why)

Decisions are grounded in the OpenClaw docs so reviewers can see the intent:

- **Event types consumed** — `prompt.submitted` → user turn, `model.completed` →
  assistant turn. These are on OpenClaw's documented runtime-event list
  ([`docs/tools/trajectory.md`](https://docs.openclaw.ai/tools/trajectory)), so we
  code against the published contract, not inference.
- **Schema-marker validation** — trajectory events carry
  `{"traceSchema":"openclaw-trajectory","schemaVersion":1}`. We skip files with a
  foreign `traceSchema` and warn-but-best-effort-parse on an unknown
  `schemaVersion`, so a future version bump degrades gracefully instead of
  crashing.
- **Discovery across all documented capture locations** — default beside-session
  sidecars, the `OPENCLAW_TRAJECTORY_DIR` relocation directory, and the
  `<session>.trajectory-path.json` pointer file (all per `docs/tools/trajectory.md`),
  de-duplicated. A single-file `SourceRef.local_path` bypasses lookup.
- **Truncation tolerance** — live capture caps a sidecar at 10 MiB and emits a
  `trace.truncated` marker; lines above 256 KiB are truncated. We skip the marker
  event and partial/corrupt final lines rather than failing on an incomplete file.
- **Secret redaction** — agent trajectories routinely contain credentials, so a
  declared `openclaw_redact_secrets` transform runs before chunking, replacing
  AWS keys, common token prefixes (`ghp_`/`github_pat_`/`gho_`/`lin_api_`/`xoxb-`/
  `sk-`/`sk-proj-`/`clh_`/`ATATT`…), `Bearer`/`Basic` header values, PEM private
  keys, and `key=value` secret pairs with `[REDACTED:<kind>]` placeholders. This
  is best-effort defence-in-depth, not a guarantee (`default_privacy_class`
  remains `pii_potential`).
- **Incremental version = file size** — trajectory files are append-only, so the
  byte size is a cheap, monotonic session version; it is read via `stat()` without
  a full parse, so unchanged files are skipped without re-reading. (Per-event
  `seq` is per-run, not whole-file monotonic, so it is deliberately not used.)
- **Single-pass extraction** — one streaming pass over `iter_events()` produces
  both the turn text and session metadata, so the full event list is never
  materialized; the runtime path is byte-identical to the declared text→text
  transforms (parity-locked by tests), avoiding a second JSON parse.
- **Event-source abstraction + SQLite seam** — the
  [`database-first` refactor](https://docs.openclaw.ai/refactor/database-first) is migrating trajectory
  storage from `*.trajectory.jsonl` sidecars to a per-agent SQLite table
  `trajectory_runtime_events(session_id, run_id, seq, event_json, created_at)`,
  with JSONL demoted to legacy/export-only. To stay durable across that migration,
  the adapter reads through a `TrajectoryEventSource` protocol; this PR ships the
  concrete `JsonlTrajectoryEventSource` and leaves the SQLite reader as a
  documented seam. We deliberately do **not** implement the SQLite source yet:
  verified on OpenClaw 2026.6.10 that the SQLite trajectory store is not shipped
  (no `trajectory_runtime_events` table in any agent DB, no code references), so
  there is no stable schema or real data to build and test against. Extraction /
  transform / chunking are source-agnostic, so the SQLite reader drops in when it
  ships.

## Implementation

- `source_file` scheme: `openclaw://<absolute-path>#session=<session-id>`.
- Declared transformations (RFC §7.3, reference impls in `transforms.py`):
  `openclaw_extract_turns`, `openclaw_strip_runtime_context`,
  `openclaw_strip_metadata_preamble`, `openclaw_redact_secrets`,
  `openclaw_format_exchange`, `newline_normalize`, `whitespace_trim`. The strip
  transforms remove OpenClaw runtime-context blocks and Slack/media envelope
  plumbing from user turns; a user turn that is empty after stripping emits a
  `> [non-text user turn]` placeholder so a following assistant reply is never
  orphaned/dropped by chunking.
- Chunking: reuses `convo_miner.chunk_exchanges` (exchange-pair) to match the
  existing conversation drawer shape.
- `describe_schema`: `session_id`, `session_key`, `workspace_dir`, `model_id`,
  `session_created_at`, `message_count` (raw exchange-pair count), `extract_mode`.
- `is_current`: compares the stored file-size version against the current one;
  the skip check uses `PalaceContext.is_skip_requested()` when present, falling
  back to the underlying flag so it works on `develop` before #1484 merges (no
  `context.py` collision).
- Privacy: `default_privacy_class = "pii_potential"` (plus redaction, above).
- Registration: `mempalace.sources` entry point.

## Testing

- 130 tests, all passing; `ruff format --check` and `ruff check` clean.
- Fixtures are built programmatically (synthetic trajectory JSONL) — no recorded
  sessions committed; seeded secrets in redaction tests are fake.
- Verified end-to-end against real on-disk trajectory files: `message_count`
  populated, transcripts free of Slack/media plumbing and redacted of seeded
  secrets, schema validation passes, discovery resolves all capture locations,
  and the runtime extraction path is byte-identical to the declared transforms.

## Scope / non-goals

- v1 is pull-mode over on-disk trajectory files; no live/webhook ingest.
- Exchange-pair extraction only; no LLM-based structured extraction.
- SQLite `trajectory_runtime_events` source is a documented seam, not implemented
  (blocked on the database-first migration shipping).

## Related

RFC 002 #989 · Closes #1943 · pattern PR #1484
