### PR TITLE
style(tests): fix ruff format check left red by #1960

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4899,9 +4899,7 @@ def test_peer_writer_readonly_self_heals_after_peer_exits(monkeypatch):
         calls["count"] += 1
         if calls["count"] == 1:
             # First attempt: a live peer still holds the lease.
-            raise palace.MineAlreadyRunning(
-                f"palace {palace_path} is held by pid=999"
-            )
+            raise palace.MineAlreadyRunning(f"palace {palace_path} is held by pid=999")
         # Second attempt: peer has exited, flock is free.
         return _DummyLock()
 


### PR DESCRIPTION
## Problem

#1960 was merged with a **red `lint` job**. The failing step was `ruff format --check .` (not an actual test — all six test jobs on linux 3.9/3.11/3.13, macOS and Windows passed). The formatter wanted to collapse the multi-line `raise palace.MineAlreadyRunning(...)` in the new `test_peer_writer_readonly_self_heals_after_peer_exits` onto a single line, since it fits the configured line length.

Because the merge went in red, `develop` is now also red on `lint`.

## Fix

Run `ruff format` on that one statement. Verified with the exact CI command on the full tree:

```
$ ruff format --check .
187 files already formatted
$ ruff check tests/test_mcp_server.py
All checks passed!
```

No logic change — pure formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)