### PR TITLE
feat(miner): add C and C++ file extensions to READABLE_EXTENSIONS

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -235,6 +235,13 @@ READABLE_EXTENSIONS = {
     ".rb",
     ".go",
     ".rs",
+    # C / C++
+    ".c",
+    ".h",
+    ".cpp",
+    ".hpp",
+    ".cc",
+    ".hh",
 }
 
 SKIP_DIRS = {

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -125,6 +125,13 @@ READABLE_EXTENSIONS = {
     ".java",
     ".go",
     ".rs",
+    # C / C++
+    ".c",
+    ".h",
+    ".cpp",
+    ".hpp",
+    ".cc",
+    ".hh",
     ".swift",
     ".kt",
     ".kts",

--- a/tests/test_miner_c_cpp_visibility.py
+++ b/tests/test_miner_c_cpp_visibility.py
@@ -1,0 +1,34 @@
+"""C/C++ sources must not be silently skipped by the project miner.
+
+Same failure class as test_miner_jsonl_visibility.py: scan_project keeps
+only files whose suffix is in READABLE_EXTENSIONS. The whitelist grew
+per-stack (C#, PHP, Swift/Kotlin, LaTeX) but never gained C or C++, so
+mining any C project silently drops every .c/.h file — no warning, no
+log line.
+"""
+
+import tempfile
+from pathlib import Path
+
+from mempalace.miner import READABLE_EXTENSIONS, scan_project
+
+C_CPP_EXTENSIONS = {".c", ".h", ".cpp", ".hpp", ".cc", ".hh"}
+
+
+class TestCAndCppNotSilentlySkipped:
+    def test_c_cpp_in_readable_extensions(self):
+        missing = C_CPP_EXTENSIONS - READABLE_EXTENSIONS
+        assert not missing, (
+            f"READABLE_EXTENSIONS is missing C/C++ suffixes {sorted(missing)}; "
+            "every such file in a mined project is silently skipped."
+        )
+
+    def test_scan_project_picks_up_c_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            c_path = tmpdir / "probe.c"
+            c_path.write_text(
+                '#include <stdio.h>\nint main(void) { printf("hello\\n"); return 0; }\n'
+            )
+            found = [p.name for p in scan_project(str(tmpdir))]
+            assert "probe.c" in found, f"scan_project silently dropped probe.c. Returned: {found}"


### PR DESCRIPTION
## Problem

`READABLE_EXTENSIONS` has grown per-stack over time (C#/.NET in #952, PHP, Swift/Kotlin in #1368, LaTeX) but never gained C or C++. Mining any C project silently drops every `.c`/`.h` file at the `scan_project` suffix gate — no warning, no log line. Found in the wild when a mine run of a directory containing a `.c` probe file reported it as neither processed nor visibly skipped.

## Change

- Add `.c .h .cpp .hpp .cc .hh` to `miner.py:READABLE_EXTENSIONS`
- Same addition to `entity_detector.py`'s twin list so entity detection sees the same files
- Visibility test following the pattern of `tests/test_miner_jsonl_visibility.py` (whitelist membership + `scan_project` picks up a real `.c` file)

`uv run pytest tests/ ` green locally; ruff check/format clean.

Happy to rebase onto the config-driven extensions work (#1420 et al.) if that's landing soon — this just closes the gap in the shipped default list meanwhile.