### PR TITLE
feat(mcp): opt-in write forwarding to the daemon (MEMPALACE_MCP_FORWARD_WRITES)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -407,6 +407,158 @@ def _truthy_env(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+# MCP write forwarding (opt-in; #1646 / #1497).
+#
+# When MEMPALACE_MCP_FORWARD_WRITES is set, mutating tool calls are submitted to
+# the long-lived write daemon (``mempalace.daemon``) as ``mcp_tool`` jobs
+# instead of executing in-process — so this MCP server never acquires the
+# per-palace writer lease, and any number of concurrent stdio sessions (plus
+# CLI/hook daemon jobs) converge on the daemon as the single palace writer.
+_MCP_FORWARD_WRITES_ENV = "MEMPALACE_MCP_FORWARD_WRITES"
+_MCP_FORWARD_TIMEOUT_ENV = "MEMPALACE_MCP_FORWARD_TIMEOUT"
+_MCP_FORWARD_TIMEOUT_DEFAULT = 120.0
+_mcp_forward_mode_warned = False
+
+
+def _mcp_forward_mode() -> str:
+    """Resolve MEMPALACE_MCP_FORWARD_WRITES to ``prefer``, ``require``, or ``""``.
+
+    - unset/empty: off — current direct-write behavior.
+    - ``prefer`` (or a bare truthy value): forward writes to a running daemon;
+      fall back to the direct path when no daemon is reachable.
+    - ``require``: forward writes; refuse when no daemon is reachable. This
+      server then never takes the palace writer lease.
+    """
+    global _mcp_forward_mode_warned
+    raw = os.environ.get(_MCP_FORWARD_WRITES_ENV, "").strip().lower()
+    if not raw:
+        return ""
+    if raw in {"prefer", "require"}:
+        return raw
+    if raw in {"1", "true", "yes", "on"}:
+        return "prefer"
+    if not _mcp_forward_mode_warned:
+        logger.warning(
+            "%s=%r not recognized (expected 'prefer' or 'require'); write forwarding stays OFF",
+            _MCP_FORWARD_WRITES_ENV,
+            raw,
+        )
+        _mcp_forward_mode_warned = True
+    return ""
+
+
+def _mcp_forward_error(req_id, tool_name: str, message: str):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {
+            "code": -32004,
+            "message": message,
+            "data": {"tool": tool_name},
+        },
+    }
+
+
+def _mcp_maybe_forward_write(req_id, tool_name: str, tool_args: dict):
+    """Forward a mutating tool call to the write daemon when enabled.
+
+    Returns a complete JSON-RPC response when the call was handled here
+    (forwarded, refused, or failed), or ``None`` to fall through to the direct
+    dispatch path.
+
+    Scope: only tools that are both in ``_MUTATING_TOOLS`` and classified
+    ``write`` by the daemon's own allowlist (``service.classify_tool``) are
+    forwarded. Maintenance tools (``mempalace_mine`` / ``mempalace_sync``) keep
+    the direct path — the daemon has dedicated job kinds for those (wired via
+    the CLI ``--daemon`` flag), and ``run_mcp_tool`` would reject them.
+
+    Fallback safety: ``prefer`` mode falls back to the direct path ONLY when
+    the job was never submitted. After submission the daemon owns the write; a
+    wait/transport failure returns an error instead of retrying directly,
+    because re-applying a non-idempotent mutation (``diary_write``) could
+    double-write.
+    """
+    mode = _mcp_forward_mode()
+    if not mode or tool_name not in _MUTATING_TOOLS:
+        return None
+
+    from .service import classify_tool
+
+    if classify_tool(tool_name) != "write":
+        return None
+
+    read_only_error = _mcp_read_only_refusal(req_id, tool_name)
+    if read_only_error is not None:
+        return read_only_error
+    sqlite_integrity_error = _mcp_sqlite_integrity_refusal(req_id, tool_name)
+    if sqlite_integrity_error is not None:
+        return sqlite_integrity_error
+
+    from . import daemon as daemon_mod
+
+    try:
+        client = daemon_mod.get_client_if_running(_config.palace_path)
+        if client is None:
+            raise daemon_mod.DaemonError(
+                f"no running mempalace write daemon for {_config.palace_path!r}"
+            )
+        payload = {
+            "name": tool_name,
+            "arguments": tool_args,
+            "palace_path": daemon_mod.canonical_palace_path(_config.palace_path),
+        }
+        job = client.submit("mcp_tool", payload)
+    except Exception as exc:
+        if mode == "require":
+            return _mcp_forward_error(
+                req_id,
+                tool_name,
+                f"write daemon unavailable and {_MCP_FORWARD_WRITES_ENV}=require: {exc}",
+            )
+        logger.warning(
+            "MCP write forwarding: daemon unavailable (%s); falling back to direct write for %r",
+            exc,
+            tool_name,
+        )
+        return None
+
+    try:
+        timeout_raw = os.environ.get(_MCP_FORWARD_TIMEOUT_ENV, "")
+        try:
+            timeout = float(timeout_raw) if timeout_raw else _MCP_FORWARD_TIMEOUT_DEFAULT
+        except ValueError:
+            timeout = _MCP_FORWARD_TIMEOUT_DEFAULT
+        job = client.wait(job["id"], timeout=timeout)
+    except Exception as exc:
+        return _mcp_forward_error(
+            req_id,
+            tool_name,
+            f"write daemon job {job.get('id')!r} did not report a result "
+            f"({exc}); the write may still complete — not retrying directly "
+            "to avoid a double-write",
+        )
+
+    result = job.get("result") if isinstance(job.get("result"), dict) else {}
+    if job.get("state") != "succeeded" or result.get("success") is False:
+        detail = result.get("error") or job.get("error") or f"job state: {job.get('state')}"
+        return _mcp_forward_error(req_id, tool_name, f"write daemon job failed: {detail}")
+
+    # Strip the daemon's job-transport keys so the forwarded result matches
+    # what the in-process handler would have returned.
+    for transport_key in ("stdout", "stderr", "exit_code"):
+        result.pop(transport_key, None)
+    decorated = _decorate_mcp_tool_result(tool_name, result)
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "content": [
+                {"type": "text", "text": json.dumps(decorated, indent=2, ensure_ascii=False)}
+            ]
+        },
+    }
+
+
 def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     """Acquire this process's per-palace MCP writer lease.
 
@@ -4838,21 +4990,33 @@ def handle_request(request):
                     "error": {"code": -32602, "message": f"Invalid value for parameter '{key}'"},
                 }
         tool_args.pop("wait_for_previous", None)
-        preflight_error = _mcp_tool_preflight_refusal(req_id, tool_name)
-        if preflight_error is not None:
-            return preflight_error
 
         # 'content' is an accepted alias for diary_write's 'entry' (callers often
-        # reuse add_drawer's 'content' name). Map it in here, before dispatch, so a
-        # content-only call still satisfies the required 'entry' param while the
-        # signature-based missing-parameter diagnostic (-32602) keeps working.
-        # 'entry' wins if both are supplied.
+        # reuse add_drawer's 'content' name). Map it in here, before dispatch AND
+        # before write forwarding, so a content-only call still satisfies the
+        # required 'entry' param — and a forwarded job carries the resolved
+        # arguments — while the signature-based missing-parameter diagnostic
+        # (-32602) keeps working. 'entry' wins if both are supplied.
         if tool_name == "mempalace_diary_write" and "content" in tool_args:
             content_val = tool_args.pop("content")
             # Only fill from the alias when the caller did not supply 'entry' at
             # all (or passed it as null). An explicit entry — even "" — wins.
             if "entry" not in tool_args or tool_args["entry"] is None:
                 tool_args["entry"] = content_val
+
+        # Opt-in write forwarding (MEMPALACE_MCP_FORWARD_WRITES): mutating tools
+        # go to the write daemon so this server never takes the writer lease.
+        # Runs BEFORE _mcp_tool_preflight_refusal because that preflight's
+        # peer-writer gate ACQUIRES the lease for mutating tools; the read-only
+        # and sqlite-integrity gates are re-applied inside the forwarder.
+        forwarded = _mcp_maybe_forward_write(req_id, tool_name, tool_args)
+        if forwarded is not None:
+            return forwarded
+
+        preflight_error = _mcp_tool_preflight_refusal(req_id, tool_name)
+        if preflight_error is not None:
+            return preflight_error
+
         try:
             result = _decorate_mcp_tool_result(tool_name, TOOLS[tool_name]["handler"](**tool_args))
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -423,28 +423,44 @@ _mcp_forward_mode_warned = False
 def _mcp_forward_mode() -> str:
     """Resolve MEMPALACE_MCP_FORWARD_WRITES to ``prefer``, ``require``, or ``""``.
 
