### PR TITLE
feat(cli): warn in mempalace status when hooks are active but daemon off

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -33,6 +33,7 @@ import os
 import sys
 import shlex
 import argparse
+import time
 from pathlib import Path
 
 from .config import MempalaceConfig
@@ -1016,11 +1017,57 @@ def cmd_hallways(args):
         print(f"    {label}")
 
 
+def _warn_if_hooks_active_daemon_off(palace_path: str) -> None:
+    """Warn when stop-hooks are actively saving but the daemon isn't running.
+
+    This is the at-risk topology from epic #1963: when hooks fire
+    concurrently without the daemon serializing them, ``mine_palace_lock``
+    fails fast on the loser and the write is deferred. The repeated
+    concurrent-open pressure against ChromaDB's single-writer HNSW segment
+    contributes to recurring divergence. Surfacing this state in
+    ``mempalace status`` is the cheapest adoption nudge — users running
+    status (a common command) learn the daemon exists and that they're
+    not using it.
+
+    Best-effort: never raises, never blocks the status output. A daemon
+    probe that fails just means we can't tell, so we stay silent rather
+    than crying wolf.
+    """
+    try:
+        from .daemon import get_client_if_running
+
+        if get_client_if_running(palace_path) is not None:
+            return  # Daemon is up — hook saves are serialized through it.
+    except Exception:
+        return  # Don't let probe failures break status.
+
+    # Evidence of recent hook activity: ~/.mempalace/hook_state/hook.log
+    # touched in the last week. Older than that and the user isn't actively
+    # using hooks, so the warning would be noise.
+    hook_log = os.path.join(os.path.expanduser("~"), ".mempalace", "hook_state", "hook.log")
+    if not os.path.exists(hook_log):
+        return
+    seven_days_s = 7 * 24 * 3600
+    try:
+        if time.time() - os.path.getmtime(hook_log) > seven_days_s:
+            return
+    except OSError:
+        return
+
+    print()
+    print("  WARNING: hooks are active but the daemon is not running.")
+    print("           Concurrent hook saves fail-fast and the repeated")
+    print("           concurrent-open pressure contributes to recurring HNSW")
+    print("           divergence (epic #1963). Run `mempalace daemon start`")
+    print("           to serialize hook writes through a single ChromaDB client.")
+
+
 def cmd_status(args):
     from .miner import status
 
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     status(palace_path=palace_path)
+    _warn_if_hooks_active_daemon_off(palace_path)
 
 
 def cmd_palace_set_embedder(args):

--- a/tests/test_cli_daemon_warning.py
+++ b/tests/test_cli_daemon_warning.py
@@ -1,0 +1,90 @@
+"""Tests for the 'hooks active but daemon off' status warning.
+
+The warning surfaces the at-risk topology from epic #1963: stop-hooks are
+actively saving but the daemon isn't running, so concurrent hook saves
+fail-fast on ``mine_palace_lock`` and the repeated concurrent-open pressure
+against ChromaDB's single-writer HNSW segment contributes to recurring
+divergence. ``mempalace status`` is a common command — surfacing the state
+there is the cheapest adoption nudge.
+"""
+
+import os
+import time
+from unittest.mock import patch
+
+from mempalace.cli import _warn_if_hooks_active_daemon_off
+
+
+def _seed_recent_hook_log(tmp_path):
+    """Stand up a ~/.mempalace/hook_state/hook.log that looks recently active."""
+    state_dir = tmp_path / ".mempalace" / "hook_state"
+    state_dir.mkdir(parents=True)
+    (state_dir / "hook.log").write_text("[recent hook activity]\n")
+
+
+def test_no_warning_when_daemon_running(tmp_path, capsys, monkeypatch):
+    """Daemon up → hook saves are serialized → no warning."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _seed_recent_hook_log(tmp_path)
+
+    with patch("mempalace.daemon.get_client_if_running", return_value=object()):
+        _warn_if_hooks_active_daemon_off(str(tmp_path / "palace"))
+
+    captured = capsys.readouterr()
+    assert "daemon is not running" not in captured.out
+
+
+def test_warning_when_hooks_active_daemon_off(tmp_path, capsys, monkeypatch):
+    """Hooks active (recent hook.log) + daemon off → warn + actionable hint."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _seed_recent_hook_log(tmp_path)
+
+    with patch("mempalace.daemon.get_client_if_running", return_value=None):
+        _warn_if_hooks_active_daemon_off(str(tmp_path / "palace"))
+
+    captured = capsys.readouterr()
+    assert "daemon is not running" in captured.out
+    assert "mempalace daemon start" in captured.out
+
+
+def test_no_warning_when_hooks_never_ran(tmp_path, capsys, monkeypatch):
+    """No hook.log at all → hooks never active here → nothing to warn about."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Intentionally do NOT create ~/.mempalace/hook_state/hook.log.
+
+    with patch("mempalace.daemon.get_client_if_running", return_value=None):
+        _warn_if_hooks_active_daemon_off(str(tmp_path / "palace"))
+
+    captured = capsys.readouterr()
+    assert "daemon is not running" not in captured.out
+
+
+def test_no_warning_when_hook_activity_stale(tmp_path, capsys, monkeypatch):
+    """hook.log older than the 7-day window → hooks effectively inactive → no warning."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _seed_recent_hook_log(tmp_path)
+    log = tmp_path / ".mempalace" / "hook_state" / "hook.log"
+    old = time.time() - (30 * 24 * 3600)  # 30 days ago
+    os.utime(log, (old, old))
+
+    with patch("mempalace.daemon.get_client_if_running", return_value=None):
+        _warn_if_hooks_active_daemon_off(str(tmp_path / "palace"))
+
+    captured = capsys.readouterr()
+    assert "daemon is not running" not in captured.out
+
+
+def test_no_warning_when_daemon_probe_raises(tmp_path, capsys, monkeypatch):
+    """Best-effort contract: a daemon probe that raises must not break status."""
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _seed_recent_hook_log(tmp_path)
+
+    with patch("mempalace.daemon.get_client_if_running", side_effect=boom):
+        _warn_if_hooks_active_daemon_off(str(tmp_path / "palace"))
+
+    captured = capsys.readouterr()
+    assert "daemon is not running" not in captured.out


