### PR TITLE
fix(mcp): mark sqlite_integrity not-applicable on non-chroma backends (#1931)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -581,6 +581,34 @@ def _ensure_sqlite_integrity_status() -> None:
 def _sqlite_integrity_payload() -> dict:
     _ensure_sqlite_integrity_status()
 
+    # The integrity gate only knows how to check chroma.sqlite3, and
+    # _refresh_sqlite_integrity_status short-circuits for non-chroma backends,
+    # so on a non-chroma backend no quick_check runs. Reporting checked/ok true
+    # would imply a verification that never happened and reference a
+    # chroma.sqlite3 the active backend does not use (#1931). Recorded errors
+    # only ever come from the chroma path, so surface them regardless of the
+    # backend lookup (which may itself fail); only the clean case is
+    # reclassified as not-applicable.
+    if not _sqlite_integrity_errors:
+        try:
+            backend_name = _selected_backend_name()
+        except Exception:
+            logger.debug("backend resolution failed for integrity payload", exc_info=True)
+            backend_name = ""
+        if backend_name != "chroma":
+            return {
+                "checked": False,
+                "ok": None,
+                "palace": _config.palace_path or "",
+                "sqlite_path": "",
+                "error_count": 0,
+                "errors": [],
+                "reason": (
+                    "chroma.sqlite3 integrity check does not run for backend "
+                    f"{backend_name or 'unknown'!r}"
+                ),
+            }
+
     payload = {
         "checked": _sqlite_integrity_checked,
         "ok": not _sqlite_integrity_errors,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4943,6 +4943,73 @@ def test_sqlite_integrity_status_surfaces_payload_without_chroma(monkeypatch):
     assert "malformed inverted index" in payload["sqlite_integrity"]["errors"][0]
 
 
+def test_sqlite_integrity_payload_not_applicable_on_non_chroma_backend(monkeypatch):
+    """#1931: a non-chroma backend runs no sqlite quick_check, so status must
+    report the check as not-applicable rather than implying it passed.
+
+    Before the fix the payload reported ``checked=True``/``ok=True`` and a
+    ``chroma.sqlite3`` path that does not exist for the active backend.
+    """
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(mcp_server, "_selected_backend_name", lambda: "qdrant")
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_checked", True)
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_errors", [])
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_check_error", "")
+
+    payload = mcp_server._sqlite_integrity_payload()
+
+    assert payload["checked"] is False
+    assert payload["ok"] is None
+    assert "qdrant" in payload["reason"]
+    # No chroma.sqlite3 reference and a shape stable with the chroma payload.
+    assert payload["sqlite_path"] == ""
+    assert payload["error_count"] == 0
+    assert payload["errors"] == []
+
+
+def test_sqlite_integrity_payload_reports_unknown_when_backend_unresolvable(monkeypatch):
+    """#1931: if backend resolution raises, status still must not claim an
+    integrity pass; it reports not-applicable for an unknown backend.
+    """
+    from mempalace import mcp_server
+
+    def _boom():
+        raise RuntimeError("backend registry unavailable")
+
+    monkeypatch.setattr(mcp_server, "_selected_backend_name", _boom)
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_checked", True)
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_errors", [])
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_check_error", "")
+
+    payload = mcp_server._sqlite_integrity_payload()
+
+    assert payload["checked"] is False
+    assert payload["ok"] is None
+    assert "unknown" in payload["reason"]
+
+
+def test_sqlite_integrity_payload_full_shape_on_chroma_backend(monkeypatch):
+    """#1931 guard: a chroma backend with no recorded errors must still return
+    the full integrity payload; the not-applicable branch must not swallow the
+    chroma path.
+    """
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(mcp_server, "_selected_backend_name", lambda: "chroma")
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_checked", True)
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_errors", [])
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_check_error", "")
+
+    payload = mcp_server._sqlite_integrity_payload()
+
+    assert payload["checked"] is True
+    assert payload["ok"] is True
+    assert "sqlite_path" in payload
+    assert payload["error_count"] == 0
+    assert "reason" not in payload
+
+
 def test_sqlite_integrity_reconnect_allowed_when_corrupt(monkeypatch):
     from mempalace import mcp_server
 


### PR DESCRIPTION
Fixes #1931

## What does this PR do?

On a non-chroma backend (qdrant, pgvector, sqlite_exact, sqlite_vec) the MCP
`mempalace_status` tool reported a passing SQLite integrity check that never ran:

```json
"sqlite_integrity": { "checked": true, "ok": true,
                      "sqlite_path": ".../chroma.sqlite3",
                      "error_count": 0, "errors": [] }
```

`_refresh_sqlite_integrity_status()` already short-circuits the check for
non-chroma backends, and `chroma.sqlite3` does not exist for the active backend,
so this reads as "integrity verified OK" when nothing was verified and points at
a file that is not there.

`_sqlite_integrity_payload()` now detects a non-chroma backend and reports the
check as not-applicable:

```json
"sqlite_integrity": { "checked": false, "ok": null, "sqlite_path": "",
                      "error_count": 0, "errors": [],
                      "reason": "chroma.sqlite3 integrity check does not run for backend 'qdrant'" }
```

Recorded errors only ever come from the chroma path, so a genuine corruption
report is still surfaced unchanged; only the clean non-chroma case is
reclassified. The chroma payload keeps the same keys, so existing clients are
unaffected, and backend resolution is wrapped so status output cannot raise.

Scope is limited to the status payload. `repair.sqlite_integrity_errors()` is
reached only behind existing chroma guards, so it is left unchanged.

## How to test

```bash
uv run pytest tests/test_mcp_server.py -k sqlite_integrity
```

New tests cover the non-chroma not-applicable payload, an unresolved-backend
fallback, and a regression guard that the chroma payload is unchanged.

Manual check on any non-chroma palace (for example `MEMPALACE_BACKEND=sqlite_exact`):
`mempalace_status` now returns `sqlite_integrity.checked == false` and
`ok == null` with a `reason`, instead of `true`/`true` referencing a
non-existent `chroma.sqlite3`.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
