### PR TITLE
fix(search): expose MCP candidate union

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2373,6 +2373,7 @@ def tool_search(
     max_distance: float = 1.5,
     min_similarity: float = None,
     context: str = None,
+    candidate_strategy: str = "vector",
 ):
     limit = max(1, min(limit, _MAX_RESULTS))
     try:
@@ -2383,6 +2384,9 @@ def tool_search(
         return {"error": str(e)}
     # since/before are validated inside search_memories (shared
     # parse_window), which returns the same {"error": ...} shape.
+    candidate_strategy = candidate_strategy or "vector"
+    if not isinstance(candidate_strategy, str) or candidate_strategy not in {"vector", "union"}:
+        return {"error": "candidate_strategy must be one of ('vector', 'union')"}
     # Backwards compat: accept old name
     # Backwards compat: convert old similarity scale (higher=stricter) to
     # distance scale (lower=stricter). Similarity 0.8 → distance 0.2.
@@ -2405,6 +2409,7 @@ def tool_search(
         n_results=limit,
         max_distance=dist,
         vector_disabled=_vector_disabled,
+        candidate_strategy=candidate_strategy,
         collection_name=_config.collection_name,
     )
     if _is_transient_index_error(result):
@@ -2425,6 +2430,7 @@ def tool_search(
             n_results=limit,
             max_distance=dist,
             vector_disabled=_vector_disabled,
+            candidate_strategy=candidate_strategy,
             collection_name=_config.collection_name,
         )
         if not _is_transient_index_error(result):
@@ -4983,6 +4989,11 @@ TOOLS = {
                 "max_distance": {
                     "type": "number",
                     "description": "Max cosine distance threshold (0=identical, 2=opposite). Results further than this are dropped. Lower = stricter. Default 1.5. Set to 0 to disable.",
+                },
+                "candidate_strategy": {
+                    "type": "string",
+                    "enum": ["vector", "union"],
+                    "description": "Candidate source strategy. 'vector' preserves default semantic search; 'union' also merges backend BM25 lexical candidates before reranking.",
                 },
                 "context": {
                     "type": "string",

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -273,6 +273,64 @@ def _metric_for_collection(col) -> str:
     return metric if metric in ("cosine", "l2", "ip") else "cosine"
 
 
+def _vector_distance(
+    query_vector: list[float], candidate_vector: list[float], metric: str
+) -> float:
+    """Return a backend-style distance between two already-normalized vectors."""
+    if not query_vector or not candidate_vector or len(query_vector) != len(candidate_vector):
+        raise ValueError("embedding dimensions do not match")
+
+    if metric == "l2":
+        return math.sqrt(sum((a - b) ** 2 for a, b in zip(query_vector, candidate_vector)))
+
+    dot = sum(a * b for a, b in zip(query_vector, candidate_vector))
+    if metric == "ip":
+        return -dot
+
+    q_norm = math.sqrt(sum(a * a for a in query_vector))
+    c_norm = math.sqrt(sum(b * b for b in candidate_vector))
+    if q_norm == 0.0 or c_norm == 0.0:
+        raise ValueError("zero-norm embedding")
+    return 1.0 - (dot / (q_norm * c_norm))
+
+
+def _lexical_hit_vector_distances(drawers_col, query: str, lexical_hits: list, metric: str) -> dict:
+    """Compute vector distances for lexical hits when stored embeddings are available."""
+    ids = [hit.id for hit in lexical_hits if getattr(hit, "id", None)]
+    if not ids:
+        return {}
+
+    try:
+        from .backends.embedding_wrapper import _embed_texts
+
+        query_vector = _embed_texts([query])[0]
+        stored = drawers_col.get(ids=ids, include=["embeddings"])
+    except Exception:
+        logger.debug(
+            "candidate_strategy=union: failed to load lexical hit embeddings", exc_info=True
+        )
+        return {}
+
+    stored_ids = getattr(stored, "ids", None) if not isinstance(stored, dict) else stored.get("ids")
+    embeddings = (
+        getattr(stored, "embeddings", None)
+        if not isinstance(stored, dict)
+        else stored.get("embeddings")
+    )
+    if not stored_ids or not embeddings:
+        return {}
+
+    distances = {}
+    for doc_id, candidate_vector in zip(stored_ids, embeddings):
+        try:
+            distances[doc_id] = _vector_distance(query_vector, candidate_vector, metric)
+        except Exception:
+            logger.debug(
+                "candidate_strategy=union: failed to score lexical hit %s", doc_id, exc_info=True
+            )
+    return distances
+
+
 def _hybrid_rank(
     results: list,
     query: str,
@@ -1099,18 +1157,12 @@ def _merge_bm25_union_candidates(
     contributing chunk M of the same file. Falls back to ``source_file``
     only when full-path/chunk metadata is absent.
 
-    BM25-only additions carry ``distance=None`` so ``_hybrid_rank`` scores
-    them on BM25 contribution alone.
-
-    When ``max_distance > 0.0`` (a strict vector-distance threshold is
-    set), BM25-only candidates are skipped entirely — they have no vector
-    distance to satisfy the threshold, and silently injecting them would
-    break the existing ``max_distance`` guarantee that hybrid results lie
-    within the requested vector-distance bound.
+    BM25-only additions carry ``distance=None`` unless a strict
+    ``max_distance`` threshold is set. Under a threshold, union mode loads
+    stored embeddings for lexical hits and computes their vector distance
+    before admitting them, preserving the same distance guarantee as the
+    vector-only path.
     """
-    if max_distance > 0.0:
-        return
-
     where = build_where_filter(wing, room, source_file)
     try:
         lexical = drawers_col.lexical_search(
@@ -1124,6 +1176,13 @@ def _merge_bm25_union_candidates(
         logger.debug("candidate_strategy=union: lexical fetch failed", exc_info=True)
         return
 
+    metric = _metric_for_collection(drawers_col)
+    lexical_distances = (
+        _lexical_hit_vector_distances(drawers_col, query, lexical.hits, metric)
+        if max_distance > 0.0
+        else {}
+    )
+
     bm25_extra = []
     for hit in lexical.hits:
         meta = hit.metadata or {}
@@ -1135,6 +1194,11 @@ def _merge_bm25_union_candidates(
         ):
             continue
         full_source = meta.get("source_file", "") or ""
+        distance = lexical_distances.get(hit.id)
+        if max_distance > 0.0:
+            if distance is None or distance > max_distance:
+                continue
+            distance = round(distance, 4)
         bm25_extra.append(
             {
                 "drawer_id": _result_drawer_id(meta, hit.id),
@@ -1145,9 +1209,13 @@ def _merge_bm25_union_candidates(
                 "source_path": full_source,
                 "created_at": meta.get("filed_at", "unknown"),
                 "authored_at": meta.get("authored_at", meta.get("filed_at", "unknown")),
-                "similarity": None,
-                "distance": None,
-                "effective_distance": None,
+                "similarity": (
+                    None
+                    if distance is None
+                    else round(_distance_to_similarity(distance, metric), 3)
+                ),
+                "distance": distance,
+                "effective_distance": distance,
                 "closet_boost": 0.0,
                 "matched_via": "bm25_backend",
                 "bm25_score": round(float(hit.score), 3),
@@ -1171,8 +1239,6 @@ def _merge_bm25_union_candidates(
         key = _dedup_key(bh)
         if not key or key == "?" or key in seen:
             continue
-        bh["distance"] = None
-        bh["effective_distance"] = None
         bh["closet_boost"] = 0.0
         hits.append(bh)
         seen.add(key)
@@ -1657,8 +1723,8 @@ def search_memories(
               characterized.
 
               When ``max_distance > 0.0`` is also set, BM25-only candidates
-              are skipped — they have no vector distance and would silently
-              violate the requested distance threshold.
+              are admitted only if their stored embeddings can be loaded and
+              their computed vector distance satisfies that threshold.
         lang: Locale code for BM25 stop-word filtering (opt-in). When
             omitted, reads ``MempalaceConfig().lang_explicit`` — returns an
             empty set unless the user has set ``MEMPALACE_LANG`` /

--- a/tests/test_hybrid_candidate_union.py
+++ b/tests/test_hybrid_candidate_union.py
@@ -141,11 +141,10 @@ class TestCandidateUnion:
             f"union must trim to n_results=2; got {len(result['results'])} results"
         )
 
-    def test_union_skipped_when_max_distance_set(self, tmp_path):
-        """``max_distance`` is a vector-distance threshold; BM25-only
-        candidates have ``distance=None`` and cannot satisfy it. Union
-        must not silently inject them when a strict threshold is set,
-        otherwise the existing ``max_distance`` guarantee regresses."""
+    def test_union_respects_max_distance_set(self, tmp_path):
+        """``max_distance`` remains a vector-distance threshold in union mode:
+        lexical candidates may join only when they have a real distance that
+        satisfies it."""
         palace = str(tmp_path / "palace")
         _seed_drawers(palace)
         # Sanity: without max_distance, union surfaces the BM25-strong doc.
@@ -154,8 +153,8 @@ class TestCandidateUnion:
         )
         assert "brand_voice_D4.md" in {h["source_file"] for h in unfiltered["results"]}
 
-        # With a tight max_distance, union must NOT inject BM25-only hits —
-        # every returned hit must have a real (non-None) distance.
+        # With a tight max_distance, every returned hit must have a real
+        # (non-None) distance that satisfies the threshold.
         filtered = search_memories(
             _NARRATIVE_QUERY,
             palace,
@@ -165,8 +164,7 @@ class TestCandidateUnion:
         )
         for h in filtered["results"]:
             assert h.get("distance") is not None, (
-                f"union under max_distance must not inject BM25-only "
-                f"(distance=None) candidates; offending hit: {h}"
+                f"union under max_distance must not inject unscored candidates; offending hit: {h}"
             )
             assert h["distance"] <= 0.5, f"hit violates max_distance=0.5: distance={h['distance']}"
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1747,6 +1747,35 @@ class TestSearchTool:
         result_loose = tool_search(query="JWT", max_distance=0.01, min_similarity=999.0)
         assert len(result_strict["results"]) <= len(result_loose["results"])
 
+    def test_search_passes_candidate_strategy(self, monkeypatch, config, kg):
+        """MCP callers can opt into backend BM25/vector union candidate gathering."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        seen = {}
+
+        def fake_search(*args, **kwargs):
+            seen["candidate_strategy"] = kwargs.get("candidate_strategy")
+            return {"results": []}
+
+        monkeypatch.setattr(mcp_server, "search_memories", fake_search)
+
+        result = mcp_server.tool_search(query="rareterm", candidate_strategy="union")
+
+        assert "error" not in result
+        assert seen["candidate_strategy"] == "union"
+
+    def test_search_rejects_invalid_candidate_strategy(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "search_memories", lambda *a, **kw: pytest.fail())
+
+        result = mcp_server.tool_search(query="rareterm", candidate_strategy="bm25")
+
+        assert "error" in result
+        assert "candidate_strategy" in result["error"]
+
     def test_list_rooms_rejects_invalid_wing(self, monkeypatch, config, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         from mempalace import mcp_server
@@ -1808,11 +1837,11 @@ class TestSearchTool:
                 collection_name="custom_drawers",
             ),
         )
-        seen_collection_names = []
+        seen_calls = []
 
         def fake_search(*args, **kwargs):
-            seen_collection_names.append(kwargs.get("collection_name"))
-            if len(seen_collection_names) == 1:
+            seen_calls.append((kwargs.get("collection_name"), kwargs.get("candidate_strategy")))
+            if len(seen_calls) == 1:
                 return {
                     "error": "Search error: Error executing plan: Internal error: Error finding id"
                 }
@@ -1822,10 +1851,12 @@ class TestSearchTool:
         monkeypatch.setattr(mcp_server, "_force_chroma_cache_reset", lambda: None)
         monkeypatch.setattr(mcp_server.time, "sleep", lambda _: None)
 
-        result = mcp_server.tool_search(query="anything", wing="wing_api")
+        result = mcp_server.tool_search(
+            query="anything", wing="wing_api", candidate_strategy="union"
+        )
 
         assert "results" in result
-        assert seen_collection_names == ["custom_drawers", "custom_drawers"]
+        assert seen_calls == [("custom_drawers", "union"), ("custom_drawers", "union")]
 
     def test_search_does_not_retry_on_non_transient_error(self, monkeypatch, config, kg):
         """Validation / unrelated errors must not trigger the retry path."""

--- a/tests/test_sqlite_exact_backend.py
+++ b/tests/test_sqlite_exact_backend.py
@@ -884,10 +884,12 @@ def test_search_union_uses_sqlite_exact_lexical_search(tmp_path, monkeypatch):
         str(tmp_path),
         n_results=1,
         candidate_strategy="union",
+        max_distance=1.5,
     )
 
     assert result["results"][0]["source_file"] == "rare.md"
     assert result["results"][0]["matched_via"] == "bm25_backend"
+    assert result["results"][0]["distance"] <= 1.5
 
 
 def test_search_union_reports_unsupported_lexical_capability(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- expose `candidate_strategy` on the `mempalace_search` MCP tool so callers can opt into backend BM25/vector union search
- preserve the selected strategy across the transient-index retry path
- when union runs under `max_distance > 0`, compute vector distances for lexical hits from stored embeddings before admitting them, so BM25 rescue works with the default MCP threshold without weakening the distance guarantee

Refs #1949.

## Tests
- `uv run ruff format --check mempalace/searcher.py mempalace/mcp_server.py tests/test_sqlite_exact_backend.py tests/test_hybrid_candidate_union.py tests/test_mcp_server.py`
- `uv run ruff check mempalace/searcher.py mempalace/mcp_server.py tests/test_sqlite_exact_backend.py tests/test_hybrid_candidate_union.py tests/test_mcp_server.py`
- `git diff --check`
- `uv run pytest tests/test_sqlite_exact_backend.py tests/test_hybrid_candidate_union.py tests/test_mcp_server.py::TestSearchTool tests/test_hnsw_capacity.py::test_bm25_fallback_returns_matches tests/test_hnsw_capacity.py::test_bm25_fallback_filters_by_wing -q` (67 passed)
- `uv run pytest tests/test_searcher.py tests/test_hybrid_search.py -q` (54 passed)
- `uv run pytest tests/ -q --ignore=tests/benchmarks` (3259 passed, 20 skipped, 2 failed)

The two full-suite failures are baseline failures on clean `origin/develop` in `tests/test_repair.py` around FTS5 corruption message wording; I reproduced the same two failures there before opening this PR.