-    - unset/empty: off — current direct-write behavior.
-    - ``prefer`` (or a bare truthy value): forward writes to a running daemon;
-      fall back to the direct path when no daemon is reachable.
+    - unset/empty or ``direct``: off — current direct-write behavior.
+    - ``prefer`` (or a legacy bare truthy value): forward writes to a running
+      daemon; fall back to the direct path when no daemon is reachable.
     - ``require``: forward writes; refuse when no daemon is reachable. This
       server then never takes the palace writer lease.
+
+    Parsing goes through the shared write-routing policy model
+    (``write_routing.parse_write_routing_policy``, #2027) so the MCP transport
+    accepts the same vocabulary as every other write caller. The routing
+    *decision* stays transport-specific: an MCP server discovers daemon
+    availability by submitting the job, not by probing first.
     """
     global _mcp_forward_mode_warned
-    raw = os.environ.get(_MCP_FORWARD_WRITES_ENV, "").strip().lower()
+    raw = os.environ.get(_MCP_FORWARD_WRITES_ENV, "").strip()
     if not raw:
         return ""
-    if raw in {"prefer", "require"}:
-        return raw
-    if raw in {"1", "true", "yes", "on"}:
-        return "prefer"
-    if not _mcp_forward_mode_warned:
-        logger.warning(
-            "%s=%r not recognized (expected 'prefer' or 'require'); write forwarding stays OFF",
-            _MCP_FORWARD_WRITES_ENV,
-            raw,
-        )
-        _mcp_forward_mode_warned = True
-    return ""
+
+    from .write_routing import (
+        WriteRoutingError,
+        WriteRoutingPolicy,
+        parse_write_routing_policy,
+    )
+
+    try:
+        policy = parse_write_routing_policy(raw, legacy_boolean=True)
+    except WriteRoutingError:
+        if not _mcp_forward_mode_warned:
+            logger.warning(
+                "%s=%r not recognized (expected 'direct', 'prefer', or 'require'); "
+                "write forwarding stays OFF",
+                _MCP_FORWARD_WRITES_ENV,
+                raw,
+            )
+            _mcp_forward_mode_warned = True
+        return ""
+    if policy is WriteRoutingPolicy.DIRECT:
+        return ""
+    return policy.value
 
 
 def _mcp_forward_error(req_id, tool_name: str, message: str):
@@ -466,11 +482,19 @@ def _mcp_maybe_forward_write(req_id, tool_name: str, tool_args: dict):
     (forwarded, refused, or failed), or ``None`` to fall through to the direct
     dispatch path.
 
-    Scope: only tools that are both in ``_MUTATING_TOOLS`` and classified
-    ``write`` by the daemon's own allowlist (``service.classify_tool``) are
-    forwarded. Maintenance tools (``mempalace_mine`` / ``mempalace_sync``) keep
-    the direct path — the daemon has dedicated job kinds for those (wired via
-    the CLI ``--daemon`` flag), and ``run_mcp_tool`` would reject them.
+    Scope: the forwardable set is ``_MUTATING_TOOLS`` minus
+    ``service.MAINTENANCE_TOOLS``. Maintenance tools are not forwardable as
+    ``mcp_tool`` jobs (the daemon has dedicated job kinds for them, wired via
+    the CLI ``--daemon`` flag, and ``run_mcp_tool`` would reject them) — so
+    under ``prefer`` they keep the direct path, and under ``require`` they are
+    refused outright: running them in-process would take the writer lease this
+    mode promises never to take. Any remaining
+    tool that ``service.classify_tool`` does NOT report as ``write`` is
+    classifier drift, never a routing decision: under ``require`` the call is
+    refused (a silent direct write is the exact outcome forwarding exists to
+    prevent); under ``prefer`` it falls back to the documented direct path
+    with a warning. ``test_every_mutating_tool_is_classified_for_forwarding``
+    pins list parity so the drift branch is unreachable at a healthy commit.
 
     Fallback safety: ``prefer`` mode falls back to the direct path ONLY when
     the job was never submitted. After submission the daemon owns the write; a
@@ -482,9 +506,39 @@ def _mcp_maybe_forward_write(req_id, tool_name: str, tool_args: dict):
     if not mode or tool_name not in _MUTATING_TOOLS:
         return None
 
-    from .service import classify_tool
+    from .service import MAINTENANCE_TOOLS, classify_tool
 
-    if classify_tool(tool_name) != "write":
+    if tool_name in MAINTENANCE_TOOLS:
+        if mode == "require":
+            return _mcp_forward_error(
+                req_id,
+                tool_name,
+                f"{tool_name} is a maintenance operation with a dedicated daemon "
+                f"job kind, and running it in-process would take the palace "
+                f"writer lease — refused under {_MCP_FORWARD_WRITES_ENV}=require. "
+                "Run it through the CLI daemon path (e.g. `mempalace mine "
+                "--daemon`) or use prefer mode.",
+            )
+        return None
+
+    classification = classify_tool(tool_name)
+    if classification != "write":
+        if mode == "require":
+            return _mcp_forward_error(
+                req_id,
+                tool_name,
+                f"{tool_name} is a mutating tool the daemon's write classifier "
+                f"does not recognize (classify_tool -> {classification!r}); "
+                f"refusing a direct write under {_MCP_FORWARD_WRITES_ENV}=require. "
+                "service.WRITE_TOOLS is missing this tool.",
+            )
+        logger.warning(
+            "MCP write forwarding: %r is in _MUTATING_TOOLS but classify_tool() "
+            "returned %r; falling back to a direct write under prefer mode. "
+            "service.WRITE_TOOLS is likely missing this tool.",
+            tool_name,
+            classification,
+        )
         return None
 
     read_only_error = _mcp_read_only_refusal(req_id, tool_name)

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -61,6 +61,7 @@ WRITE_TOOLS = frozenset(
         "mempalace_diary_write",
         "mempalace_kg_add",
         "mempalace_kg_invalidate",
+        "mempalace_kg_supersede",
         "mempalace_create_tunnel",
         "mempalace_delete_tunnel",
         "mempalace_delete_hallway",

--- a/tests/test_mcp_write_forwarding.py
+++ b/tests/test_mcp_write_forwarding.py
@@ -1,0 +1,307 @@
+"""Tests for opt-in MCP write forwarding to the daemon (#1646 / #1497).
+
+When MEMPALACE_MCP_FORWARD_WRITES is set, mutating tool calls are submitted to
+the write daemon as ``mcp_tool`` jobs instead of executing in-process, so the
+MCP server never acquires the per-palace writer lease. These tests exercise
+``handle_request`` end-to-end with a fake daemon client, mirroring the style of
+the peer-writer guard tests in test_mcp_server.py.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from mempalace import mcp_server
+
+
+WRITE_TOOL = "mempalace_add_drawer"
+
+_WRITE_TOOL_ENTRY = {
+    "description": "test write tool",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "wing": {"type": "string"},
+            "room": {"type": "string"},
+            "content": {"type": "string"},
+        },
+    },
+}
+
+
+class _FakeClient:
+    """Stand-in for daemon.DaemonClient: records submits, scripted results."""
+
+    def __init__(self, wait_job=None, submit_exc=None, wait_exc=None):
+        self.submitted = []
+        self.wait_job = wait_job or {
+            "id": "job-1",
+            "state": "succeeded",
+            "result": {"success": True, "ok": 1, "stdout": "noise", "exit_code": 0},
+        }
+        self.submit_exc = submit_exc
+        self.wait_exc = wait_exc
+
+    def submit(self, kind, payload, **kwargs):
+        if self.submit_exc is not None:
+            raise self.submit_exc
+        self.submitted.append((kind, payload))
+        return {"id": "job-1"}
+
+    def wait(self, job_id, timeout=None):
+        if self.wait_exc is not None:
+            raise self.wait_exc
+        return self.wait_job
+
+
+def _forbidden_lock():
+    raise AssertionError("forwarding-enabled server must not acquire the writer lock")
+
+
+def _install(monkeypatch, tmp_path, *, handler=None, client="unset", lock="allow"):
+    """Wire the module for a forwarding test.
+
+    handler: fake in-process handler for WRITE_TOOL (records direct dispatch)
+    client:  _FakeClient instance, None (daemon down), or "unset" (forbid use)
+    lock:    "allow" -> lock acquisition succeeds; "forbid" -> lock use asserts
+    """
+    called = {"direct": False}
+
+    def _handler(**kwargs):
+        called["direct"] = True
+        return {"ok": "direct"}
+
+    entry = dict(_WRITE_TOOL_ENTRY)
+    entry["handler"] = handler or _handler
+    monkeypatch.setitem(mcp_server.TOOLS, WRITE_TOOL, entry)
+    monkeypatch.setattr(mcp_server, "_config", SimpleNamespace(palace_path=str(tmp_path)))
+    monkeypatch.setattr(mcp_server, "_mcp_forward_mode_warned", False)
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_checked", True)
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_errors", [])
+    monkeypatch.setattr(mcp_server, "_sqlite_integrity_check_error", "")
+
+    if lock == "allow":
+        monkeypatch.setattr(mcp_server, "_acquire_mcp_writer_lock", lambda: (True, ""))
+    else:
+        monkeypatch.setattr(mcp_server, "_acquire_mcp_writer_lock", _forbidden_lock)
+
+    from mempalace import daemon as daemon_mod
+
+    if client == "unset":
+
+        def _forbidden_client(palace_path):
+            raise AssertionError("daemon client must not be consulted in this test")
+
+        monkeypatch.setattr(daemon_mod, "get_client_if_running", _forbidden_client)
+    else:
+        monkeypatch.setattr(daemon_mod, "get_client_if_running", lambda palace_path: client)
+
+    return called
+
+
+def _call(tool=WRITE_TOOL, arguments=None):
+    if arguments is None:  # explicit None check: {} is a legitimate empty-args call
+        arguments = {"content": "hello"}
+    return mcp_server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": arguments},
+        }
+    )
+
+
+def test_forwarding_off_by_default_uses_direct_path(monkeypatch, tmp_path):
+    monkeypatch.delenv("MEMPALACE_MCP_FORWARD_WRITES", raising=False)
+    called = _install(monkeypatch, tmp_path, client="unset", lock="allow")
+
+    response = _call()
+
+    assert called["direct"] is True
+    assert '"ok": "direct"' in response["result"]["content"][0]["text"]
+
+
+def test_prefer_forwards_and_never_takes_the_lock(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "prefer")
+    client = _FakeClient()
+    called = _install(monkeypatch, tmp_path, client=client, lock="forbid")
+
+    response = _call()
+
+    assert called["direct"] is False
+    kind, payload = client.submitted[0]
+    assert kind == "mcp_tool"
+    assert payload["name"] == WRITE_TOOL
+    assert payload["arguments"] == {"content": "hello"}
+    text = response["result"]["content"][0]["text"]
+    assert '"ok": 1' in text
+    # Daemon job-transport keys must not leak into the tool result.
+    assert "stdout" not in text
+    assert "exit_code" not in text
+
+
+def test_prefer_falls_back_to_direct_when_daemon_down(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "prefer")
+    called = _install(monkeypatch, tmp_path, client=None, lock="allow")
+
+    response = _call()
+
+    assert called["direct"] is True
+    assert '"ok": "direct"' in response["result"]["content"][0]["text"]
+
+
+def test_require_refuses_when_daemon_down(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "require")
+    called = _install(monkeypatch, tmp_path, client=None, lock="forbid")
+
+    response = _call()
+
+    assert called["direct"] is False
+    assert response["error"]["code"] == -32004
+    assert "require" in response["error"]["message"]
+    assert response["error"]["data"]["tool"] == WRITE_TOOL
+
+
+def test_no_direct_fallback_after_submission(monkeypatch, tmp_path):
+    """Once the job is submitted the daemon owns the write: a wait failure must
+    surface as an error, never retry in-process (double-write risk for
+    non-idempotent mutations like diary_write)."""
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "prefer")
+    client = _FakeClient(wait_exc=RuntimeError("daemon restarted mid-wait"))
+    called = _install(monkeypatch, tmp_path, client=client, lock="forbid")
+
+    response = _call()
+
+    assert called["direct"] is False
+    assert response["error"]["code"] == -32004
+    assert "double-write" in response["error"]["message"]
+
+
+def test_failed_daemon_job_surfaces_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "prefer")
+    client = _FakeClient(
+        wait_job={
+            "id": "job-1",
+            "state": "failed",
+            "result": {"success": False, "error": "boom from daemon"},
+        }
+    )
+    called = _install(monkeypatch, tmp_path, client=client, lock="forbid")
+
+    response = _call()
+
+    assert called["direct"] is False
+    assert response["error"]["code"] == -32004
+    assert "boom from daemon" in response["error"]["message"]
+
+
+def test_read_tools_are_never_forwarded(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "prefer")
+    _install(monkeypatch, tmp_path, client="unset", lock="forbid")
+    monkeypatch.setitem(
+        mcp_server.TOOLS,
+        "mempalace_status",
+        {
+            "description": "test read tool",
+            "input_schema": {"type": "object", "properties": {}},
+            "handler": lambda: {"ok": True},
+        },
+    )
+
+    response = _call(tool="mempalace_status", arguments={})
+
+    assert "result" in response, response
+    assert '"ok": true' in response["result"]["content"][0]["text"]
+
+
+def test_maintenance_tools_keep_direct_path(monkeypatch, tmp_path):
+    """mempalace_mine is in _MUTATING_TOOLS but classified 'maintenance' — the
+    daemon's mcp_tool kind would reject it, so it must fall through to the
+    direct path (the daemon has a dedicated 'mine' job kind via the CLI)."""
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "prefer")
+    called = _install(monkeypatch, tmp_path, client="unset", lock="allow")
+    entry = dict(_WRITE_TOOL_ENTRY)
+
+    def _handler(**kwargs):
+        called["direct"] = True
+        return {"ok": "direct"}
+
+    entry["handler"] = _handler
+    monkeypatch.setitem(mcp_server.TOOLS, "mempalace_mine", entry)
+
+    response = _call(tool="mempalace_mine", arguments={"content": "x"})
+
+    assert called["direct"] is True
+    assert '"ok": "direct"' in response["result"]["content"][0]["text"]
+
+
+def test_diary_content_alias_resolves_before_forwarding(monkeypatch, tmp_path):
+    """A diary_write call using the 'content' alias must forward with the
+    resolved 'entry' argument, not the raw alias."""
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "prefer")
+    client = _FakeClient()
+    _install(monkeypatch, tmp_path, client=client, lock="forbid")
+    monkeypatch.setitem(
+        mcp_server.TOOLS,
+        "mempalace_diary_write",
+        {
+            "description": "test diary tool",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "agent_name": {"type": "string"},
+                    "entry": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+            },
+            "handler": lambda **kw: {"success": True},
+        },
+    )
+
+    _call(
+        tool="mempalace_diary_write",
+        arguments={"agent_name": "qa", "content": "aliased entry"},
+    )
+
+    _kind, payload = client.submitted[0]
+    assert payload["arguments"]["entry"] == "aliased entry"
+    assert "content" not in payload["arguments"]
+
+
+def test_unrecognized_mode_value_stays_off(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "sometimes")
+    called = _install(monkeypatch, tmp_path, client="unset", lock="allow")
+
+    response = _call()
+
+    assert called["direct"] is True
+    assert '"ok": "direct"' in response["result"]["content"][0]["text"]
+
+
+def test_require_mode_read_only_gate_still_wins(monkeypatch, tmp_path):
+    """A server in read-only mode must refuse mutating tools, not forward them."""
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "require")
+    _install(monkeypatch, tmp_path, client="unset", lock="forbid")
+    monkeypatch.setattr(mcp_server, "_READ_ONLY", True)
+
+    response = _call()
+
+    assert response["error"]["code"] == -32003
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("prefer", "prefer"),
+        ("require", "require"),
+        ("1", "prefer"),
+        ("true", "prefer"),
+        ("", ""),
+        ("nonsense", ""),
+    ],
+)
+def test_forward_mode_parsing(monkeypatch, raw, expected):
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", raw)
+    monkeypatch.setattr(mcp_server, "_mcp_forward_mode_warned", False)
+    assert mcp_server._mcp_forward_mode() == expected

