### PR TITLE
fix(mcp): don't log a traceback when an HTTP client disconnects mid-response (#2003)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -5188,6 +5188,28 @@ def _build_http_server(host: str, port: int):
         daemon_threads = True
         allow_reuse_address = True
 
+        def handle_error(self, request, client_address):
+            # A client hanging up mid-response makes the send path raise
+            # ConnectionError (BrokenPipeError / ConnectionResetError), or
+            # ssl.SSLEOFError over TLS. That is a routine disconnect, not a
+            # server fault, so log it at DEBUG rather than let the default
+            # handler dump a per-request traceback. Real errors (including
+            # genuine TLS handshake/cert failures) still reach that handler.
+            exc = sys.exc_info()[1]
+            is_disconnect = isinstance(exc, ConnectionError)
+            if not is_disconnect:
+                import ssl
+
+                # Only the abrupt-EOF SSLError; genuine TLS errors must surface.
+                is_disconnect = isinstance(exc, ssl.SSLEOFError)
+            if is_disconnect:
+                logger.debug(
+                    "HTTP client %s disconnected before the response completed",
+                    client_address,
+                )
+                return
+            super().handle_error(request, client_address)
+
     class _Handler(BaseHTTPRequestHandler):
         protocol_version = "HTTP/1.1"
         timeout = 10

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -19,6 +19,9 @@ Design constraints
 
 import http.client
 import json
+import logging
+import socketserver
+import ssl
 import threading
 
 import pytest
@@ -230,6 +233,67 @@ def test_read_only_off_exposes_mutating_tools(http_server):
     status, body = _post(port, "/mcp", {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
     names = {t["name"] for t in json.loads(body)["result"]["tools"]}
     assert "mempalace_add_drawer" in names
+
+
+@pytest.mark.parametrize(
+    "disconnect_exc",
+    [
+        ConnectionResetError(104, "connection reset by peer"),
+        BrokenPipeError(32, "broken pipe"),
+        ssl.SSLEOFError("unexpected eof while reading"),
+    ],
+    ids=["connreset", "brokenpipe", "ssleof"],
+)
+def test_handle_error_quiets_client_disconnect(caplog, monkeypatch, disconnect_exc):
+    """Regression for #2003: a client that hangs up mid-response makes the send
+    path raise ConnectionError (BrokenPipeError / ConnectionResetError), or
+    ssl.SSLEOFError on the TLS transport. The server must log that quietly at
+    DEBUG instead of routing it to the default handler's per-request traceback.
+    """
+    httpd = mcp._build_http_server("127.0.0.1", 0)
+    try:
+        delegated = []
+        monkeypatch.setattr(
+            socketserver.BaseServer,
+            "handle_error",
+            lambda self, request, addr: delegated.append(addr),
+        )
+        addr = ("127.0.0.1", 51234)
+
+        with caplog.at_level(logging.DEBUG, logger="mempalace_mcp"):
+            try:
+                raise disconnect_exc
+            except type(disconnect_exc):
+                httpd.handle_error(None, addr)
+
+        assert delegated == []  # noisy default handler NOT invoked
+        rec = next(r for r in caplog.records if "disconnect" in r.getMessage().lower())
+        assert rec.levelno == logging.DEBUG
+        assert rec.name == "mempalace_mcp"
+    finally:
+        httpd.server_close()
+
+
+def test_handle_error_delegates_real_errors(monkeypatch):
+    """A genuine error is NOT misclassified as a disconnect: it reaches the
+    default handler, so its traceback is still surfaced.
+    """
+    httpd = mcp._build_http_server("127.0.0.1", 0)
+    try:
+        delegated = []
+        monkeypatch.setattr(
+            socketserver.BaseServer,
+            "handle_error",
+            lambda self, request, addr: delegated.append(addr),
+        )
+        addr = ("127.0.0.1", 51234)
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            httpd.handle_error(None, addr)
+        assert delegated == [addr]
+    finally:
+        httpd.server_close()
 
 
 def _make_self_signed_cert(tmp_path):


### PR DESCRIPTION
## What does this PR do?

On the `--transport http` server, a client that hangs up mid-response makes the send path raise an unhandled `BrokenPipeError` / `ConnectionResetError`, so `socketserver`'s default `handle_error` logs a full traceback for a routine disconnect. The daemon keeps serving; the only effect is log noise per dropped connection.

This overrides `handle_error` on the HTTP server: a client disconnect (`ConnectionError`, plus `ssl.SSLEOFError` over TLS) is logged at DEBUG and dropped, while every other exception still reaches the default handler with its traceback. Handling it at the server's per-request error boundary catches the disconnect wherever the send path raises it, in one place, with no change to any response. The wider `ssl.SSLError` tree is deliberately not caught, so real TLS handshake/cert errors still surface.

Addresses the disconnect half of #2003. The stale-lock half is separate and not reproducible on `develop` (details in an issue comment). Reported by @westonale-facet, who suggested catching the disconnect.

## How to test

```bash
uv run pytest tests/test_mcp_http_transport.py -v
```

`test_handle_error_quiets_client_disconnect` (parametrized over `ConnectionResetError` / `BrokenPipeError` / `ssl.SSLEOFError`) asserts the disconnect is logged at DEBUG and not routed to the default handler; `test_handle_error_delegates_real_errors` asserts a genuine error still is. Both drive the real `_build_http_server` and are deterministic (no sockets or timing).

End to end: start `mempalace-mcp --transport http`, send a request and close the client before reading the response. Before this change the log shows a `BrokenPipeError` traceback; after, a single DEBUG line and the server keeps serving.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
