### PR TITLE
fix(mcp): release the writer lease after a mutating-idle window (#1888)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -44,6 +44,7 @@ except (OSError, AttributeError):
 sys.stdout = sys.stderr
 
 import argparse  # noqa: E402  (deferred until after stdio protection above)
+import contextlib  # noqa: E402
 import json  # noqa: E402
 import logging  # noqa: E402
 import re  # noqa: E402
@@ -368,14 +369,39 @@ _STARTUP_INTEGRITY_MAX_MB_DEFAULT = 512.0
 #
 # The existing per-operation palace lock serializes individual writes, but it
 # cannot make another long-lived Chroma PersistentClient forget stale in-memory
-# HNSW/FTS state. Hold the same per-palace mine lock for this MCP process
-# lifetime. A peer MCP process can still serve read tools, but mutating tools
-# refuse before touching Chroma or the knowledge graph.
+# HNSW/FTS state. Hold the same per-palace mine lock across mutating tools —
+# not per write — and release it only after an idle window plus a full Chroma
+# cache reset (see the cooperative-lease block below). A peer MCP process can
+# still serve read tools, but mutating tools refuse before touching Chroma or
+# the knowledge graph while this server holds the lease.
 _MCP_WRITER_LOCK_CM = None
 _MCP_WRITER_READ_ONLY = False
 _MCP_WRITER_LOCK_FAILED = False
 _MCP_WRITER_LOCK_ERROR = ""
 _MCP_ALLOW_PEER_WRITER_ENV = "MEMPALACE_MCP_ALLOW_PEER_WRITER"
+
+# Cooperative lease (#1888, #1963): a lifetime-held writer lease starves every
+# other writer on the palace — hook/manual mines exit with MineAlreadyRunning
+# and daemon jobs fail — for as long as this server lives, which for an
+# interactive session can be hours. Instead, release the lease once no
+# mutating tool has run for MEMPALACE_MCP_WRITER_LEASE_IDLE_S seconds
+# (default 300; 0 restores the legacy hold-until-exit behavior). Release must
+# also drop every cached Chroma handle (_force_chroma_cache_reset): the whole
+# reason the lease is lifetime-scoped is that a PersistentClient's in-memory
+# HNSW graph goes stale the moment a peer writes, so a re-acquire is only
+# safe if the next write reopens the palace from disk.
+_MCP_WRITER_LEASE_IDLE_S_ENV = "MEMPALACE_MCP_WRITER_LEASE_IDLE_S"
+_MCP_WRITER_LEASE_IDLE_S_DEFAULT = 300.0
+# Guards every transition of _MCP_WRITER_LOCK_CM (acquire, idle release,
+# atexit release) plus the in-flight counter: the idle release runs on the
+# watchdog thread while mutating tools run on the stdio loop or HTTP worker
+# threads. Leaf lock — nothing is called while holding it that takes another
+# mempalace lock (mine_palace_lock's internal guard is taken by __enter__ /
+# __exit__, which we call while holding this, but palace.py never takes ours).
+_MCP_WRITER_LEASE_GUARD = threading.Lock()
+_MCP_WRITER_LAST_MUTATION_TS = 0.0  # monotonic; 0 = no mutation yet
+_MCP_WRITER_INFLIGHT = 0  # mutating tools currently executing
+_MCP_WRITER_ATEXIT_REGISTERED = False
 
 _MUTATING_TOOLS = frozenset(
     {
@@ -419,51 +445,158 @@ def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     """
 
     global _MCP_WRITER_LOCK_CM, _MCP_WRITER_READ_ONLY, _MCP_WRITER_LOCK_FAILED
-    global _MCP_WRITER_LOCK_ERROR
+    global _MCP_WRITER_LOCK_ERROR, _MCP_WRITER_LAST_MUTATION_TS
+    global _MCP_WRITER_ATEXIT_REGISTERED
 
     if _truthy_env(_MCP_ALLOW_PEER_WRITER_ENV):
         return True, ""
 
-    if _MCP_WRITER_LOCK_CM is not None:
+    with _MCP_WRITER_LEASE_GUARD:
+        if _MCP_WRITER_LOCK_CM is not None:
+            _MCP_WRITER_LAST_MUTATION_TS = time.monotonic()
+            return True, ""
+
+        # NB: deliberately NO sticky read-only short-circuit here. If a peer held
+        # the lease at startup we fall through and retry mine_palace_lock below, so
+        # the server self-heals into the writer the moment the peer exits. A broken
+        # lock *mechanism* (below) is still cached, since retrying it can't help.
+        if _MCP_WRITER_LOCK_FAILED:
+            return True, _MCP_WRITER_LOCK_ERROR
+
+        try:
+            from .palace import MineAlreadyRunning, mine_palace_lock
+
+            lock_cm = mine_palace_lock(_config.palace_path)
+            lock_cm.__enter__()
+        except MineAlreadyRunning as exc:
+            _MCP_WRITER_READ_ONLY = True
+            _MCP_WRITER_LOCK_ERROR = (
+                "another mempalace writer already holds the palace lock for "
+                f"{_config.palace_path!r}: {exc}"
+            )
+            return False, _MCP_WRITER_LOCK_ERROR
+        except Exception as exc:
+            _MCP_WRITER_LOCK_FAILED = True
+            _MCP_WRITER_LOCK_ERROR = (
+                "could not acquire MCP peer-writer lock for "
+                f"{_config.palace_path!r}: {exc!r}; continuing without "
+                "peer-writer protection"
+            )
+            logger.warning(_MCP_WRITER_LOCK_ERROR)
+            return True, _MCP_WRITER_LOCK_ERROR
+
+        _MCP_WRITER_LOCK_CM = lock_cm
+        _MCP_WRITER_LAST_MUTATION_TS = time.monotonic()
+        if not _MCP_WRITER_ATEXIT_REGISTERED:
+            # Register once and read the CURRENT lease at exit time. A
+            # per-acquire lambda would go stale under the idle-release cycle:
+            # each release/re-acquire would pile up another callback pointing
+            # at an already-exited context manager.
+            import atexit
+
+            atexit.register(_release_mcp_writer_lock_at_exit)
+            _MCP_WRITER_ATEXIT_REGISTERED = True
+        _MCP_WRITER_READ_ONLY = False
+        _MCP_WRITER_LOCK_FAILED = False
+        _MCP_WRITER_LOCK_ERROR = ""
         return True, ""
 
-    # NB: deliberately NO sticky read-only short-circuit here. If a peer held
-    # the lease at startup we fall through and retry mine_palace_lock below, so
-    # the server self-heals into the writer the moment the peer exits. A broken
-    # lock *mechanism* (below) is still cached, since retrying it can't help.
-    if _MCP_WRITER_LOCK_FAILED:
-        return True, _MCP_WRITER_LOCK_ERROR
 
+def _writer_lease_idle_seconds() -> float:
+    """Idle seconds after which the writer lease is released (0 = never).
+
+    Invalid values fall back to the default rather than raising: a bad env
+    var must not take down the server or silently disable the release.
+    """
+    raw = os.environ.get(_MCP_WRITER_LEASE_IDLE_S_ENV, "").strip()
+    if not raw:
+        return _MCP_WRITER_LEASE_IDLE_S_DEFAULT
     try:
-        from .palace import MineAlreadyRunning, mine_palace_lock
-
-        lock_cm = mine_palace_lock(_config.palace_path)
-        lock_cm.__enter__()
-    except MineAlreadyRunning as exc:
-        _MCP_WRITER_READ_ONLY = True
-        _MCP_WRITER_LOCK_ERROR = (
-            "another mempalace writer already holds the palace lock for "
-            f"{_config.palace_path!r}: {exc}"
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; using default %.0f s",
+            _MCP_WRITER_LEASE_IDLE_S_ENV,
+            raw,
+            _MCP_WRITER_LEASE_IDLE_S_DEFAULT,
         )
-        return False, _MCP_WRITER_LOCK_ERROR
-    except Exception as exc:
-        _MCP_WRITER_LOCK_FAILED = True
-        _MCP_WRITER_LOCK_ERROR = (
-            "could not acquire MCP peer-writer lock for "
-            f"{_config.palace_path!r}: {exc!r}; continuing without "
-            "peer-writer protection"
-        )
-        logger.warning(_MCP_WRITER_LOCK_ERROR)
-        return True, _MCP_WRITER_LOCK_ERROR
+        return _MCP_WRITER_LEASE_IDLE_S_DEFAULT
+    return max(0.0, value)
 
-    _MCP_WRITER_LOCK_CM = lock_cm
-    import atexit
 
-    atexit.register(lambda: lock_cm.__exit__(None, None, None))
-    _MCP_WRITER_READ_ONLY = False
-    _MCP_WRITER_LOCK_FAILED = False
-    _MCP_WRITER_LOCK_ERROR = ""
-    return True, ""
+@contextlib.contextmanager
+def _writer_lease_activity(tool_name: str):
+    """Track a mutating tool's execution window for the idle-release clock.
+
+    While at least one mutating tool is in flight the lease is never
+    released, and the idle clock restarts when the last one finishes.
+    Non-mutating tools pass through untouched.
+    """
+    global _MCP_WRITER_INFLIGHT, _MCP_WRITER_LAST_MUTATION_TS
+    if tool_name not in _MUTATING_TOOLS:
+        yield
+        return
+    with _MCP_WRITER_LEASE_GUARD:
+        _MCP_WRITER_INFLIGHT += 1
+    try:
+        yield
+    finally:
+        with _MCP_WRITER_LEASE_GUARD:
+            _MCP_WRITER_INFLIGHT -= 1
+            _MCP_WRITER_LAST_MUTATION_TS = time.monotonic()
+
+
+def _release_mcp_writer_lock_if_idle() -> bool:
+    """Release the writer lease once mutating tools have been idle long enough.
+
+    Called periodically from the idle watchdog thread. Returns True when the
+    lease was actually released. Releasing lets starved peers (hook/manual
+    mines, daemon jobs, another session's MCP server — see #1888) write to the
+    palace; the next mutating tool on this server transparently re-acquires
+    via the existing self-heal retry in ``_acquire_mcp_writer_lock``.
+    """
+    global _MCP_WRITER_LOCK_CM, _MCP_WRITER_READ_ONLY
+    idle_limit = _writer_lease_idle_seconds()
+    if idle_limit <= 0:
+        return False
+    with _MCP_WRITER_LEASE_GUARD:
+        if _MCP_WRITER_LOCK_CM is None or _MCP_WRITER_INFLIGHT > 0:
+            return False
+        idle = time.monotonic() - _MCP_WRITER_LAST_MUTATION_TS
+        if idle < idle_limit:
+            return False
+        lock_cm = _MCP_WRITER_LOCK_CM
+        _MCP_WRITER_LOCK_CM = None
+        _MCP_WRITER_READ_ONLY = False
+        try:
+            lock_cm.__exit__(None, None, None)
+        except Exception:
+            logger.warning("Failed to release idle MCP writer lease", exc_info=True)
+    # Outside the guard: this tears down Chroma handles and can take a
+    # moment. A mutating call that lands in this window re-acquires the
+    # lease and may open a fresh collection that the reset then drops —
+    # that only costs that call a re-open, never correctness (the reset
+    # only clears caches; it writes nothing).
+    _force_chroma_cache_reset()
+    logger.info(
+        "Released MCP writer lease after %.0f s without mutating tools; "
+        "peer writers (mines, daemon jobs, other sessions) may now write.",
+        idle,
+    )
+    return True
+
+
+def _release_mcp_writer_lock_at_exit() -> None:
+    """atexit hook: release the current lease, if any (registered once)."""
+    global _MCP_WRITER_LOCK_CM
+    with _MCP_WRITER_LEASE_GUARD:
+        lock_cm = _MCP_WRITER_LOCK_CM
+        _MCP_WRITER_LOCK_CM = None
+    if lock_cm is not None:
+        try:
+            lock_cm.__exit__(None, None, None)
+        except Exception:
+            pass
 
 
 def _mcp_peer_writer_refusal(req_id, tool_name: str):
@@ -4806,7 +4939,10 @@ def handle_request(request):
             if "entry" not in tool_args or tool_args["entry"] is None:
                 tool_args["entry"] = content_val
         try:
-            result = _decorate_mcp_tool_result(tool_name, TOOLS[tool_name]["handler"](**tool_args))
+            with _writer_lease_activity(tool_name):
+                result = _decorate_mcp_tool_result(
+                    tool_name, TOOLS[tool_name]["handler"](**tool_args)
+                )
 
             return {
                 "jsonrpc": "2.0",
@@ -5040,16 +5176,32 @@ def _start_idle_exit_watchdog() -> None:
     servers from ended Claude Code sessions do not accumulate ChromaDB /
     HNSW file handles on Windows (#1552).
 
-    Set ``MEMPALACE_MCP_IDLE_HOURS=0`` to disable the watchdog.
+    Set ``MEMPALACE_MCP_IDLE_HOURS=0`` to disable the idle exit.
+
+    The same thread also drives the cooperative writer-lease release
+    (#1888): every tick it releases the per-palace write lock if no
+    mutating tool has run for ``MEMPALACE_MCP_WRITER_LEASE_IDLE_S``
+    seconds, so hook/manual mines and daemon jobs are not starved for
+    this server's whole lifetime. The thread therefore starts when
+    EITHER feature is enabled.
     """
     timeout = _mcp_idle_timeout_secs()
-    if timeout <= 0:
+    lease_idle = _writer_lease_idle_seconds()
+    if timeout <= 0 and lease_idle <= 0:
         return
-    check_interval = min(60.0, timeout / 4)
+    candidates = [t / 4 for t in (timeout,) if t > 0]
+    candidates += [t / 2 for t in (lease_idle,) if t > 0]
+    check_interval = min(60.0, *candidates)
 
     def _watchdog() -> None:
         while True:
             time.sleep(check_interval)
+            try:
+                _release_mcp_writer_lock_if_idle()
+            except Exception:  # noqa: BLE001 - release failure must not kill the thread
+                logger.warning("Idle writer-lease release failed", exc_info=True)
+            if timeout <= 0:
+                continue
             idle = time.monotonic() - _last_request_time
             if idle >= timeout:
                 logger.info(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4899,9 +4899,7 @@ def test_peer_writer_readonly_self_heals_after_peer_exits(monkeypatch):
         calls["count"] += 1
         if calls["count"] == 1:
             # First attempt: a live peer still holds the lease.
-            raise palace.MineAlreadyRunning(
-                f"palace {palace_path} is held by pid=999"
-            )
+            raise palace.MineAlreadyRunning(f"palace {palace_path} is held by pid=999")
         # Second attempt: peer has exited, flock is free.
         return _DummyLock()
 
@@ -4925,6 +4923,150 @@ def test_peer_writer_readonly_self_heals_after_peer_exits(monkeypatch):
     assert calls["count"] == 2  # retried, not stranded read-only
     assert mcp_server._MCP_WRITER_LOCK_CM is not None
     assert mcp_server._MCP_WRITER_READ_ONLY is False
+
+
+class _ReleasableDummyLock:
+    def __init__(self):
+        self.exited = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.exited += 1
+        return False
+
+
+def _install_writer_lease(monkeypatch, *, idle_env="0.01", last_mutation_age=999.0):
+    """Give the server a held dummy lease that is already past the idle window."""
+    import time
+
+    from mempalace import mcp_server
+
+    lock = _ReleasableDummyLock()
+    monkeypatch.delenv(mcp_server._MCP_ALLOW_PEER_WRITER_ENV, raising=False)
+    monkeypatch.setenv(mcp_server._MCP_WRITER_LEASE_IDLE_S_ENV, idle_env)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_CM", lock)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_READ_ONLY", False)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_LOCK_FAILED", False)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_INFLIGHT", 0)
+    monkeypatch.setattr(
+        mcp_server, "_MCP_WRITER_LAST_MUTATION_TS", time.monotonic() - last_mutation_age
+    )
+    resets = []
+    monkeypatch.setattr(mcp_server, "_force_chroma_cache_reset", lambda: resets.append(1))
+    return lock, resets
+
+
+def test_writer_lease_released_after_idle(monkeypatch):
+    """An idle lease must be released AND the Chroma caches dropped, so a
+    later re-acquire reopens the palace from disk instead of writing through
+    a stale in-memory HNSW graph (#1888)."""
+    from mempalace import mcp_server
+
+    lock, resets = _install_writer_lease(monkeypatch)
+
+    assert mcp_server._release_mcp_writer_lock_if_idle() is True
+    assert mcp_server._MCP_WRITER_LOCK_CM is None
+    assert lock.exited == 1
+    assert resets == [1]
+
+
+def test_writer_lease_not_released_before_idle_window(monkeypatch):
+    from mempalace import mcp_server
+
+    lock, resets = _install_writer_lease(monkeypatch, idle_env="3600", last_mutation_age=1.0)
+
+    assert mcp_server._release_mcp_writer_lock_if_idle() is False
+    assert mcp_server._MCP_WRITER_LOCK_CM is lock
+    assert lock.exited == 0
+    assert resets == []
+
+
+def test_writer_lease_not_released_while_mutating_tool_in_flight(monkeypatch):
+    from mempalace import mcp_server
+
+    lock, resets = _install_writer_lease(monkeypatch)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_INFLIGHT", 1)
+
+    assert mcp_server._release_mcp_writer_lock_if_idle() is False
+    assert mcp_server._MCP_WRITER_LOCK_CM is lock
+    assert resets == []
+
+
+def test_writer_lease_release_disabled_by_env_zero(monkeypatch):
+    """MEMPALACE_MCP_WRITER_LEASE_IDLE_S=0 restores the legacy
+    hold-until-exit behavior."""
+    from mempalace import mcp_server
+
+    lock, resets = _install_writer_lease(monkeypatch, idle_env="0")
+
+    assert mcp_server._release_mcp_writer_lock_if_idle() is False
+    assert mcp_server._MCP_WRITER_LOCK_CM is lock
+    assert resets == []
+
+
+def test_writer_lease_invalid_idle_env_falls_back_to_default(monkeypatch):
+    from mempalace import mcp_server
+
+    monkeypatch.setenv(mcp_server._MCP_WRITER_LEASE_IDLE_S_ENV, "banana")
+    assert mcp_server._writer_lease_idle_seconds() == mcp_server._MCP_WRITER_LEASE_IDLE_S_DEFAULT
+
+    monkeypatch.setenv(mcp_server._MCP_WRITER_LEASE_IDLE_S_ENV, "-5")
+    assert mcp_server._writer_lease_idle_seconds() == 0.0
+
+
+def test_writer_lease_reacquired_after_idle_release(monkeypatch):
+    """After an idle release the next mutating call must transparently win
+    the lease back (same self-heal path as a peer exit)."""
+    from mempalace import mcp_server, palace
+
+    lock, _resets = _install_writer_lease(monkeypatch)
+    fresh = _ReleasableDummyLock()
+    monkeypatch.setattr(palace, "mine_palace_lock", lambda palace_path: fresh)
+
+    assert mcp_server._release_mcp_writer_lock_if_idle() is True
+    ok, reason = mcp_server._acquire_mcp_writer_lock()
+    assert ok is True
+    assert reason == ""
+    assert mcp_server._MCP_WRITER_LOCK_CM is fresh
+
+
+def test_writer_lease_activity_tracks_inflight_and_restarts_idle_clock(monkeypatch):
+    import time
+
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_INFLIGHT", 0)
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_LAST_MUTATION_TS", 0.0)
+
+    before = time.monotonic()
+    with mcp_server._writer_lease_activity("mempalace_add_drawer"):
+        assert mcp_server._MCP_WRITER_INFLIGHT == 1
+    assert mcp_server._MCP_WRITER_INFLIGHT == 0
+    assert mcp_server._MCP_WRITER_LAST_MUTATION_TS >= before
+
+    # Non-mutating tools never touch the lease bookkeeping.
+    monkeypatch.setattr(mcp_server, "_MCP_WRITER_LAST_MUTATION_TS", 0.0)
+    with mcp_server._writer_lease_activity("mempalace_search"):
+        assert mcp_server._MCP_WRITER_INFLIGHT == 0
+    assert mcp_server._MCP_WRITER_LAST_MUTATION_TS == 0.0
+
+
+def test_writer_lease_atexit_release_uses_current_lease(monkeypatch):
+    """The once-registered atexit hook must release whatever lease is held at
+    exit time (a per-acquire callback would point at an already-exited CM
+    after an idle-release/re-acquire cycle)."""
+    from mempalace import mcp_server
+
+    lock, _resets = _install_writer_lease(monkeypatch)
+    mcp_server._release_mcp_writer_lock_at_exit()
+    assert lock.exited == 1
+    assert mcp_server._MCP_WRITER_LOCK_CM is None
+
+    # Idempotent when nothing is held.
+    mcp_server._release_mcp_writer_lock_at_exit()
+    assert lock.exited == 1
 
 
 def test_sqlite_integrity_gate_refuses_non_status_tool(monkeypatch):


### PR DESCRIPTION
## Problem

The per-palace writer lease (#1818/#1823) is held for the **whole MCP process lifetime**. As #1888 reports, one interactive session therefore starves every other writer on the palace for hours:

- hook-driven and manual `mempalace mine` runs exit with `MineAlreadyRunning`
- queued-writes daemon jobs fail against the held flock
- a second session's mutating tools are refused with `-32001` until the first session ends

We hit this in production daily: multiple Claude Code sessions plus lifecycle hooks against one palace produced recurring sqlite→HNSW divergence (362 drawers in one day) before 3.5.0's lease, and with the lease the starvation above.

## Fix — cooperative lease

Release the lease once no mutating tool has run for `MEMPALACE_MCP_WRITER_LEASE_IDLE_S` seconds (default 300; `0` restores the legacy hold-until-exit behavior).

The critical correctness piece: the release also runs `_force_chroma_cache_reset()`, so the next mutating call reopens the palace from disk. Stale in-memory HNSW state is *why* the lease was lifetime-scoped; dropping every cached Chroma handle at release time is what makes a re-acquire safe. Re-acquisition rides the existing self-heal retry path (#1960), so the first mutating tool after a release transparently wins the lease back — no restart, no user action.

Implementation notes:
- A mutating-tool in-flight counter plus last-mutation timestamp (guarded by a leaf `threading.Lock`) drive the idle clock; the lease is never released mid-write.
- The idle-exit watchdog thread performs the release check and now also starts when only the lease release is enabled (`MEMPALACE_MCP_IDLE_HOURS=0` no longer disables it).
- The atexit hook is registered once and reads the *current* lease, replacing the per-acquire lambda that would go stale across release/re-acquire cycles.

## Tests

8 new tests in `tests/test_mcp_server.py` covering: idle release + cache reset, no release before the window / while a mutation is in flight / when disabled via env, env fallback on invalid values, re-acquire after release, in-flight tracking, and atexit idempotency. Full suite: **3267 passed, 20 skipped**; ruff check/format clean.

## Scope

Part of the #1963 concurrent-writer cluster (tactical tier — no architectural change; fully compatible with both the queued-writes daemon and the #1270 bridge direction). Fixes the starvation half of #1888; the thread-local re-entrancy half was already fixed by the process-wide holder set in `palace.py`.

Follow-up candidate (separate PR if wanted): `service.run_mcp_tool` executes write handlers without taking `mine_palace_lock`, so daemon-executed `mcp_tool` jobs could still interleave with a live lease holder once something starts submitting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)