--- a/tests/test_mcp_write_forwarding.py
+++ b/tests/test_mcp_write_forwarding.py
@@ -236,6 +236,29 @@ def test_maintenance_tools_keep_direct_path(monkeypatch, tmp_path):
     assert '"ok": "direct"' in response["result"]["content"][0]["text"]
 
 
+def test_require_refuses_maintenance_tools(monkeypatch, tmp_path):
+    """Under ``require`` a maintenance tool must be REFUSED, not run direct:
+    executing mempalace_mine in-process would take the palace writer lease
+    that require mode promises never to take. The daemon path for these is
+    the dedicated CLI job kind, not an mcp_tool job."""
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "require")
+    called = _install(monkeypatch, tmp_path, client="unset", lock="forbid")
+    entry = dict(_WRITE_TOOL_ENTRY)
+
+    def _handler(**kwargs):
+        called["direct"] = True
+        return {"ok": "direct"}
+
+    entry["handler"] = _handler
+    monkeypatch.setitem(mcp_server.TOOLS, "mempalace_mine", entry)
+
+    response = _call(tool="mempalace_mine", arguments={"content": "x"})
+
+    assert called["direct"] is False
+    assert response["error"]["code"] == -32004
+    assert "writer lease" in response["error"]["message"]
+
+
 def test_diary_content_alias_resolves_before_forwarding(monkeypatch, tmp_path):
     """A diary_write call using the 'content' alias must forward with the
     resolved 'entry' argument, not the raw alias."""
