### PR TITLE
fix(mcp): answer initialize immediately — run startup preflight in a background thread

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -342,6 +342,11 @@ _last_request_time: float = time.monotonic()
 _sqlite_integrity_checked = False
 _sqlite_integrity_errors: list[str] = []
 _sqlite_integrity_check_error = ""
+# Serializes quick_check runs between the async startup preflight thread and
+# lazy consumers on the protocol thread (double-checked in
+# _ensure_sqlite_integrity_status) so the O(database size) probe never runs
+# twice concurrently.
+_sqlite_integrity_refresh_lock = threading.Lock()
 _SQLITE_INTEGRITY_ERROR_CODE = -32002
 _SQLITE_INTEGRITY_ALLOWED_TOOLS = frozenset(
     {
@@ -526,6 +531,12 @@ def _refresh_sqlite_integrity_status() -> None:
     SQLite-layer corruption (#1818).
     """
 
+    with _sqlite_integrity_refresh_lock:
+        _refresh_sqlite_integrity_status_locked()
+
+
+def _refresh_sqlite_integrity_status_locked() -> None:
+    # Probe body; callers must hold _sqlite_integrity_refresh_lock.
     global _sqlite_integrity_checked
     global _sqlite_integrity_errors
     global _sqlite_integrity_check_error
@@ -583,8 +594,14 @@ def _refresh_sqlite_integrity_status() -> None:
 
 
 def _ensure_sqlite_integrity_status() -> None:
-    if not _sqlite_integrity_checked:
-        _refresh_sqlite_integrity_status()
+    if _sqlite_integrity_checked:
+        return
+    with _sqlite_integrity_refresh_lock:
+        # Double-checked: the startup preflight thread may have finished the
+        # probe while this caller waited on the lock — don't pay the
+        # O(database size) quick_check twice.
+        if not _sqlite_integrity_checked:
+            _refresh_sqlite_integrity_status_locked()
 
 
 def _sqlite_integrity_payload() -> dict:
@@ -5357,6 +5374,21 @@ def _serve_http(host: str, port: int) -> None:
             logger.info("MemPalace MCP HTTP server shutting down")
 
 
+def _startup_preflight() -> None:
+    """Startup SQLite integrity + HNSW capacity probes, off the protocol thread.
+
+    Runs the same checks the stdio loop used to run synchronously before
+    reading the first request. Failures must never take down the server: the
+    lazy consumers (_ensure_sqlite_integrity_status, _get_client) re-run or
+    re-check on demand, so an exception here only loses the early warning.
+    """
+    try:
+        _ensure_sqlite_integrity_status()
+        _refresh_vector_disabled_flag()
+    except Exception:
+        logger.exception("startup preflight failed")
+
+
 def _run_stdio_loop() -> None:
     _restore_stdout()
 
@@ -5373,11 +5405,19 @@ def _run_stdio_loop() -> None:
 
     logger.info("MemPalace MCP Server starting...")
 
-    # Pre-flight: probe HNSW capacity before any tool call so the warning
-    # is visible at startup rather than on first use (#1222). Pure
-    # filesystem read; never opens a chromadb client.
-    _refresh_sqlite_integrity_status()
-    _refresh_vector_disabled_flag()
+    # Pre-flight in a background thread: PRAGMA quick_check reads every page
+    # of chroma.sqlite3 (20s+ on multi-GB palaces) and running it before the
+    # protocol loop starves the client's initialize timeout, even though the
+    # handshake itself never touches the database. The #1222 intent (warnings
+    # visible at startup rather than on first use) is preserved — the probe
+    # starts now and logs as soon as it finishes; tool calls that need the
+    # verdict serialize on _sqlite_integrity_refresh_lock via
+    # _ensure_sqlite_integrity_status instead of re-running the probe.
+    threading.Thread(
+        target=_startup_preflight,
+        name="mcp-startup-preflight",
+        daemon=True,
+    ).start()
 
     # Opt-in: pre-load the embedder so the first chromadb-write tool call
     # does not pay the ONNX/CoreML cold-load tax under the MCP client

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5341,3 +5341,99 @@ class TestListDrawersDateFilters:
 
         since = datetime(2026, 1, 2)
         assert _filed_at_in_window("2026-01-02T08:00:00Z", since, None) is True
+
+
+# ── MCP stdio startup: async preflight ───────────────────────────────────
+
+
+def test_startup_preflight_does_not_block_initialize(monkeypatch):
+    """The startup integrity probe is O(database size) (PRAGMA quick_check
+    reads every page of chroma.sqlite3 — 20s+ on multi-GB palaces) and used
+    to run before the protocol loop, starving the client's initialize
+    timeout. It now runs on the mcp-startup-preflight thread; the handshake
+    must answer immediately while the probe is still in flight."""
+    import threading
+    import time
+
+    from mempalace import mcp_server
+
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+
+    def slow_probe():
+        probe_started.set()
+        release_probe.wait(10)
+        mcp_server._sqlite_integrity_checked = True
+
+    monkeypatch.setattr(mcp_server, "_refresh_sqlite_integrity_status_locked", slow_probe)
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_checked", False)
+    monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", lambda: None)
+
+    preflight = threading.Thread(target=mcp_server._startup_preflight, daemon=True)
+    preflight.start()
+    try:
+        assert probe_started.wait(5), "preflight thread never started the probe"
+
+        started = time.monotonic()
+        response = mcp_server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": "2024-11-05"},
+            }
+        )
+        elapsed = time.monotonic() - started
+
+        assert response["result"]["serverInfo"]["name"] == "mempalace"
+        assert elapsed < 1.0, f"initialize blocked {elapsed:.2f}s behind the startup probe"
+    finally:
+        release_probe.set()
+        preflight.join(5)
+
+
+def test_ensure_sqlite_integrity_status_joins_inflight_probe(monkeypatch):
+    """A lazy consumer (tool-call integrity gate) arriving while the startup
+    preflight probe is still running must wait for that probe's verdict on
+    _sqlite_integrity_refresh_lock — not run a second O(database size)
+    quick_check concurrently, and not proceed without a verdict."""
+    import threading
+
+    from mempalace import mcp_server
+
+    probe_calls = []
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+
+    def slow_probe():
+        probe_calls.append(1)
+        probe_started.set()
+        release_probe.wait(10)
+        mcp_server._sqlite_integrity_checked = True
+
+    monkeypatch.setattr(mcp_server, "_refresh_sqlite_integrity_status_locked", slow_probe)
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_checked", False)
+
+    background = threading.Thread(
+        target=mcp_server._refresh_sqlite_integrity_status, daemon=True
+    )
+    background.start()
+    assert probe_started.wait(5), "background probe never started"
+
+    consumer_done = threading.Event()
+
+    def consumer():
+        mcp_server._ensure_sqlite_integrity_status()
+        consumer_done.set()
+
+    consumer_thread = threading.Thread(target=consumer, daemon=True)
+    consumer_thread.start()
+    try:
+        assert not consumer_done.wait(0.3), "consumer bypassed the in-flight probe"
+        release_probe.set()
+        assert consumer_done.wait(5), "consumer never unblocked after the probe finished"
+        assert probe_calls == [1], "quick_check probe ran more than once"
+    finally:
+        release_probe.set()
+        background.join(5)
+        consumer_thread.join(5)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5414,9 +5414,7 @@ def test_ensure_sqlite_integrity_status_joins_inflight_probe(monkeypatch):
     monkeypatch.setattr(mcp_server, "_refresh_sqlite_integrity_status_locked", slow_probe)
     monkeypatch.setattr(mcp_server, "_sqlite_integrity_checked", False)
 
-    background = threading.Thread(
-        target=mcp_server._refresh_sqlite_integrity_status, daemon=True
-    )
+    background = threading.Thread(target=mcp_server._refresh_sqlite_integrity_status, daemon=True)
     background.start()
     assert probe_started.wait(5), "background probe never started"
 


### PR DESCRIPTION
## Problem

`_run_stdio_loop` runs `_refresh_sqlite_integrity_status()` and `_refresh_vector_disabled_flag()` **before** reading the first JSON-RPC request. `PRAGMA quick_check` reads every page of `chroma.sqlite3`, so the startup probe is O(database size) — and the MCP client's connect timeout keeps ticking the whole time, even though the `initialize` response itself never touches the database.

Measured on a real palace (1.72 GB `chroma.sqlite3`, 326k drawers, Windows 11, NVMe):

- `PRAGMA quick_check` alone: **20.31 s** (40–46 s under disk/lock contention with a second MemPalace process on the same palace)
- Startup timeline (stdio probe): `initialize` sent at 0.0 s → `"MemPalace MCP Server starting..."` at 1.45 s (imports done) → initialize response at **20.45 s**. The entire gap is the synchronous probe.
- Claude Code caps the MCP connect handshake at 60 s (hard cap). On palaces this size the handshake regularly starves and the client drops the server — the exact "MemPalace MCP hangs / VS Code won't start" failure mode.

c54531a already mitigates by skipping the startup probe above 512 MB, but that trades away the startup check entirely for large palaces — and any palace under the limit still pays up to tens of seconds of handshake latency.

## Fix

Run the startup preflight on a background daemon thread (`mcp-startup-preflight`) instead of blocking the protocol loop:

- `initialize` answers immediately (it is pure in-memory protocol negotiation).
- The #1222 intent is preserved: the probe still starts at startup and logs its warning as soon as it finishes — it just no longer holds the handshake hostage.
- New `_sqlite_integrity_refresh_lock` with double-checked locking in `_ensure_sqlite_integrity_status`: a tool call arriving mid-probe **waits for the in-flight verdict** on the lock instead of running a second O(database size) quick_check — and never proceeds unverified. The integrity gate semantics (#1818) are unchanged: no tool result is served without a verdict.
- `tool_reconnect`'s explicit re-check and the >512 MB startup gate (c54531a) both keep working unchanged; the gate now only bounds the background probe.
- The HTTP transport already starts without the synchronous probe ("never make the listener wait", `_run_http_loop`) — this aligns stdio with that precedent.
- Eager embedder warmup (#1495, opt-in) is deliberately untouched.

## Measurements (same 1.72 GB palace, `MEMPALACE_STARTUP_INTEGRITY_MAX_MB=0` so the **full** quick_check runs)

| | before | after |
|---|---|---|
| `initialize` response | 20.5 s (up to 46 s under contention) | **1.3–1.6 s** |
| tool call arriving mid-probe | n/a (handshake still blocked) | waits on the lock for the verdict (by design) |
| `mempalace_status` after probe completes | — | 3.4 s, `sqlite_integrity: checked=true, ok=true` |

## Tests

- `test_startup_preflight_does_not_block_initialize` — initialize answers < 1 s while a (mocked slow) probe is in flight on the preflight thread.
- `test_ensure_sqlite_integrity_status_joins_inflight_probe` — a lazy consumer arriving mid-probe blocks on the lock, unblocks on the verdict, and the probe body runs exactly once.
- Full suite: `tests/test_mcp_server.py` → **270 passed, 3 skipped** on this branch.
