### PR TITLE
fix(palace): pair the mine_palace_lock holder-set update with its release (#1970)

### DIFF
--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -1165,8 +1165,14 @@ def mine_palace_lock(palace_path: str):
                 ) from exc
         # Record our own identity for any later contender's diagnostic message.
         _write_lock_holder(lf)
-        _mark_held(palace_key)
+        # Mark the hold from inside the try so it always pairs with
+        # _mark_released. If it sat before the try, an async exception
+        # (a SIGINT/KeyboardInterrupt) landing in the gap would orphan
+        # palace_key in the holder set while the outer finally frees the
+        # flock, so the in-memory hold would outlive the OS lock and a later
+        # re-entrant acquire would pass through and write without the flock.
         try:
+            _mark_held(palace_key)
             yield
         finally:
             _mark_released(palace_key)

--- a/tests/test_palace_locks.py
+++ b/tests/test_palace_locks.py
@@ -17,6 +17,7 @@ import sys
 
 import pytest
 
+import mempalace.palace as palace_mod
 from mempalace.palace import (
     _write_lock_holder,
     MineAlreadyRunning,
@@ -394,3 +395,47 @@ def test_mine_global_lock_is_alias_for_back_compat(tmp_path, monkeypatch):
     assert mine_global_lock is mine_palace_lock
     with mine_global_lock(str(tmp_path / "palace")):
         pass  # the alias accepts the same palace_path argument
+
+
+def test_holder_set_not_orphaned_by_interrupt_after_mark_held(tmp_path, monkeypatch):
+    """An async interrupt right after the hold is recorded must not leave the
+    palace key stranded in the process-wide holder set.
+
+    ``_mark_held`` sits inside the ``try`` whose ``finally`` runs
+    ``_mark_released``, so the two are paired on every exit. If ``_mark_held``
+    ran before the ``try``, a ``KeyboardInterrupt``/signal landing in the gap
+    would strand the key: the outer ``finally`` still frees the flock, so
+    ``_held_by_this_process`` would report a hold the OS lock no longer backs,
+    and the next re-entrant acquire in this process would pass through and
+    write without the flock (two concurrent writers into one palace).
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    palace = str(tmp_path / "palace")
+
+    before = set(palace_mod._palace_lock_keys)
+
+    # Model the interrupt: run the real _mark_held (records the hold), then
+    # raise, as a signal arriving at that instant would.
+    real_mark_held = palace_mod._mark_held
+
+    def _mark_then_interrupt(lock_key):
+        real_mark_held(lock_key)
+        raise KeyboardInterrupt
+
+    palace_mod._mark_held = _mark_then_interrupt
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            with mine_palace_lock(palace):
+                pass
+    finally:
+        # Restore by hand (not monkeypatch.setattr, which unpatches only at
+        # teardown) so the reuse check below calls the real _mark_held.
+        palace_mod._mark_held = real_mark_held
+
+    assert set(palace_mod._palace_lock_keys) == before, (
+        "palace key was stranded in the holder set after an interrupt: "
+        "the in-memory hold outlived the flock"
+    )
+    # The flock was freed and no stale hold remains, so the lock is reusable.
+    with mine_palace_lock(palace):
+        pass


### PR DESCRIPTION
Fixes #1970.

## What does this PR do?

`mine_palace_lock()` recorded the process-wide hold with `_mark_held(palace_key)` *before* the `try:` whose `finally:` runs `_mark_released()`. An async exception (a `KeyboardInterrupt`/SIGINT, or one injected into a thread) landing in the gap after `_mark_held()` and before the `try:` skips `_mark_released()`, so `palace_key` is left in the `_palace_lock_keys` set. The outer `finally:` still frees the flock, so the in-memory holder set outlives the OS lock: `_held_by_this_process()` then reports a hold the flock no longer backs, the next re-entrant acquire in this process passes through and writes without the flock, and another process is free to acquire it at the same time. That is two writers into one palace, the HNSW-corruption race the lock is there to stop.

The fix moves `_mark_held()` to the first line inside the `try:`, so it pairs with `_mark_released()` on every exit. `_mark_released()` is a `set.discard`, so releasing a key that was never added is a no-op, and the normal acquire/release path is unchanged.

## How to test

`tests/test_palace_locks.py::test_holder_set_not_orphaned_by_interrupt_after_mark_held` runs the real `_mark_held`, then raises in the window as a signal would, and asserts the holder set is unchanged afterwards. It fails on the current code (the key is stranded) and passes with the fix.

```
uv run pytest tests/test_palace_locks.py tests/test_chroma_collection_lock.py
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