@@ -299,9 +322,80 @@ def test_require_mode_read_only_gate_still_wins(monkeypatch, tmp_path):
         ("true", "prefer"),
         ("", ""),
         ("nonsense", ""),
+        # shared write-routing vocabulary (#2027)
+        ("direct", ""),
+        ("0", ""),
+        ("false", ""),
+        ("off", ""),
+        ("daemon", "prefer"),
+        ("REQUIRE", "require"),
     ],
 )
 def test_forward_mode_parsing(monkeypatch, raw, expected):
     monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", raw)
     monkeypatch.setattr(mcp_server, "_mcp_forward_mode_warned", False)
     assert mcp_server._mcp_forward_mode() == expected
+
+
+def test_every_mutating_tool_is_classified_for_forwarding():
+    """Table-driven parity between ``_MUTATING_TOOLS`` and the daemon allowlist.
+
+    Every member of ``_MUTATING_TOOLS`` must be classified ``write`` by
+    ``service.classify_tool`` unless it is a documented maintenance tool with
+    its own daemon job kind (``service.MAINTENANCE_TOOLS``). A tool that fails
+    this parity lands in the forwarding gate's classifier-drift branch, and
+    under ``prefer`` would silently become a direct palace writer — the review
+    finding on mempalace_kg_supersede.
+    """
+    from mempalace.service import MAINTENANCE_TOOLS, classify_tool
+
+    misclassified = {
+        tool: classify_tool(tool)
+        for tool in sorted(mcp_server._MUTATING_TOOLS)
+        if tool not in MAINTENANCE_TOOLS and classify_tool(tool) != "write"
+    }
+
+    assert misclassified == {}, (
+        f"mutating tools missing from service.WRITE_TOOLS: {misclassified}"
+    )
+
+
+def test_require_refuses_drifted_mutating_tool(monkeypatch, tmp_path):
+    """A mutating tool unknown to the daemon classifier must be REFUSED under
+    ``require`` — never silently executed as a direct write, and never
+    submitted as a job the daemon would reject."""
+    import mempalace.service as service_mod
+
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "require")
+    called = _install(monkeypatch, tmp_path, client="unset", lock="forbid")
+    monkeypatch.setattr(
+        service_mod,
+        "classify_tool",
+        lambda name: "unknown" if name == WRITE_TOOL else "write",
+    )
+
+    response = _call()
+
+    assert called["direct"] is False
+    assert response["error"]["code"] == -32004
+    assert "classifier" in response["error"]["message"]
+
+
+def test_prefer_falls_back_on_drifted_mutating_tool(monkeypatch, tmp_path):
+    """Under ``prefer``, a classifier-drifted tool takes the documented direct
+    fallback (with a warning) instead of a daemon submission that would be
+    rejected."""
+    import mempalace.service as service_mod
+
+    monkeypatch.setenv("MEMPALACE_MCP_FORWARD_WRITES", "prefer")
+    called = _install(monkeypatch, tmp_path, client="unset", lock="allow")
+    monkeypatch.setattr(
+        service_mod,
+        "classify_tool",
+        lambda name: "unknown" if name == WRITE_TOOL else "write",
+    )
+
+    response = _call()
+
+    assert called["direct"] is True
+    assert '"ok": "direct"' in response["result"]["content"][0]["text"]


