### PR TITLE
feat: make readable_extensions configurable via config.json (rebase of #1420)

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -320,6 +320,77 @@ DEFAULT_HALL_KEYWORDS = {
 }
 
 
+# Kept in sync by hand with miner.READABLE_EXTENSIONS | miner.PHP_EXTENSIONS --
+# config.py can't import miner.py (miner.py imports config.py at module level,
+# so the reverse would be circular), so this is a duplicated literal, not a
+# derived one. Update both when either changes.
+DEFAULT_READABLE_EXTENSIONS = {
+    ".txt",
+    ".md",
+    ".py",
+    ".js",
+    ".ts",
+    ".jsx",
+    ".tsx",
+    ".json",
+    ".jsonl",
+    ".yaml",
+    ".yml",
+    ".html",
+    ".css",
+    ".java",
+    ".go",
+    ".rs",
+    ".swift",
+    ".kt",
+    ".kts",
+    ".rb",
+    ".sh",
+    ".csv",
+    ".sql",
+    ".toml",
+    ".tex",
+    ".bib",
+    # C# / .NET
+    ".cs",
+    ".csproj",
+    ".sln",
+    ".razor",
+    ".cshtml",
+    # C / C++
+    ".hpp",
+    ".cpp",
+    ".c",
+    ".h",
+} | {
+    # PHP_EXTENSIONS (miner.py) -- compound Blade templates such as
+    # ``view.blade.php`` are covered by the final ``.php`` suffix.
+    ".php",
+    ".php3",
+    ".php4",
+    ".php5",
+    ".php7",
+    ".php8",
+    ".phtml",
+    ".phps",
+    ".phpt",
+    ".inc",
+    ".aw",
+    ".fcgi",
+    ".ctp",
+    ".module",
+    ".install",
+    ".profile",
+    ".theme",
+    ".engine",
+    ".twig",
+    ".blade",
+    ".tpl",
+    ".latte",
+    ".volt",
+}
+
+
 class MempalaceConfig:
     """Configuration manager for MemPalace.
 
@@ -603,6 +674,11 @@ class MempalaceConfig:
         return coerced
 
     @property
+    def readable_extensions(self):
+        """Set of file extensions that are considered readable for mining."""
+        return set(self._file_config.get("readable_extensions", DEFAULT_READABLE_EXTENSIONS))
+
+    @property
     def entity_languages(self):
         """Languages whose entity-detection patterns should be applied.
 
@@ -857,6 +933,7 @@ class MempalaceConfig:
                 "collection_name": DEFAULT_COLLECTION_NAME,
                 "topic_wings": DEFAULT_TOPIC_WINGS,
                 "hall_keywords": DEFAULT_HALL_KEYWORDS,
+                "readable_extensions": list(DEFAULT_READABLE_EXTENSIONS),
             }
             with open(self._config_file, "w") as f:
                 json.dump(default_config, f, indent=2)

--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -844,9 +844,12 @@ def scan_for_detection(project_dir: str, max_files: int = 10) -> list:
     Prose only (.txt, .md, .rst, .csv) — code files produce too many false positives.
     Falls back to all readable files if no prose found.
     """
+    from .config import MempalaceConfig
+
     project_path = Path(project_dir).expanduser().resolve()
     prose_files = []
     all_files = []
+    readable_extensions = MempalaceConfig().readable_extensions
 
     for root, dirs, filenames in os.walk(project_path):
         dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
@@ -857,7 +860,7 @@ def scan_for_detection(project_dir: str, max_files: int = 10) -> list:
             ext = filepath.suffix.lower()
             if ext in PROSE_EXTENSIONS:
                 prose_files.append(filepath)
-            elif ext in READABLE_EXTENSIONS:
+            elif ext in readable_extensions:
                 all_files.append(filepath)
 
     # Prefer prose files — fall back to all readable if too few prose files

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -149,6 +149,9 @@ READABLE_EXTENSIONS = {
 } | PHP_EXTENSIONS
 
 
+_READABLE_EXTS_CACHE = None
+
+
 def get_readable_extensions() -> set:
     """Get the set of readable file extensions, including any project override.
 
@@ -156,10 +159,21 @@ def get_readable_extensions() -> set:
     with config.DEFAULT_READABLE_EXTENSIONS); config.json's own
     ``readable_extensions`` key can replace it entirely for callers who want
     a narrower or wider allow-list.
