### PR TITLE
fix(mcp): self-heal writer lease instead of latching read-only for life

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -405,9 +405,17 @@ def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     """Acquire this process's per-palace MCP writer lease.
 
     Returns (True, "") when this process may write. Returns (False, reason)
-    when another live writer already owns the per-palace lease. Once a server
-    starts read-only it stays read-only for its lifetime; restarting is the
-    safe way to become the writer after the original holder exits.
+    when another live writer already owns the per-palace lease.
+
+    Self-healing: a server that came up read-only (a peer held the lease at
+    startup) RE-ATTEMPTS the non-blocking flock on every subsequent call.
+    ``_mcp_peer_writer_refusal`` invokes this on each mutating tool, so once
+    the original holder exits — the OS releases its flock on process death —
+    the next mutating call transparently promotes this server to writer, with
+    no restart. The flock is arbitrated by the kernel (LOCK_NB), so two servers
+    can never both win the retry. ``_MCP_WRITER_READ_ONLY`` is now only a
+    status flag; it no longer short-circuits the retry (that sticky latch used
+    to strand a server read-only for life even after the peer was long gone).
     """
 
     global _MCP_WRITER_LOCK_CM, _MCP_WRITER_READ_ONLY, _MCP_WRITER_LOCK_FAILED
@@ -419,9 +427,10 @@ def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     if _MCP_WRITER_LOCK_CM is not None:
         return True, ""
 
-    if _MCP_WRITER_READ_ONLY:
-        return False, _MCP_WRITER_LOCK_ERROR
-
+    # NB: deliberately NO sticky read-only short-circuit here. If a peer held
+    # the lease at startup we fall through and retry mine_palace_lock below, so
+    # the server self-heals into the writer the moment the peer exits. A broken
+    # lock *mechanism* (below) is still cached, since retrying it can't help.
     if _MCP_WRITER_LOCK_FAILED:
         return True, _MCP_WRITER_LOCK_ERROR
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4881,6 +4881,52 @@ def test_peer_writer_lock_setup_failure_is_cached(monkeypatch):
     assert reason_second == reason_first
 
 
+def test_peer_writer_readonly_self_heals_after_peer_exits(monkeypatch):
+    """A server that came up read-only must retry the flock and promote itself
+    to writer once the peer holding the lease exits — no restart required."""
+    from mempalace import mcp_server, palace
+
+    class _DummyLock:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    calls = {"count": 0}
+
+    def flaky_mine_palace_lock(palace_path):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            # First attempt: a live peer still holds the lease.
+            raise palace.MineAlreadyRunning(
+                f"palace {palace_path} is held by pid=999"
+            )
+        # Second attempt: peer has exited, flock is free.
+        return _DummyLock()
+
+    monkeypatch.delenv(mcp_server._MCP_ALLOW_PEER_WRITER_ENV, raising=False)
+    monkeypatch.setattr(palace, "mine_palace_lock", flaky_mine_palace_lock)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_CM", None)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_READ_ONLY", False)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_FAILED", False)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_ERROR", "")
+
+    # First call: refused, latched read-only for reporting.
+    ok_first, reason_first = mcp_server._acquire_mcp_writer_lock()
+    assert ok_first is False
+    assert mcp_server._MCP_WRITER_READ_ONLY is True
+    assert "already holds" in reason_first
+
+    # Second call: the sticky latch must NOT short-circuit — retry succeeds.
+    ok_second, reason_second = mcp_server._acquire_mcp_writer_lock()
+    assert ok_second is True
+    assert reason_second == ""
+    assert calls["count"] == 2  # retried, not stranded read-only
+    assert mcp_server._MCP_WRITER_LOCK_CM is not None
+    assert mcp_server._MCP_WRITER_READ_ONLY is False
+
+
 def test_sqlite_integrity_gate_refuses_non_status_tool(monkeypatch):
     from mempalace import mcp_server
 


### PR DESCRIPTION
## Problem

The `#1818` peer-writer guard latches `_MCP_WRITER_READ_ONLY=True` on the first `MineAlreadyRunning` and then short-circuits **every** subsequent `_acquire_mcp_writer_lock()` call for the rest of the process lifetime (the docstring even documents this as intentional).

That strands a server read-only forever in the common case of **several overlapping MCP sessions on the same palace** (one server per session): whichever server starts while a peer holds the per-palace flock comes up read-only — and stays read-only even after that peer exits and the OS releases the flock. Mutating tools keep returning `-32001`; the only remedy is killing/restarting the stranded server. `mempalace_reconnect` doesn't help (it refreshes the DB/HNSW, not the write lease).

Real-world hit: two Claude Code sessions sharing one palace; the writer session closed first, the survivor was permanently read-only until manually killed.

## Fix

Drop the sticky read-only short-circuit in `_acquire_mcp_writer_lock()`. `_mcp_peer_writer_refusal` already calls it on every mutating tool, so when read-only we now **re-attempt the non-blocking flock each call** and transparently promote to writer once the peer is gone. No restart needed.

- Race-safe: `fcntl.flock(..., LOCK_EX | LOCK_NB)` is kernel-arbitrated — two servers can never both win the retry.
- No fd leak: `mine_palace_lock` is a `@contextmanager` whose `finally` always `close()`s the lock file, including on the `MineAlreadyRunning` path.
- The genuinely-broken-lock-mechanism path (`_MCP_WRITER_LOCK_FAILED`) is still cached — retrying a broken lock subsystem can't help.
- `_MCP_WRITER_READ_ONLY` is now purely a status flag.

## Test

Adds `test_peer_writer_readonly_self_heals_after_peer_exits`: first acquisition refused (read-only latched for reporting), second acquisition retries and promotes to writer after the peer "exits". Existing `test_peer_writer_lock_setup_failure_is_cached` still passes (broken-mechanism path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)