### PR DESCRIPTION
## Problem

Multiple concurrent MCP stdio sessions against one palace still contend on the per-palace writer lease: the first session to write holds it for its **entire process lifetime**, so every other session's mutating tools refuse until that terminal closes. The self-healing retry (recently landed) fixes the *stale-latch* half, but while the holder lives, concurrent writers are still locked out.

This is the standing pain in #1646 (N agent profiles, one palace) and #1497 (single-writer/gateway question). My own setup hits it daily: multiple git-worktree Claude Code sessions, where each agent team's *last* task writes its diary — so the first team to finish locks all the others out for the rest of the day.

## Approach

The write daemon (`mempalace.daemon`) already exists as an opt-in queued writer with an `mcp_tool` job kind. This PR wires the MCP server to it, strictly opt-in:

**`MEMPALACE_MCP_FORWARD_WRITES`** =
- unset (default): behavior unchanged.
- `prefer` (or bare truthy): mutating tool calls are submitted to a *running* daemon as `mcp_tool` jobs; if no daemon is reachable, fall back to today's direct path.
- `require`: forward, and refuse (`-32004`) when no daemon is reachable — the server then **never** acquires the writer lease.

With the daemon as the single palace writer, any number of stdio sessions plus CLI/hook daemon jobs converge on one writer — no lease contention, no corruption risk from a second long-lived Chroma client's stale HNSW/FTS state. Complements the HTTP transport (#1801): stdio remains Claude Code's default wiring, and forwarding also covers hosts that can't switch transports.