-    """
-    from .config import MempalaceConfig
 
-    return MempalaceConfig().readable_extensions
+    Cached for the life of the process after the first call, to avoid a
+    MempalaceConfig() construction (a config.json read + JSON parse) per file
+    in a large scan. Trade-off: a config.json edit to readable_extensions
+    made while a long-running process (e.g. the MCP server) is up won't take
+    effect until restart -- inherent to caching a config value past the
+    point it was read, not something specific to this cache.
+    """
+    global _READABLE_EXTS_CACHE
+    if _READABLE_EXTS_CACHE is None:
+        from .config import MempalaceConfig
+
+        _READABLE_EXTS_CACHE = MempalaceConfig().readable_extensions
+    return _READABLE_EXTS_CACHE
+
 
 SKIP_FILENAMES = {
     "entities.json",

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -148,6 +148,19 @@ READABLE_EXTENSIONS = {
     ".h",
 } | PHP_EXTENSIONS
 
+
+def get_readable_extensions() -> set:
+    """Get the set of readable file extensions, including any project override.
+
+    Defaults to READABLE_EXTENSIONS (this module's built-in set, kept in sync
+    with config.DEFAULT_READABLE_EXTENSIONS); config.json's own
+    ``readable_extensions`` key can replace it entirely for callers who want
+    a narrower or wider allow-list.
+    """
+    from .config import MempalaceConfig
+
+    return MempalaceConfig().readable_extensions
+
 SKIP_FILENAMES = {
     "entities.json",
     "mempalace.yaml",
@@ -1583,7 +1596,7 @@ def scan_project(
 
             if not force_include and filename in SKIP_FILENAMES:
                 continue
-            if filepath.suffix.lower() not in READABLE_EXTENSIONS and not exact_force_include:
+            if filepath.suffix.lower() not in get_readable_extensions() and not exact_force_include:
                 continue
             if respect_gitignore and active_matchers and not force_include:
                 if is_gitignored(filepath, active_matchers, is_dir=False):

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -141,6 +141,11 @@ READABLE_EXTENSIONS = {
     ".sln",
     ".razor",
     ".cshtml",
+    # C / C++
+    ".hpp",
+    ".cpp",
+    ".c",
+    ".h",
 } | PHP_EXTENSIONS
 
 SKIP_FILENAMES = {

--- a/tests/test_miner_jsonl_visibility.py
+++ b/tests/test_miner_jsonl_visibility.py
@@ -25,7 +25,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-from mempalace.miner import MAX_FILE_SIZE, READABLE_EXTENSIONS, scan_project
+from mempalace.miner import MAX_FILE_SIZE, get_readable_extensions, scan_project
 
 
 class TestJsonlNotSilentlySkipped:
@@ -37,7 +37,7 @@ class TestJsonlNotSilentlySkipped:
         of Claude Code's transcripts, ChatGPT exports, and similar
         tooling writes `.jsonl`. Excluding it silently drops user data.
         """
-        assert ".jsonl" in READABLE_EXTENSIONS, (
+        assert ".jsonl" in get_readable_extensions(), (
             "mempalace/miner.py:READABLE_EXTENSIONS contains `.json` "
             "but NOT `.jsonl`. Every jsonl file in a mined project is "
             "silently skipped at miner.py:722 "


### PR DESCRIPTION
Rebase of #1420 onto current `develop` — that PR is showing as conflicting against the base branch as of this writing.

## What changed vs. the original PR
All three of PokeParadox's original commits are preserved with authorship intact (see the commits themselves). On top of a straight rebase:

- `config.py`'s `DEFAULT_READABLE_EXTENSIONS` had gone stale relative to `miner.py`'s actual `READABLE_EXTENSIONS` (missing `.swift`/`.kt`/`.kts`/`.tex`/`.bib`/the C#/.NET group/all of `PHP_EXTENSIONS` — extensions added by other commits merged after this PR's original base). Brought the two back into sync so `get_readable_extensions()`'s default doesn't silently narrow what gets mined for anyone not overriding `readable_extensions` in config.json. Left a comment noting they're a duplicated literal (not derived — `config.py` can't import `miner.py`, the reverse import already exists) so this doesn't quietly drift again.
- One trailing-whitespace / formatting fix to keep `ruff format --check` clean after the rebase.

Full suite passes (same 2 pre-existing, unrelated `test_repair.py` FTS5 failures present on plain `develop` today — see #1928). `ruff check` / `ruff format --check` clean.

Happy to close this in favor of #1420 being merged directly if a maintainer prefers to resolve the conflict there instead.
