### PR TITLE
docs: align MCP tool count and add recall-first schemas

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,6 +1,6 @@
 # MemPalace Claude Code Plugin
 
-A Claude Code plugin that gives your AI a persistent memory system. Mine projects and conversations into a searchable palace backed by ChromaDB, with 35 MCP tools, auto-save hooks, and 5 guided skills.
+A Claude Code plugin that gives your AI a persistent memory system. Mine projects and conversations into a searchable palace backed by ChromaDB, with 36 MCP tools, auto-save hooks, and 5 guided skills.
 
 ## Prerequisites
 
@@ -51,7 +51,7 @@ Set the `MEMPAL_DIR` environment variable to a directory path to automatically r
 
 ## MCP Server
 
-The plugin automatically configures a local MCP server with 34 tools for storing, searching, and managing memories. No manual MCP setup is required -- `/mempalace:init` handles everything.
+The plugin automatically configures a local MCP server with 36 tools for storing, searching, and managing memories. No manual MCP setup is required -- `/mempalace:init` handles everything.
 
 ## Full Documentation
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mempalace",
   "version": "3.5.0",
-  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 35 MCP tools, auto-save hooks, and guided setup.",
+  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 36 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"
   },
@@ -27,7 +27,7 @@
   "interface": {
     "displayName": "MemPalace",
     "shortDescription": "AI memory system for Codex",
-    "longDescription": "Give your AI a persistent memory — mine projects and conversations into a searchable palace backed by ChromaDB, with 35 MCP tools, auto-save hooks, and guided skills.",
+    "longDescription": "Give your AI a persistent memory — mine projects and conversations into a searchable palace backed by ChromaDB, with 36 MCP tools, auto-save hooks, and guided skills.",
     "developerName": "milla-jovovich",
     "category": "Coding",
     "capabilities": [

--- a/.cursor-plugin/README.md
+++ b/.cursor-plugin/README.md
@@ -1,6 +1,6 @@
 # MemPalace Cursor Plugin
 
-A Cursor IDE plugin that gives your agent a persistent memory system. Auto-registers the `mempalace-mcp` server (35 MCP tools), ships 5 slash commands, two model-invocable skills (setup/mining/search and a recall protocol), and an optional recall rule.
+A Cursor IDE plugin that gives your agent a persistent memory system. Auto-registers the `mempalace-mcp` server (36 MCP tools), ships 5 slash commands, two model-invocable skills (setup/mining/search and a recall protocol), and an optional recall rule.
 
 > Hooks (auto-save + session-start memory recall) are shipped separately under `hooks/cursor/` so the plugin is safe to install in any Cursor workspace without touching the agent loop. See [Hooks](#hooks-optional) below.
 
@@ -87,7 +87,7 @@ This plugin ships `mcp.json` at the plugin root, so Cursor auto-loads the `mempa
 }
 ```
 
-All 34 MemPalace MCP tools (`mempalace_search`, `mempalace_add_drawer`, `mempalace_diary_write`, `mempalace_check_duplicate`, `mempalace_diary_read`, …) become available to the agent immediately. No manual `~/.cursor/mcp.json` edit required.
+All 36 MemPalace MCP tools (`mempalace_search`, `mempalace_add_drawer`, `mempalace_diary_write`, `mempalace_check_duplicate`, `mempalace_diary_read`, …) become available to the agent immediately. No manual `~/.cursor/mcp.json` edit required.
 
 If the server doesn't appear, confirm `mempalace-mcp` is on the user `$PATH`:
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Usage and tool reference:
 
 ## MCP server
 
-35 MCP tools cover palace reads/writes, knowledge-graph operations,
+36 MCP tools cover palace reads/writes, knowledge-graph operations,
 cross-wing navigation, drawer management, and agent diaries. Installation
 and the full tool list:
 [mempalaceofficial.com/reference/mcp-tools](https://mempalaceofficial.com/reference/mcp-tools.html).

--- a/examples/mcp_setup.md
+++ b/examples/mcp_setup.md
@@ -2,13 +2,13 @@
 
 ## Setup
 
-Run the MCP server:
+Choose a client path that fits your workflow:
 
 ```bash
 mempalace-mcp
 ```
 
-Or add it to Claude Code:
+Then register it where needed:
 
 ```bash
 claude mcp add mempalace -- mempalace-mcp
@@ -16,12 +16,25 @@ claude mcp add mempalace -- mempalace-mcp
 
 ## Available Tools
 
-The server exposes the full MemPalace MCP toolset. Common entry points include:
+The server exposes the full MemPalace MCP toolset. For memory-aware assistants, these are the high-value calls:
 
-- **mempalace_status** — palace stats (wings, rooms, drawer counts)
-- **mempalace_search** — semantic search across all memories
-- **mempalace_list_wings** — list all projects in the palace
+- **mempalace_status** — protocol + AAAK dialect bootstrap.
+- **mempalace_search** — scoped semantic recall.
+- **mempalace_kg_query** — time-bounded relationship checks.
+- **mempalace_get_drawer** — full-text verification of one fact.
+- **mempalace_diary_write/read** — persistent agent memory continuity.
 
 ## Usage in Claude Code
 
 Once configured, Claude Code can search your memories directly during conversations.
+
+## Recommended recall pattern
+
+For each new turn:
+
+1. Call `mempalace_status` once at startup.
+2. Search first (`mempalace_search`) before answering about people, projects, or prior decisions.
+3. If a statement is time-sensitive, call `mempalace_kg_query` with `as_of` before asserting it.
+4. End the session with a `mempalace_diary_write` entry (AAAK format preferred).
+
+That pattern keeps context fresh without guessing and preserves continuity across sessions.

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -46,7 +46,7 @@ You have access to a local memory palace via MCP tools. The palace stores verbat
 
 ## Available Tools
 
-Full MCP surface: 35 tools. Destructive or host-level tools are documented so
+Full MCP surface: 36 tools. Destructive or host-level tools are documented so
 you know they exist, but use them only when the user explicitly asks or when a
 tool-specific workflow below says to.
 

--- a/mempalace/README.md
+++ b/mempalace/README.md
@@ -13,10 +13,10 @@ The Python package that powers MemPalace. All modules, all logic.
 | `convo_miner.py` | Conversation ingest — chunks by exchange pair (Q+A), detects rooms from content |
 | `searcher.py` | Semantic search via ChromaDB vectors — filters by wing/room, returns verbatim + scores |
 | `layers.py` | 4-layer memory stack: L0 (identity), L1 (critical facts), L2 (room recall), L3 (deep search) |
-| `dialect.py` | AAAK compression — entity codes, emotion markers, 30x lossless ratio |
+| `dialect.py` | AAAK compression — entity codes, emotion markers, ~30x lossy compression ratio |
 | `knowledge_graph.py` | Temporal entity-relationship graph — SQLite, time-filtered queries, fact invalidation |
 | `palace_graph.py` | Room-based navigation graph — BFS traversal, tunnel detection across wings |
-| `mcp_server.py` | MCP server — 34 tools, AAAK auto-teach, Palace Protocol, agent diary |
+| `mcp_server.py` | MCP server — 36 tools, AAAK auto-teach, Palace Protocol, agent diary |
 | `onboarding.py` | Guided first-run setup — asks about people/projects, generates AAAK bootstrap + wing config |
 | `entity_registry.py` | Entity code registry — maps names to AAAK codes, handles ambiguous names |
 | `entity_detector.py` | Auto-detect people and projects from file content |

--- a/mempalace/README.md
+++ b/mempalace/README.md
@@ -13,7 +13,7 @@ The Python package that powers MemPalace. All modules, all logic.
 | `convo_miner.py` | Conversation ingest — chunks by exchange pair (Q+A), detects rooms from content |
 | `searcher.py` | Semantic search via ChromaDB vectors — filters by wing/room, returns verbatim + scores |
 | `layers.py` | 4-layer memory stack: L0 (identity), L1 (critical facts), L2 (room recall), L3 (deep search) |
-| `dialect.py` | AAAK compression — entity codes, emotion markers, ~30x lossy compression ratio |
+| `dialect.py` | AAAK dialect — entity codes, emotion markers, ~30× shorter lossy summaries (index/scan layer) |
 | `knowledge_graph.py` | Temporal entity-relationship graph — SQLite, time-filtered queries, fact invalidation |
 | `palace_graph.py` | Room-based navigation graph — BFS traversal, tunnel detection across wings |
 | `mcp_server.py` | MCP server — 36 tools, AAAK auto-teach, Palace Protocol, agent diary |

--- a/skills/mempalace/SKILL.md
+++ b/skills/mempalace/SKILL.md
@@ -42,6 +42,6 @@ search-before-answer so the agent reads the palace instead of guessing.
 
 ## Cursor-specific notes
 
-- The `mempalace-mcp` server is auto-registered by this plugin. Once installed, all 34 MemPalace MCP tools (`mempalace_search`, `mempalace_add_drawer`, `mempalace_diary_write`, `mempalace_check_duplicate`, `mempalace_diary_read`, etc.) are available to the agent without any further configuration.
+- The `mempalace-mcp` server is auto-registered by this plugin. Once installed, all 36 MemPalace MCP tools (`mempalace_search`, `mempalace_add_drawer`, `mempalace_diary_write`, `mempalace_check_duplicate`, `mempalace_diary_read`, etc.) are available to the agent without any further configuration.
 - For automatic background saving every N agent turns plus session-start memory recall, also install the Cursor hooks separately by running `hooks/cursor/install.sh --scope user` from a cloned MemPalace repo. See [`website/guide/cursor-hooks.md`](../../website/guide/cursor-hooks.md) for the full walkthrough.
 - The recommended `agent_name` when calling `mempalace_diary_write` from a Cursor session is `cursor-ide` (matches the precedent of `claude-code` and `codex`).

--- a/tests/test_mcp_tool_inventory.py
+++ b/tests/test_mcp_tool_inventory.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Ensure MCP tool-count claims in documentation stay aligned with the implementation.
+"""
+
+import re
+from pathlib import Path
+
+
+DOC_PATHS = [
+    Path("README.md"),
+    Path("mempalace/README.md"),
+    Path("website/guide/mcp-integration.md"),
+    Path("website/guide/claude-code.md"),
+    Path("website/guide/openclaw.md"),
+    Path("website/reference/modules.md"),
+    Path("website/reference/mcp-tools.md"),
+    Path("skills/mempalace/SKILL.md"),
+    Path("integrations/openclaw/SKILL.md"),
+]
+
+
+def _tool_count_from_server() -> int:
+    server_src = Path("mempalace/mcp_server.py").read_text(encoding="utf-8")
+    return len(re.findall(r'"(mempalace_\w+)":\s*\{', server_src))
+
+
+def _doc_tool_counts(path: Path) -> list[int]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    # Tool-count claims can be adjacent ("30 MCP tools") or with
+    # an extra qualifier ("all 30 MemPalace MCP tools") on the same line.
+    return [int(m.group(1)) for m in re.finditer(r"\b(\d+)\b(?:(?!\n).){0,40}\btools?\b", text)]
+
+
+def test_mcp_tool_count_claims_match_code():
+    actual = _tool_count_from_server()
+    for path in DOC_PATHS:
+        counts = _doc_tool_counts(path)
+        assert counts, f"{path} is expected to claim MCP tool count in a 'N tools' phrase"
+        if len(set(counts)) != 1:
+            raise AssertionError(f"{path} has inconsistent tool count claims: {counts}")
+        assert counts[0] == actual, (
+            f"{path} claims {counts[0]} MCP tools, but mcp_server.py registers {actual}"
+        )

--- a/tests/test_mcp_tool_inventory.py
+++ b/tests/test_mcp_tool_inventory.py
@@ -3,6 +3,7 @@
 Ensure MCP tool-count claims in documentation stay aligned with the implementation.
 """
 
+import ast
 import re
 from pathlib import Path
 
@@ -15,6 +16,9 @@ DOC_PATHS = [
     Path("website/guide/openclaw.md"),
     Path("website/reference/modules.md"),
     Path("website/reference/mcp-tools.md"),
+    Path(".claude-plugin/README.md"),
+    Path(".cursor-plugin/README.md"),
+    Path(".codex-plugin/plugin.json"),
     Path("skills/mempalace/SKILL.md"),
     Path("integrations/openclaw/SKILL.md"),
 ]
@@ -22,7 +26,21 @@ DOC_PATHS = [
 
 def _tool_count_from_server() -> int:
     server_src = Path("mempalace/mcp_server.py").read_text(encoding="utf-8")
-    return len(re.findall(r'"(mempalace_\w+)":\s*\{', server_src))
+    module = ast.parse(server_src)
+    for node in module.body:
+        if (
+            isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "TOOLS" for target in node.targets)
+            and isinstance(node.value, ast.Dict)
+        ):
+            return sum(
+                1
+                for key in node.value.keys
+                if isinstance(key, ast.Constant)
+                and isinstance(key.value, str)
+                and key.value.startswith("mempalace_")
+            )
+    raise AssertionError("mempalace/mcp_server.py does not define a TOOLS dict")
 
 
 def _doc_tool_counts(path: Path) -> list[int]:

--- a/website/concepts/agents.md
+++ b/website/concepts/agents.md
@@ -43,6 +43,17 @@ MCP tool: mempalace_diary_read
 | `mempalace_diary_write` | Write an AAAK diary entry |
 | `mempalace_diary_read` | Read recent diary entries |
 
+## Persistent Agent Pattern
+
+Use one stable `agent_name` and the same workflow each session:
+
+```text
+1) start: mempalace_status
+2) recall: mempalace_search("topic"), and mempalace_kg_query(entity, as_of=...) when facts may have changed
+3) verify: mempalace_get_drawer(id) for critical claims
+4) persist: mempalace_diary_write(agent_name="<agent_name>", entry="what changed + open risks")
+```
+
 ## How It Works
 
 Each named agent maps to its own wing in the palace:

--- a/website/guide/claude-code.md
+++ b/website/guide/claude-code.md
@@ -15,7 +15,7 @@ Restart Claude Code, then type `/skills` to verify "mempalace" appears.
 
 With the plugin installed, Claude Code automatically:
 - Starts the MemPalace MCP server on launch
-- Has access to all 34 tools
+- Has access to all 36 tools
 - Learns the AAAK dialect and memory protocol from the `mempalace_status` response
 - Searches the palace before answering questions about past work
 

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -36,6 +36,29 @@ non-default backend is opt-in.
 | `pgvector` | Server (Postgres) | `mempalace[pgvector]` | ✓ | ✓ |
 <!-- New backends add one row here and one `### <Backend>` subsection (with its connection variables) below; keep README's compatibility table in sync. -->
 