## Design notes

- **Scope**: only tools in `_MUTATING_TOOLS` that `service.classify_tool()` calls `write` are forwarded — `run_mcp_tool` is kept as the single arbiter. Maintenance tools (`mempalace_mine`/`mempalace_sync`) keep the direct path (the daemon has dedicated job kinds for them, wired via the CLI `--daemon` flag). Side observation while aligning the sets: `mempalace_kg_supersede` is in `_MUTATING_TOOLS` but absent from `service.WRITE_TOOLS` — possibly drift worth a look; under this PR it simply falls through to the direct path.
- **Gate ordering**: the read-only-mode and sqlite-integrity gates are applied *before* forwarding (a read-only team server must refuse, not forward); the peer-writer gate is what forwarding replaces.
- **Fallback safety**: `prefer` falls back to direct **only when the job was never submitted**. After submission the daemon owns the write; a wait/transport failure returns an error rather than retrying in-process, because re-applying a non-idempotent mutation (`diary_write`) could double-write.
- **Result parity**: the daemon's job-transport keys (`stdout`/`stderr`/`exit_code`) are stripped so the forwarded result matches what the in-process handler returns; `_decorate_mcp_tool_result` is applied the same way.
- The diary `content`→`entry` alias mapping is hoisted above the preflight (behavior-neutral for the direct path — preflight gates key on tool name only) so forwarded jobs carry resolved arguments.
- `MEMPALACE_MCP_FORWARD_TIMEOUT` (seconds, default 120) bounds the job wait — an MCP client shouldn't inherit the daemon client's 1-hour default.

## Testing

- New `tests/test_mcp_write_forwarding.py` — 17 tests through `handle_request` with a fake daemon client, mirroring the peer-writer guard test style: off-by-default, prefer/require daemon-up/down, no-fallback-after-submission (the double-write guard), failed-job surfacing, read tools never forwarded, maintenance tools keep the direct path, alias-before-forwarding, read-only gate precedence, mode parsing.
- `tests/test_mcp_server.py`, `test_mcp_stdio_protection.py`, `test_mcp_http_transport.py`, `test_daemon.py`: **325 passed** (no regressions).
- `pre-commit` (ruff + ruff format) clean.

Happy to adjust naming/defaults to whatever direction you prefer for the #1646 family.