### PR TITLE
fix(backends): validate SQLite integrity before granting HNSW flush-lag pass

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -39,6 +39,40 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
+def _sqlite_integrity_errors(palace_path: str) -> list[str]:
+    """Module-level shim for :func:`mempalace.repair.sqlite_integrity_errors`,
+    filtered to the signals the quarantine gate can act on safely.
+
+    Deferred to avoid a circular import (repair.py imports from this module).
+    Exposed at module scope so tests can monkeypatch it without having to
+    reach into ``repair``'s namespace directly.
+
+    The underlying helper returns two qualitatively different shapes:
+
+    * **Real page-level corruption** — ``PRAGMA quick_check`` opened the
+      DB and returned messages like ``"row X is corrupt"`` or
+      ``"*** in database main ***"``. These come back as rows. This is
+      the signal ``quarantine_stale_hnsw`` should act on.
+    * **Couldn't-even-open cases** — the SQLite file is missing, locked,
+      mid-checkpoint, a test-fixture placeholder, or genuinely not a
+      SQLite file at all. These raise ``sqlite3.Error`` and surface as
+      ``"PRAGMA quick_check failed: <reason>"`` entries.
+
+    Treating the second bucket as corruption causes false-positive
+    quarantines whenever the SQLite layer can't be probed — including
+    #1716's all-layer-0 regression test, whose fixture writes a
+    placeholder ``chroma.sqlite3`` because it only cares about the HNSW
+    segment. The quarantine decision must not fire on "unknown". Filter
+    the couldn't-open bucket out here; if SQLite is genuinely so
+    corrupted it can't be opened, the next chromadb client open will
+    raise a real diagnostic on its own.
+    """
+    from ..repair import sqlite_integrity_errors  # noqa: PLC0415
+
+    raw = sqlite_integrity_errors(palace_path)
+    return [e for e in raw if not e.startswith("PRAGMA quick_check failed:")]
+
+
 _REQUIRED_OPERATORS = frozenset({"$eq", "$ne", "$in", "$nin", "$and", "$or", "$contains"})
 _OPTIONAL_OPERATORS = frozenset({"$gt", "$gte", "$lt", "$lte"})
 _SUPPORTED_OPERATORS = _REQUIRED_OPERATORS | _OPTIONAL_OPERATORS
@@ -445,16 +479,59 @@ def quarantine_stale_hnsw(palace_path: str, stale_seconds: float = 300.0) -> lis
 
         # Stage 2: integrity gate. Mtime drift alone is not corruption because
         # Chroma flushes HNSW asynchronously. A healthy metadata file proves the
-        # ordinary stale-by-mtime case is just flush lag.
+        # ordinary stale-by-mtime case is just flush lag — but only if the SQLite
+        # layer is also clean and HNSW element counts match SQLite's ground truth.
+        sq_errors: list[str] = []
+        count_diverged = False
+        hnsw_cnt: Optional[int] = None
+        sqlite_cnt: Optional[int] = None
         if not payload_corrupt and _segment_appears_healthy(seg_dir):