+## Local-first backend contract
+
+MemPalace keeps the memory stack local-first by default. For the two local backends
+(`chroma`, `sqlite_exact`), embeddings, indexes, and verbatim drawer text all stay
+on disk under `palace_path`.
+
+| Backend | Data location | Network required | Notes |
+| ------- | ------------- | ---------------- | ----- |
+| `chroma` | `~/.mempalace/palace` or `--palace` directory | No | Default |
+| `sqlite_exact` | `~/.mempalace/palace` or `--palace` directory | No | Exact-cosine local baseline |
+| `qdrant` | Self-hosted Qdrant server | Yes (configured endpoint) | Opt-in server mode |
+| `pgvector` | Self-hosted Postgres | Yes (configured DSN) | Opt-in server mode |
+
+Only server-mode backends (`qdrant`, `pgvector`) send verbatim payloads beyond the
+local machine, and only to the exact endpoint you configured.
+
+When server-mode backends are used:
+
+- `MEMPALACE_<BACKEND>_NAMESPACE` values should be set per workflow to avoid tenant overlap.
+- Each palace writes `<backend>_backend.json` so reopen checks can reject mismatched backends.
+- Treat namespace and endpoint as part of your deployment trust boundary; MemPalace does
+  not abstract that security policy for you.
+
 Select a backend with `--backend <name>` on any `mempalace` / `mempalace-mcp`
 command, `MEMPALACE_BACKEND=<name>` in the environment, or `"backend": "<name>"`
 in `config.json`.

