### PR TITLE
fix: bounded retry before MCP writer lease goes permanently read-only

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -377,6 +377,35 @@ _MCP_WRITER_LOCK_FAILED = False
 _MCP_WRITER_LOCK_ERROR = ""
 _MCP_ALLOW_PEER_WRITER_ENV = "MEMPALACE_MCP_ALLOW_PEER_WRITER"
 
+# A peer writer is very often a short-lived `mempalace mine` kicked off by a
+# SessionStart/ingest hook, not a competing interactive session. Without a
+# grace period, an MCP server whose *very first* mutating tool call happens
+# to land inside that mine's lock window goes permanently read-only for its
+# entire process lifetime (see the "once read-only, stays read-only"
+# contract on _acquire_mcp_writer_lock) even though the peer releases the
+# lock moments later — the only way back is a full client reconnect. Retry
+# the initial acquisition for a short, bounded window before committing to
+# that permanent decision. This does not change behavior once a server has
+# already decided read-write or read-only — only the first attempt gets the
+# grace period, and only against MineAlreadyRunning (a transient peer-writer
+# collision), not against setup failures (those still fail open immediately,
+# unchanged).
+_MCP_WRITER_LOCK_RETRY_SECONDS_ENV = "MEMPALACE_MCP_WRITER_LOCK_RETRY_SECONDS"
+_MCP_WRITER_LOCK_RETRY_SECONDS_DEFAULT = 5.0
+_MCP_WRITER_LOCK_RETRY_INTERVAL_SECONDS = 0.5
+
+
+def _mcp_writer_lock_retry_seconds() -> float:
+    raw = os.environ.get(_MCP_WRITER_LOCK_RETRY_SECONDS_ENV, "")
+    if not raw.strip():
+        return _MCP_WRITER_LOCK_RETRY_SECONDS_DEFAULT
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return _MCP_WRITER_LOCK_RETRY_SECONDS_DEFAULT
+    return max(0.0, seconds)
+
+
 _MUTATING_TOOLS = frozenset(
     {
         "mempalace_kg_add",
@@ -405,9 +434,11 @@ def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     """Acquire this process's per-palace MCP writer lease.
 
     Returns (True, "") when this process may write. Returns (False, reason)
-    when another live writer already owns the per-palace lease. Once a server
-    starts read-only it stays read-only for its lifetime; restarting is the
-    safe way to become the writer after the original holder exits.
+    when another live writer still owns the per-palace lease after the
+    MEMPALACE_MCP_WRITER_LOCK_RETRY_SECONDS grace period (default 5s,
+    polled every 0.5s) has elapsed. Once a server starts read-only it stays
+    read-only for its lifetime; restarting is the safe way to become the
+    writer after the original holder exits.
     """
 
     global _MCP_WRITER_LOCK_CM, _MCP_WRITER_READ_ONLY, _MCP_WRITER_LOCK_FAILED
@@ -428,8 +459,22 @@ def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     try:
         from .palace import MineAlreadyRunning, mine_palace_lock
 
-        lock_cm = mine_palace_lock(_config.palace_path)
-        lock_cm.__enter__()
+        deadline = time.monotonic() + _mcp_writer_lock_retry_seconds()
+        lock_cm = None
+        last_exc = None
+        while True:
+            try:
+                lock_cm = mine_palace_lock(_config.palace_path)
+                lock_cm.__enter__()
+                last_exc = None
+                break
+            except MineAlreadyRunning as exc:
+                last_exc = exc
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(_MCP_WRITER_LOCK_RETRY_INTERVAL_SECONDS)
+        if last_exc is not None:
+            raise last_exc
     except MineAlreadyRunning as exc:
         _MCP_WRITER_READ_ONLY = True
         _MCP_WRITER_LOCK_ERROR = (

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4881,6 +4881,146 @@ def test_peer_writer_lock_setup_failure_is_cached(monkeypatch):
     assert reason_second == reason_first
 
 
+class _FakeWriterLockCM:
+    """Stand-in for the context manager mine_palace_lock() normally returns."""
+
+    def __enter__(self):
+        return None
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def _reset_peer_writer_state(monkeypatch, mcp_server):
+    monkeypatch.delenv(mcp_server._MCP_ALLOW_PEER_WRITER_ENV, raising=False)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_CM", None)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_READ_ONLY", False)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_FAILED", False)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_ERROR", "")
+
+
+def _fake_clock(monkeypatch, mcp_server):
+    """Replace time.monotonic/time.sleep with an instant, controllable clock
+    so retry-window tests don't burn wall-clock time."""
+    state = {"t": 0.0}
+    monkeypatch.setattr(mcp_server.time, "monotonic", lambda: state["t"])
+    monkeypatch.setattr(mcp_server.time, "sleep", lambda s: state.__setitem__("t", state["t"] + s))
+    return state
+
+
+def test_peer_writer_lock_retries_before_going_read_only(monkeypatch):
+    """A peer writer that releases within the grace period must not
+    permanently flip this process read-only (#1908 follow-up)."""
+    from mempalace import mcp_server, palace
+
+    monkeypatch.setenv(mcp_server._MCP_WRITER_LOCK_RETRY_SECONDS_ENV, "5")
+    _reset_peer_writer_state(monkeypatch, mcp_server)
+    _fake_clock(monkeypatch, mcp_server)
+
+    calls = {"count": 0}
+
+    def flaky_mine_palace_lock(palace_path):
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise palace.MineAlreadyRunning("pid=999")
+        return _FakeWriterLockCM()
+
+    monkeypatch.setattr(palace, "mine_palace_lock", flaky_mine_palace_lock)
+
+    ok, reason = mcp_server._acquire_mcp_writer_lock()
+
+    assert ok is True
+    assert reason == ""
+    assert calls["count"] == 3
+    assert mcp_server._MCP_WRITER_READ_ONLY is False
+
+    # Cached from here — a second call must not re-probe the lock at all.
+    ok2, reason2 = mcp_server._acquire_mcp_writer_lock()
+    assert ok2 is True
+    assert calls["count"] == 3
+
+
+def test_peer_writer_lock_becomes_permanently_read_only_after_retry_window(monkeypatch):
+    """If the peer writer never releases within the grace period, the
+    existing 'permanently read-only for this process' contract still
+    holds — the retry only widens the window, it doesn't remove it."""
+    from mempalace import mcp_server, palace
+
+    monkeypatch.setenv(mcp_server._MCP_WRITER_LOCK_RETRY_SECONDS_ENV, "2")
+    _reset_peer_writer_state(monkeypatch, mcp_server)
+    _fake_clock(monkeypatch, mcp_server)
+
+    calls = {"count": 0}
+
+    def always_busy(palace_path):
+        calls["count"] += 1
+        raise palace.MineAlreadyRunning("pid=999")
+
+    monkeypatch.setattr(palace, "mine_palace_lock", always_busy)
+
+    ok, reason = mcp_server._acquire_mcp_writer_lock()
+
+    assert ok is False
+    assert "another mempalace writer already holds" in reason
+    assert mcp_server._MCP_WRITER_READ_ONLY is True
+    assert calls["count"] >= 2  # more than a single bare probe
+
+    calls_after_first_decision = calls["count"]
+    ok2, reason2 = mcp_server._acquire_mcp_writer_lock()
+    assert ok2 is False
+    assert reason2 == reason
+    assert calls["count"] == calls_after_first_decision  # no new attempt
+
+
+def test_peer_writer_lock_retry_disabled_by_zero_fails_immediately(monkeypatch):
+    """MEMPALACE_MCP_WRITER_LOCK_RETRY_SECONDS=0 preserves the pre-retry
+    behavior exactly: one probe, no sleep, immediate read-only."""
+    from mempalace import mcp_server, palace
+
+    monkeypatch.setenv(mcp_server._MCP_WRITER_LOCK_RETRY_SECONDS_ENV, "0")
+    _reset_peer_writer_state(monkeypatch, mcp_server)
+
+    calls = {"count": 0}
+
+    def always_busy(palace_path):
+        calls["count"] += 1
+        raise palace.MineAlreadyRunning("pid=999")
+
+    monkeypatch.setattr(palace, "mine_palace_lock", always_busy)
+    monkeypatch.setattr(
+        mcp_server.time,
+        "sleep",
+        lambda s: (_ for _ in ()).throw(AssertionError("retry disabled must not sleep")),
+    )
+
+    ok, reason = mcp_server._acquire_mcp_writer_lock()
+
+    assert ok is False
+    assert calls["count"] == 1
+
+
+def test_mcp_writer_lock_retry_seconds_env_parsing(monkeypatch):
+    from mempalace import mcp_server
+
+    monkeypatch.delenv(mcp_server._MCP_WRITER_LOCK_RETRY_SECONDS_ENV, raising=False)
+    assert (
+        mcp_server._mcp_writer_lock_retry_seconds()
+        == mcp_server._MCP_WRITER_LOCK_RETRY_SECONDS_DEFAULT
+    )
+
+    monkeypatch.setenv(mcp_server._MCP_WRITER_LOCK_RETRY_SECONDS_ENV, "12.5")
+    assert mcp_server._mcp_writer_lock_retry_seconds() == 12.5
+
+    monkeypatch.setenv(mcp_server._MCP_WRITER_LOCK_RETRY_SECONDS_ENV, "-3")
+    assert mcp_server._mcp_writer_lock_retry_seconds() == 0.0
+
+    monkeypatch.setenv(mcp_server._MCP_WRITER_LOCK_RETRY_SECONDS_ENV, "not-a-number")
+    assert (
+        mcp_server._mcp_writer_lock_retry_seconds()
+        == mcp_server._MCP_WRITER_LOCK_RETRY_SECONDS_DEFAULT
+    )
+
+
 def test_sqlite_integrity_gate_refuses_non_status_tool(monkeypatch):
     from mempalace import mcp_server
 


### PR DESCRIPTION
## Problem

`_acquire_mcp_writer_lock()` decides read-write vs read-only for an entire MCP server process on its *very first* mutating tool call, and per its own docstring that decision is permanent for the process lifetime once it goes read-only ("Once a server starts read-only it stays read-only for its lifetime; restarting is the safe way to become the writer").

In practice, a peer writer is very often a short-lived `mempalace mine` kicked off by a SessionStart/ingest hook — not a competing interactive session. If the very first mutating tool call in a session happens to land inside that mine's lock window, the *entire* session goes read-only for `mempalace_kg_add` / `mempalace_add_drawer` / `mempalace_diary_write` / etc., even though the peer releases the lock moments later. The only way back is a full client reconnect.

I hit this live: a normal search-heavy session raced a background session-ingest mine on its first knowledge-graph write and got permanently locked out for the rest of the session, well after the ingest had already finished.

## Fix

Add a short, bounded retry around the *first* acquisition attempt only: default 5s, polled every 0.5s, configurable via `MEMPALACE_MCP_WRITER_LOCK_RETRY_SECONDS`. Setting it to `0` reproduces the exact pre-existing immediate-fail behavior (single probe, no sleep).

Scope, deliberately narrow:
- Only affects the `MineAlreadyRunning` branch (a transient peer-writer collision). Setup failures (any other exception acquiring the lock) still fail open immediately, unchanged.
- Does **not** touch the "once read-only, stays read-only for the rest of the process lifetime" contract — that's still exactly as strict as before. This only widens the window for the *initial* decision.
- Does not change `mine_palace_lock()` itself or its use by the `mine` CLI path, which is intentionally non-blocking for a different reason (so hook-spawned miners don't pile up as waiting workers).

## Tests

4 new tests in `tests/test_mcp_server.py`, using a fake monotonic clock (no real sleeping in the suite):
- retry succeeds when the peer releases within the grace window
- retry window expires and the process still goes permanently read-only (existing contract preserved)
- `RETRY_SECONDS=0` reproduces the old single-probe, no-sleep behavior exactly
- env var parsing (default / valid float / negative clamps to 0 / invalid falls back to default)

Full suite: `pytest tests/test_mcp_server.py tests/test_palace_locks.py` → 280 passed, 0 failed, 3 skipped (pre-existing, unrelated). `ruff check` + `ruff format --check` clean on both touched files.

## Related

Not a fix for #1908 (that was the startup connection-refusal / compactor path) — this is a separate, narrower issue in the peer-writer guard added for #1818.