### PR DESCRIPTION
## What does this PR do?

Surfaces the at-risk "hooks active but daemon off" topology in `mempalace status`, the cheapest adoption nudge for the opt-in daemon.

The daemon (`mempalace/daemon.py`) serializes hook writes through a single ChromaDB PersistentClient, eliminating the concurrent-open pressure that produces recurring HNSW divergence (epic #1963; cluster: #357 #1092 #1581 #1799 #1845). It is **off by default**, requires an explicit `mempalace daemon start`, and is never surfaced in onboarding or status — so users whose stop-hooks are actively saving have no signal that they're in the at-risk topology until divergence recurs (4-5 times, in the reporter's case).

This PR adds a best-effort warning to `cmd_status`:

- When `daemon.get_client_if_running(palace_path)` reports the daemon isn't running
- AND `~/.mempalace/hook_state/hook.log` shows activity within the last 7 days

…print a clear pointer at `mempalace daemon start`. The warning never raises and never blocks the status output — a probe that fails just means we can't tell, so we stay silent rather than crying wolf.

## How to test

```bash
uv run pytest tests/test_cli_daemon_warning.py -v        # the 5 new tests
uv run pytest tests/test_cli.py -v                       # no regression on cmd_status callers
```

Five new tests cover the seams:

- `test_no_warning_when_daemon_running` — daemon up → no warning (hook saves serialized)
- `test_warning_when_hooks_active_daemon_off` — the at-risk state → warn + actionable hint
- `test_no_warning_when_hooks_never_ran` — no hook.log → nothing to warn about
- `test_no_warning_when_hook_activity_stale` — hook.log older than 7 days → effectively inactive
- `test_no_warning_when_daemon_probe_raises` — best-effort contract: probe failure must not break status

## Checklist

- [x] Tests pass (`uv run pytest tests/test_cli_daemon_warning.py tests/test_cli.py` → 87 passed)
- [x] No hardcoded paths
- [x] Linter passes on changed files (`uvx --from "ruff==0.15.14" ruff check` + `ruff format --check` clean)

## Scope

Intentionally narrow — one helper + one call site + tests. Part of epic #1963. Follow-ups (deferred to keep this PR focused):

- Onboarding offer to enable + start the daemon after hooks are set up
- A `mempalace daemon install-launchd` (macOS) / systemd (Linux) helper so the daemon survives reboots — without this, the daemon dies on reboot and hooks silently fall back to the direct fail-fast path

🤖 This PR was prepared with AI assistance per CONTRIBUTING.md.