-            logger.info(
-                "HNSW mtime gap %.0fs on %s exceeds threshold but segment "
-                "metadata and payload size are intact — flush-lag, not "
-                "corruption. Leaving in place.",
-                sqlite_mtime - hnsw_mtime,
-                seg_dir,
-            )
-            continue
+            # --- Deep integrity check (only reached on anomalous mtime gap) ---
+            # 1. SQLite quick_check: catches page-level corruption that would
+            #    cause ChromaDB to crash or silently return garbage.
+            sq_errors = _sqlite_integrity_errors(palace_path)
+
+            # 2. Count cross-check: HNSW id_to_label vs SQLite embeddings.
+            #    segment directory name IS the segment UUID in ChromaDB's layout.
+            seg_id = name  # name is already the UUID from the enclosing loop
+            hnsw_cnt = _hnsw_element_count(palace_path, seg_id)
+            sqlite_cnt = _sqlite_embedding_count_for_segment(palace_path, seg_id)
+
+            if hnsw_cnt is not None and sqlite_cnt is not None:
+                divergence = sqlite_cnt - hnsw_cnt
+                # Use the same tolerance already established for hnsw_capacity_status:
+                # max(FALLBACK_FLOOR, FRACTION * sqlite_cnt). Anything past that is
+                # real divergence, not expected async-flush lag.
+                threshold = max(
+                    _HNSW_DIVERGENCE_FALLBACK_FLOOR,
+                    int(sqlite_cnt * _HNSW_DIVERGENCE_FRACTION),
+                )
+                count_diverged = divergence > threshold
+
+            if sq_errors or count_diverged:
+                # Corruption signal wins — fall through to the quarantine path below.
+                err_summary = (
+                    f"SQLite errors: {sq_errors[:3]}"
+                    if sq_errors
+                    else f"HNSW count {hnsw_cnt} vs SQLite count {sqlite_cnt}"
+                )
+                logger.warning(
+                    "HNSW mtime gap %.0fs on %s with integrity failure — "
+                    "treating as corruption, quarantining. (%s)",
+                    sqlite_mtime - hnsw_mtime,
+                    seg_dir,
+                    err_summary,
+                )
+                # Do NOT continue — fall through to the rename/quarantine block.
+            else:
+                logger.info(
+                    "HNSW mtime gap %.0fs on %s exceeds threshold but segment "
+                    "metadata and payload size are intact — flush-lag, not "
+                    "corruption. Leaving in place.",
+                    sqlite_mtime - hnsw_mtime,
+                    seg_dir,
+                )
+                continue
 
         stamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
         target = f"{seg_dir}.drift-{stamp}"
@@ -464,10 +541,20 @@ def quarantine_stale_hnsw(palace_path: str, stale_seconds: float = 300.0) -> lis
                 f"link_lists.bin/data_level0.bin ratio {payload_ratio:.1f}x "
                 f"exceeds {_HNSW_LINK_TO_DATA_MAX_RATIO:.1f}x"
             )
+        elif sq_errors:
+            reason = (
+                f"sqlite {sqlite_mtime - hnsw_mtime:.0f}s newer than HNSW, "
+                f"SQLite integrity errors: {sq_errors[:3]}"
+            )
+        elif count_diverged:
+            reason = (
+                f"sqlite {sqlite_mtime - hnsw_mtime:.0f}s newer than HNSW, "
+                f"HNSW element count {hnsw_cnt} vs SQLite count {sqlite_cnt}"
+            )
         else:
             reason = (
                 f"sqlite {sqlite_mtime - hnsw_mtime:.0f}s newer than HNSW "
-                "and integrity check failed"
+                "and metadata sniff-test failed"
             )
 
         try:
@@ -964,6 +1051,34 @@ def _sqlite_wing_room_counts(
         wing_rooms[wing][room] += int(n)
         total += int(n)
     return total, wing_rooms
+
+
+def _sqlite_embedding_count_for_segment(palace_path: str, segment_id: str) -> Optional[int]:
+    """Count embeddings in chroma.sqlite3 for a specific VECTOR segment UUID.
+
+    Used by :func:`quarantine_stale_hnsw` to cross-check the HNSW
+    ``id_to_label`` count against the SQLite ground truth for exactly
+    the segment under examination, without needing to resolve its
+    collection name first.
+
+    Returns ``None`` when the palace DB is absent, unreadable, or the
+    segment UUID is not found.
+    """
+    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM embeddings WHERE segment_id = ?",
+                (segment_id,),
+            ).fetchone()
+            return int(row[0]) if row and row[0] is not None else None
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
 
 
 def _pin_hnsw_threads(collection) -> None:

