### PR TITLE
fix(searcher): probe HNSW divergence in CLI search to avoid silent SIGBUS

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -407,6 +407,86 @@ def _warn_if_legacy_metric(col) -> None:
     )
 
 
+def _hnsw_capacity_diverged(palace_path: str) -> bool:
+    """Return True if HNSW divergence is severe enough to crash ChromaDB.
+
+    Thin, exception-safe wrapper around
+    :func:`mempalace.backends.chroma.hnsw_capacity_status`. Used by the
+    CLI search path to short-circuit to the BM25-only fallback before
+    touching ``col.query()``, which would otherwise segfault the Rust
+    bindings on a diverged segment (#1222 covers the MCP path via the
+    module-level ``_vector_disabled`` flag; this covers the CLI path).
+
+    A probe that raises falls through to ``False`` so the caller proceeds
+    to the normal vector path — the underlying query then either succeeds
+    (probe was a false negative) or raises its own diagnostic error. The
+    probe itself must never be the thing that crashes search.
+    """
+    try:
+        from .backends.chroma import hnsw_capacity_status
+        from .config import get_configured_collection_name
+
+        info = hnsw_capacity_status(palace_path, get_configured_collection_name())
+        return bool(info.get("diverged"))
+    except Exception:
+        logger.debug("HNSW capacity probe raised; proceeding to vector path", exc_info=True)
+        return False
+
+
+def _print_search_results_bm25_only(
+    query: str, palace_path: str, wing: str, room: str, n_results: int
+) -> None:
+    """CLI fallback printer for when HNSW divergence fences off vector search.
+
+    Mirrors the vector-path output shape so users get lexical matches in
+    the format they expect, plus a clear notice pointing at
+    ``mempalace repair``. Replaces the silent SIGBUS users otherwise hit
+    when the CLI called ``col.query()`` against a diverged segment.
+    """
+    result = _bm25_only_via_sqlite(
+        query=query,
+        palace_path=palace_path,
+        wing=wing,
+        room=room,
+        n_results=n_results,
+    )
+    hits = result.get("results", [])
+
+    print(
+        "\n  NOTICE: vector search disabled — HNSW index has diverged from SQLite.\n"
+        "          Showing BM25-only results. Run `mempalace repair` to restore "
+        "vector search.\n"
+    )
+    print(f"{'=' * 60}")
+    print(f'  Results for: "{query}"')
+    if wing:
+        print(f"  Wing: {wing}")
+    if room:
+        print(f"  Room: {room}")
+    print(f"{'=' * 60}\n")
+
+    if not hits:
+        print(f'  No results found for: "{query}"')
+        return
+
+    for i, hit in enumerate(hits, 1):
+        bm25 = hit.get("bm25_score", 0.0)
+        wing_name = hit.get("wing", "?")
+        room_name = hit.get("room", "?")
+        source = hit.get("source_file", "?")
+
+        print(f"  [{i}] {wing_name} / {room_name}")
+        print(f"      Source: {source}")
+        print(f"      Match:  bm25={bm25}  (vector disabled)")
+        print()
+        for line in (hit.get("text", "") or "").strip().split("\n"):
+            print(f"      {line}")
+        print()
+        print(f"  {'─' * 56}")
+
+    print()
+
+
 def search(query: str, palace_path: str, wing: str = None, room: str = None, n_results: int = 5):
     """
     Search the palace. Returns verbatim drawer content.
@@ -417,6 +497,16 @@ def search(query: str, palace_path: str, wing: str = None, room: str = None, n_r
         if not os.path.isdir(palace_path):
             raise SearchError(f"No palace found at {palace_path}")
         raise SearchError(f"No palace database at {palace_path}")
+
+    # Probe HNSW divergence before _warn_if_legacy_metric and col.query().
+    # col.query() against a diverged segment segfaults ChromaDB's Rust
+    # bindings (exit 139 / SIGBUS at chromadb/api/rust.py:_query, zero
+    # diagnostic output). The MCP path gates this via the module-level
+    # _vector_disabled flag (#1222); the CLI path was missing the gate, so
+    # `mempalace search` on a diverged palace crashed silently instead of
+    # routing to the BM25-only sqlite fallback. See epic #1963.
+    if _hnsw_capacity_diverged(palace_path):
+        return _print_search_results_bm25_only(query, palace_path, wing, room, n_results)
 
     # Alert the user if this palace predates hnsw:space=cosine being set on
     # creation — their similarity scores will be junk until they run repair.

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -519,3 +519,78 @@ class TestSearchCLI:
         captured = capsys.readouterr()
         assert "[1]" in captured.out
         assert "[2]" in captured.out
+
+    def test_search_routes_to_bm25_when_hnsw_diverged(self, fake_palace_path, capsys):
+        """Regression: `mempalace search` on a diverged HNSW segment must not
+        segfault ChromaDB's Rust bindings.
+
+        The MCP path gates this via ``_vector_disabled`` (#1222); the CLI
+        path was missing the gate, so any query into a diverged palace
+        exited 139 (SIGBUS) at ``chromadb/api/rust.py:_query`` with zero
+        diagnostic output. This test verifies the CLI now probes
+        ``hnsw_capacity_status`` and routes to the BM25-only sqlite
+        fallback instead of calling ``col.query()`` against a segment
+        that would crash it.
+        """
+        mock_col = MagicMock()
+        bm25_result = {
+            "query": "anything",
+            "filters": {},
+            "total_before_filter": 1,
+            "results": [
+                {
+                    "text": "diary entry that matches the query",
+                    "wing": "wing_test",
+                    "room": "diary",
+                    "source_file": "test.jsonl",
+                    "bm25_score": 1.5,
+                    "distance": None,
+                }
+            ],
+            "fallback": "bm25_only_via_sqlite",
+            "fallback_reason": "vector_search_disabled",
+        }
+        with (
+            patch(
+                "mempalace.backends.chroma.hnsw_capacity_status",
+                return_value={"diverged": True, "message": "test divergence"},
+            ),
+            patch("mempalace.searcher._bm25_only_via_sqlite", return_value=bm25_result),
+            patch("mempalace.searcher.get_collection", return_value=mock_col),
+        ):
+            search("anything", fake_palace_path)
+        captured = capsys.readouterr()
+        # Routed to BM25 — never touched the vector path that would segfault.
+        mock_col.query.assert_not_called()
+        # User got actionable output, not a silent crash.
+        assert "mempalace repair" in captured.out
+        assert "diary entry that matches" in captured.out
+
+    def test_search_proceeds_to_vector_when_hnsw_healthy(self, fake_palace_path, capsys):
+        """Paired guard: when HNSW is healthy, the divergence probe must NOT
+        short-circuit to BM25 — vector search proceeds normally.
+
+        Prevents a regression where the gate accidentally always fires.
+        """
+        mock_col = MagicMock()
+        mock_col.metadata = {"hnsw:space": "cosine"}
+        mock_col.query.return_value = {
+            "documents": [["a matching doc"]],
+            "metadatas": [[{"source_file": "a.md", "wing": "w", "room": "r"}]],
+            "distances": [[0.1]],
+        }
+        with (
+            patch(
+                "mempalace.backends.chroma.hnsw_capacity_status",
+                return_value={"diverged": False, "status": "ok"},
+            ),
+            patch("mempalace.searcher._bm25_only_via_sqlite") as mock_bm25,
+            patch("mempalace.searcher.get_collection", return_value=mock_col),
+        ):
+            search("anything", fake_palace_path)
+        captured = capsys.readouterr()
+        # Vector path ran.
+        mock_col.query.assert_called_once()
+        # BM25 fallback was NOT invoked.
+        mock_bm25.assert_not_called()
+        assert "a matching doc" in captured.out


### PR DESCRIPTION
## What does this PR do?

Adds the HNSW divergence gate to the CLI `search()` path that the MCP path has had since #1222.

**Bug**: `mempalace search` on a palace whose HNSW segment has diverged from SQLite segfaults ChromaDB's Rust bindings — exit 139 (SIGBUS) at `chromadb/api/rust.py:_query`, zero stdout, zero stderr. The MCP path avoids this via the module-level `_vector_disabled` flag (set when `hnsw_capacity_status` reports divergence → route to BM25-only SQLite fallback). The CLI `search()` path was missing the same gate, so it called `col.query()` straight into the diverged segment.

**Fix**: before `_warn_if_legacy_metric(col)` and `col.query()`, probe `hnsw_capacity_status`. If diverged, route to a new `_print_search_results_bm25_only()` helper that:
- Emits a clear NOTICE pointing at `mempalace repair`
- Renders BM25-only results in the same shape as the vector path (so users get lexical matches in the format they expect)

The probe is exception-safe: any failure falls through to `False` so the probe itself can never be the thing that crashes search.

## How to test

```bash
uv run pytest tests/test_searcher.py -v                # 47 pass, includes 2 new
uv run pytest tests/test_searcher.py::TestSearchCLI -v # focused
```

Two new regression tests in `TestSearchCLI`:

- `test_search_routes_to_bm25_when_hnsw_diverged` — verifies `col.query()` is NOT called and the BM25 fallback fires when the probe reports divergence. Reproduces the bug pattern (without the actual segfault) by mocking `hnsw_capacity_status` to return `{"diverged": True}`.
- `test_search_proceeds_to_vector_when_hnsw_healthy` — paired guard that the probe does not short-circuit on a healthy palace (prevents a regression where the gate accidentally always fires).

## Checklist

- [x] Tests pass (`uv run pytest tests/test_searcher.py tests/test_hnsw_capacity.py tests/test_backends.py` → 168 passed)
- [x] No hardcoded paths
- [x] Linter passes on changed files (`uvx --from "ruff==0.15.14" ruff check mempalace/searcher.py tests/test_searcher.py` → All checks passed; `ruff format --check` → 2 files already formatted)

## Scope

Intentionally narrow — one probe + one fallback printer in `searcher.py`, plus the two regression tests. No changes to `hnsw_capacity_status` (the detection probe, owned by `d70433`), no changes to `_bm25_only_via_sqlite` (the existing fallback used by the MCP path), no changes to the MCP server's `_vector_disabled` mechanism.

Part of epic #1963 (concurrent-writer HNSW corruption cluster). This is a Tier-1 tactical guardrail — it doesn't prevent divergence, but it stops the CLI from silently crashing when divergence exists.

🤖 This PR was prepared with AI assistance. The fix design and implementation are mine; the AI pair helped with test scaffolding and PR logistics.

---

## Note on test-windows CI

The  job failed with `tests/test_daemon.py::test_worker_overrides_client_palace_path - DaemonError: timed out`. This is a **pre-existing Windows timing flake**, not a regression from this PR:

- This PR's diff touches only `mempalace/searcher.py` and `tests/test_searcher.py` — zero connection to the daemon (`grep -iE 'daemon|queue|worker'` on the diff is empty).
- The failing test starts a real HTTP daemon server and asserts with a tight `timeout=5`. On slower Windows runners that window is too tight; the test passes locally on macOS in 0.94s.
- pytest's `--only-rerun "Failed to apply logs to the hnsw segment writer"` filter doesn't match `DaemonError: timed out`, so the flake never gets an automatic retry.
- Multiple recent **merged** PRs (#1945, #1946, #1957, #1960) show the same CI failure pattern — the lint slip on `test_mcp_server.py` plus this daemon Windows timing issue are both currently affecting all PRs opened against `develop`.

The four green test jobs (Linux 3.9/3.11/3.13, macOS) cover the actual change in this PR.