### PR TITLE
fix(repair): rebuild FTS5 after SQLite recovery

### DIFF
--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -1480,13 +1480,20 @@ def rebuild_from_sqlite(
             else:
                 print(f"    done: {upserted} rows in {cname}")
 
-        print(f"\n  Rebuild complete. {sum(counts.values())} total rows.")
-        if archive_path is not None:
-            print(f"  Original palace archived at: {archive_path}")
-        print(f"{'=' * 55}\n")
-        return counts
     finally:
         backend.close()
+
+    # Bulk Chroma upserts can leave the derived FTS5 index internally
+    # inconsistent even when all source rows landed.  Rebuild it only after
+    # the backend releases its SQLite handle; otherwise VACUUM cannot obtain
+    # the exclusive lock it needs on Windows.
+    _vacuum_and_rebuild_fts5(dest_palace)
+
+    print(f"\n  Rebuild complete. {sum(counts.values())} total rows.")
+    if archive_path is not None:
+        print(f"  Original palace archived at: {archive_path}")
+    print(f"{'=' * 55}\n")
+    return counts
 
 
 def status(palace_path=None, collection_name: Optional[str] = None) -> dict:

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1752,6 +1752,32 @@ def test_rebuild_from_sqlite_roundtrips_via_real_chromadb(tmp_path):
     assert closet_row["metadatas"][0] == {"wing": "alpha"}
 
 
+def test_rebuild_from_sqlite_rebuilds_fts5_after_chroma_closes(tmp_path, monkeypatch):
+    """The SQLite recovery path must finish by rebuilding Chroma's FTS5 index.
+
+    Large bulk upserts can leave the derived full-text index malformed even
+    when every source drawer survived.  The repair is not complete until the
+    Chroma client releases its SQLite handle and FTS5 is rebuilt.
+    """
+    source = tmp_path / "source"
+    dest = tmp_path / "dest"
+    _seed_palace(source, "mempalace_drawers", [("d1", "doc", {"wing": "w"})])
+
+    calls = []
+    real_rebuild = repair._vacuum_and_rebuild_fts5
+
+    def _spy(path, progress=print):
+        calls.append(path)
+        return real_rebuild(path, progress=progress)
+
+    monkeypatch.setattr(repair, "_vacuum_and_rebuild_fts5", _spy)
+
+    counts = repair.rebuild_from_sqlite(str(source), str(dest))
+
+    assert counts["mempalace_drawers"] == 1
+    assert calls == [str(dest)]
+
+
 def test_rebuild_from_sqlite_refuses_existing_dest(tmp_path):
     """Refuse to write into a directory that already exists when source
     and dest differ. Without this, an unattended re-run would silently


### PR DESCRIPTION
## What changed

- Run the existing FTS5 rebuild and SQLite vacuum after `rebuild_from_sqlite` finishes its Chroma upserts.
- Move the success return until after cleanup completes.
- Ensure Chroma's backend closes before cleanup so SQLite can obtain the exclusive lock required on Windows.
- Add a regression test proving the cleanup hook runs after a successful SQLite recovery.

## Why

Large bulk recovery upserts can leave Chroma's derived `embedding_fulltext_search` FTS5 index malformed even when every source row survives. The legacy rebuild path already performs this cleanup, but the corruption-recovery path that reads directly from SQLite did not.

That allowed `rebuild_from_sqlite` to report success while a later `PRAGMA quick_check` still failed with a malformed FTS5 inverted index.

## Impact

SQLite-based recovery now completes the same derived-index cleanup as the legacy rebuild. If FTS5 rebuild or vacuum fails, recovery no longer prints a successful completion message.

## Validation

- `92 passed` in `tests/test_repair.py` on the latest upstream `develop` branch.
- A real recovery rebuilt 22,492 rows and both SQLite `quick_check` and `integrity_check` returned `ok` afterward.