--- a/tests/test_quarantine_integrity.py
+++ b/tests/test_quarantine_integrity.py
@@ -1,0 +1,206 @@
+"""Tests for the deep integrity gate added to quarantine_stale_hnsw.
+
+Verifies that a segment which passes the surface sniff-test
+(_segment_appears_healthy returns True) is still quarantined when the
+deep integrity checks reveal corruption, and that the flush-lag pass is
+preserved when both checks are clean.
+"""
+
+import os
+import time
+
+import mempalace.backends.chroma as chroma_mod
+from mempalace.backends.chroma import quarantine_stale_hnsw
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_segment(
+    palace_dir: str,
+    seg_name: str,
+    *,
+    data_size: int = 2048,
+    stale_seconds: float = 400.0,
+) -> str:
+    """Build a minimal fake HNSW segment that passes _segment_appears_healthy.
+
+    Creates:
+    * data_level0.bin  — ``data_size`` bytes of null payload (> 1024 threshold)
+    * link_lists.bin   — 8 non-zero bytes (non-empty, small ratio to data)
+    * index_metadata.pickle — valid magic bytes (0x80 ... 0x2e) with enough
+                              padding to pass the 16-byte size floor
+
+    Sets data_level0.bin mtime ``stale_seconds`` in the past relative to
+    chroma.sqlite3's mtime so the mtime gap check fires.
+
+    Returns the full path to the segment directory.
+    """
+    seg_dir = os.path.join(palace_dir, seg_name)
+    os.makedirs(seg_dir, exist_ok=True)
+
+    # data_level0.bin — oversized enough to pass the missing-metadata floor
+    data_path = os.path.join(seg_dir, "data_level0.bin")
+    with open(data_path, "wb") as f:
+        f.write(b"\x00" * data_size)
+
+    # link_lists.bin — small relative to data so ratio check passes
+    link_path = os.path.join(seg_dir, "link_lists.bin")
+    with open(link_path, "wb") as f:
+        f.write(b"\x01" * 8)
+
+    # index_metadata.pickle — magic bytes only (no real structure needed for
+    # _segment_appears_healthy's sniff-test: byte0==0x80, last-byte==0x2e,
+    # total size >= 16 bytes).
+    meta_path = os.path.join(seg_dir, "index_metadata.pickle")
+    payload = b"\x80" + b"\x00" * 30 + b"\x2e"
+    with open(meta_path, "wb") as f:
+        f.write(payload)
+
+    # Stamp chroma.sqlite3 as recent, data_level0.bin as stale.
+    now = time.time()
+    db_path = os.path.join(palace_dir, "chroma.sqlite3")
+    # Touch chroma.sqlite3 with current time (already exists from caller, or
+    # created here).
+    with open(db_path, "ab"):
+        pass
+    os.utime(db_path, (now, now))
+    old_time = now - stale_seconds - 10  # comfortably past the threshold
+    os.utime(data_path, (old_time, old_time))
+
+    return seg_dir
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_sqlite_is_quarantined_not_flushlag(tmp_path, monkeypatch):
+    """A segment that passes the sniff-test is quarantined when sqlite_integrity_errors
+    returns a non-empty list — i.e. SQLite corruption takes precedence over flush-lag.
+    """
+    palace_dir = str(tmp_path)
+    seg_name = "aabbccdd-0000-1111-2222-333333333333"
+    seg_dir = _make_fake_segment(palace_dir, seg_name, stale_seconds=400.0)
+
+    # Monkeypatch the integrity-check shim so it reports corruption.
+    monkeypatch.setattr(chroma_mod, "_sqlite_integrity_errors", lambda _path: ["malformed"])
+
+    # Count helpers: return matching counts so only the SQLite signal fires.
+    monkeypatch.setattr(chroma_mod, "_hnsw_element_count", lambda _palace, _seg: 100)
+    monkeypatch.setattr(
+        chroma_mod, "_sqlite_embedding_count_for_segment", lambda _palace, _seg: 100
+    )
+
+    moved = quarantine_stale_hnsw(palace_dir, stale_seconds=300.0)
+
+    # The segment must have been renamed aside (quarantined).
+    assert len(moved) == 1, f"Expected one quarantined segment, got: {moved}"
+    assert not os.path.isdir(seg_dir), "Original segment dir should not exist after quarantine"
+    assert os.path.isdir(moved[0]), "Quarantined rename target should exist on disk"
+    assert ".drift-" in moved[0], "Quarantine rename should include .drift- marker"
+
+
+def test_clean_store_keeps_flushlag_pass(tmp_path, monkeypatch):
+    """A segment that passes the sniff-test AND the deep integrity gate is left
+    in place — existing flush-lag behaviour is preserved.
+    """
+    palace_dir = str(tmp_path)
+    seg_name = "aabbccdd-0000-1111-2222-444444444444"
+    seg_dir = _make_fake_segment(palace_dir, seg_name, stale_seconds=400.0)
+
+    # Both integrity signals are clean.
+    monkeypatch.setattr(chroma_mod, "_sqlite_integrity_errors", lambda _path: [])
+    # Counts match — no divergence.
+    monkeypatch.setattr(chroma_mod, "_hnsw_element_count", lambda _palace, _seg: 50)
+    monkeypatch.setattr(chroma_mod, "_sqlite_embedding_count_for_segment", lambda _palace, _seg: 50)
+
+    moved = quarantine_stale_hnsw(palace_dir, stale_seconds=300.0)
+
+    # Segment must NOT have been quarantined.
+    assert moved == [], f"Expected no quarantined segments, got: {moved}"
+    assert os.path.isdir(seg_dir), "Segment dir should still exist — flush-lag pass preserved"
+
+
+def test_count_divergence_triggers_quarantine(tmp_path, monkeypatch):
+    """A segment with clean SQLite but severely diverged HNSW/SQLite counts is
+    quarantined — count divergence alone is sufficient to reject the flush-lag pass.
+    """
+    palace_dir = str(tmp_path)
+    seg_name = "aabbccdd-0000-1111-2222-555555555555"
+    seg_dir = _make_fake_segment(palace_dir, seg_name, stale_seconds=400.0)
+
+    monkeypatch.setattr(chroma_mod, "_sqlite_integrity_errors", lambda _path: [])
+    # HNSW count is tiny, SQLite count is huge — far beyond any tolerance.
+    monkeypatch.setattr(chroma_mod, "_hnsw_element_count", lambda _palace, _seg: 100)
+    monkeypatch.setattr(
+        chroma_mod, "_sqlite_embedding_count_for_segment", lambda _palace, _seg: 200_000
+    )
+
+    moved = quarantine_stale_hnsw(palace_dir, stale_seconds=300.0)
+
+    assert len(moved) == 1, f"Expected one quarantined segment, got: {moved}"
+    assert not os.path.isdir(seg_dir)
+
+
+def test_unknown_counts_do_not_block_flushlag(tmp_path, monkeypatch):
+    """When count helpers return None (e.g. fresh segment, no pickle yet), the
+    count divergence check is inconclusive and must NOT block the flush-lag pass.
+    The segment should be left in place provided SQLite is clean.
+    """
+    palace_dir = str(tmp_path)
+    seg_name = "aabbccdd-0000-1111-2222-666666666666"
+    seg_dir = _make_fake_segment(palace_dir, seg_name, stale_seconds=400.0)
+
+    monkeypatch.setattr(chroma_mod, "_sqlite_integrity_errors", lambda _path: [])
+    # Both counts unknown — no divergence signal possible.
+    monkeypatch.setattr(chroma_mod, "_hnsw_element_count", lambda _palace, _seg: None)
+    monkeypatch.setattr(
+        chroma_mod, "_sqlite_embedding_count_for_segment", lambda _palace, _seg: None
+    )
+
+    moved = quarantine_stale_hnsw(palace_dir, stale_seconds=300.0)
+
+    assert moved == [], f"Unknown counts should not trigger quarantine, got: {moved}"
+    assert os.path.isdir(seg_dir)
+
+
+def test_unreadable_sqlite_does_not_trigger_quarantine(tmp_path):
+    """Regression: when chroma.sqlite3 cannot be opened (placeholder file,
+    locked, mid-checkpoint, or genuinely not SQLite), the integrity probe
+    is "unknown" — not "corruption". The shim must filter the couldn't-open
+    signal out so the flush-lag pass is preserved.
+
+    Locks down the fix for a false-positive quarantine on #1716's all-layer-0
+    regression fixture (whose ``chroma.sqlite3`` is a placeholder string,
+    not a real SQLite file). Before the fix, the shim passed
+    ``"PRAGMA quick_check failed: file is not a database"`` straight through
+    to the quarantine gate, which then quarantined a healthy segment on
+    every CI run.
+
+    Uses a real placeholder file (no monkeypatching) so the full chain is
+    exercised: real ``repair.sqlite_integrity_errors`` returns the
+    couldn't-open shape, the shim filters it, the quarantine gate stays
+    open.
+    """
+    palace_dir = str(tmp_path)
+    seg_name = "aabbccdd-0000-1111-2222-777777777777"
+    seg_dir = _make_fake_segment(palace_dir, seg_name, stale_seconds=400.0)
+
+    # Overwrite chroma.sqlite3 with a placeholder — NOT real SQLite.
+    # _make_fake_segment already touched the file; replace with junk content.
+    db_path = os.path.join(palace_dir, "chroma.sqlite3")
+    with open(db_path, "w") as f:
+        f.write("sqlite placeholder")
+    # Re-stamp mtime so the gap check still fires (write may have changed it).
+    now = time.time()
+    os.utime(db_path, (now, now))
+
+    moved = quarantine_stale_hnsw(palace_dir, stale_seconds=300.0)
+
+    # Couldn't-open is NOT corruption — leave the segment alone.
+    assert moved == [], f"Unreadable SQLite should not trigger quarantine, got: {moved}"
+    assert os.path.isdir(seg_dir), "Segment should be left in place — flush-lag pass preserved"


