### PR TITLE
docs: align website contributing guide with root (#1980)

### DIFF
--- a/website/reference/contributing.md
+++ b/website/reference/contributing.md
@@ -5,15 +5,22 @@ PRs welcome. MemPalace is open source and we welcome contributions of all sizes 
 ## Getting Started
 
 ```bash
-git clone https://github.com/MemPalace/mempalace.git
+# Fork the repo on GitHub first, then clone your fork
+git clone https://github.com/<your-username>/mempalace.git
 cd mempalace
+git remote add upstream https://github.com/MemPalace/mempalace.git
 
 # Recommended: uv (https://docs.astral.sh/uv/) manages the venv for you
 uv sync --extra dev
 
 # Or with pip in your own venv:
 # pip install -e ".[dev]"
+
+# Activate pre-commit hooks (one-time, per clone)
+pre-commit install
 ```
+
+The `pre-commit install` step matters: the repo pins ruff to the exact version CI uses, so without it you can commit code that passes your local lint but fails CI on push.
 
 ## Running Tests
 
@@ -46,7 +53,7 @@ See [Benchmarks](/reference/benchmarks) for data download instructions.
    - `fix: handle empty transcript files`
    - `docs: update MCP tool descriptions`
    - `bench: add LoCoMo turn-level metrics`
-6. Push to your fork and open a PR against `main`
+6. Push to your fork and open a PR against `develop`
 
 ## Code Style
 


### PR DESCRIPTION
## What does this PR do?

Fixes #1980.

The website copy of the contributing guide (`website/reference/contributing.md`)
had drifted from the authoritative root `CONTRIBUTING.md`. Beyond the branch
contradiction in #1980, two more setup steps were out of sync, and all three
push contributors toward the "avoidable triage load" the report describes:

- **PR target** (the reported bug): the website said to open a PR against
  `main`. Contributions merge into `develop`; `main` holds tagged production
  releases only (per the `ROADMAP.md` branch model), so a PR against it gets
  re-targeted or closed.
- **Getting Started** cloned `MemPalace/mempalace` directly, with no fork and
  no `upstream` remote. That contradicts the "Fork the repo" step further down
  the same page.
- **`pre-commit install`** was absent. That step installs the hook pinning ruff
  to CI's exact version; without it a contributor's code passes local lint and
  then fails CI on push.

Root `CONTRIBUTING.md` was already correct and is untouched. Only the website
copy changed.

## How to test

- `grep -n "PR against" CONTRIBUTING.md website/reference/contributing.md` now
  shows `develop` in both.
- Single file changed, no new doc links, so the VitePress build is unaffected.

## Checklist
- [x] Docs-only change, no code touched (pytest / `ruff check .` scope unchanged)
- [x] No hardcoded paths
- [x] No new documentation links (VitePress dead-link build unaffected)
