### PR TITLE
fix(repair): use os.rename for in-place archive, not shutil.move

### DIFF
--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -1405,7 +1405,30 @@ def rebuild_from_sqlite(
         ts = datetime.now().strftime("%Y%m%d-%H%M%S")
         archive_path = f"{dest_palace}.pre-rebuild-{ts}"
         print(f"  Archiving {dest_palace} → {archive_path}")
-        shutil.move(dest_palace, archive_path)
+        # os.rename, NOT shutil.move. When any file inside the palace is
+        # held open by another process (MCP server, a running mine, another
+        # harness), renaming the directory fails atomically UP FRONT on
+        # Windows and the palace is left untouched. shutil.move's fallback
+        # for a failed rename is copytree + rmtree — and that rmtree
+        # deletes the live palace file-by-file until it hits the first
+        # locked file, leaving the palace partially gutted next to a
+        # partial archive copy. Observed live (Windows 11, 2026-07-05/06):
+        # two interrupted in-place repairs; the palace survived only
+        # because the locked chroma.sqlite3/*.bin themselves could not be
+        # unlinked. Same lesson as the source-validation comment above:
+        # fail cleanly before touching anything.
+        try:
+            os.rename(dest_palace, archive_path)
+        except OSError as exc:
+            print(
+                f"\n  Cannot archive the existing palace: a file inside it "
+                f"is held open by another process (MCP server, running "
+                f"mine, another harness?).\n"
+                f"  Close those processes and retry. The palace was left "
+                f"untouched.\n"
+                f"  ({exc})"
+            )
+            return {}
         source_palace = archive_path
         src_db = os.path.join(source_palace, "chroma.sqlite3")
 

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1817,6 +1817,45 @@ def test_rebuild_from_sqlite_in_place_refuses_without_archive_flag(tmp_path):
     assert archives == []
 
 
+def test_rebuild_from_sqlite_in_place_archive_failure_leaves_palace_untouched(
+    tmp_path, monkeypatch
+):
+    """A file inside the palace held open by another process (MCP server,
+    a running mine, another harness) must abort the archive step cleanly,
+    leaving the live palace fully intact.
+
+    Regression test for a real-world incident (2026-07-05/06, Windows 11):
+    the archive step used ``shutil.move``, whose fallback for a failed
+    ``os.rename`` is copytree + rmtree. That rmtree deletes the live
+    palace file-by-file until it hits the first locked file, so an
+    in-progress mine or a live MCP server holding one file open left the
+    palace partially gutted next to a partial archive copy -- twice, on
+    two separate nights. os.rename fails atomically up front with nothing
+    touched; this test locks that behaviour in so a future change back to
+    shutil.move (or an equivalent copy+delete fallback) fails loudly.
+    """
+    palace = tmp_path / "palace"
+    rows = [("d1", "doc one", {"wing": "w"}), ("d2", "doc two", {"wing": "w"})]
+    _seed_palace(palace, "mempalace_drawers", rows)
+    sqlite_before = (palace / "chroma.sqlite3").stat().st_size
+    entries_before = sorted(p.name for p in palace.iterdir())
+
+    def _raise(*_args, **_kwargs):
+        raise PermissionError("[WinError 32] simulated: file held open by another process")
+
+    monkeypatch.setattr(repair.os, "rename", _raise)
+
+    counts = repair.rebuild_from_sqlite(str(palace), str(palace), archive_existing_dest=True)
+
+    assert counts == {}
+    # Palace directory contents and the sqlite file itself are byte-for-byte
+    # untouched -- no partial delete, no partial archive left behind.
+    assert sorted(p.name for p in palace.iterdir()) == entries_before
+    assert (palace / "chroma.sqlite3").stat().st_size == sqlite_before
+    archives = [p for p in tmp_path.iterdir() if "pre-rebuild" in p.name]
+    assert archives == []
+
+
 def test_rebuild_from_sqlite_source_missing_chroma_db(tmp_path):
     """Source dir exists but has no chroma.sqlite3 → returns empty,
     leaves dest untouched."""


### PR DESCRIPTION
## Problem

`rebuild_from_sqlite`'s in-place archive step (`--archive-existing`) uses `shutil.move(dest_palace, archive_path)`. When `os.rename` fails (cross-filesystem, or on Windows when a file inside the tree is held open by another process), `shutil.move` falls back to `copytree` + `rmtree`. That `rmtree` deletes the live palace file-by-file — and if it hits a locked file partway through, the palace is left partially deleted next to a partial (or empty) archive copy.

## Real-world repro

Hit this live, twice, on two separate nights (Windows 11, 2026-07-05 and 2026-07-06): running `mempalace repair --mode from-sqlite --yes --archive-existing` while an MCP server / a detached mine process held `palace/<segment-uuid>/data_level0.bin` open. Both times:

```
PermissionError: [WinError 5] Zugriff verweigert: '...palace' -> '...palace.pre-rebuild-...'
...
PermissionError: [WinError 32] Der Prozess kann nicht auf die Datei zugreifen, da sie von einem anderen Prozess verwendet wird: '...\data_level0.bin'
```

The palace survived only because the specific locked files happened to be ones `rmtree` couldn't unlink — a different lock pattern (a lock on whichever file `rmtree` reaches *first*) would have lost data with no way back, since the archive itself is also incomplete at that point.

## Fix

`os.rename` instead of `shutil.move` for this step. It's atomic on both platforms this matters on (POSIX `rename(2)`, Windows `MoveFileEx`) — either fully succeeds or fails touching nothing. Catch the failure and print actionable guidance (close the process holding the lock, retry) instead of a raw traceback or a silently mangled palace.

## Testing

- New regression test `test_rebuild_from_sqlite_in_place_archive_failure_leaves_palace_untouched` (monkeypatches `os.rename` to raise, matching the real Windows error) — asserts the palace directory and `chroma.sqlite3` are byte-for-byte untouched and no archive dir is created.
- Full `tests/test_repair.py`: 91 passed, 0 failed.

Related to the general lock-contention family (#1908, #1888) but this is specifically about the archive-move fallback behavior, not the peer-writer lock itself.