### PR DESCRIPTION
## What does this PR do?

`quarantine_stale_hnsw` previously decided "flush-lag vs corruption" from only mtime gap + file-size ratio + two pickle magic bytes (`_segment_appears_healthy`), never running an actual integrity check. A torn/interrupted write that leaves `chroma.sqlite3` with page-level corruption but an intact-looking pickle header got the "flush-lag, not corruption — leaving in place" verdict and was then handed to ChromaDB's Rust core, which segfaults on any access (including `count()`).

This adds a real gate **before** granting the flush-lag pass (only reached on the already-anomalous mtime-gap branch, so the fast open path is unaffected and the <500ms hook budget is preserved):

1. `sqlite_integrity_errors()` (`PRAGMA quick_check`) — catches page-level corruption.
2. HNSW `id_to_label` vs SQLite embedding count cross-check, using the existing `_HNSW_DIVERGENCE_*` tolerances.

Either signal ⇒ treat as corruption and fall through to quarantine instead of leaving the bad segment in place. The genuine flush-lag case (clean integrity + matching counts) is preserved.

## How to test

```bash
uv run pytest tests/test_quarantine_integrity.py -v        # the 4 new tests
uv run pytest tests/test_hnsw_capacity.py tests/test_backends.py -v   # no regression
```

New file `tests/test_quarantine_integrity.py` covers:

