### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Wire it into an MCP client (e.g. Claude Code) as a stdio server:
 }
 ```
 
+For Autohand Code, register the same Docker-backed stdio server with:
+
+```bash
+autohand mcp add mempalace docker run -i --rm -v mempalace-data:/data mempalace
+```
+
+Add `--scope project` after `add` to keep the server configuration in the current project. See [Autohand Code](https://github.com/autohandai/code-cli/) for current installation and CLI details.
+
 `docker compose run --rm mcp` works too (see `docker-compose.yml`). For
 CUDA-accelerated embeddings, build the GPU variant with
 `docker build -f Dockerfile.gpu -t mempalace:gpu .` and run it with


### PR DESCRIPTION
Adds an Autohand Code setup beside MemPalace Docker MCP client configuration. The command reuses the same persistent mempalace-data volume, interactive stdio flag, and mempalace image already documented for other clients.

The note also includes the project-scoped option.

Verification:
- Checked the Docker stdio command against the current Autohand Code MCP CLI
- git diff --check passed
- uv run pytest tests/ -q: 3,266 passed, 31 skipped, 106 deselected, 3 failed

The three failures are unrelated to this README-only patch: one timezone-sensitive mtime assertion expected 2023-07-15 but resolved 2023-07-16 in Pacific/Auckland, and two SQLite/FTS5 corruption-message classification assertions differed with the local SQLite build.