### PR TITLE
fix: make _HTTP_REQUEST_LOCK write-only so reads run concurrently

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -322,6 +322,9 @@ _READ_ONLY = bool(getattr(_args, "read_only", False)) or os.environ.get(
 
 _kg_by_path: dict[str, KnowledgeGraph] = {}
 _kg_cache_lock = threading.Lock()
+# Narrow guards so read paths do not depend on the (now write-only) global lock.
+_metadata_cache_lock = threading.Lock()
+_collection_cache_lock = threading.RLock()
 _palace_flag_given: bool = bool(_args.palace)
 
 # MCP server idle auto-exit (#1552).  Stale MCP servers from ended Claude
@@ -1041,23 +1044,27 @@ def _get_collection(create=False):
                 ):
                     _collection_open_error = None
                     return _collection_cache
-                _collection_cache = None
-                _collection_cache_backend = None
-                _collection_cache_palace = None
-                if _collection_cache is None:
-                    from .palace import get_collection as palace_get_collection
+                with _collection_cache_lock:
+                    # Double-checked locking: another thread may have rebuilt
+                    # the handle while we waited on the lock.
+                    if not (
+                        _collection_cache is not None
+                        and _collection_cache_backend == backend_name
+                        and _collection_cache_palace == _config.palace_path
+                    ):
+                        from .palace import get_collection as palace_get_collection
 
-                    _collection_cache = palace_get_collection(
-                        _config.palace_path,
-                        collection_name=_config.collection_name,
-                        create=create,
-                        backend=backend_name,
-                    )
-                    _collection_cache_backend = backend_name
-                    _collection_cache_palace = _config.palace_path
-                    _collection_open_error = None
-                    _metadata_cache = None
-                    _metadata_cache_time = 0
+                        _collection_cache = palace_get_collection(
+                            _config.palace_path,
+                            collection_name=_config.collection_name,
+                            create=create,
+                            backend=backend_name,
+                        )
+                        _collection_cache_backend = backend_name
+                        _collection_cache_palace = _config.palace_path
+                        _collection_open_error = None
+                        _metadata_cache = None
+                        _metadata_cache_time = 0
                 return _collection_cache
             except (BackendMismatchError, KeyError) as exc:
                 logger.warning("backend open failed for %s: %s", _config.palace_path, exc)
@@ -1360,8 +1367,9 @@ def _get_cached_metadata(col, where=None):
         return _metadata_cache
     result = _fetch_all_metadata(col, where=where)
     if where is None:
-        _metadata_cache = result
-        _metadata_cache_time = now
+        with _metadata_cache_lock:
+            _metadata_cache = result
+            _metadata_cache_time = now
     return result
 
 
@@ -5075,6 +5083,25 @@ def _json_rpc_parse_error(req_id=None):
 # Defined here (not inside main()) so _serve_http() / _build_http_server()
 # can reference them as free names without a NameError.
 _HTTP_REQUEST_LOCK = threading.Lock()
+
+# Only mutating tools acquire _HTTP_REQUEST_LOCK; all reads (and
+# initialize/ping/tools/list) run concurrently, lock-free. Derived from the
+# canonical _MUTATING_TOOLS set (defined above) so it cannot drift from it.
+# mempalace_reconnect is added on top because tool_reconnect() closes and
+# rebuilds the shared backend handle, which must not race a concurrent read.
+_WRITE_TOOLS = _MUTATING_TOOLS | {"mempalace_reconnect"}
+
+
+def _request_is_mutation(request):
+    # True only for a tools/call to a mutating tool; everything else is lock-free.
+    if not isinstance(request, dict):
+        return False
+    if request.get("method") != "tools/call":
+        return False
+    params = request.get("params") or {}
+    if not isinstance(params, dict):
+        return False
+    return params.get("name") in _WRITE_TOOLS
 _HTTP_MAX_REQUEST_BYTES = 16 * 1024 * 1024
 # Host literals that always denote this machine. Used both to decide whether a
 # bind is loopback (skip the network-exposure warning) and to pin the Host
@@ -5280,10 +5307,15 @@ def _build_http_server(host: str, port: int):
                 self._send_json(400, _json_rpc_parse_error())
                 return
 
-            # Preserve the single-process / single-palace-handle behavior that
-            # stdio deployments rely on. HTTP gives us a safer transport, not
-            # concurrent Chroma/HNSW mutation.
-            with _HTTP_REQUEST_LOCK:
+            # Write-only serialization: the global lock previously wrapped
+            # EVERY request, so a slow read (e.g. a list_wings full-scan) blocked
+            # all concurrent searches and stalled client connects. Only mutating
+            # tools take the single-writer guard now; reads (and
+            # initialize/ping/tools/list) run concurrently, lock-free.
+            if _request_is_mutation(request):
+                with _HTTP_REQUEST_LOCK:
+                    response = handle_request(request)
+            else:
                 response = handle_request(request)
 
             if response is None:


### PR DESCRIPTION
Fixes #1984.

`_HTTP_REQUEST_LOCK` wrapped the whole `handle_request()` dispatch, serializing every tool despite `ThreadingHTTPServer(daemon_threads=True)`. Its purpose (per its comment) is preventing concurrent Chroma/HNSW mutation, and the Chroma guards are gated by `_is_chroma_backend()` — so on the Qdrant backend it needlessly serialized reads, and a slow read (e.g. a `list_wings` full-scan) starved concurrent searches and caused MCP connect timeouts.

**Change**
- Acquire `_HTTP_REQUEST_LOCK` only for mutating tools; reads and `initialize`/`ping`/`tools/list` run lock-free.
- Add a `_metadata_cache` guard (paired store in `_get_cached_metadata`; the fetch stays outside the lock).
- Add a `_collection_cache` rebuild guard in `_get_collection` (double-checked; warm cache-hit stays lock-free).
- Leave the cross-process writer flock (`_MCP_WRITER_LOCK`) unchanged — write-vs-write still serializes.

Chroma's HNSW-mutation hazards remain covered where `_is_chroma_backend()` applies; this only stops the lock from serializing reads on backends that don't need it.

**Port note (please review):** the fix was authored against v3.5.0, whose `mcp_server.py` is ~400 lines shorter than `develop` HEAD. Two judgment calls while porting:
- The mutating-tool set reuses `develop`'s canonical `_MUTATING_TOOLS` (`_WRITE_TOOLS = _MUTATING_TOOLS | {"mempalace_reconnect"}`) rather than the hand-rolled list from v3.5.0. This automatically picks up `mempalace_kg_supersede` (a mutator that exists on `develop` but not in the v3.5.0 list) and avoids a parallel set that would drift. `mempalace_reconnect` is added on top because `tool_reconnect()` closes and rebuilds the shared backend handle, which must not race a concurrent lock-free read — `develop` deliberately keeps it out of `_MUTATING_TOOLS`, but under today's wrap-everything lock it is serialized, and this preserves that.
- The second `_HTTP_REQUEST_LOCK` acquisition (the `_warmup_with_lock` eager-embedder-warmup thread) is intentionally left holding the lock — it mutates embedder/HNSW state and is not a per-request read path.

**Verification — please note honestly:** authored and concurrency-tested on **v3.5.0** (search 3.75s while `list_wings` still scanning — pre-fix hung; 5 concurrent searches <5s; aggregate reads race-free; 2 concurrent writes serialize; read-during-write 0.196s). This PR **ports** that fix onto `develop` HEAD; the port is verified by inspection + `py_compile`, **not** re-run against the concurrency suite on `develop`. Maintainer verification against your test setup is welcome.