- `test_corrupt_sqlite_is_quarantined_not_flushlag` — page-level corruption triggers quarantine even when the pickle sniff test would have passed.
- `test_clean_store_keeps_flushlag_pass` — clean SQLite + matching counts ⇒ flush-lag verdict preserved (no regression).
- `test_count_divergence_triggers_quarantine` — HNSW vs SQLite count gap beyond tolerance ⇒ quarantine.
- `test_unknown_counts_do_not_block_flushlag` — when either count is unreadable, fall back to the original behavior (don't block on missing data).

## Checklist

- [x] Tests pass (`uv run pytest tests/test_quarantine_integrity.py tests/test_hnsw_capacity.py tests/test_backends.py -v` → 125 passed)
- [x] No hardcoded paths
- [x] Linter passes on changed files (`uvx --from "ruff==0.15.14" ruff check mempalace/backends/chroma.py tests/test_quarantine_integrity.py` → All checks passed; `ruff format --check` → 2 files already formatted)

## Scope

Intentionally narrow — one extra gate in one branch of one function, plus the helpers it needs. No changes to the fast open path. No changes to the divergence detection probe (`hnsw_capacity_status`, owned by `d704433`).

## Note on lint CI

The lint job on this PR currently fails on `tests/test_mcp_server.py:4899`, which is a pre-existing format slip on `develop` itself (introduced by #1960, unrelated to this PR's files). My changed files (`mempalace/backends/chroma.py`, `tests/test_quarantine_integrity.py`) both pass `ruff check` and `ruff format --check` under the exact CI-pinned `ruff==0.15.14`. Once `develop`'s lint slip is addressed separately, this PR's lint job will go green on the next push/re-run.
