### PR TITLE
feat: read-only mempalace_find_duplicates near-duplicate cluster finder

### DIFF
--- a/mempalace/dedup.py
+++ b/mempalace/dedup.py
@@ -38,6 +38,8 @@ COLLECTION_NAME = "mempalace_drawers"
 # For looser dedup of paraphrased content, try 0.3–0.4.
 DEFAULT_THRESHOLD = 0.15
 MIN_DRAWERS_TO_CHECK = 5
+FIND_DUPLICATES_INITIAL_K = 32
+FIND_DUPLICATES_MAX_NEIGHBORS = 512
 
 
 def _get_palace_path():
@@ -93,6 +95,197 @@ def get_source_groups(
         offset += len(batch["ids"])
 
     return {src: ids for src, ids in groups.items() if len(ids) >= min_count}
+
+
+def _logical_drawer_id(row_id, metadata):
+    metadata = metadata if isinstance(metadata, dict) else {}
+    parent_id = metadata.get("parent_drawer_id")
+    if isinstance(parent_id, str) and parent_id.strip():
+        return parent_id
+    return row_id
+
+
+def _scope_where(wing=None, room=None):
+    where = {}
+    if wing:
+        where["wing"] = wing
+    if room:
+        where["room"] = room
+    return where or None
+
+
+def _fetch_duplicate_rows(col, where=None, batch_size=1000):
+    rows = []
+    offset = 0
+    while True:
+        batch = col.get(
+            where=where,
+            include=["documents", "metadatas"],
+            limit=batch_size,
+            offset=offset,
+        )
+        ids = batch.get("ids") or []
+        if not ids:
+            break
+        documents = batch.get("documents") or [None] * len(ids)
+        metadatas = batch.get("metadatas") or [{}] * len(ids)
+        for row_id, document, metadata in zip(ids, documents, metadatas):
+            rows.append(
+                {
+                    "row_id": row_id,
+                    "document": document,
+                    "metadata": metadata if isinstance(metadata, dict) else {},
+                    "logical_id": _logical_drawer_id(row_id, metadata),
+                }
+            )
+        if len(ids) < batch_size:
+            break
+        offset += len(ids)
+    return rows
+
+
+def _represent_logical_drawers(rows):
+    by_logical = {}
+    row_to_logical = {}
+    for item in rows:
+        row_to_logical[item["row_id"]] = item["logical_id"]
+        document = item.get("document") or ""
+        if not document:
+            continue
+        current = by_logical.get(item["logical_id"])
+        if current is None or len(document) > len(current.get("document") or ""):
+            by_logical[item["logical_id"]] = item
+    return list(by_logical.values()), row_to_logical
+
+
+def _component_root(parent, node):
+    while parent[node] != node:
+        parent[node] = parent[parent[node]]
+        node = parent[node]
+    return node
+
+
+def _component_union(parent, a, b):
+    root_a = _component_root(parent, a)
+    root_b = _component_root(parent, b)
+    if root_a != root_b:
+        parent[root_b] = root_a
+
+
+def find_duplicate_clusters(
+    col,
+    *,
+    wing=None,
+    room=None,
+    threshold=DEFAULT_THRESHOLD,
+    max_clusters=None,
+    initial_k=FIND_DUPLICATES_INITIAL_K,
+    max_neighbors=FIND_DUPLICATES_MAX_NEIGHBORS,
+):
+    """Return read-only connected components of near-duplicate logical drawers.
+
+    Candidate rows are fetched through the backend interface and collapsed by
+    ``parent_drawer_id`` before clustering, so chunks from the same logical
+    drawer never duplicate each other. Neighbor search grows K while the
+    boundary result is still under ``threshold`` and stops at
+    ``min(physical_rows, max_neighbors)``; dense duplicate regions beyond that
+    bound are intentionally capped to keep the read-only tool predictable.
+    """
+    threshold = float(threshold)
+    if max_clusters is not None:
+        max_clusters = int(max_clusters)
+    where = _scope_where(wing=wing, room=room)
+    rows = _fetch_duplicate_rows(col, where=where)
+    candidates, row_to_logical = _represent_logical_drawers(rows)
+    neighbor_bound = min(len(rows), int(max_neighbors)) if rows else 0
+    params = {
+        "wing": wing,
+        "room": room,
+        "threshold": threshold,
+        "max_clusters": max_clusters,
+        "initial_k": int(initial_k),
+        "neighbor_bound": neighbor_bound,
+    }
+    if len(candidates) < 2 or neighbor_bound < 2:
+        return {"clusters": [], "params": params}
+
+    parent = {item["logical_id"]: item["logical_id"] for item in candidates}
+    edges = {}
+    initial_k = max(2, int(initial_k))
+
+    for item in candidates:
+        query_id = item["logical_id"]
+        document = item.get("document")
+        if not document:
+            continue
+        k = min(initial_k, neighbor_bound)
+        seen_query_size = None
+        while k and k != seen_query_size:
+            seen_query_size = k
+            results = col.query(
+                query_texts=[document],
+                n_results=k,
+                include=["distances"],
+                where=where,
+            )
+            result_ids = (results.get("ids") or [[]])[0] or []
+            distances = (results.get("distances") or [[]])[0] or []
+            for neighbor_row_id, distance in zip(result_ids, distances):
+                if neighbor_row_id not in row_to_logical:
+                    continue
+                neighbor_id = row_to_logical.get(neighbor_row_id, neighbor_row_id)
+                if neighbor_row_id == item["row_id"] or neighbor_id == query_id:
+                    continue
+                distance = float(distance)
+                if distance >= threshold:
+                    continue
+                a, b = sorted((query_id, neighbor_id))
+                previous = edges.get((a, b))
+                if previous is None or distance < previous:
+                    edges[(a, b)] = distance
+                if neighbor_id not in parent:
+                    parent[neighbor_id] = neighbor_id
+                _component_union(parent, query_id, neighbor_id)
+
+            kth_distance = float(distances[-1]) if len(distances) >= k else None
+            if kth_distance is not None and kth_distance < threshold and k < neighbor_bound:
+                k = min(neighbor_bound, k * 2)
+                continue
+            break
+
+    components = defaultdict(set)
+    for a, b in edges:
+        root = _component_root(parent, a)
+        components[root].update((a, b))
+
+    clusters = []
+    for drawer_ids in components.values():
+        if len(drawer_ids) < 2:
+            continue
+        cluster_pairs = [
+            {"a": a, "b": b, "distance": distance}
+            for (a, b), distance in sorted(edges.items())
+            if a in drawer_ids and b in drawer_ids
+        ]
+        clusters.append(
+            {
+                "drawer_ids": sorted(drawer_ids),
+                "pairs": cluster_pairs,
+                "size": len(drawer_ids),
+            }
+        )
+
+    clusters.sort(key=lambda cluster: (-cluster["size"], cluster["drawer_ids"]))
+    truncated = False
+    if max_clusters is not None:
+        max_clusters = max(0, int(max_clusters))
+        truncated = len(clusters) > max_clusters
+        clusters = clusters[:max_clusters]
+
+    result = {"clusters": clusters, "params": params}
+    if truncated:
+        result["truncated"] = True
+    return result
 
 
 def dedup_source_group(col, drawer_ids, threshold=DEFAULT_THRESHOLD, dry_run=True):

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -11,6 +11,7 @@ Tools (read):
   mempalace_get_taxonomy    — full wing → room → count tree
   mempalace_search          — semantic search, optional wing/room/source_file filter
   mempalace_check_duplicate — check if content already exists before filing
+  mempalace_find_duplicates — find read-only near-duplicate drawer clusters
 
 Tools (write):
   mempalace_add_drawer      — file verbatim content into a wing/room
@@ -86,6 +87,7 @@ from .searcher import (  # noqa: E402
     _metric_for_collection,
     search_memories,
 )
+from .dedup import DEFAULT_THRESHOLD as DEDUP_DEFAULT_THRESHOLD, find_duplicate_clusters  # noqa: E402
 from .palace_graph import (  # noqa: E402
     traverse,
     find_tunnels,
@@ -2591,6 +2593,60 @@ def tool_check_duplicate(content: str, threshold: float = 0.9):
     except Exception:
         logger.exception("check_duplicate failed")
         return {"error": "Duplicate check failed"}
+
+
+def tool_find_duplicates(
+    wing: str = None,
+    room: str = None,
+    threshold: float = DEDUP_DEFAULT_THRESHOLD,
+    max_clusters: int = None,
+):
+    try:
+        wing = _sanitize_optional_name(wing, "wing")
+        room = _sanitize_optional_name(room, "room")
+        threshold = float(threshold)
+        if threshold < 0 or threshold > 2:
+            return {"error": "threshold must be between 0 and 2"}
+        if max_clusters is not None:
+            max_clusters = int(max_clusters)
+            if max_clusters < 1:
+                return {"error": "max_clusters must be at least 1"}
+    except (TypeError, ValueError) as e:
+        return {"error": str(e)}
+
+    _refresh_vector_disabled_flag()
+    if _vector_disabled:
+        return {
+            "clusters": [],
+            "params": {
+                "wing": wing,
+                "room": room,
+                "threshold": threshold,
+                "max_clusters": max_clusters,
+            },
+            "vector_disabled": True,
+            "vector_disabled_reason": _vector_disabled_reason,
+            "hint": (
+                "duplicate cluster detection requires vector search; "
+                "run `mempalace repair` to restore"
+            ),
+        }
+
+    col = _get_collection()
+    if not col:
+        return _collection_error_or_no_palace()
+
+    try:
+        return find_duplicate_clusters(
+            col,
+            wing=wing,
+            room=room,
+            threshold=threshold,
+            max_clusters=max_clusters,
+        )
+    except Exception:
+        logger.exception("find_duplicates failed")
+        return {"error": "Duplicate cluster detection failed"}
 
 
 def tool_get_aaak_spec():
@@ -5279,6 +5335,26 @@ TOOLS = {
             "required": ["content"],
         },
         "handler": tool_check_duplicate,
+    },
+    "mempalace_find_duplicates": {
+        "description": "Read-only duplicate audit. Returns connected clusters of near-duplicate logical drawers with pairwise cosine distances; never returns raw vectors or content.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "wing": {"type": "string", "description": "Filter by wing (optional)"},
+                "room": {"type": "string", "description": "Filter by room (optional)"},
+                "threshold": {
+                    "type": "number",
+                    "description": "Cosine distance threshold (default 0.15). Lower is stricter.",
+                },
+                "max_clusters": {
+                    "type": "integer",
+                    "description": "Maximum number of duplicate clusters to return (optional)",
+                    "minimum": 1,
+                },
+            },
+        },
+        "handler": tool_find_duplicates,
     },
     "mempalace_add_drawer": {
         "description": "File verbatim content into the palace. Checks for duplicates first.",

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -72,6 +72,7 @@ READ_TOOLS = frozenset(
         "mempalace_follow_tunnels",
         "mempalace_search",
         "mempalace_check_duplicate",
+        "mempalace_find_duplicates",
         "mempalace_get_drawer",
         "mempalace_list_drawers",
         "mempalace_diary_read",

--- a/tests/test_find_duplicates.py
+++ b/tests/test_find_duplicates.py
@@ -1,0 +1,320 @@
+"""Tests for read-only near-duplicate cluster discovery."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+class FakeDuplicateCollection:
+    """Small backend-like fake with filtered get/query and deterministic distances."""
+
+    def __init__(self, rows, neighbors=None):
+        self.rows = {row["id"]: row for row in rows}
+        self.neighbors = neighbors or {}
+        self.query_calls = []
+        self.get_calls = []
+        self.delete = MagicMock()
+
+    def count(self):
+        return len(self.rows)
+
+    def get(
+        self, *, ids=None, where=None, include=None, limit=None, offset=None, where_document=None
+    ):
+        self.get_calls.append(
+            {
+                "ids": ids,
+                "where": where,
+                "include": include,
+                "limit": limit,
+                "offset": offset,
+                "where_document": where_document,
+            }
+        )
+        rows = [self.rows[row_id] for row_id in ids] if ids else list(self.rows.values())
+        rows = [row for row in rows if self._matches(row, where)]
+        if offset is not None:
+            rows = rows[offset:]
+        if limit is not None:
+            rows = rows[:limit]
+        return {
+            "ids": [row["id"] for row in rows],
+            "documents": [row.get("document") for row in rows],
+            "metadatas": [row.get("metadata", {}) for row in rows],
+        }
+
+    def query(self, *, query_texts=None, n_results=10, where=None, include=None, **_kwargs):
+        query_doc = query_texts[0]
+        query_id = next(row["id"] for row in self.rows.values() if row.get("document") == query_doc)
+        self.query_calls.append(
+            {"query_id": query_id, "n_results": n_results, "where": where, "include": include}
+        )
+        scoped_ids = {row_id for row_id, row in self.rows.items() if self._matches(row, where)}
+        ids = []
+        distances = []
+        metadatas = []
+        for neighbor_id, distance in self.neighbors.get(query_id, []):
+            if neighbor_id not in scoped_ids:
+                continue
+            ids.append(neighbor_id)
+            distances.append(distance)
+            metadatas.append(self.rows[neighbor_id].get("metadata", {}))
+        return {
+            "ids": [ids[:n_results]],
+            "distances": [distances[:n_results]],
+            "metadatas": [metadatas[:n_results]],
+        }
+
+    @staticmethod
+    def _matches(row, where):
+        if not where:
+            return True
+        metadata = row.get("metadata", {}) or {}
+        return all(metadata.get(key) == value for key, value in where.items())
+
+
+def row(row_id, document=None, wing="w", room="r", parent=None, chunk_index=0):
+    metadata = {"wing": wing, "room": room, "chunk_index": chunk_index}
+    if parent is not None:
+        metadata["parent_drawer_id"] = parent
+    return {"id": row_id, "document": document or f"document for {row_id}", "metadata": metadata}
+
+
+def assert_cluster_ids(result, expected):
+    actual = [set(cluster["drawer_ids"]) for cluster in result["clusters"]]
+    assert set(map(frozenset, actual)) == set(map(frozenset, expected))
+
+
+def test_find_duplicate_clusters_groups_near_identical_drawers():
+    from mempalace.dedup import find_duplicate_clusters
+
+    col = FakeDuplicateCollection(
+        [row("a"), row("b")],
+        {"a": [("a", 0.0), ("b", 0.01)], "b": [("b", 0.0), ("a", 0.01)]},
+    )
+
+    result = find_duplicate_clusters(col, threshold=0.15)
+
+    assert_cluster_ids(result, [{"a", "b"}])
+    assert result["clusters"][0]["pairs"] == [{"a": "a", "b": "b", "distance": 0.01}]
+    col.delete.assert_not_called()
+
+
+def test_find_duplicate_clusters_ignores_dissimilar_drawers():
+    from mempalace.dedup import find_duplicate_clusters
+
+    col = FakeDuplicateCollection(
+        [row("a"), row("b")],
+        {"a": [("a", 0.0), ("b", 0.6)], "b": [("b", 0.0), ("a", 0.6)]},
+    )
+
+    result = find_duplicate_clusters(col, threshold=0.15)
+
+    assert result["clusters"] == []
+
+
+def test_find_duplicate_clusters_uses_strict_threshold_boundary():
+    from mempalace.dedup import find_duplicate_clusters
+
+    col = FakeDuplicateCollection(
+        [row("a"), row("b"), row("c")],
+        {
+            "a": [("a", 0.0), ("b", 0.149), ("c", 0.15)],
+            "b": [("b", 0.0), ("a", 0.149)],
+            "c": [("c", 0.0), ("a", 0.15)],
+        },
+    )
+
+    result = find_duplicate_clusters(col, threshold=0.15)
+
+    assert_cluster_ids(result, [{"a", "b"}])
+    assert all("c" not in cluster["drawer_ids"] for cluster in result["clusters"])
+
+
+def test_find_duplicate_clusters_applies_wing_and_room_scope_to_get_and_query():
+    from mempalace.dedup import find_duplicate_clusters
+
+    col = FakeDuplicateCollection(
+        [
+            row("a", wing="w", room="r"),
+            row("b", wing="w", room="r"),
+            row("other", wing="w", room="x"),
+        ],
+        {"a": [("a", 0.0), ("b", 0.01), ("other", 0.01)], "b": [("b", 0.0), ("a", 0.01)]},
+    )
+
+    result = find_duplicate_clusters(col, wing="w", room="r", threshold=0.15)
+
+    assert_cluster_ids(result, [{"a", "b"}])
+    assert col.get_calls[0]["where"] == {"wing": "w", "room": "r"}
+    assert all(call["where"] == {"wing": "w", "room": "r"} for call in col.query_calls)
+
+
+def test_find_duplicate_clusters_excludes_self_matches():
+    from mempalace.dedup import find_duplicate_clusters
+
+    col = FakeDuplicateCollection([row("a")], {"a": [("a", 0.0)]})
+
+    result = find_duplicate_clusters(col, threshold=0.15)
+
+    assert result["clusters"] == []
+
+
+def test_find_duplicate_clusters_connects_bridge_components_without_inventing_pairs():
+    from mempalace.dedup import find_duplicate_clusters
+
+    col = FakeDuplicateCollection(
+        [row("a"), row("b"), row("c")],
+        {
+            "a": [("a", 0.0), ("b", 0.01), ("c", 0.4)],
+            "b": [("b", 0.0), ("a", 0.01), ("c", 0.02)],
+            "c": [("c", 0.0), ("b", 0.02), ("a", 0.4)],
+        },
+    )
+
+    result = find_duplicate_clusters(col, threshold=0.15)
+
+    assert_cluster_ids(result, [{"a", "b", "c"}])
+    assert {tuple(pair[key] for key in ("a", "b")) for pair in result["clusters"][0]["pairs"]} == {
+        ("a", "b"),
+        ("b", "c"),
+    }
+
+
+def test_find_duplicate_clusters_does_not_self_cluster_chunks_of_one_logical_drawer():
+    from mempalace.dedup import find_duplicate_clusters
+
+    col = FakeDuplicateCollection(
+        [
+            row("chunk-0", parent="drawer-parent", chunk_index=0),
+            row("chunk-1", parent="drawer-parent", chunk_index=1),
+        ],
+        {
+            "chunk-0": [("chunk-0", 0.0), ("chunk-1", 0.01)],
+            "chunk-1": [("chunk-1", 0.0), ("chunk-0", 0.01)],
+        },
+    )
+
+    result = find_duplicate_clusters(col, threshold=0.15)
+
+    assert result["clusters"] == []
+
+
+def test_find_duplicate_clusters_returns_logical_parent_ids_for_chunked_drawers():
+    from mempalace.dedup import find_duplicate_clusters
+
+    col = FakeDuplicateCollection(
+        [row("a-chunk", parent="drawer-a"), row("b-chunk", parent="drawer-b")],
+        {
+            "a-chunk": [("a-chunk", 0.0), ("b-chunk", 0.01)],
+            "b-chunk": [("b-chunk", 0.0), ("a-chunk", 0.01)],
+        },
+    )
+
+    result = find_duplicate_clusters(col, threshold=0.15)
+
+    assert_cluster_ids(result, [{"drawer-a", "drawer-b"}])
+    assert result["clusters"][0]["pairs"] == [{"a": "drawer-a", "b": "drawer-b", "distance": 0.01}]
+
+
+def test_find_duplicate_clusters_respects_max_clusters():
+    from mempalace.dedup import find_duplicate_clusters
+
+    col = FakeDuplicateCollection(
+        [row("a"), row("b"), row("c"), row("d")],
+        {
+            "a": [("a", 0.0), ("b", 0.01)],
+            "b": [("b", 0.0), ("a", 0.01)],
+            "c": [("c", 0.0), ("d", 0.02)],
+            "d": [("d", 0.0), ("c", 0.02)],
+        },
+    )
+
+    result = find_duplicate_clusters(col, threshold=0.15, max_clusters=1)
+
+    assert len(result["clusters"]) == 1
+    assert result["truncated"] is True
+
+
+def test_find_duplicate_clusters_handles_empty_and_single_drawer():
+    from mempalace.dedup import find_duplicate_clusters
+
+    assert find_duplicate_clusters(FakeDuplicateCollection([]), threshold=0.15)["clusters"] == []
+    assert (
+        find_duplicate_clusters(FakeDuplicateCollection([row("only")]), threshold=0.15)["clusters"]
+        == []
+    )
+
+
+def test_find_duplicate_clusters_adapts_k_while_boundary_neighbor_is_below_threshold():
+    from mempalace.dedup import find_duplicate_clusters
+
+    rows = [row("a"), row("b"), row("c")]
+    col = FakeDuplicateCollection(rows, {"a": [("a", 0.0), ("b", 0.01), ("c", 0.02)]})
+
+    result = find_duplicate_clusters(col, threshold=0.15, initial_k=2, max_neighbors=3)
+
+    assert_cluster_ids(result, [{"a", "b", "c"}])
+    assert [call["n_results"] for call in col.query_calls if call["query_id"] == "a"] == [2, 3]
+    assert result["params"]["neighbor_bound"] == 3
+
+
+def test_tool_find_duplicates_returns_vector_disabled_response(monkeypatch):
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(
+        mcp_server,
+        "hnsw_capacity_status",
+        lambda *_args, **_kwargs: {"diverged": True, "message": "capacity mismatch"},
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "_get_collection",
+        lambda: (_ for _ in ()).throw(AssertionError("collection should not be opened")),
+    )
+
+    result = mcp_server.tool_find_duplicates()
+
+    assert result["clusters"] == []
+    assert result["vector_disabled"] is True
+    assert result["vector_disabled_reason"] == "capacity mismatch"
+
+
+def test_tool_find_duplicates_sanitizes_scope_and_shapes_response(monkeypatch):
+    from mempalace import mcp_server
+
+    col = FakeDuplicateCollection(
+        [row("a", wing="project", room="backend"), row("b", wing="project", room="backend")],
+        {"a": [("a", 0.0), ("b", 0.01)], "b": [("b", 0.0), ("a", 0.01)]},
+    )
+    monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", lambda: None)
+    monkeypatch.setattr(mcp_server, "_vector_disabled", False)
+    monkeypatch.setattr(mcp_server, "_get_collection", lambda: col)
+
+    result = mcp_server.tool_find_duplicates(
+        wing="project", room="backend", threshold=0.15, max_clusters=5
+    )
+
+    assert_cluster_ids(result, [{"a", "b"}])
+    assert result["params"]["wing"] == "project"
+    assert result["params"]["room"] == "backend"
+    assert "documents" not in result
+    assert "embeddings" not in result
+
+
+def test_tool_find_duplicates_rejects_invalid_scope(monkeypatch):
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", lambda: None)
+    result = mcp_server.tool_find_duplicates(wing="../bad")
+
+    assert "error" in result
+
+
+def test_find_duplicates_is_registered_as_read_tool():
+    from mempalace import mcp_server, service
+
+    assert "mempalace_find_duplicates" in mcp_server.TOOLS
+    assert service.classify_tool("mempalace_find_duplicates") == "read"
+    assert "mempalace_find_duplicates" not in mcp_server._MUTATING_TOOLS
+    assert "mempalace_find_duplicates" not in mcp_server._SQLITE_INTEGRITY_ALLOWED_TOOLS

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -76,6 +76,21 @@ Check if content already exists in the palace before filing.
 
 ---
 
+### `mempalace_find_duplicates`
+
+Read-only duplicate audit. Returns connected clusters of near-duplicate logical drawers with pairwise cosine distances — never raw vectors or content. Clusters are the connected components of the "distance < threshold" graph (similarity is symmetric but not transitive). Chunked drawers are deduped by `parent_drawer_id`, and each drawer's own chunks are never reported as duplicates of one another.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `wing` | string | No | Filter by wing |
+| `room` | string | No | Filter by room |
+| `threshold` | number | No | Cosine distance threshold (default 0.15). Lower is stricter. |
+| `max_clusters` | integer | No | Maximum number of clusters to return |
+
+**Returns:** `{ clusters: [{ drawer_ids, pairs: [{ a, b, distance }], size }], params }`
+
+---
+
 ### `mempalace_get_aaak_spec`
 
 Returns the AAAK dialect specification.


### PR DESCRIPTION
## What does this PR do?
- Adds a non-destructive, read-only MCP tool, `mempalace_find_duplicates(wing, room, threshold=0.15, max_clusters)`, for auditing near-duplicate logical drawers. Closes #1919.
- Adds `find_duplicate_clusters` in `mempalace/dedup.py`, using union-find to return connected-component clusters over pairwise cosine-distance edges below the threshold because similarity is symmetric but not transitive.
- Collapses chunked drawers by `parent_drawer_id`, excludes self/same-logical-parent matches, and adaptively grows neighbor search from K=32 while the boundary neighbor remains under threshold, with a cap for predictable read-only behavior.
- Returns only drawer IDs and pairwise distances through the existing backend `get`/`query` interface; it never returns raw vectors or drawer content.
- Wires the MCP schema/handler and `service.READ_TOOLS` as read-only, deliberately leaving `_MUTATING_TOOLS` and the destructive `dedup` flow unchanged. CLI `dedup --list --json` is deferred as a follow-up/non-goal.

## How to test
- `uv run pytest tests/test_find_duplicates.py -v` → 15 passed
- `uv run pytest tests/test_dedup.py -v` → 15 passed (no regression)
- `uv run pytest tests/ --ignore=tests/benchmarks` → 3268 passed; 3 unrelated pre-existing develop failures (2 tracked in #1925, 1 antigravity install). This branch does not touch those areas.
- `uv run ruff check .` → clean
- `uv run ruff format --check .` → clean

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
