### PR TITLE
feat(chroma): opt-in HTTP client/server mode for multi-process palaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ non-default backend is opt-in.
 
 | Backend | Mode | Install | Namespaces | Lexical | Configure with |
 | ------- | ---- | ------- | :--------: | :-----: | -------------- |
-| `chroma` _(default)_ | Local (embedded) | bundled | – | ✓ | – |
+| `chroma` _(default)_ | Local (embedded) · Server opt-in | bundled | – | ✓ | `MEMPALACE_CHROMA_MODE=http` |
 | `sqlite_exact` | Local (exact) | bundled | – | ✓ | – |
 | `milvus` | Local (Lite) · Server opt-in | `mempalace[milvus]` | ✓ | ✓ | `MEMPALACE_MILVUS_URI` |
 | `qdrant` | Server (REST) | bundled | ✓ | ✓ | `MEMPALACE_QDRANT_URL` |
@@ -125,6 +125,13 @@ Select with `--backend <name>`, `MEMPALACE_BACKEND=<name>`, or
 `"backend": "<name>"` in `config.json`. See
 [Storage backends](/guide/configuration#storage-backends) for connection
 variables, namespace behavior, and deployment notes.
+
+When more than one process shares a Chroma palace (multiple MCP servers,
+hook-triggered mines), embedded mode is unsafe — set
+`MEMPALACE_CHROMA_MODE=http` and run one standalone `chroma run` server
+that owns the palace directory; all MemPalace processes become thin HTTP
+clients with structured errors and hard timeouts. See
+[docs/chroma-client-server.md](docs/chroma-client-server.md).
 
 ## Quickstart
 

--- a/docs/chroma-client-server.md
+++ b/docs/chroma-client-server.md
@@ -1,0 +1,213 @@
+# Chroma HTTP mode: client/server topology for multi-process palaces
+
+Opt-in transport for the ChromaDB backend (#832, #1096): one standalone
+`chroma run` server exclusively owns the palace directory, and every
+MemPalace process (MCP servers, hooks, mining CLI) is a thin HTTP client.
+Enable it with `MEMPALACE_CHROMA_MODE=http`.
+
+## Why
+
+Embedded `chromadb.PersistentClient` is not process-safe: when more than
+one process writes the same palace — multiple MCP server instances,
+stop-hook mines firing alongside an interactive session, a manual
+`mempalace mine` — writers contest the sqlite file lock and can corrupt
+the HNSW index (see the incident cluster tracked in #1963). Worse, a
+blocked writer waits on the file lock with no timeout, so palace calls
+can hang the MCP server indefinitely.
+
+In HTTP mode, one server process owns the files and serializes writes;
+concurrency is handled where ChromaDB supports it. Every client call is
+health-probed and timeout-bounded, so failures surface as structured
+errors instead of hangs.
+
+Single-process installs need none of this: the default remains
+`embedded`, with zero configuration and no external service.
+
+## Topology
+
+- **One server**: `chroma run --path <palace-path> --host 127.0.0.1
+  --port 8801`, typically managed as a user service (examples below). It
+  must be the **only** process that opens the files under the palace
+  directory.
+- **Thin clients**: every MemPalace process constructs its Chroma client
+  through [`mempalace/palace_client.py`](../mempalace/palace_client.py) —
+  the single construction point. In HTTP mode nothing outside that module
+  may build a Chroma client; that rule is what prevents a second embedded
+  writer from re-appearing.
+- The client returned by `make_http_client()` is wrapped in a
+  `TimeoutProxy` that also wraps every collection obtained from it, so the
+  whole call graph is timeout-guarded without call-site changes.
+
+## Config surface
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `MEMPALACE_CHROMA_MODE` | `embedded` | Set `http` to enable client/server mode. |
+| `CHROMA_HOST` | `127.0.0.1` | Server address the clients connect to. |
+| `CHROMA_PORT` | `8801` | Server port. |
+| `MEMPALACE_OP_TIMEOUT` | `15` (seconds) | Hard per-operation ceiling on every wire call. |
+
+While the server is running, never open the same palace in embedded mode
+(e.g. offline repair tooling): two writers on the same sqlite/HNSW files
+is the corruption scenario HTTP mode exists to remove. Stop the server
+first.
+
+## Error contract
+
+Palace failures in HTTP mode are **structured errors, never hangs**. If a
+call blocks forever, that is a bug in this contract, not expected
+behavior. The two shapes (both in `mempalace/palace_client.py`):
+
+- `PalaceBackendUnreachableError` — the server did not answer. Raised by
+  the construction-time health probe (`GET /api/v2/heartbeat`, 3 s
+  timeout, error names `host:port`) **and** by in-flight calls whose
+  transport dies mid-request (`httpx.TransportError` / builtin
+  `ConnectionError` are translated into this same shape), so consumers see
+  one error whether the server died before or during the call.
+- `PalaceOperationTimeoutError` — a single operation exceeded the
+  `MEMPALACE_OP_TIMEOUT` ceiling. The error names the operation (e.g.
+  `collection[memories].query`) and the backend address.
+
+The MCP server catches both and returns a structured tool error with a
+recovery hint. Errors are not retried internally — the probe/timeout
+already bounded the wait; a retry would just double it.
+
+## Running the server as a user service
+
+### macOS (launchd)
+
+`~/Library/LaunchAgents/com.example.chroma-server.plist` (adjust the
+`chroma` binary path — `which chroma` — and the palace path):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.example.chroma-server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/path/to/bin/chroma</string>
+        <string>run</string>
+        <string>--path</string>
+        <string>/path/to/.mempalace/palace</string>
+        <string>--host</string>
+        <string>127.0.0.1</string>
+        <string>--port</string>
+        <string>8801</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/chroma-server.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/chroma-server.err</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>ANONYMIZED_TELEMETRY</key>
+        <string>False</string>
+    </dict>
+</dict>
+</plist>
+```
+
+```bash
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.example.chroma-server.plist
+launchctl print gui/$UID/com.example.chroma-server | grep state   # → running
+# restart:
+launchctl bootout gui/$UID/com.example.chroma-server
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.example.chroma-server.plist
+```
+
+### Linux (systemd user unit)
+
+`~/.config/systemd/user/chroma-server.service`:
+
+```ini
+[Unit]
+Description=ChromaDB server for MemPalace
+
+[Service]
+ExecStart=/path/to/bin/chroma run --path %h/.mempalace/palace --host 127.0.0.1 --port 8801
+Restart=always
+RestartSec=2
+Environment=ANONYMIZED_TELEMETRY=False
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now chroma-server
+systemctl --user status chroma-server
+journalctl --user -u chroma-server -f   # logs
+```
+
+## Operations
+
+**Heartbeat** (is the server up?):
+
+```bash
+curl http://127.0.0.1:8801/api/v2/heartbeat
+# → {"nanosecond heartbeat": ...}
+```
+
+**Respawn behavior**: with `KeepAlive` (launchd) / `Restart=always`
+(systemd), the service manager restarts the server within seconds if it
+crashes. Clients need no action: the MCP server health-probes on
+construction and returns structured errors until the backend is back,
+then reconnects on the next call.
+
+**Backup / restore**: back up with the server stopped (or accept a
+crash-consistent copy at your own risk):
+
+```bash
+# stop the service (see above), then:
+tar -czf mempalace-backup-$(date +%Y%m%d-%H%M).tar.gz -C ~/.mempalace palace
+# restart the service
+```
+
+Restore is the reverse: stop, untar over the palace directory, start.
+
+**Vacuum** (chromadb 1.5.x): stop all writers first, take a backup, then:
+
+```bash
+# stop the service, then:
+chroma vacuum --path ~/.mempalace/palace
+# restart the service
+```
+
+## Embedded-only mechanisms gated off in HTTP mode
+
+Several embedded-era mechanisms are explicitly skipped in HTTP mode. Each
+is correct for a process that owns the palace files and wrong for a thin
+HTTP client:
+
+1. **Pre-open repair pass** (`ChromaBackend.make_client`) — quarantining
+   HNSW segments client-side against files a live server owns is a
+   corruption risk; the server does its own segment management.
+2. **Inode-keyed client cache** (`ChromaBackend._client`) — the cache is
+   keyed on the server address instead; file identity is meaningless when
+   this process never opens the files.
+3. **mtime-based reconnect** (`mcp_server._get_client`) — the server bumps
+   `chroma.sqlite3`'s mtime on every write, so the embedded freshness check
+   would force a client rebuild on every call; the client is cached for the
+   process lifetime instead.
+4. **HNSW capacity probe** (`mcp_server._refresh_vector_disabled_flag`) —
+   guards an embedded-only segfault (#1222) that cannot happen in a process
+   that never loads HNSW segments; left on it would wrongly route search to
+   the BM25 fallback.
+5. **Collection `_write_lock` flock** (`ChromaCollection._write_lock`) —
+   the `mine_palace_lock` flock guarded embedded ChromaDB's multi-threaded
+   HNSW corruption (#974/#965); over HTTP the server serializes writes, and
+   the non-blocking flock turned legitimate concurrent writers into hard
+   `MineAlreadyRunning` errors.
+6. **MCP peer-writer lease** (#1818) — the process-lifetime writer lease
+   protects peers from each other's stale in-memory embedded state; in HTTP
+   mode it would turn the multi-process topology this transport exists for
+   into read-only peers (#1888). Whole mining passes still take
+   `mine_palace_lock` for their own application-level atomicity.

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -20,6 +20,7 @@ import chromadb
 from chromadb.errors import NotFoundError as _ChromaNotFoundError
 
 from ..config import sqlite_read_uri
+from ..palace_client import backend_address, http_mode, make_http_client
 from ._sidecar import EMBEDDER_SIDECAR_FILENAME, read_embedder_sidecar, write_embedder_sidecar
 from .base import (
     BaseBackend,
@@ -2019,6 +2020,19 @@ class ChromaBackend(BaseBackend):
 
             raise BackendClosedError("ChromaBackend has been closed")
 
+        if http_mode():
+            # HTTP mode: the standalone Chroma server owns the persist
+            # directory. Cache keyed on the server address — inode/mtime
+            # freshness is meaningless over HTTP (the server, not this
+            # process, sees on-disk rebuilds), and the embedded pre-open
+            # repair pass must never touch files a live server owns.
+            key = f"http://{backend_address()}"
+            cached = self._clients.get(key)
+            if cached is None:
+                cached = make_http_client()
+                self._clients[key] = cached
+            return cached
+
         cached = self._clients.get(palace_path)
         cached_inode, cached_mtime = self._freshness.get(palace_path, (0, 0.0))
         current_inode, current_mtime = self._db_stat(palace_path)
@@ -2130,6 +2144,12 @@ class ChromaBackend(BaseBackend):
         Quarantines HNSW segments on first open and after any detected
         disk change. See :attr:`_quarantined_paths` for the gate logic.
         """
+        if http_mode():
+            # HTTP mode: server-owned files — skip the embedded pre-open
+            # repair pass entirely (client-side repair against a live
+            # server's files is a corruption risk, and the server does
+            # its own segment management).
+            return make_http_client()
         ChromaBackend._prepare_palace_for_open(palace_path)
         return chromadb.PersistentClient(path=palace_path)
 

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1340,9 +1340,14 @@ class ChromaCollection(BaseCollection):
     def _write_lock(self):
         """Acquire ``mine_palace_lock`` for the configured palace, if any.
 
-        No-op (yields immediately) when ``self._palace_path`` is None.
+        No-op (yields immediately) when ``self._palace_path`` is None, and in
+        HTTP mode: the flock guarded embedded ChromaDB's
+        multi-threaded HNSW corruption (#974/#965), but over HTTP the server
+        serializes writes itself. Kept on, the non-blocking flock turns the
+        multi-process topology this transport exists for (MCP servers + hook
+        CLI writing concurrently) into hard ``MineAlreadyRunning`` errors.
         """
-        if self._palace_path is None:
+        if self._palace_path is None or http_mode():
             yield
             return
         # Late import — palace.py imports ChromaBackend from this module.

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -431,6 +431,16 @@ def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     if _truthy_env(_MCP_ALLOW_PEER_WRITER_ENV):
         return True, ""
 
+    if http_mode():
+        # HTTP mode: the standalone Chroma server serializes writes, so a
+        # peer MemPalace writer cannot corrupt another process's in-memory
+        # HNSW/FTS state — the hazard this lease guards against (#1818).
+        # Holding a process-lifetime lease here would turn the multi-process
+        # topology HTTP mode exists for into read-only peers (#1888).
+        # Individual mining passes still take mine_palace_lock for their
+        # own application-level atomicity.
+        return True, ""
+
     if _MCP_WRITER_LOCK_CM is not None:
         return True, ""
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -76,6 +76,13 @@ from .backends.chroma import (  # noqa: E402
     hnsw_capacity_status,
 )
 from .backends import BackendMismatchError, PalaceRef, detect_backend_for_path  # noqa: E402
+from .palace_client import (  # noqa: E402
+    PalaceBackendUnreachableError,
+    PalaceOperationTimeoutError,
+    backend_address,
+    http_mode,
+    probe_backend,
+)
 from .query_sanitizer import sanitize_query  # noqa: E402
 from .searcher import (  # noqa: E402
     _distance_to_similarity,
@@ -885,6 +892,16 @@ def _refresh_vector_disabled_flag() -> None:
         _vector_disabled_reason = ""
         _vector_capacity_status = None
         return
+    if http_mode():
+        # HTTP mode: over HTTP this process never loads HNSW segments, so the
+        # embedded-mode segfault the probe guards against (#1222) cannot
+        # happen here. Leaving the probe on would let a client-side reading
+        # of the server's live files wrongly route search to the BM25
+        # fallback for divergence the server already handles itself.
+        _vector_disabled = False
+        _vector_disabled_reason = ""
+        _vector_capacity_status = None
+        return
     try:
         info = hnsw_capacity_status(_config.palace_path, _config.collection_name)
     except Exception:
@@ -947,6 +964,15 @@ def _get_client():
         _metadata_cache_time
     if not _is_chroma_backend():
         raise RuntimeError("_get_client is only available for the Chroma backend")
+    if http_mode():
+        # HTTP transport. The standalone Chroma server owns rebuild
+        # detection, so the inode/mtime reconnect logic below is meaningless
+        # here — worse, the server bumps chroma.sqlite3's mtime on every
+        # write, which would force a client rebuild on every call. Cache for
+        # the process lifetime; make_client() health-probes on construction.
+        if _client_cache is None:
+            _client_cache = ChromaBackend.make_client(_config.palace_path)
+        return _client_cache
     db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
     try:
         st = os.stat(db_path)
@@ -1175,6 +1201,29 @@ def _get_collection(create=False):
                 _metadata_cache = None
                 _metadata_cache_time = 0
             return _collection_cache
+        except (PalaceBackendUnreachableError, PalaceOperationTimeoutError) as exc:
+            # Structured, non-retried error — the health probe / operation
+            # timeout already bounded the wait; a second attempt would just
+            # double it. The MCP client gets a clean error, never a hang.
+            logger.error("palace backend error: %s", exc)
+            _collection_open_error = {
+                "error": "Palace backend unreachable"
+                if isinstance(exc, PalaceBackendUnreachableError)
+                else "Palace operation timeout",
+                "details": str(exc),
+                "hint": (
+                    f"Check the Chroma server: curl http://{backend_address()}"
+                    "/api/v2/heartbeat ; if you run it under a service "
+                    "manager (launchd/systemd), it should respawn shortly."
+                ),
+            }
+            _client_cache = None
+            _collection_cache = None
+            _collection_cache_backend = None
+            _collection_cache_palace = None
+            _metadata_cache = None
+            _metadata_cache_time = 0
+            return None
         except (BackendMismatchError, KeyError) as exc:
             _collection_open_error = {
                 "error": "Backend mismatch"
@@ -5373,6 +5422,20 @@ def _run_stdio_loop() -> None:
 
     logger.info("MemPalace MCP Server starting...")
 
+    # Startup health probe against the standalone Chroma server (HTTP mode
+    # only). Non-fatal — the server keeps running and every tool returns the
+    # structured unreachable error until the backend is back.
+    if http_mode():
+        try:
+            probe_backend()
+            logger.info("Palace backend reachable at %s", backend_address())
+        except PalaceBackendUnreachableError as exc:
+            logger.error(
+                "%s — tools will return structured errors until the Chroma "
+                "server is back (restart it via your service manager, e.g. "
+                "launchd/systemd).",
+                exc,
+            )
     # Pre-flight: probe HNSW capacity before any tool call so the warning
     # is visible at startup rather than on first use (#1222). Pure
     # filesystem read; never opens a chromadb client.

--- a/mempalace/palace_client.py
+++ b/mempalace/palace_client.py
@@ -1,0 +1,225 @@
+"""Single construction point for MemPalace's Chroma client (HTTP mode).
+
+Opt-in topology for multi-process palace access (#832, #1096): one
+standalone ``chroma run`` server exclusively owns the persist directory;
+every MemPalace process (MCP servers, hook CLI, miner) is a thin HTTP
+client built here. Nothing outside this module may construct a Chroma
+client in HTTP mode — that is what prevents a second embedded writer from
+re-appearing and racing on the shared sqlite/HNSW files.
+
+Transport selection:
+    MEMPALACE_CHROMA_MODE=embedded (default) | http
+The default stays embedded so single-process installs keep working with
+zero configuration and no external service. Set ``http`` when more than
+one process (multiple MCP servers, stop-hook mines, manual CLI runs)
+touches the same palace concurrently — the case embedded
+``PersistentClient`` does not support.
+
+Server address (HTTP mode):
+    CHROMA_HOST (default 127.0.0.1) / CHROMA_PORT (default 8801)
+
+Guarantees provided to every caller in HTTP mode:
+
+* Health probe — client construction first hits ``/api/v2/heartbeat`` with a
+  3-second timeout and raises :class:`PalaceBackendUnreachableError` (naming
+  host:port) instead of hanging when the server is down.
+* Hard per-operation timeout — every method call on the returned client (and
+  on any collection obtained from it) runs under a 15-second ceiling
+  (``MEMPALACE_OP_TIMEOUT`` overrides) and raises
+  :class:`PalaceOperationTimeoutError` naming the operation. No palace call
+  may ever block the MCP server indefinitely.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as _FutureTimeoutError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CHROMA_HOST = "127.0.0.1"
+DEFAULT_CHROMA_PORT = 8801
+HEALTH_PROBE_TIMEOUT_S = 3.0
+DEFAULT_OP_TIMEOUT_S = 15.0
+
+
+class PalaceBackendUnreachableError(RuntimeError):
+    """The standalone Chroma server did not answer the health probe."""
+
+
+class PalaceOperationTimeoutError(RuntimeError):
+    """A palace operation exceeded the hard per-operation timeout."""
+
+
+def http_mode() -> bool:
+    """True only when ``MEMPALACE_CHROMA_MODE=http`` opts in."""
+    return os.environ.get("MEMPALACE_CHROMA_MODE", "embedded").strip().lower() == "http"
+
+
+def chroma_host() -> str:
+    return os.environ.get("CHROMA_HOST", "").strip() or DEFAULT_CHROMA_HOST
+
+
+def chroma_port() -> int:
+    raw = os.environ.get("CHROMA_PORT", "").strip()
+    if not raw:
+        return DEFAULT_CHROMA_PORT
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid CHROMA_PORT=%r; using default %d", raw, DEFAULT_CHROMA_PORT)
+        return DEFAULT_CHROMA_PORT
+
+
+def backend_address() -> str:
+    return f"{chroma_host()}:{chroma_port()}"
+
+
+def op_timeout_s() -> float:
+    raw = os.environ.get("MEMPALACE_OP_TIMEOUT", "").strip()
+    if not raw:
+        return DEFAULT_OP_TIMEOUT_S
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid MEMPALACE_OP_TIMEOUT=%r; using default %.0fs", raw, DEFAULT_OP_TIMEOUT_S
+        )
+        return DEFAULT_OP_TIMEOUT_S
+
+
+def probe_backend(timeout_s: float = HEALTH_PROBE_TIMEOUT_S) -> None:
+    """Hit the server's v2 heartbeat; raise on any failure, never hang.
+
+    chromadb 1.5.x serves ``GET /api/v2/heartbeat`` (verified against the
+    `chroma run` server, chromadb 1.5.x; the v1 path is gone in the Rust frontend).
+    """
+    url = f"http://{backend_address()}/api/v2/heartbeat"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout_s) as resp:
+            if resp.status != 200:
+                raise PalaceBackendUnreachableError(
+                    f"palace backend unreachable at {backend_address()} "
+                    f"(heartbeat returned HTTP {resp.status})"
+                )
+    except PalaceBackendUnreachableError:
+        raise
+    except Exception as exc:
+        raise PalaceBackendUnreachableError(
+            f"palace backend unreachable at {backend_address()} ({exc.__class__.__name__}: {exc})"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Hard per-operation timeout
+# ---------------------------------------------------------------------------
+
+# chromadb's sync client blocks the calling thread, so the ceiling is
+# enforced by running the call in a worker and bounding the wait. A timed-out
+# call keeps running in its worker until the socket dies — the executor
+# exists to bound *our* wait, not to cancel the remote work.
+_executor: ThreadPoolExecutor | None = None
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    global _executor
+    if _executor is None:
+        _executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="palace-op")
+    return _executor
+
+
+def run_with_timeout(op_name: str, fn, /, *args, timeout_s: float | None = None, **kwargs):
+    """Run ``fn(*args, **kwargs)`` under the hard operation timeout.
+
+    Raises :class:`PalaceOperationTimeoutError` naming ``op_name`` when the
+    ceiling is hit. Exceptions raised by ``fn`` propagate unchanged so
+    callers' existing except-clauses (e.g. Chroma NotFoundError handling)
+    keep working.
+    """
+    limit = op_timeout_s() if timeout_s is None else timeout_s
+    future = _get_executor().submit(fn, *args, **kwargs)
+    try:
+        return future.result(timeout=limit)
+    except _FutureTimeoutError:
+        future.cancel()
+        raise PalaceOperationTimeoutError(
+            f"palace operation '{op_name}' timed out after {limit:g}s against {backend_address()}"
+        ) from None
+
+
+# Duck-type check for chromadb Collection objects so the proxy can wrap
+# collections returned by client methods without importing chromadb types.
+_COLLECTION_MARKERS = ("query", "upsert", "get", "count")
+
+
+def _looks_like_collection(obj) -> bool:
+    return all(callable(getattr(obj, m, None)) for m in _COLLECTION_MARKERS)
+
+
+def _wrap_result(result, label: str):
+    if _looks_like_collection(result):
+        name = getattr(result, "name", "?")
+        return TimeoutProxy(result, label=f"collection[{name}]")
+    if isinstance(result, list):
+        return [_wrap_result(item, label) for item in result]
+    return result
+
+
+class TimeoutProxy:
+    """Timeout guard for a chromadb client or collection.
+
+    Every method call on the proxied object runs under
+    :func:`run_with_timeout`; non-callable attributes pass through raw.
+    Collection-shaped return values (single or in lists) are wrapped
+    recursively, so ``client.get_collection(...).query(...)`` is guarded end
+    to end without any call-site changes.
+    """
+
+    __slots__ = ("_tp_inner", "_tp_label")
+
+    def __init__(self, inner, label: str):
+        self._tp_inner = inner
+        self._tp_label = label
+
+    def __getattr__(self, name):
+        attr = getattr(self._tp_inner, name)
+        if not callable(attr):
+            return attr
+        label = self._tp_label
+
+        def _timed(*args, **kwargs):
+            result = run_with_timeout(f"{label}.{name}", attr, *args, **kwargs)
+            return _wrap_result(result, label)
+
+        _timed.__name__ = name
+        return _timed
+
+    def __repr__(self):
+        return f"TimeoutProxy({self._tp_inner!r})"
+
+
+def make_http_client():
+    """Probe the backend, then return a timeout-guarded chromadb HttpClient.
+
+    The only place MemPalace constructs a Chroma client in HTTP mode. The
+    HttpClient constructor itself performs wire calls (tenant/database
+    validation), so it too runs under the operation timeout.
+    """
+    probe_backend()
+    import chromadb  # late import: keeps module import side-effect free
+
+    try:
+        client = run_with_timeout(
+            "chroma.connect",
+            lambda: chromadb.HttpClient(host=chroma_host(), port=chroma_port()),
+        )
+    except PalaceOperationTimeoutError:
+        raise
+    except Exception as exc:
+        raise PalaceBackendUnreachableError(
+            f"palace backend unreachable at {backend_address()} (client construction failed: {exc})"
+        ) from exc
+    return TimeoutProxy(client, label="chroma")

--- a/mempalace/palace_client.py
+++ b/mempalace/palace_client.py
@@ -131,13 +131,31 @@ def _get_executor() -> ThreadPoolExecutor:
     return _executor
 
 
+def _is_transport_failure(exc: BaseException) -> bool:
+    """True when ``exc`` means the backend is gone, not that the call was bad.
+
+    chromadb's sync client rides on httpx; a killed/restarting server surfaces
+    as ``httpx.TransportError`` (connect refused, read cut mid-response, …).
+    The builtin ``ConnectionError`` covers non-httpx paths.
+    """
+    if isinstance(exc, ConnectionError):
+        return True
+    try:
+        import httpx
+    except ImportError:
+        return False
+    return isinstance(exc, httpx.TransportError)
+
+
 def run_with_timeout(op_name: str, fn, /, *args, timeout_s: float | None = None, **kwargs):
     """Run ``fn(*args, **kwargs)`` under the hard operation timeout.
 
     Raises :class:`PalaceOperationTimeoutError` naming ``op_name`` when the
-    ceiling is hit. Exceptions raised by ``fn`` propagate unchanged so
-    callers' existing except-clauses (e.g. Chroma NotFoundError handling)
-    keep working.
+    ceiling is hit, and translates transport-level failures (server killed
+    mid-call) into :class:`PalaceBackendUnreachableError` so every consumer
+    gets the same structured error whether the server died before or during
+    the call. All other exceptions propagate unchanged so callers' existing
+    except-clauses (e.g. Chroma NotFoundError handling) keep working.
     """
     limit = op_timeout_s() if timeout_s is None else timeout_s
     future = _get_executor().submit(fn, *args, **kwargs)
@@ -148,6 +166,13 @@ def run_with_timeout(op_name: str, fn, /, *args, timeout_s: float | None = None,
         raise PalaceOperationTimeoutError(
             f"palace operation '{op_name}' timed out after {limit:g}s against {backend_address()}"
         ) from None
+    except Exception as exc:
+        if _is_transport_failure(exc):
+            raise PalaceBackendUnreachableError(
+                f"palace backend unreachable at {backend_address()} during "
+                f"'{op_name}' ({type(exc).__name__}: {exc})"
+            ) from exc
+        raise
 
 
 # Duck-type check for chromadb Collection objects so the proxy can wrap

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,13 @@ os.environ["USERPROFILE"] = _session_tmp
 os.environ["HOMEDRIVE"] = os.path.splitdrive(_session_tmp)[0] or "C:"
 os.environ["HOMEPATH"] = os.path.splitdrive(_session_tmp)[1] or _session_tmp
 
+# The suite exercises palaces in throwaway temp directories, which
+# only works through the embedded client. Force embedded mode so tests can
+# never reach a real Chroma server — in HTTP mode palace_path is ignored and
+# every write would land in the developer's live palace. HTTP-mode behavior
+# is covered by tests/test_palace_client.py, which sets the env explicitly.
+os.environ["MEMPALACE_CHROMA_MODE"] = "embedded"
+
 # Now it is safe to import mempalace modules that trigger initialisation.
 import chromadb  # noqa: E402
 import pytest  # noqa: E402

--- a/tests/test_palace_client.py
+++ b/tests/test_palace_client.py
@@ -1,0 +1,155 @@
+"""palace_client unit tests: env resolution, unreachable-server
+structured errors, and the hard per-operation timeout.
+
+These tests never need a running Chroma server — the unreachable cases use
+port 1 (nothing listens there; connect fails fast) and the timeout cases use
+plain slow callables.
+"""
+
+import time
+
+import pytest
+
+from mempalace import palace_client
+from mempalace.palace_client import (
+    PalaceBackendUnreachableError,
+    PalaceOperationTimeoutError,
+    TimeoutProxy,
+    chroma_host,
+    chroma_port,
+    http_mode,
+    make_http_client,
+    probe_backend,
+    run_with_timeout,
+)
+
+DEAD_PORT = "1"
+
+
+class TestEnvResolution:
+    def test_defaults(self, monkeypatch):
+        monkeypatch.delenv("CHROMA_HOST", raising=False)
+        monkeypatch.delenv("CHROMA_PORT", raising=False)
+        assert chroma_host() == "127.0.0.1"
+        assert chroma_port() == 8801
+        assert palace_client.backend_address() == "127.0.0.1:8801"
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("CHROMA_HOST", "10.0.0.5")
+        monkeypatch.setenv("CHROMA_PORT", "8805")
+        assert chroma_host() == "10.0.0.5"
+        assert chroma_port() == 8805
+        assert palace_client.backend_address() == "10.0.0.5:8805"
+
+    def test_invalid_port_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("CHROMA_PORT", "not-a-port")
+        assert chroma_port() == 8801
+
+    def test_embedded_is_default_and_http_opts_in(self, monkeypatch):
+        monkeypatch.delenv("MEMPALACE_CHROMA_MODE", raising=False)
+        assert http_mode() is False
+        monkeypatch.setenv("MEMPALACE_CHROMA_MODE", "http")
+        assert http_mode() is True
+        monkeypatch.setenv("MEMPALACE_CHROMA_MODE", "HTTP")
+        assert http_mode() is True
+        monkeypatch.setenv("MEMPALACE_CHROMA_MODE", "embedded")
+        assert http_mode() is False
+
+    def test_op_timeout_env_override(self, monkeypatch):
+        monkeypatch.delenv("MEMPALACE_OP_TIMEOUT", raising=False)
+        assert palace_client.op_timeout_s() == palace_client.DEFAULT_OP_TIMEOUT_S
+        monkeypatch.setenv("MEMPALACE_OP_TIMEOUT", "2.5")
+        assert palace_client.op_timeout_s() == 2.5
+        monkeypatch.setenv("MEMPALACE_OP_TIMEOUT", "garbage")
+        assert palace_client.op_timeout_s() == palace_client.DEFAULT_OP_TIMEOUT_S
+
+
+class TestUnreachableServer:
+    def test_probe_raises_structured_error_fast(self, monkeypatch):
+        monkeypatch.setenv("CHROMA_HOST", "127.0.0.1")
+        monkeypatch.setenv("CHROMA_PORT", DEAD_PORT)
+        start = time.monotonic()
+        with pytest.raises(PalaceBackendUnreachableError) as excinfo:
+            probe_backend()
+        elapsed = time.monotonic() - start
+        assert elapsed < 4.0, f"probe took {elapsed:.1f}s; must fail within the 3s ceiling"
+        assert "palace backend unreachable at 127.0.0.1:1" in str(excinfo.value)
+
+    def test_make_http_client_raises_unreachable(self, monkeypatch):
+        monkeypatch.setenv("CHROMA_HOST", "127.0.0.1")
+        monkeypatch.setenv("CHROMA_PORT", DEAD_PORT)
+        with pytest.raises(PalaceBackendUnreachableError):
+            make_http_client()
+
+    def test_backend_make_client_routes_http_and_surfaces_unreachable(self, monkeypatch):
+        from mempalace.backends.chroma import ChromaBackend
+
+        monkeypatch.setenv("MEMPALACE_CHROMA_MODE", "http")
+        monkeypatch.setenv("CHROMA_HOST", "127.0.0.1")
+        monkeypatch.setenv("CHROMA_PORT", DEAD_PORT)
+        with pytest.raises(PalaceBackendUnreachableError):
+            ChromaBackend.make_client("/tmp/does-not-matter-in-http-mode")
+
+
+class TestOperationTimeout:
+    def test_timeout_fires_and_names_operation(self):
+        start = time.monotonic()
+        with pytest.raises(PalaceOperationTimeoutError) as excinfo:
+            run_with_timeout("collection.query", time.sleep, 5, timeout_s=0.2)
+        assert time.monotonic() - start < 2.0
+        assert "collection.query" in str(excinfo.value)
+
+    def test_result_passthrough(self):
+        assert run_with_timeout("ok", lambda: 42) == 42
+
+    def test_exception_passthrough_unchanged(self):
+        def boom():
+            raise ValueError("original error")
+
+        with pytest.raises(ValueError, match="original error"):
+            run_with_timeout("boom", boom)
+
+
+class TestTimeoutProxy:
+    class _FakeCollection:
+        name = "fake"
+
+        def query(self):
+            return "queried"
+
+        def upsert(self):
+            return "upserted"
+
+        def get(self):
+            return "got"
+
+        def count(self):
+            return 7
+
+        def slow(self):
+            time.sleep(5)
+            return "late"
+
+    def test_attributes_pass_through_and_methods_work(self):
+        proxy = TimeoutProxy(self._FakeCollection(), label="t")
+        assert proxy.name == "fake"
+        assert proxy.count() == 7
+
+    def test_slow_method_hits_ceiling(self, monkeypatch):
+        monkeypatch.setenv("MEMPALACE_OP_TIMEOUT", "0.2")
+        proxy = TimeoutProxy(self._FakeCollection(), label="t")
+        with pytest.raises(PalaceOperationTimeoutError) as excinfo:
+            proxy.slow()
+        assert "t.slow" in str(excinfo.value)
+
+    def test_collection_shaped_returns_get_wrapped(self):
+        fake = self._FakeCollection()
+
+        class FakeClient:
+            def get_collection(self, name):
+                return fake
+
+        proxy = TimeoutProxy(FakeClient(), label="chroma")
+        col = proxy.get_collection("fake")
+        assert isinstance(col, TimeoutProxy)
+        assert col.query() == "queried"

--- a/tests/test_palace_client.py
+++ b/tests/test_palace_client.py
@@ -153,3 +153,26 @@ class TestTimeoutProxy:
         col = proxy.get_collection("fake")
         assert isinstance(col, TimeoutProxy)
         assert col.query() == "queried"
+
+
+class TestTransportFailureTranslation:
+    def test_connection_failure_becomes_unreachable(self):
+        import httpx
+
+        def dead_call():
+            raise httpx.ConnectError("[Errno 61] Connection refused")
+
+        with pytest.raises(PalaceBackendUnreachableError) as excinfo:
+            run_with_timeout("collection.query", dead_call)
+        assert "during 'collection.query'" in str(excinfo.value)
+
+    def test_builtin_connection_error_translates(self):
+        def dead_call():
+            raise ConnectionRefusedError("refused")
+
+        with pytest.raises(PalaceBackendUnreachableError):
+            run_with_timeout("op", dead_call)
+
+    def test_non_transport_errors_untouched(self):
+        with pytest.raises(KeyError):
+            run_with_timeout("op", lambda: (_ for _ in ()).throw(KeyError("k")))


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in HTTP client/server mode for the ChromaDB backend, as requested in #832 and #1096 — and implements the "ChromaDB HTTP server mode" option named in the architectural decision epic #1963.

**Problem.** Embedded `chromadb.PersistentClient` is not process-safe. When more than one process writes the same palace — multiple MCP server instances, stop-hook mines firing alongside an interactive session, a manual `mempalace mine` — writers contest the same sqlite/HNSW files and can corrupt the index (the #1963 cluster). Worse, a blocked writer waits on the file lock with no timeout, so palace calls can hang the MCP server indefinitely.

**Fix.** With `MEMPALACE_CHROMA_MODE=http`, one standalone `chroma run` server exclusively owns the palace directory and every MemPalace process is a thin HTTP client constructed in one place (`mempalace/palace_client.py`). The server serializes writes where ChromaDB actually supports concurrency; clients get:

- **Health probe** — construction hits `/api/v2/heartbeat` (3 s timeout) and raises `PalaceBackendUnreachableError` naming host:port instead of hanging.
- **Hard per-operation timeout** — every wire call runs under a 15 s ceiling (`MEMPALACE_OP_TIMEOUT`) via a `TimeoutProxy` wrapping the client and every collection obtained from it; timeouts raise `PalaceOperationTimeoutError` naming the operation.
- **One error shape** — transport failures mid-call (`httpx.TransportError`, `ConnectionError`) are translated into the same structured unreachable error the probe gives; the MCP server returns these as structured tool errors, never hangs, never retries (the bound already happened).

**Default unchanged.** `embedded` remains the default: zero change and no external service for single-process installs. Config surface: `MEMPALACE_CHROMA_MODE`, `CHROMA_HOST`/`CHROMA_PORT` (default `127.0.0.1:8801`), `MEMPALACE_OP_TIMEOUT`.

**Embedded-only mechanisms gated off in HTTP mode** (each is correct for a process that owns the files, wrong for a thin client):

- the pre-open repair pass — client-side repair against a live server's files is a corruption risk;
- the inode-keyed client cache and mtime reconnect — file identity is meaningless over HTTP, and the server bumps mtime on every write;
- the HNSW capacity probe — #1222 guards an embedded-only segfault; left on it would wrongly route search to BM25;
- the collection `_write_lock` flock — #974/#965 guarded embedded multi-threaded corruption; kept on it turns legitimate concurrent writers into `MineAlreadyRunning` errors;
- the MCP peer-writer lease (#1818) — in HTTP mode it would force peer servers read-only, the same incompatibility #1888 reports for daemon topologies.

Mining passes still take `mine_palace_lock` for application-level atomicity in both modes.

**Docs:** `docs/chroma-client-server.md` — topology, config, error contract, launchd + systemd service examples, heartbeat/backup/vacuum runbook (#1096 asked for exactly this).

**Relationship to the daemon+bridge direction (#1270/#1976):** complementary, not competing — this is opt-in, changes nothing by default, and gives multi-process users a supported deployment today at the layer where ChromaDB itself supports concurrency.

Closes #832. Closes #1096. Related to #1963, #1581, #1799, #1888.

## How to test

```bash
python -m pytest tests/ -v                      # suite forces embedded mode; 17 new tests in tests/test_palace_client.py
# live smoke test:
chroma run --path /tmp/palace-http --port 8801 &
MEMPALACE_CHROMA_MODE=http mempalace init ~/somewhere && MEMPALACE_CHROMA_MODE=http mempalace mine ~/somewhere
# kill the server mid-session → structured PalaceBackendUnreachableError, no hang
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`) — 3284 passed; the 2 failures in `test_repair.py` (`_errors_are_isolated_fts5` string matching) fail identically on clean `develop` in this environment
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
