### PR TITLE
ci(lint): align ruff pin in ci.yml with pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,6 @@ jobs:
       # Keep this pin identical to the `ruff==` pin in pyproject.toml
       # ([project.optional-dependencies].dev and [dependency-groups].dev)
       # so CI and `pip install -e ".[dev]"` format/lint identically.
-      - run: pip install "ruff==0.15.14"
+      - run: pip install "ruff==0.15.20"
       - run: ruff check .
       - run: ruff format --check .


### PR DESCRIPTION
The lint job hardcodes `pip install "ruff==0.15.14"`, but `pyproject.toml` pins `ruff==0.15.20` (bumped by #1883). There's a comment directly above the hardcoded pin saying to keep the two in sync — they'd drifted.

Found this because it was causing a spurious lint failure (`ruff format --check` demanding a reformat of `tests/test_mcp_server.py`) on an unrelated PR that never touched that file — CI was formatting against an older ruff than what `pip install -e ".[dev]"` gives every contributor locally, so the two disagreed on an edge case.

Verified locally with ruff 0.15.20 (the corrected pin): `ruff check .` and `ruff format --check .` both pass clean on the current tree as-is — pure CI-config fix, no source changes needed.

One heads-up: there's an open dependabot PR (#1986) bumping the `pyproject.toml` pin again, to 0.15.21 — it only touches `pyproject.toml`, same as #1883 did, so `ci.yml` will need this same manual sync once that one lands too.
