### PR TITLE
feat: per-drawer salience (dynamics extended to drawers)

### DIFF
--- a/mempalace/dynamics.py
+++ b/mempalace/dynamics.py
@@ -6,10 +6,10 @@ spacing effect: stability grows when reinforcement is spaced rather than
 massed.
 
 This module is pure. No I/O, no DB, no chromadb. It operates on plain
-dicts (hall records, tunnel records) and mutates them in place. Callers
-in ``hallways.py`` and ``palace_graph.py`` invoke these functions; the
-math lives here in one place so both connection kinds share identical
-semantics.
+dicts (hall records, tunnel records, drawer metadata records) and mutates
+them in place. Callers in ``hallways.py`` and ``palace_graph.py`` invoke
+these functions; the math lives here in one place so both connection kinds
+and drawer salience share identical semantics.
 
 Schema fields added to hall + tunnel records (all default-safe — existing
 records without them work via ``initialize_dynamics_fields``):
@@ -100,6 +100,44 @@ def initialize_dynamics_fields(connection: dict, *, now: Optional[datetime] = No
     connection.setdefault("last_activated", created_at)
     connection.setdefault("access_count", 0)
     return connection
+
+
+def initialize_drawer_dynamics_fields(
+    drawer_metadata: dict, *, now: Optional[datetime] = None
+) -> dict:
+    """Populate dynamics fields on drawer metadata, using ``filed_at`` as creation time.
+
+    Drawer metadata historically has ``filed_at`` rather than connection-style
+    ``created_at``. This adapter keeps the shared dynamics math unchanged while
+    preserving the drawer metadata shape: ``created_at`` is only supplied as a
+    temporary fallback and is not left behind when absent from the input.
+    """
+
+    missing_created_at = "created_at" not in drawer_metadata
+    if missing_created_at and drawer_metadata.get("filed_at"):
+        drawer_metadata["created_at"] = drawer_metadata["filed_at"]
+
+    initialize_dynamics_fields(drawer_metadata, now=now)
+
+    if missing_created_at:
+        drawer_metadata.pop("created_at", None)
+
+    return drawer_metadata
+
+
+def drawer_salience(drawer_metadata: dict, *, now: Optional[datetime] = None) -> dict:
+    """Return lazy-decayed salience for drawer metadata without mutating input."""
+
+    record = dict(drawer_metadata or {})
+    initialize_drawer_dynamics_fields(record, now=now)
+    if _parse_iso(record.get("last_activated")) is not None:
+        apply_decay(record, now=now)
+    return {
+        "strength": float(record.get("strength", DEFAULT_STRENGTH)),
+        "stability": float(record.get("stability", DEFAULT_STABILITY)),
+        "last_activated": record.get("last_activated"),
+        "access_count": int(record.get("access_count", 0)),
+    }
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -53,7 +53,7 @@ import hmac  # noqa: E402
 import sqlite3  # noqa: E402
 import threading  # noqa: E402
 import time  # noqa: E402
-from datetime import date, datetime  # noqa: E402
+from datetime import date, datetime, timezone  # noqa: E402
 from pathlib import Path  # noqa: E402
 from typing import Optional  # noqa: E402
 from urllib.parse import urlparse  # noqa: E402
@@ -66,6 +66,12 @@ from .config import (  # noqa: E402
     sanitize_iso_temporal,
     sqlite_read_uri,
     strip_lone_surrogates,
+)
+from .dynamics import (  # noqa: E402
+    apply_decay,
+    drawer_salience,
+    initialize_drawer_dynamics_fields,
+    potentiate,
 )
 from .version import __version__  # noqa: E402
 from chromadb.errors import NotFoundError as _ChromaNotFoundError  # noqa: E402
@@ -416,6 +422,7 @@ _MCP_WRITER_LOCK_FAILED = False
 _MCP_WRITER_LOCK_ERROR = ""
 _MCP_WRITER_ATEXIT_REGISTERED = False
 _MCP_ALLOW_PEER_WRITER_ENV = "MEMPALACE_MCP_ALLOW_PEER_WRITER"
+_SALIENCE_POTENTIATE_ENV = "MEMPALACE_SALIENCE_POTENTIATE"
 
 _MUTATING_TOOLS = frozenset(
     {
@@ -623,6 +630,10 @@ _stale_library_reported_drift: list = []
 
 def _truthy_env(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 def _discard_mcp_storage_handles() -> None:
@@ -2535,7 +2546,76 @@ def tool_search(
         }
     if context:
         result["context_received"] = True
+    if "results" in result:
+        _maybe_potentiate_search_results(result["results"])
+        for hit in result["results"]:
+            hit.pop("_parent_drawer_id", None)
     return result
+
+
+def _can_potentiate_on_search() -> bool:
+    if not _truthy_env(_SALIENCE_POTENTIATE_ENV):
+        return False
+    if _READ_ONLY:
+        return False
+    if _MCP_WRITER_LOCK_CM is not None:
+        return True
+    ok, _reason = _acquire_mcp_writer_lock()
+    return ok and _MCP_WRITER_LOCK_CM is not None
+
+
+def _logical_ids_from_search_hits(hits: list[dict]) -> list[str]:
+    ids = []
+    seen = set()
+    for hit in hits:
+        drawer_id = hit.get("_parent_drawer_id") or hit.get("id") or hit.get("drawer_id")
+        if not drawer_id:
+            continue
+        if drawer_id in seen:
+            continue
+        seen.add(drawer_id)
+        ids.append(drawer_id)
+    return ids
+
+
+def _maybe_potentiate_search_results(hits: list[dict]) -> None:
+    """Best-effort opt-in salience write for logical drawers surfaced by search.
+
+    Chunked drawers are counted once per logical parent. We persist identical
+    salience metadata to every physical chunk in the parent group, so listing
+    and direct chunk reads observe a consistent value. The read-modify-write is
+    intentionally best effort for v1; concurrent searches may lose increments.
+    """
+
+    global _metadata_cache
+
+    if not hits or not _can_potentiate_on_search():
+        return
+
+    col = _get_collection()
+    if not col:
+        return
+
+    now = _now()
+    for drawer_id in _logical_ids_from_search_hits(hits):
+        try:
+            record = _logical_drawer_record(col, drawer_id)
+            if record is None:
+                continue
+            base_meta = dict(_safe_meta(record["metadata"]))
+            initialize_drawer_dynamics_fields(base_meta, now=now)
+            apply_decay(base_meta, now=now)
+            potentiate(base_meta, now=now)
+            update_metas = []
+            for old_meta in record["metadatas"]:
+                merged = dict(_safe_meta(old_meta))
+                for key in ("strength", "stability", "last_activated", "access_count"):
+                    merged[key] = base_meta[key]
+                update_metas.append(merged)
+            col.update(ids=record["ids"], metadatas=update_metas)
+            _metadata_cache = None
+        except Exception:
+            logger.debug("drawer salience potentiation failed for %s", drawer_id, exc_info=True)
 
 
 def tool_check_duplicate(content: str, threshold: float = 0.9):
@@ -2873,6 +2953,7 @@ def _drawer_payload(record):
         "content": record["content"],
         "wing": safe_meta.get("wing", ""),
         "room": safe_meta.get("room", ""),
+        "salience": drawer_salience(record["metadata"], now=_now()),
         "metadata": safe_meta,
     }
 
@@ -2883,6 +2964,19 @@ def _drawer_payload(record):
         payload["metadata"]["chunk_ids"] = record["ids"]
 
     return payload
+
+
+def _metadata_where_filter(wing: str = None, room: str = None):
+    conditions = []
+    if wing:
+        conditions.append({"wing": wing})
+    if room:
+        conditions.append({"room": room})
+    if len(conditions) == 1:
+        return conditions[0]
+    if len(conditions) > 1:
+        return {"$and": conditions}
+    return None
 
 
 def _fetch_drawer_rows(col, where=None, page_size: int = 1000, include=None):
@@ -3757,18 +3851,7 @@ def tool_list_drawers(
         return {"error": str(e)}
 
     try:
-        where = None
-        conditions = []
-
-        if wing:
-            conditions.append({"wing": wing})
-        if room:
-            conditions.append({"room": room})
-
-        if len(conditions) == 1:
-            where = conditions[0]
-        elif len(conditions) > 1:
-            where = {"$and": conditions}
+        where = _metadata_where_filter(wing=wing, room=room)
 
         listed = None
         if _is_chroma_backend() and _config.palace_path:
@@ -3812,6 +3895,66 @@ def tool_list_drawers(
         }
     except Exception as e:
         logger.exception("tool_list_drawers failed")
+        return {"error": str(e)}
+
+
+def tool_drawer_salience(
+    wing: str = None,
+    room: str = None,
+    limit: int = 100,
+    order_by: str = "strength",
+):
+    """List lazy-decayed drawer salience at logical drawer granularity."""
+
+    limit = max(1, min(limit, _MAX_RESULTS))
+    if order_by not in {"strength", "access_count", "last_activated"}:
+        return {"error": "order_by must be one of: strength, access_count, last_activated"}
+
+    try:
+        wing = _sanitize_optional_name(wing, "wing")
+        room = _sanitize_optional_name(room, "room")
+    except ValueError as e:
+        return {"error": str(e)}
+
+    col = _get_collection()
+    if not col:
+        return _collection_error_or_no_palace()
+
+    try:
+        ids, documents, metadatas = _fetch_drawer_rows(
+            col, where=_metadata_where_filter(wing=wing, room=room)
+        )
+        drawers = _collapse_drawer_rows(ids, documents, metadatas)
+        rows = []
+        now = _now()
+        for drawer in drawers:
+            salience = drawer_salience(drawer.get("metadata", {}), now=now)
+            rows.append(
+                {
+                    "id": drawer["drawer_id"],
+                    "wing": drawer.get("wing", ""),
+                    "room": drawer.get("room", ""),
+                    **salience,
+                }
+            )
+
+        def sort_key(item):
+            value = item.get(order_by)
+            if order_by == "last_activated":
+                parsed = datetime.min.replace(tzinfo=timezone.utc)
+                try:
+                    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+                    if parsed.tzinfo is None:
+                        parsed = parsed.replace(tzinfo=timezone.utc)
+                except (TypeError, ValueError):
+                    pass
+                return (parsed, item["id"])
+            return (value, item["id"])
+
+        rows.sort(key=sort_key, reverse=True)
+        return {"drawers": rows[:limit]}
+    except Exception as e:
+        logger.exception("tool_drawer_salience failed")
         return {"error": str(e)}
 
 
@@ -5493,6 +5636,28 @@ TOOLS = {
             },
         },
         "handler": tool_list_drawers,
+    },
+    "mempalace_drawer_salience": {
+        "description": "List lazy-decayed per-drawer salience at logical drawer granularity. Chunked drawers are deduped by parent_drawer_id.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "wing": {"type": "string", "description": "Filter by wing (optional)"},
+                "room": {"type": "string", "description": "Filter by room (optional)"},
+                "limit": {
+                    "type": "integer",
+                    "description": "Max drawers to return (default 100, max 100)",
+                    "minimum": 1,
+                    "maximum": 100,
+                },
+                "order_by": {
+                    "type": "string",
+                    "enum": ["strength", "access_count", "last_activated"],
+                    "description": "Sort field (default strength)",
+                },
+            },
+        },
+        "handler": tool_drawer_salience,
     },
     "mempalace_update_drawer": {
         "description": "Update an existing drawer's content and/or metadata (wing, room). Fetches existing drawer first; returns error if not found.",

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -28,6 +28,7 @@ from .backends import (
 )
 from .config import MempalaceConfig, sqlite_read_uri
 from .date_window import filed_at_in_window, parse_window
+from .dynamics import drawer_salience
 from .i18n import _canonical_lang, get_stopwords
 from .palace import (
     _open_collection_or_explain,
@@ -2145,6 +2146,7 @@ def search_memories(
             "effective_distance": round(effective_dist, 4),
             "closet_boost": round(boost, 3),
             "matched_via": matched_via,
+            "salience": drawer_salience(meta),
             # Internal: retain the full source_file path + chunk_index so the
             # enrichment step below doesn't have to reverse-lookup via
             # basename-suffix matching (which silently collides when two

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -74,6 +74,7 @@ READ_TOOLS = frozenset(
         "mempalace_check_duplicate",
         "mempalace_get_drawer",
         "mempalace_list_drawers",
+        "mempalace_drawer_salience",
         "mempalace_diary_read",
         "mempalace_memories_filed_away",
         "mempalace_kg_query",

--- a/tests/test_drawer_salience.py
+++ b/tests/test_drawer_salience.py
@@ -1,0 +1,291 @@
+"""Drawer salience tests for issue #1921.
+
+These tests pin the additive drawer-facing behavior before implementation:
+lazy read exposure must not mutate stored metadata, while opt-in search
+potentiation must update stored drawer salience safely.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from mempalace.dynamics import (
+    DEFAULT_STABILITY,
+    DEFAULT_STRENGTH,
+    POTENTIATION_INCREMENT,
+    STABILITY_INCREMENT,
+)
+
+
+T0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _patch_mcp_server(monkeypatch, config, kg):
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(mcp_server, "_config", config)
+    monkeypatch.setattr(mcp_server, "_get_kg", lambda *a, **kw: kg)
+
+
+def _stored_meta(collection, drawer_id: str) -> dict:
+    result = collection.get(ids=[drawer_id], include=["metadatas"])
+    ids = result["ids"] if isinstance(result, dict) else result.ids
+    assert ids == [drawer_id]
+    metas = result["metadatas"] if isinstance(result, dict) else result.metadatas
+    return dict(metas[0])
+
+
+def _add_drawer(collection, drawer_id: str, text: str, **meta):
+    base_meta = {
+        "wing": "salience",
+        "room": "lab",
+        "source_file": f"{drawer_id}.md",
+        "chunk_index": 0,
+        "added_by": "test",
+        "filed_at": T0.isoformat(),
+    }
+    base_meta.update(meta)
+    collection.add(ids=[drawer_id], documents=[text], metadatas=[base_meta])
+
+
+def _add_chunked_drawer(collection, parent_id: str):
+    filed_at = T0.isoformat()
+    collection.add(
+        ids=[f"{parent_id}_chunk_000000", f"{parent_id}_chunk_000001"],
+        documents=[
+            "chunked logical drawer first half with nebula keyword",
+            "chunked logical drawer second half with nebula keyword",
+        ],
+        metadatas=[
+            {
+                "wing": "salience",
+                "room": "chunks",
+                "source_file": "chunked.md",
+                "added_by": "test",
+                "filed_at": filed_at,
+                "parent_drawer_id": parent_id,
+                "chunk_index": 0,
+            },
+            {
+                "wing": "salience",
+                "room": "chunks",
+                "source_file": "chunked.md",
+                "added_by": "test",
+                "filed_at": filed_at,
+                "parent_drawer_id": parent_id,
+                "chunk_index": 1,
+            },
+        ],
+    )
+
+
+class TestDrawerDynamicsAdapter:
+    def test_initializes_last_activated_from_filed_at(self):
+        from mempalace.dynamics import initialize_drawer_dynamics_fields
+
+        meta = {"filed_at": T0.isoformat()}
+        initialize_drawer_dynamics_fields(meta, now=T0 + timedelta(days=3))
+
+        assert meta["strength"] == DEFAULT_STRENGTH
+        assert meta["stability"] == DEFAULT_STABILITY
+        assert meta["last_activated"] == T0.isoformat()
+        assert meta["access_count"] == 0
+
+    def test_missing_and_unparseable_filed_at_are_default_safe(self):
+        from mempalace.dynamics import drawer_salience
+
+        missing = drawer_salience({}, now=T0)
+        invalid = drawer_salience({"filed_at": "not a timestamp"}, now=T0)
+
+        assert missing == {
+            "strength": DEFAULT_STRENGTH,
+            "stability": DEFAULT_STABILITY,
+            "last_activated": T0.isoformat(),
+            "access_count": 0,
+        }
+        assert invalid["strength"] == DEFAULT_STRENGTH
+        assert invalid["stability"] == DEFAULT_STABILITY
+        assert invalid["last_activated"] == "not a timestamp"
+        assert invalid["access_count"] == 0
+
+
+class TestDrawerSalienceReadExposure:
+    def test_search_includes_lazy_salience_without_mutating_store(
+        self, monkeypatch, config, collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _add_drawer(collection, "drawer_salience_search", "rare heliotrope search target")
+        before = _stored_meta(collection, "drawer_salience_search")
+
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_now", lambda: T0 + timedelta(days=1))
+        result = mcp_server.tool_search(query="heliotrope", limit=1, max_distance=0)
+
+        assert result["results"]
+        salience = result["results"][0]["salience"]
+        assert set(salience) == {"strength", "stability", "last_activated", "access_count"}
+        assert salience["strength"] < DEFAULT_STRENGTH
+        assert salience["last_activated"] == T0.isoformat()
+        assert _stored_meta(collection, "drawer_salience_search") == before
+
+    def test_get_drawer_includes_lazy_salience_without_mutating_store(
+        self, monkeypatch, config, collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _add_drawer(collection, "drawer_salience_get", "drawer body")
+        before = _stored_meta(collection, "drawer_salience_get")
+
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_now", lambda: T0 + timedelta(days=1))
+        result = mcp_server.tool_get_drawer("drawer_salience_get")
+
+        assert result["salience"]["strength"] < DEFAULT_STRENGTH
+        assert result["salience"]["last_activated"] == T0.isoformat()
+        assert _stored_meta(collection, "drawer_salience_get") == before
+
+
+class TestDrawerSalienceTool:
+    def test_orders_by_strength_access_count_and_last_activated(
+        self, monkeypatch, config, collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _add_drawer(
+            collection,
+            "drawer_strength_hot",
+            "hot drawer",
+            strength=2.0,
+            access_count=1,
+            last_activated=(T0 + timedelta(hours=1)).isoformat(),
+        )
+        _add_drawer(
+            collection,
+            "drawer_count_hot",
+            "count drawer",
+            strength=1.5,
+            access_count=9,
+            last_activated=(T0 + timedelta(hours=2)).isoformat(),
+        )
+        _add_drawer(
+            collection,
+            "drawer_recent_hot",
+            "recent drawer",
+            strength=1.0,
+            access_count=3,
+            last_activated=(T0 + timedelta(hours=3)).isoformat(),
+        )
+
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_now", lambda: T0 + timedelta(hours=3))
+
+        by_strength = mcp_server.tool_drawer_salience(order_by="strength", limit=3)["drawers"]
+        by_count = mcp_server.tool_drawer_salience(order_by="access_count", limit=3)["drawers"]
+        by_recent = mcp_server.tool_drawer_salience(order_by="last_activated", limit=3)["drawers"]
+
+        assert by_strength[0]["id"] == "drawer_strength_hot"
+        assert by_count[0]["id"] == "drawer_count_hot"
+        assert by_recent[0]["id"] == "drawer_recent_hot"
+
+    def test_dedupes_chunked_drawers_by_parent(self, monkeypatch, config, collection, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _add_chunked_drawer(collection, "drawer_parent_salience")
+
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_now", lambda: T0)
+        result = mcp_server.tool_drawer_salience(wing="salience", room="chunks")
+
+        assert result["drawers"] == [
+            {
+                "id": "drawer_parent_salience",
+                "wing": "salience",
+                "room": "chunks",
+                "strength": DEFAULT_STRENGTH,
+                "stability": DEFAULT_STABILITY,
+                "last_activated": T0.isoformat(),
+                "access_count": 0,
+            }
+        ]
+
+
+class TestPotentiateOnSearch:
+    def test_flag_off_search_writes_nothing(self, monkeypatch, config, collection, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _add_drawer(collection, "drawer_no_potentiate", "flag off aquamarine target")
+
+        from mempalace import mcp_server
+
+        monkeypatch.delenv("MEMPALACE_SALIENCE_POTENTIATE", raising=False)
+        result = mcp_server.tool_search(query="aquamarine", limit=1, max_distance=0)
+
+        assert result["results"]
+        stored = _stored_meta(collection, "drawer_no_potentiate")
+        assert stored.get("access_count") is None
+
+    def test_flag_on_potentiates_store_once(self, monkeypatch, config, collection, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _add_drawer(collection, "drawer_potentiate", "flag on vermillion target")
+
+        from mempalace import mcp_server
+
+        now = T0 + timedelta(hours=2)
+        monkeypatch.setenv("MEMPALACE_SALIENCE_POTENTIATE", "true")
+        monkeypatch.setattr(mcp_server, "_READ_ONLY", False)
+        monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_CM", object())
+        monkeypatch.setattr(mcp_server, "_now", lambda: now)
+
+        result = mcp_server.tool_search(query="vermillion", limit=1, max_distance=0)
+
+        assert result["results"]
+        stored = _stored_meta(collection, "drawer_potentiate")
+        assert stored["access_count"] == 1
+        assert stored["last_activated"] == now.isoformat()
+        assert stored["strength"] > DEFAULT_STRENGTH * 0.9
+        assert stored["strength"] < DEFAULT_STRENGTH + POTENTIATION_INCREMENT
+        assert stored["stability"] == pytest.approx(DEFAULT_STABILITY + STABILITY_INCREMENT)
+
+    def test_chunked_drawer_potentiates_parent_once_and_updates_all_chunks(
+        self, monkeypatch, config, collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _add_chunked_drawer(collection, "drawer_parent_once")
+
+        from mempalace import mcp_server
+
+        now = T0 + timedelta(hours=2)
+        monkeypatch.setenv("MEMPALACE_SALIENCE_POTENTIATE", "true")
+        monkeypatch.setattr(mcp_server, "_READ_ONLY", False)
+        monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_CM", object())
+        monkeypatch.setattr(mcp_server, "_now", lambda: now)
+
+        result = mcp_server.tool_search(query="nebula", limit=2, max_distance=0)
+
+        assert result["results"]
+        rows = collection.get(
+            ids=["drawer_parent_once_chunk_000000", "drawer_parent_once_chunk_000001"],
+            include=["metadatas"],
+        )
+        for meta in rows["metadatas"]:
+            assert meta["access_count"] == 1
+            assert meta["last_activated"] == now.isoformat()
+
+    def test_read_only_mode_with_flag_on_still_writes_nothing(
+        self, monkeypatch, config, collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _add_drawer(collection, "drawer_read_only", "read only chartreuse target")
+        before = _stored_meta(collection, "drawer_read_only")
+
+        from mempalace import mcp_server
+
+        monkeypatch.setenv("MEMPALACE_SALIENCE_POTENTIATE", "true")
+        monkeypatch.setattr(mcp_server, "_READ_ONLY", True)
+        monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_CM", object())
+        result = mcp_server.tool_search(query="chartreuse", limit=1, max_distance=0)
+
+        assert result["results"]
+        assert _stored_meta(collection, "drawer_read_only") == before

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -50,7 +50,7 @@ Full wing → room → drawer count tree.
 
 ### `mempalace_search`
 
-Semantic search. Returns verbatim drawer content with similarity scores.
+Semantic search. Returns verbatim drawer content with similarity scores and a lazy-decayed `salience` block. By default this is read-only. If `MEMPALACE_SALIENCE_POTENTIATE=true`, surfaced logical drawers are potentiated best-effort unless the MCP server is read-only or lacks the palace writer lock.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -59,7 +59,7 @@ Semantic search. Returns verbatim drawer content with similarity scores.
 | `wing` | string | No | Filter by wing |
 | `room` | string | No | Filter by room |
 
-**Returns:** `{ query, filters, results: [{ text, wing, room, source_file, similarity }] }`
+**Returns:** `{ query, filters, results: [{ text, wing, room, source_file, similarity, salience }] }`
 
 ---
 
@@ -183,13 +183,13 @@ Only `gitignored` and `missing` are removed. A source file that is not at its pa
 
 ### `mempalace_get_drawer`
 
-Fetch a single drawer by ID — returns full content and metadata.
+Fetch a single drawer by ID — returns full content, metadata, and lazy-decayed salience.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `drawer_id` | string | **Yes** | ID of the drawer to fetch |
 
-**Returns:** `{ drawer_id, content, wing, room, metadata }` where `metadata.source_file`, when present, is the basename only — the absolute path written by the miners is reduced before the dict is returned to MCP clients.
+**Returns:** `{ drawer_id, content, wing, room, salience, metadata }` where `metadata.source_file`, when present, is the basename only — the absolute path written by the miners is reduced before the dict is returned to MCP clients.
 
 ---
 
@@ -205,6 +205,21 @@ List drawers with pagination. Optional wing/room filter. Returns IDs, wings, roo
 | `offset` | integer | No | Offset for pagination (default 0) |
 
 **Returns:** `{ drawers: [...], total, limit, offset }`
+
+---
+
+### `mempalace_drawer_salience`
+
+List lazy-decayed salience for logical drawers. Chunked drawers are deduped by `parent_drawer_id`; when opt-in search potentiation updates a chunked drawer, every physical chunk receives the same salience metadata so the parent remains consistent.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `wing` | string | No | Filter by wing |
+| `room` | string | No | Filter by room |
+| `limit` | integer | No | Max results (default 100, max 100) |
+| `order_by` | string | No | Sort by `strength`, `access_count`, or `last_activated` (default `strength`) |
+
+**Returns:** `{ drawers: [{ id, wing, room, strength, stability, last_activated, access_count }] }`
 
 ---
 


### PR DESCRIPTION
## What does this PR do?
Adds per-drawer salience by reusing the existing dynamics model (Hebbian potentiation, Ebbinghaus decay, and Cepeda spacing) for drawer metadata as well as graph connections. Drawer reads now expose a lazy-decayed `salience` block from copied metadata, with `filed_at` used as the drawer fallback for `last_activated` initialization.

This is backward-compatible and default-safe: metadata fields are additive, search/get read paths remain read-only by default, and retrieval potentiation is opt-in only via `MEMPALACE_SALIENCE_POTENTIATE=true`. When enabled, search updates drawer metadata only (no re-embedding), skips writes on read-only servers or when the MCP writer lock is unavailable, and keeps chunked logical drawers consistent across all physical chunks.

Also adds the read-only `mempalace_drawer_salience` tool and wires it through `TOOLS` and `service.READ_TOOLS`.

Closes #1921

## How to test
- `uv run pytest tests/test_drawer_salience.py -v` → 10 passed
- `uv run pytest tests/test_dynamics.py -v` → 25 passed
- `uv run pytest tests/test_searcher.py -v` → 45 passed
- `uv run pytest tests/test_closets.py -v` → green after the `_parent_drawer_id` regression fix
- `uv run pytest tests/ --ignore=tests/benchmarks` → 3268 passed; 3 unrelated pre-existing develop failures (2 tracked in #1925, 1 antigravity install)
- `uv run ruff check .` → clean
- `uv run ruff format --check .` → clean

Note: the second commit restores `_parent_drawer_id` scrubbing from public search hits, exposes the logical drawer id as `drawer_id`, and uses that field for potentiation; `tests/test_closets.py` covers the regression.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)