--- a/website/guide/mcp-integration.md
+++ b/website/guide/mcp-integration.md
@@ -1,6 +1,6 @@
 # MCP Integration
 
-MemPalace provides 34 tools through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), giving any MCP-compatible AI full read/write access to your palace.
+MemPalace provides 36 tools through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), giving any MCP-compatible AI full read/write access to your palace.
 
 ## Setup
 
@@ -26,7 +26,7 @@ claude mcp add mempalace -- python -m mempalace.mcp_server --palace /path/to/pal
 codex mcp add mempalace -- python -m mempalace.mcp_server --palace /path/to/palace
 ```
 
-Now your AI has all 34 tools available. Ask it anything:
+Now your AI has all 36 tools available. Ask it anything:
 
 > *"What did we decide about auth last month?"*
 

--- a/website/guide/openclaw.md
+++ b/website/guide/openclaw.md
@@ -27,7 +27,7 @@ Or by directly editing your OpenClaw configuration:
 
 ## How It Works
 
-Once connected, OpenClaw agents receive all 34 tools along with the **Memory Protocol**—a strict behavioral guide indicating they should:
+Once connected, OpenClaw agents receive all 36 tools along with the **Memory Protocol**—a strict behavioral guide indicating they should:
 1. **Never guess**: Query `mempalace_search` or `mempalace_kg_query` before confidently answering.
 2. **Keep an agent diary**: Maintain continuity between sessions by writing to `mempalace_diary_write`.
 3. **Manage the Knowledge Graph**: Update declarative facts when things change using `mempalace_kg_add` and `mempalace_kg_invalidate`.

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -1,7 +1,73 @@
 # MCP Tools Reference
 
-Detailed parameter schemas for all 35 MCP tools.
+Detailed parameter schemas for all 36 MCP tools.
+## Persistent Recall Schemas
 
+Agents that build memory-first workflows should start with these stable outputs:
+
+- `mempalace_status` for protocol framing and AAAK loading.
+- `mempalace_search` for scoped recall.
+- `mempalace_get_drawer` for full-text verification.
+- `mempalace_kg_query` for temporal relationship recall when a fact may have changed.
+
+`mempalace_status` reply shape (high-value fields):
+
+```json
+{
+  "total_drawers": 1832,
+  "wings": 12,
+  "rooms": 38,
+  "protocol": {
+    "steps": [
+      "call mempalace_search before asserting facts about people/projects",
+      "prefer mempalace_kg_query for time-bound claims"
+    ]
+  },
+  "aaak_dialect": "..."
+}
+```
+
+`mempalace_search` reply shape:
+
+```json
+{
+  "query": "auth decision",
+  "filters": {
+    "wing": "api-service",
+    "room": "decisions"
+  },
+  "results": [
+    {
+      "text": "We switched from Clerk to Auth0 because ...",
+      "wing": "api-service",
+      "room": "decisions",
+      "source_file": "session_2026-01-17.md",
+      "similarity": 0.921
+    }
+  ]
+}
+```
+
+`mempalace_kg_query` reply shape:
+
+```json
+{
+  "entity": "Alex",
+  "as_of": "2026-01-17",
+  "facts": [
+    {
+      "direction": "outgoing",
+      "subject": "Alex",
+      "predicate": "works_on",
+      "object": "mempalace",
+      "valid_from": "2024-03-01",
+      "valid_to": null,
+      "current": true
+    }
+  ],
+  "count": 1
+}
+```
 ## Palace — Read Tools
 
 ### `mempalace_status`

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -15,15 +15,16 @@ Agents that build memory-first workflows should start with these stable outputs:
 ```json
 {
   "total_drawers": 1832,
-  "wings": 12,
-  "rooms": 38,
-  "protocol": {
-    "steps": [
-      "call mempalace_search before asserting facts about people/projects",
-      "prefer mempalace_kg_query for time-bound claims"
-    ]
+  "wings": {
+    "api-service": 214,
+    "frontend": 117
   },
-  "aaak_dialect": "..."
+  "rooms": {
+    "decisions": 84,
+    "incidents": 31
+  },
+  "protocol": "call mempalace_search before asserting facts about people/projects...",
+  "aaak_dialect": "AAAK dialect specification..."
 }
 ```
 

--- a/website/reference/modules.md
+++ b/website/reference/modules.md
@@ -9,7 +9,7 @@ mempalace/
 ├── README.md                  ← project documentation
 ├── mempalace/                 ← core package
 │   ├── cli.py                 ← CLI entry point
-│   ├── mcp_server.py          ← MCP server (34 tools)
+│   ├── mcp_server.py          ← MCP server (36 tools)
 │   ├── knowledge_graph.py     ← temporal entity graph
 │   ├── palace_graph.py        ← room navigation graph
 │   ├── dialect.py             ← AAAK compression
@@ -56,7 +56,7 @@ Argparse-based CLI with subcommands: `init`, `mine`, `split`, `search`, `compres
 
 ### `mcp_server.py` — MCP Server
 
-JSON-RPC over stdin/stdout. Implements the MCP protocol with 34 tools covering palace read/write, drawer CRUD, knowledge graph, navigation, tunnels, agent diary, and system operations. Includes the Memory Protocol and AAAK Spec in status responses.
+JSON-RPC over stdin/stdout. Implements the MCP protocol with 36 tools covering palace read/write, drawer CRUD, knowledge graph, navigation, tunnels, agent diary, and system operations. Includes the Memory Protocol and AAAK Spec in status responses.
 
 ### `searcher.py` — Semantic Search
 


### PR DESCRIPTION
## Summary

Aligns MCP tool-count documentation with the current runtime and adds recall-first schema guidance.

## Changes

* Updates stale MCP tool-count references to the current 36 tools
* Adds recall-oriented usage guidance for agent workflows
* Adds sample payload shapes for `mempalace_status`, `mempalace_search`, and `mempalace_kg_query`
* Adds a lightweight docs/tool-count drift test

## Validation

* `python -m py_compile tests/test_mcp_tool_inventory.py`
* Manual alignment check against `mempalace/mcp_server.py`: actual tool count is 36 and documented claims are consistent
* `pytest tests/test_mcp_tool_inventory.py -q` was blocked locally by missing `chromadb` from `tests/conftest.py`

## Notes

Kept focused on docs consistency and a small drift guard.