### PR TITLE
feat: add Apple Silicon MPS acceleration for embedding (rebase of #1133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,37 @@ For per-message recall on top of the file-level chunks the hooks produce,
 run `mempalace sweep <transcript-dir>` periodically — it stores one
 verbatim drawer per user/assistant message, idempotent and resume-safe.
 
+## Embedding device
+
+The embedding model is `all-MiniLM-L6-v2` regardless of device — switching
+device does not invalidate an existing palace. Set with `config.json` or
+the `MEMPALACE_EMBEDDING_DEVICE` env var:
+
+| Device | Extra to install | Notes |
+|---|---|---|
+| `auto` (default) | — | resolve at runtime: mps ▸ cuda ▸ coreml ▸ dml ▸ cpu |
+| `cpu` | — | bundled ONNX Runtime, works everywhere |
+| `cuda` | `mempalace[gpu]` | NVIDIA via ONNX Runtime CUDAExecutionProvider |
+| `coreml` | `mempalace[coreml]` | Apple ANE via ONNX Runtime CoreML provider |
+| `dml` | `mempalace[dml]` | Windows AMD/Intel/NVIDIA via DirectML |
+| `mps` | `mempalace[mps]` | Apple Metal GPU via PyTorch + sentence-transformers |
+
+On Apple Silicon, the `mps` device is materially faster than `coreml`
+because ChromaDB's bundled ONNX path enables `CoreMLExecutionProvider`,
+which silently falls back op-by-op to CPU for `all-MiniLM-L6-v2` — the
+ANE↔CPU copies cost more than they save. Measured on M5, 200 real
+chunks: `coreml` ≈ 2 chunks/s, `cpu` ≈ 45, `mps` ≈ 523. See
+[`benchmarks/apple_silicon_bench.py`](benchmarks/apple_silicon_bench.py)
+to reproduce.
+
+A note on reproducibility: same-model embeddings agree to ~1e-6 across
+runtimes (ONNX vs PyTorch FP arithmetic ordering), well below cosine
+retrieval's noise floor. HNSW *index construction* however is order- and
+value-sensitive, so an index built end-to-end on one device is not
+bit-identical to one built on another — query results stay correct, but
+exact `recall@k` can shift by a hit or two between devices. Pin
+`MEMPALACE_EMBEDDING_DEVICE` if you need strict reproducibility.
+
 ---
 
 ## Requirements

--- a/benchmarks/apple_silicon_bench.py
+++ b/benchmarks/apple_silicon_bench.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Apple Silicon embedding backend benchmark.
+
+Compares embedding throughput across:
+  - onnxruntime with default providers (current mempalace behavior)
+  - onnxruntime CPU-only
+  - onnxruntime CoreML-only (if available)
+  - sentence-transformers CPU
+  - sentence-transformers MPS (Metal Performance Shaders, Apple GPU)
+
+Usage:
+    python apple_silicon_bench.py                       # default 500 chunks
+    python apple_silicon_bench.py --n-chunks 2000       # more samples
+    python apple_silicon_bench.py --batch-size 64       # try batch sizes
+    python apple_silicon_bench.py --source ~/.claude/projects  # use real data
+
+Output: markdown table ready to paste into PR description.
+"""
+
+import argparse
+import json
+import platform
+import random
+import statistics
+import time
+from pathlib import Path
+from typing import Callable, List
+
+# ---- sample data --------------------------------------------------------
+# Default: generate synthetic text chunks that look like conversation exchanges.
+# With --source: sample real JSONL chunks from a user's ~/.claude/projects.
+
+
+def synthetic_chunks(n: int, seed: int = 42) -> List[str]:
+    """Generate realistic-length text chunks (100-400 chars, like real convo pairs)."""
+    random.seed(seed)
+    pool = [
+        "The quick brown fox jumps over the lazy dog near the riverbank at sunset.",
+        "When we debugged the auth token refresh flow last sprint, the race condition turned out to be in the middleware chain.",
+        "Postgres versus SQLite for this workload — concurrent writes, dataset growing past 10GB, want to avoid Mongo.",
+        "Here's the patch I applied to fix the memory leak: the reference cycle was between the event emitter and the state manager.",
+        "Let's switch the embedding backend from default ONNX to sentence-transformers with MPS device for Apple Silicon machines.",
+    ]
+    out = []
+    for i in range(n):
+        # Simulate 2-5 sentences per chunk
+        k = random.randint(2, 5)
+        out.append(" ".join(random.choices(pool, k=k)) + f" [chunk_{i}]")
+    return out
+
+
+def real_chunks(source_dir: Path, n: int, seed: int = 42) -> List[str]:
+    """Sample n chunks of conversation text from JSONL files."""
+    random.seed(seed)
+    jsonls = list(source_dir.rglob("*.jsonl"))
+    random.shuffle(jsonls)
+    chunks = []
+    for path in jsonls:
+        if len(chunks) >= n:
+            break
+        try:
+            with path.open() as f:
+                for line in f:
+                    try:
+                        entry = json.loads(line)
+                        msg = entry.get("message", {})
+                        if not isinstance(msg, dict):
+                            continue
+                        content = msg.get("content", "")
+                        if isinstance(content, list):
+                            text = " ".join(
+                                c.get("text", "") for c in content if isinstance(c, dict)
+                            )
+                        else:
+                            text = str(content)
+                        text = text.strip()
+                        if 50 < len(text) < 2000:
+                            chunks.append(text[:1500])
+                            if len(chunks) >= n:
+                                break
+                    except Exception:
+                        continue
+        except Exception:
+            continue
+    return chunks[:n]
+
+
+# ---- benchmark runners --------------------------------------------------
+
+
+def time_it(fn: Callable[[], None], warmup: int = 1, runs: int = 3) -> dict:
+    """Run fn() `runs` times after `warmup` warmups. Return timing stats."""
+    for _ in range(warmup):
+        fn()
+    samples = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        fn()
+        samples.append(time.perf_counter() - t0)
+    return {
+        "mean": statistics.mean(samples),
+        "min": min(samples),
+        "max": max(samples),
+        "std": statistics.stdev(samples) if len(samples) > 1 else 0,
+    }
+
+
+def bench_onnx_default(chunks: List[str], batch_size: int) -> dict:
+    """ChromaDB's ONNXMiniLM_L6_V2 with default providers (current mempalace)."""
+    from chromadb.utils.embedding_functions.onnx_mini_lm_l6_v2 import ONNXMiniLM_L6_V2
+
+    ef = ONNXMiniLM_L6_V2()
+    # warmup downloads model + loads session
+    _ = ef(chunks[:2])
+
+    def fn():
+        for i in range(0, len(chunks), batch_size):
+            _ = ef(chunks[i : i + batch_size])
+
+    return time_it(fn)
+
+
+def bench_onnx_cpu_only(chunks: List[str], batch_size: int) -> dict:
+    from chromadb.utils.embedding_functions.onnx_mini_lm_l6_v2 import ONNXMiniLM_L6_V2
+
+    ef = ONNXMiniLM_L6_V2(preferred_providers=["CPUExecutionProvider"])
+    _ = ef(chunks[:2])
+
+    def fn():
+        for i in range(0, len(chunks), batch_size):
+            _ = ef(chunks[i : i + batch_size])
+
+    return time_it(fn)
+
+
+def bench_onnx_coreml(chunks: List[str], batch_size: int) -> dict:
+    """Explicitly force CoreML — expected to raise or silently fall back."""
+    try:
+        import onnxruntime
+
+        if "CoreMLExecutionProvider" not in onnxruntime.get_available_providers():
+            return {"skipped": "CoreML provider not available"}
+        from chromadb.utils.embedding_functions.onnx_mini_lm_l6_v2 import (
+            ONNXMiniLM_L6_V2,
+        )
+
+        ef = ONNXMiniLM_L6_V2(
+            preferred_providers=["CoreMLExecutionProvider", "CPUExecutionProvider"]
+        )
+        _ = ef(chunks[:2])
+
+        def fn():
+            for i in range(0, len(chunks), batch_size):
+                _ = ef(chunks[i : i + batch_size])
+
+        return time_it(fn)
+    except Exception as e:
+        return {"error": str(e)[:120]}
+
+
+def bench_sentence_transformers(
+    chunks: List[str], batch_size: int, device: str
+) -> dict:
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError:
+        return {"skipped": "sentence-transformers not installed"}
+
+    try:
+        model = SentenceTransformer("all-MiniLM-L6-v2", device=device)
+    except Exception as e:
+        return {"error": f"load failed on {device}: {str(e)[:100]}"}
+
+    # warmup
+    _ = model.encode(chunks[:2], batch_size=batch_size, show_progress_bar=False)
+
+    def fn():
+        _ = model.encode(chunks, batch_size=batch_size, show_progress_bar=False)
+
+    return time_it(fn)
+
+
+# ---- main ---------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n-chunks", type=int, default=500)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--source", type=str, default=None)
+    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument(
+        "--skip",
+        type=str,
+        default="",
+        help="Comma-separated backend names to skip (e.g. 'onnx_coreml,st_cuda')",
+    )
+    args = parser.parse_args()
+    skip_set = {s.strip() for s in args.skip.split(",") if s.strip()}
+
+    print(f"\n{'='*70}")
+    print(f"  Apple Silicon Embedding Benchmark")
+    print(f"{'='*70}")
+    print(f"  Machine:    {platform.machine()} / {platform.processor()}")
+    print(f"  System:     {platform.system()} {platform.release()}")
+    print(f"  N chunks:   {args.n_chunks}")
+    print(f"  Batch size: {args.batch_size}")
+    print(f"  Runs/warm:  {args.runs}/1")
+    print(f"{'-'*70}\n")
+
+    if args.source:
+        print(f"Loading real chunks from {args.source}...")
+        chunks = real_chunks(Path(args.source).expanduser(), args.n_chunks)
+        print(f"  loaded {len(chunks)} chunks")
+    else:
+        print("Generating synthetic chunks...")
+        chunks = synthetic_chunks(args.n_chunks)
+    if not chunks:
+        print("ERROR: no chunks to benchmark")
+        return
+
+    backends = [
+        ("onnx_default",       lambda: bench_onnx_default(chunks, args.batch_size)),
+        ("onnx_cpu_only",      lambda: bench_onnx_cpu_only(chunks, args.batch_size)),
+        ("onnx_coreml",        lambda: bench_onnx_coreml(chunks, args.batch_size)),
+        ("st_cpu",             lambda: bench_sentence_transformers(chunks, args.batch_size, "cpu")),
+        ("st_mps",             lambda: bench_sentence_transformers(chunks, args.batch_size, "mps")),
+    ]
+
+    results = {}
+    for name, runner in backends:
+        if name in skip_set:
+            print(f"Running: {name:20}... SKIP (--skip)")
+            results[name] = {"skipped": "user --skip"}
+            continue
+        print(f"Running: {name:20}...", end=" ", flush=True)
+        try:
+            results[name] = runner()
+            r = results[name]
+            if "skipped" in r:
+                print(f"SKIP ({r['skipped']})")
+            elif "error" in r:
+                print(f"ERROR ({r['error']})")
+            else:
+                rate = len(chunks) / r["mean"]
+                print(
+                    f"mean {r['mean']:.2f}s  ({rate:.0f} chunks/s)  std {r['std']:.2f}"
+                )
+        except Exception as e:
+            results[name] = {"error": str(e)[:120]}
+            print(f"CRASH ({str(e)[:80]})")
+
+    # --- markdown table ---
+    print(f"\n{'='*70}")
+    print("  Results (markdown, ready for PR)")
+    print(f"{'='*70}\n")
+    print(f"| Backend | Mean (s) | Rate (chunks/s) | vs baseline |")
+    print(f"|---|---|---|---|")
+    baseline = results.get("onnx_default", {}).get("mean")
+    for name, r in results.items():
+        if "skipped" in r or "error" in r:
+            print(f"| {name} | — | — | {r.get('skipped') or r.get('error')} |")
+            continue
+        rate = len(chunks) / r["mean"]
+        if baseline:
+            speedup = baseline / r["mean"]
+            print(
+                f"| {name} | {r['mean']:.2f} | {rate:.0f} | {speedup:.2f}x |"
+            )
+        else:
+            print(f"| {name} | {r['mean']:.2f} | {rate:.0f} | — |")
+
+
+if __name__ == "__main__":
+    main()

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -640,11 +640,16 @@ class MempalaceConfig:
 
     @property
     def embedding_device(self):
-        """Hardware device for the ONNX embedding model.
+        """Hardware device for the embedding model.
 
         Values: ``"auto"`` (default), ``"cpu"``, ``"cuda"``, ``"coreml"``,
-        ``"dml"``. Read from env ``MEMPALACE_EMBEDDING_DEVICE`` first, then
-        ``embedding_device`` in ``config.json``, then ``"auto"``.
+        ``"dml"``, ``"mps"``. Read from env ``MEMPALACE_EMBEDDING_DEVICE``
+        first, then ``embedding_device`` in ``config.json``, then ``"auto"``.
+
+        ``cpu`` / ``cuda`` / ``coreml`` / ``dml`` are ONNX Runtime execution
+        providers; ``mps`` routes through PyTorch + sentence-transformers
+        instead, bypassing CoreML's op-fallback thrash on Apple Silicon
+        (see :mod:`mempalace.embedding` docstring for the full diagnosis).
 
         ``auto`` resolves to the first available accelerator at runtime via
         :mod:`mempalace.embedding`; requesting an unavailable accelerator

--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -1,7 +1,7 @@
 """Embedding function factory with hardware acceleration.
 
 Returns a ChromaDB-compatible embedding function bound to a user-selected
-ONNX Runtime execution provider.
+backend and device.
 
 Two embedding models are available, selected via ``MEMPALACE_EMBEDDING_MODEL``
 or ``embedding_model`` in ``~/.mempalace/config.json``:
@@ -16,17 +16,48 @@ or ``embedding_model`` in ``~/.mempalace/config.json``:
   on an existing palace requires ``mempalace repair rebuild-index``
   (different vector space).
 
+Independently of model choice, the *backend* that runs the model can be
+either ONNX Runtime (default) or, for the ``mps`` device specifically,
+PyTorch + sentence-transformers. Switching backend/device does not
+invalidate an existing palace — the same model weights and vector space
+are used either way.
+
 Supported devices (env ``MEMPALACE_EMBEDDING_DEVICE`` or ``embedding_device``
 in ``~/.mempalace/config.json``):
 
-* ``auto`` — prefer CUDA ▸ CoreML ▸ DirectML, fall back to CPU
-* ``cpu`` — force CPU (the historical default)
+* ``auto`` — prefer ``mps`` ▸ ``cuda`` ▸ ``coreml`` ▸ ``dml``, fall back to CPU
+* ``cpu`` — force ONNX Runtime on CPU (the historical default)
 * ``cuda`` — NVIDIA GPU via ``onnxruntime-gpu`` (``pip install mempalace[gpu]``)
-* ``coreml`` — Apple Neural Engine (macOS)
+* ``coreml`` — Apple Neural Engine via ONNX Runtime CoreML provider (macOS)
 * ``dml`` — DirectML (Windows / AMD / Intel GPUs)
+* ``mps`` — Apple Metal GPU via PyTorch + sentence-transformers
+  (``pip install mempalace[mps]``)
 
-Requesting an unavailable accelerator emits a warning and falls back to CPU
-rather than hard-failing — mining must still work on a laptop without CUDA.
+Why ``mps`` is its own path: on Apple Silicon, ChromaDB's bundled ONNX
+embedding function enables ``CoreMLExecutionProvider`` by default, which
+silently falls back op-by-op to CPU for ``all-MiniLM-L6-v2`` because some
+ops are not yet implemented in CoreML's MLProgram lowering. The resulting
+ANE↔CPU copies cost more than they save (measured 60–256× slowdown vs.
+PyTorch MPS on the same hardware, M5, 200 real chunks). Routing
+``mps`` through sentence-transformers + PyTorch bypasses CoreML
+entirely. The ``coreml`` device is retained for users who want ONNX
+Runtime's CoreML provider explicitly (e.g. on an M1 base where the
+ANE↔CPU thrash is less pronounced).
+
+The ``mps`` and ``cuda``/``coreml``/``dml`` paths produce embeddings that
+differ by ~1e-6 (numerical FP drift between ONNX Runtime and PyTorch
+implementations of the same MiniLM weights). This drift is well below the
+noise floor of cosine retrieval, so backends can be switched on an
+existing palace without re-mining. The HNSW *index* itself is
+order- and value-sensitive, so an index built end-to-end on one backend
+will not be bit-identical to one built on another (graph neighbor lists
+differ); query results stay correct, but exact ``recall@k`` can shift by
+a hit or two between runtimes. Pin ``MEMPALACE_EMBEDDING_DEVICE`` if you
+need strict reproducibility.
+
+Requesting an unavailable accelerator emits a warning and falls back to
+CPU rather than hard-failing — mining must still work on a laptop without
+CUDA, MPS, or CoreML.
 """
 
 from __future__ import annotations
@@ -38,20 +69,33 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Sentinel returned in the provider list to mark the PyTorch-MPS path.
+# Anything that consumes a (providers, device) pair must treat this as a
+# signal to take the sentence-transformers branch rather than passing the
+# providers through to ONNX Runtime.
+_MPS_SENTINEL = "__mempalace_torch_mps__"
+
 _PROVIDER_MAP = {
     "cpu": ["CPUExecutionProvider"],
     "cuda": ["CUDAExecutionProvider", "CPUExecutionProvider"],
     "coreml": ["CoreMLExecutionProvider", "CPUExecutionProvider"],
     "dml": ["DmlExecutionProvider", "CPUExecutionProvider"],
+    # "mps" is resolved without consulting onnxruntime — the sentinel exists so
+    # cache_key / EF-construction code can stay uniform across backends.
+    "mps": [_MPS_SENTINEL, "CPUExecutionProvider"],
 }
 
 _DEVICE_EXTRA = {
     "cuda": "mempalace[gpu]",
     "coreml": "mempalace[coreml]",
     "dml": "mempalace[dml]",
+    "mps": "mempalace[mps]",
 }
 
-_AUTO_ORDER = [
+# auto-resolution order. MPS is preferred over CoreML on Apple Silicon
+# because sentence-transformers + torch.mps avoids the CoreML op-fallback
+# thrash that pins ``onnx_default`` to ~2 chunks/s on this model.
+_AUTO_ORDER_ONNX = [
     ("CUDAExecutionProvider", "cuda"),
     ("CoreMLExecutionProvider", "coreml"),
     ("DmlExecutionProvider", "dml"),
@@ -65,13 +109,53 @@ _EF_CACHE_LOCK = threading.Lock()
 _WARNED: set = set()
 
 
+def _torch_mps_available() -> bool:
+    """Return True iff PyTorch is installed AND its MPS backend is usable.
+
+    Wrapped in a broad ``except`` because torch can raise platform-specific
+    errors on non-Apple Silicon hosts (NotImplementedError, RuntimeError),
+    and we want a clean False fallback rather than a stack trace.
+    """
+    try:
+        import torch
+
+        return (
+            hasattr(torch.backends, "mps")
+            and torch.backends.mps.is_available()
+            and torch.backends.mps.is_built()
+        )
+    except Exception:
+        return False
+
+
+def _sentence_transformers_available() -> bool:
+    """True iff both ``torch`` and ``sentence_transformers`` import cleanly."""
+    try:
+        import sentence_transformers  # noqa: F401
+        import torch  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def _resolve_providers(device: str) -> tuple[list, str]:
     """Return ``(provider_list, effective_device)`` for ``device``.
 
+    For ONNX devices the first element of ``provider_list`` is the
+    onnxruntime provider name. For the ``mps`` device the first element is
+    :data:`_MPS_SENTINEL` and the rest of the system reads ``effective``
+    to take the sentence-transformers branch.
+
     Falls back to CPU (with a one-shot warning) when the requested
-    accelerator is not compiled into the installed ``onnxruntime``.
+    accelerator is not compiled into the installed ``onnxruntime`` or when
+    the optional ``mempalace[mps]`` extra is missing.
     """
     device = (device or "auto").strip().lower()
+
+    # MPS is special: it does not consult onnxruntime providers at all.
+    if device == "mps":
+        return _resolve_mps_or_cpu()
 
     try:
         import onnxruntime as ort
@@ -81,7 +165,12 @@ def _resolve_providers(device: str) -> tuple[list, str]:
         return (["CPUExecutionProvider"], "cpu")
 
     if device == "auto":
-        for provider, name in _AUTO_ORDER:
+        # Prefer MPS on Apple Silicon when the optional extra is installed —
+        # CoreML thrashes on this model, so MPS is materially faster even
+        # though both target the same physical GPU.
+        if _torch_mps_available() and _sentence_transformers_available():
+            return ([_MPS_SENTINEL, "CPUExecutionProvider"], "mps")
+        for provider, name in _AUTO_ORDER_ONNX:
             if provider in available:
                 return ([provider, "CPUExecutionProvider"], name)
         return (["CPUExecutionProvider"], "cpu")
@@ -140,6 +229,28 @@ def _resolve_intra_op_threads() -> int:
     except Exception:
         logger.debug("embedding_threads resolution failed; leaving ORT default", exc_info=True)
         return 0
+
+
+def _resolve_mps_or_cpu() -> tuple[list, str]:
+    """Return MPS providers if torch+MPS+ST available, else warn and fall to CPU."""
+    if not _sentence_transformers_available():
+        if "mps" not in _WARNED:
+            logger.warning(
+                "embedding_device='mps' requested but the optional 'mps' extra "
+                "is not installed — falling back to CPU. Install %s.",
+                _DEVICE_EXTRA["mps"],
+            )
+            _WARNED.add("mps")
+        return (["CPUExecutionProvider"], "cpu")
+    if not _torch_mps_available():
+        if "mps" not in _WARNED:
+            logger.warning(
+                "embedding_device='mps' requested but torch.backends.mps is "
+                "not available on this host — falling back to CPU."
+            )
+            _WARNED.add("mps")
+        return (["CPUExecutionProvider"], "cpu")
+    return ([_MPS_SENTINEL, "CPUExecutionProvider"], "mps")
 
 
 def _build_ef_class():
@@ -360,6 +471,33 @@ class EmbeddinggemmaONNX:
         return self(input)
 
 
+def _build_mps_ef(model_name: str = "all-MiniLM-L6-v2"):
+    """Build a sentence-transformers EF on torch MPS, named ``"default"``.
+
+    The ``name()`` override mirrors :func:`_build_ef_class` — it lets a
+    palace persisted by ChromaDB's bundled default EF reopen with this EF
+    without tripping the 1.x ``Embedding function conflict`` guard. The
+    embeddings produced agree with ONNX Runtime's to ~1e-6 (same MiniLM
+    weights, FP32 vs ANE/MPS arithmetic ordering), well below cosine
+    retrieval's noise floor.
+
+    Only builds ``all-MiniLM-L6-v2`` — there is no sentence-transformers
+    equivalent wired up for ``embeddinggemma`` here (only its ONNX artifact
+    via :class:`EmbeddinggemmaONNX`). Callers must not route
+    ``model="embeddinggemma"`` through this function.
+    """
+    from chromadb.utils.embedding_functions.sentence_transformer_embedding_function import (
+        SentenceTransformerEmbeddingFunction,
+    )
+
+    class _MempalaceMPS(SentenceTransformerEmbeddingFunction):
+        @staticmethod
+        def name() -> str:
+            return "default"
+
+    return _MempalaceMPS(model_name=model_name, device="mps")
+
+
 def get_embedding_function(device: Optional[str] = None, model: Optional[str] = None):
     """Return a cached embedding function for the requested device + model.
 
@@ -378,6 +516,21 @@ def get_embedding_function(device: Optional[str] = None, model: Optional[str] = 
             model = cfg.embedding_model
 
     providers, effective = _resolve_providers(device)
+
+    if effective == "mps" and model == "embeddinggemma":
+        # _build_mps_ef only has a verified build for all-MiniLM-L6-v2.
+        # Silently taking the mps path here would build MiniLM vectors
+        # under an EF the palace still expects to be embeddinggemma-shaped
+        # — a vector-space correctness bug, not just a missed speedup.
+        # Fall back to embeddinggemma's own (CPU) ONNX path instead.
+        if "mps-embeddinggemma" not in _WARNED:
+            logger.warning(
+                "embedding_device='mps' has no embeddinggemma implementation; "
+                "using CPU for model='embeddinggemma' instead."
+            )
+            _WARNED.add("mps-embeddinggemma")
+        providers, effective = ["CPUExecutionProvider"], "cpu"
+
     cache_key = (model, tuple(providers))
     cached = _EF_CACHE.get(cache_key)  # lock-free fast path; dict.get is GIL-atomic
     if cached is not None:
@@ -390,6 +543,8 @@ def get_embedding_function(device: Optional[str] = None, model: Optional[str] = 
         threads = _resolve_intra_op_threads()
         if model == "embeddinggemma":
             ef = EmbeddinggemmaONNX(preferred_providers=providers, intra_op_num_threads=threads)
+        elif providers and providers[0] == _MPS_SENTINEL:
+            ef = _build_mps_ef()
         else:
             # Default: minilm (or anything we don't recognize — back-compat win).
             ef_cls = _build_ef_class()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,12 @@ dev = [
     # Run ad-hoc with ``mypy mempalace/``; CI doesn't gate on it yet but
     # contributors should fix mypy errors they see before pushing.
     "mypy>=1.0",
+    # dev installs include the [mps] extra so the embedding test suite can
+    # exercise the sentence-transformers branch without a separate install
+    # step. CI runners on Linux pull torch CPU wheels (no ROCm / CUDA
+    # needed for tests).
+    "sentence-transformers>=2.2.0",
+    "torch>=2.0.0",
 ]
 spellcheck = ["autocorrect>=2.0"]
 # Opt-in Postgres + pgvector backend. Only the psycopg driver is needed on the
@@ -104,14 +110,24 @@ spellcheck = ["autocorrect>=2.0"]
 # MEMPALACE_BACKEND=pgvector / --backend pgvector; never required for the
 # default (Chroma) install.
 pgvector = ["psycopg[binary]>=3.1"]
-# Hardware acceleration for the ONNX embedding model. Install exactly one:
-#   pip install mempalace[gpu]       — NVIDIA CUDA
-#   pip install mempalace[dml]       — DirectML (Windows AMD/Intel/NVIDIA)
-#   pip install mempalace[coreml]    — macOS Neural Engine
-# After install, set MEMPALACE_EMBEDDING_DEVICE=cuda|dml|coreml (or "auto").
+# Hardware acceleration for the embedding model. Install exactly one:
+#   pip install mempalace[gpu]       — NVIDIA CUDA   (ONNX Runtime CUDAExecutionProvider)
+#   pip install mempalace[dml]       — DirectML      (Windows AMD/Intel/NVIDIA via ONNX Runtime)
+#   pip install mempalace[coreml]    — Apple ANE     (ONNX Runtime CoreMLExecutionProvider)
+#   pip install mempalace[mps]       — Apple Metal   (PyTorch + sentence-transformers, bypasses ONNX)
+# After install, set MEMPALACE_EMBEDDING_DEVICE=cuda|dml|coreml|mps (or "auto").
+#
+# Why both [coreml] and [mps] for macOS: the CoreML execution provider falls
+# back op-by-op to CPU for all-MiniLM-L6-v2 because some MLProgram lowerings
+# are unimplemented; the resulting ANE↔CPU copies thrash the bus and pin
+# throughput at ~2 chunks/s on M5. Routing through PyTorch MPS instead
+# (sentence-transformers, same weights) measures ~523 chunks/s on the same
+# hardware. Users on M1 base may prefer [coreml] (less ANE pressure on smaller
+# chips); users on M2/M3/M4/M5 should prefer [mps].
 gpu = ["onnxruntime-gpu>=1.16"]
 dml = ["onnxruntime-directml>=1.16"]
 coreml = ["onnxruntime>=1.16"]
+mps = ["sentence-transformers>=2.2.0", "torch>=2.0.0"]
 # Multilingual extra kept as a no-op alias for back-compat with
 # `pip install mempalace[multilingual]` — these deps now ship in core.
 multilingual = []
@@ -132,6 +148,9 @@ extract = [
 ]
 
 [dependency-groups]
+# dev installs include the [mps] extra so the embedding test suite can
+# exercise the sentence-transformers branch without a separate install step.
+# CI runners on Linux pull torch CPU wheels (no ROCm / CUDA needed for tests).
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
@@ -144,6 +163,8 @@ dev = [
     "hypothesis>=6.0",
     "pre-commit>=3.0",
     "mypy>=1.0",
+    "sentence-transformers>=2.2.0",
+    "torch>=2.0.0",
 ]
 
 [build-system]

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -7,6 +7,11 @@ import mempalace.embedding as embedding
 def isolate_embedding_state(monkeypatch):
     monkeypatch.setattr(embedding, "_EF_CACHE", {})
     monkeypatch.setattr(embedding, "_WARNED", set())
+    # Default-off MPS for the onnx-focused tests below so they keep their
+    # original meaning even on an Apple Silicon dev machine where the [mps]
+    # extra is installed. MPS-specific tests re-enable these explicitly.
+    monkeypatch.setattr(embedding, "_torch_mps_available", lambda: False)
+    monkeypatch.setattr(embedding, "_sentence_transformers_available", lambda: False)
 
 
 def test_auto_picks_cuda(monkeypatch):
@@ -192,3 +197,148 @@ def test_describe_device_uses_resolved_effective_device(monkeypatch):
     )
 
     assert embedding.describe_device("auto") == "cuda"
+
+
+# ---------------------------------------------------------------------------
+# MPS device — sentence-transformers / torch.mps branch
+# ---------------------------------------------------------------------------
+#
+# Why MPS is its own path: ChromaDB's bundled ONNXMiniLM_L6_V2 enables
+# CoreMLExecutionProvider by default, which silently falls back op-by-op
+# to CPU for all-MiniLM-L6-v2 on Apple Silicon. The ANE↔CPU copies cost
+# more than they save (measured 60-256x slowdown). Routing through
+# sentence-transformers + torch.mps bypasses CoreML entirely and runs
+# the model directly on the Metal GPU.
+
+
+def test_mps_explicit_resolves_to_sentinel_when_available(monkeypatch):
+    """Explicit device='mps' returns the MPS sentinel when torch+ST+MPS line up."""
+    monkeypatch.setattr(embedding, "_torch_mps_available", lambda: True)
+    monkeypatch.setattr(embedding, "_sentence_transformers_available", lambda: True)
+
+    providers, effective = embedding._resolve_providers("mps")
+    assert providers[0] == embedding._MPS_SENTINEL
+    assert effective == "mps"
+
+
+def test_mps_missing_extra_warns_and_falls_to_cpu(monkeypatch, caplog):
+    """device='mps' without the [mps] extra installed -> CPU + actionable warning."""
+    monkeypatch.setattr(embedding, "_torch_mps_available", lambda: False)
+    monkeypatch.setattr(embedding, "_sentence_transformers_available", lambda: False)
+
+    providers, effective = embedding._resolve_providers("mps")
+    assert providers == ["CPUExecutionProvider"]
+    assert effective == "cpu"
+    assert "mempalace[mps]" in caplog.text
+
+
+def test_mps_st_installed_but_no_metal_warns(monkeypatch, caplog):
+    """ST installed but torch.backends.mps unavailable (e.g. Linux/Intel Mac)."""
+    monkeypatch.setattr(embedding, "_sentence_transformers_available", lambda: True)
+    monkeypatch.setattr(embedding, "_torch_mps_available", lambda: False)
+
+    providers, effective = embedding._resolve_providers("mps")
+    assert providers == ["CPUExecutionProvider"]
+    assert effective == "cpu"
+    assert "torch.backends.mps" in caplog.text
+
+
+def test_auto_prefers_mps_over_coreml_when_torch_mps_available(monkeypatch):
+    """The whole point of this PR: MPS wins on Apple Silicon, even if CoreML works."""
+    monkeypatch.setattr(embedding, "_torch_mps_available", lambda: True)
+    monkeypatch.setattr(embedding, "_sentence_transformers_available", lambda: True)
+    monkeypatch.setattr(
+        "onnxruntime.get_available_providers",
+        lambda: ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    providers, effective = embedding._resolve_providers("auto")
+    assert effective == "mps"
+    assert providers[0] == embedding._MPS_SENTINEL
+
+
+def test_auto_falls_to_coreml_when_torch_unavailable(monkeypatch):
+    """Without the [mps] extra, auto on Apple Silicon should still use CoreML."""
+    monkeypatch.setattr(embedding, "_torch_mps_available", lambda: False)
+    monkeypatch.setattr(embedding, "_sentence_transformers_available", lambda: False)
+    monkeypatch.setattr(
+        "onnxruntime.get_available_providers",
+        lambda: ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    providers, effective = embedding._resolve_providers("auto")
+    assert effective == "coreml"
+    assert providers == ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_get_embedding_function_routes_mps_to_st_branch(monkeypatch):
+    """When the resolver returns the MPS sentinel, get_embedding_function must
+    take the sentence-transformers path (``_build_mps_ef``), not the ONNX path."""
+
+    class DummySTEF:
+        pass
+
+    onnx_called = False
+
+    def fake_build_ef_class():
+        nonlocal onnx_called
+        onnx_called = True
+
+        class _Dummy:
+            def __init__(self, **_):
+                pass
+
+        return _Dummy
+
+    monkeypatch.setattr(embedding, "_build_ef_class", fake_build_ef_class)
+    monkeypatch.setattr(embedding, "_build_mps_ef", lambda: DummySTEF())
+    monkeypatch.setattr(
+        embedding,
+        "_resolve_providers",
+        lambda device: ([embedding._MPS_SENTINEL, "CPUExecutionProvider"], "mps"),
+    )
+
+    ef = embedding.get_embedding_function("mps")
+    assert isinstance(ef, DummySTEF)
+    assert onnx_called is False  # ONNX class was never built — proves routing
+
+
+def test_get_embedding_function_caches_mps_branch(monkeypatch):
+    """The MPS branch must hit the same ``_EF_CACHE`` as the ONNX branch."""
+
+    class DummySTEF:
+        pass
+
+    monkeypatch.setattr(embedding, "_build_mps_ef", lambda: DummySTEF())
+    monkeypatch.setattr(
+        embedding,
+        "_resolve_providers",
+        lambda device: ([embedding._MPS_SENTINEL, "CPUExecutionProvider"], "mps"),
+    )
+
+    a = embedding.get_embedding_function("mps")
+    b = embedding.get_embedding_function("mps")
+    assert a is b
+
+
+def test_unknown_device_does_not_match_mps_sentinel(monkeypatch, caplog):
+    """Regression guard: arbitrary unknown strings must not accidentally route to MPS."""
+    monkeypatch.setattr("onnxruntime.get_available_providers", lambda: ["CPUExecutionProvider"])
+    providers, effective = embedding._resolve_providers("__mempalace_torch_mps__")
+    assert effective == "cpu"
+    assert providers == ["CPUExecutionProvider"]
+
+
+def test_torch_mps_available_returns_bool_without_torch(monkeypatch):
+    """Helper must not raise when torch is missing — important for non-Apple CI."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "torch":
+            raise ImportError("no torch in this venv")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert embedding._torch_mps_available() is False


### PR DESCRIPTION
Rebase/reconciliation of #1133 onto current `develop` — that PR is showing as conflicting against the base branch as of this writing, and predates the `embeddinggemma` multilingual-model feature that's since landed, so this needed real reconciliation rather than a mechanical merge (see commit message for the four specific conflict points and why each was resolved the way it was — in short: merging two docstring "axes" — model choice vs. device — that didn't coexist when the original PR was written, adding a correctness guard so `device=mps` can't silently produce MiniLM vectors under an EF a palace expects to be `embeddinggemma`-shaped, keeping this PR's device-level thread-avoidance complementary to a separately-landed ORT thread-cap fix for the same underlying #1068, and wiring the new extras into both of `develop`'s now-two optional-dependency tables).

Given the amount of reconciliation, this commit is authored by me with a `Co-Authored-By` trailer crediting @yangqingggui-a11y, whose PR, benchmark data, and design this is built on — rather than presenting it as an unmodified copy of the original commit.

Verified for real on Apple Silicon hardware (MPS actually available, not just mocked): `auto` resolves to `mps`, `get_embedding_function('mps')` builds a real sentence-transformers EF and produces genuine 384-dim vectors via the actual Metal backend.

Full suite passes (same 2 pre-existing, unrelated `test_repair.py` FTS5 failures present on plain `develop` today — see #1928). `ruff check` / `ruff format --check` clean.

Happy to close this in favor of #1133 being merged directly if a maintainer or @yangqingggui-a11y prefers to resolve the conflict there instead.
