### PR TITLE
fix(dedup): scope the similarity probe to the source group so it stops under-deleting on large palaces

### DIFF
--- a/mempalace/dedup.py
+++ b/mempalace/dedup.py
@@ -83,15 +83,40 @@ def dedup_source_group(col, drawer_ids, threshold=DEFAULT_THRESHOLD, dry_run=Tru
 
     Greedy: sort by doc length (longest first), keep if not too similar
     to any already-kept drawer. Returns (kept_ids, deleted_ids).
+
+    The similarity probe is scoped to the group's ``source_file`` (when the
+    metadata carries one). On a large palace the *global* nearest neighbors
+    of a chunk are routinely near-duplicates from other sources, so an
+    unscoped top-5 never surfaces the in-group twin and the dedup silently
+    under-deletes. Legacy drawers without ``source_file`` metadata keep the
+    historical unscoped probe.
+
+    Stored embeddings are reused when the backend returns them, avoiding one
+    embedding forward pass per candidate; one extra result slot absorbs the
+    candidate's own self-match (it is in the collection at distance ~0 and
+    must not displace the kept twin it would otherwise be compared against).
     """
-    data = col.get(ids=drawer_ids, include=["documents", "metadatas"])
-    items = list(zip(data["ids"], data["documents"], data["metadatas"]))
+    data = col.get(ids=drawer_ids, include=["documents", "metadatas", "embeddings"])
+    embeddings = data.get("embeddings") if isinstance(data, dict) else data["embeddings"]
+    if embeddings is None:
+        embeddings = [None] * len(data["ids"])
+    items = list(zip(data["ids"], data["documents"], data["metadatas"], embeddings))
     items.sort(key=lambda x: len(x[1] or ""), reverse=True)
+
+    # Scope the probe to this group's source file when known. Groups are
+    # built per source_file in get_source_groups, so the first tagged meta
+    # speaks for the whole group.
+    group_where = None
+    for _, _, meta, _ in items:
+        src = (meta or {}).get("source_file")
+        if src:
+            group_where = {"source_file": src}
+            break
 
     kept = []
     to_delete = []
 
-    for did, doc, _meta in items:
+    for did, doc, _meta, emb in items:
         if not doc or len(doc) < 20:
             to_delete.append(did)
             continue
@@ -101,16 +126,25 @@ def dedup_source_group(col, drawer_ids, threshold=DEFAULT_THRESHOLD, dry_run=Tru
             continue
 
         try:
-            results = col.query(
-                query_texts=[doc],
-                n_results=min(len(kept), 5),
-                include=["distances"],
-            )
+            kwargs = {
+                # +1 slot for the candidate's own self-match.
+                "n_results": min(len(kept) + 1, 6),
+                "include": ["distances"],
+            }
+            if emb is not None:
+                kwargs["query_embeddings"] = [emb]
+            else:
+                kwargs["query_texts"] = [doc]
+            if group_where is not None:
+                kwargs["where"] = group_where
+            results = col.query(**kwargs)
             dists = results["distances"][0] if results["distances"] else []
             kept_ids_set = {k[0] for k in kept}
 
             is_dup = False
             for rid, dist in zip(results["ids"][0], dists):
+                if rid == did:
+                    continue  # the candidate itself, distance ~0 — not a twin
                 if rid in kept_ids_set and dist < threshold:
                     is_dup = True
                     break

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -295,7 +295,9 @@ class _ScopedFakeCol:
             "metadatas": [{"source_file": self.docs[i][1]} for i in ids],
         }
 
-    def query(self, query_texts=None, query_embeddings=None, n_results=5, where=None, include=None, **kw):
+    def query(
+        self, query_texts=None, query_embeddings=None, n_results=5, where=None, include=None, **kw
+    ):
         self.query_calls.append({"where": where, "n_results": n_results})
         pool = [i for i, (_, src) in self.docs.items()]
         if where and "source_file" in where:

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -267,3 +267,107 @@ def test_dedup_palace_no_groups(mock_get_collection, mock_groups, mock_dedup_gro
     mock_groups.return_value = {}
     dedup.dedup_palace(palace_path=str(tmp_path), dry_run=True)
     mock_dedup_group.assert_not_called()
+
+
+# ── dedup_source_group — group scoping (the under-deletion bug) ────────
+
+
+class _ScopedFakeCol:
+    """Fake collection with a global corpus: query() honors the `where`
+    source_file filter the way ChromaDB does. Models the failure mode on a
+    large palace: the globally nearest neighbors of a doc are near-dups from
+    OTHER sources, so an unscoped top-5 never surfaces the in-group twin.
+    """
+
+    def __init__(self):
+        # d1/d2 are twins in a.txt; x1..x5 are foreign near-dups in other files.
+        self.docs = {
+            "d1": ("aaa bbb ccc ddd eee fff ggg hhh", "a.txt"),
+            "d2": ("aaa bbb ccc ddd eee fff ggg hhh", "a.txt"),
+            **{f"x{i}": ("aaa bbb ccc ddd eee fff ggg hhh", f"other{i}.txt") for i in range(1, 6)},
+        }
+        self.query_calls = []
+
+    def get(self, ids=None, include=None, **kw):
+        return {
+            "ids": list(ids),
+            "documents": [self.docs[i][0] for i in ids],
+            "metadatas": [{"source_file": self.docs[i][1]} for i in ids],
+        }
+
+    def query(self, query_texts=None, query_embeddings=None, n_results=5, where=None, include=None, **kw):
+        self.query_calls.append({"where": where, "n_results": n_results})
+        pool = [i for i, (_, src) in self.docs.items()]
+        if where and "source_file" in where:
+            pool = [i for i in pool if self.docs[i][1] == where["source_file"]]
+        # Everything is a near-identical twin: distance 0.01 for all.
+        hits = pool[:n_results]
+        return {"ids": [hits], "distances": [[0.01] * len(hits)]}
+
+    def delete(self, ids=None, **kw):
+        pass
+
+
+def test_dedup_source_group_scopes_query_to_source_file():
+    """The in-group twin must be found even when 5+ foreign near-dups are
+    globally closer — the query must carry where={'source_file': ...}."""
+    col = _ScopedFakeCol()
+    kept, deleted = dedup.dedup_source_group(col, ["d1", "d2"], threshold=0.15, dry_run=True)
+    assert deleted == ["d2"]
+    assert len(kept) == 1
+    assert all(c["where"] == {"source_file": "a.txt"} for c in col.query_calls)
+
+
+def test_dedup_source_group_unscoped_without_source_metadata():
+    """Legacy drawers without source_file metadata keep the unscoped query."""
+    col = MagicMock()
+    col.get.return_value = {
+        "ids": ["d1", "d2"],
+        "documents": ["long document one content here", "different document two here"],
+        "metadatas": [{}, {}],
+    }
+    col.query.return_value = {"ids": [["d1"]], "distances": [[0.8]]}
+    kept, deleted = dedup.dedup_source_group(col, ["d1", "d2"], threshold=0.15, dry_run=True)
+    assert len(kept) == 2
+    _, kwargs = col.query.call_args
+    assert kwargs.get("where") is None
+
+
+def test_dedup_source_group_self_match_does_not_consume_slots():
+    """The candidate itself is in the collection and comes back at distance
+    ~0. It must be skipped (not treated as a kept-twin) and must not consume
+    one of the neighbor slots that could have held the real kept twin."""
+    col = MagicMock()
+    col.get.return_value = {
+        "ids": ["d1", "d2"],
+        "documents": [
+            "long document content that is fairly long",
+            "long document content that is fairly lonG",
+        ],
+        "metadatas": [{"source_file": "a.txt"}, {"source_file": "a.txt"}],
+    }
+    # Query for d2 returns d2 itself first, then the kept twin d1.
+    col.query.return_value = {"ids": [["d2", "d1"]], "distances": [[0.0, 0.05]]}
+    kept, deleted = dedup.dedup_source_group(col, ["d1", "d2"], threshold=0.15, dry_run=True)
+    assert deleted == ["d2"]
+    _, kwargs = col.query.call_args
+    # One extra slot requested to absorb the self-match.
+    assert kwargs.get("n_results") == 2
+
+
+def test_dedup_source_group_reuses_stored_embeddings():
+    """When the initial get() returns embeddings, query with query_embeddings
+    (no re-embedding of every candidate doc)."""
+    col = MagicMock()
+    col.get.return_value = {
+        "ids": ["d1", "d2"],
+        "documents": ["long document one content here", "different document two here"],
+        "metadatas": [{"source_file": "a.txt"}, {"source_file": "a.txt"}],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+    }
+    col.query.return_value = {"ids": [["d1"]], "distances": [[0.8]]}
+    kept, deleted = dedup.dedup_source_group(col, ["d1", "d2"], threshold=0.15, dry_run=True)
+    assert len(kept) == 2
+    _, kwargs = col.query.call_args
+    assert kwargs.get("query_embeddings") is not None
+    assert kwargs.get("query_texts") is None


### PR DESCRIPTION
## Summary

`dedup_source_group()` decides "is this chunk a near-duplicate of one I already kept?" by querying the collection for the chunk's nearest neighbors and checking whether any of them is a kept id. The query is **global** — no `where` scope. On a large palace the nearest neighbors of a chunk are routinely near-duplicates from *other* source files, so the in-group twin never appears in the `min(len(kept), 5)` result window, `is_dup` stays `False`, and both copies are kept. The dedup silently **under-deletes exactly where it is needed most** — the big, heavily-re-mined sources.

Observed on a 290k-drawer palace: `dedup --stats` estimated tens of thousands of near-dups, but a live run deleted almost nothing, because the greedy keep-set for a large source never "sees" its own twins past the foreign neighbors.

## What changed

Three minimal, behavior-preserving-where-it-mattered changes to `dedup_source_group`:

1. **Scope the probe to the group's `source_file`** via `where={"source_file": src}` (groups are already built per `source_file` in `get_source_groups`, so the first tagged metadata speaks for the whole group). Legacy drawers with no `source_file` metadata keep the historical unscoped probe, so nothing regresses for pre-metadata palaces.
2. **Reuse stored embeddings.** The initial `get()` now includes `embeddings`; when the backend returns them, the probe uses `query_embeddings` instead of `query_texts`, saving one embedding forward pass per candidate drawer.
3. **Account for the candidate's own self-match.** The candidate is in the collection at distance ~0 and was silently consuming one of the neighbor slots. The probe now requests one extra slot and skips `rid == did`.

## Tests

Four new cases in `tests/test_dedup.py`:
- `test_dedup_source_group_scopes_query_to_source_file` — a where-honoring fake collection with 5 foreign near-dups proves the in-group twin is now found (and the query carries the source_file scope).
- `test_dedup_source_group_unscoped_without_source_metadata` — legacy fallback stays unscoped.
- `test_dedup_source_group_self_match_does_not_consume_slots` — self-match skipped, extra slot requested.
- `test_dedup_source_group_reuses_stored_embeddings` — embedding-reuse path.

Full `tests/test_dedup.py` passes (19).

## Notes

Found while auditing a real German-language palace's noise. Independent of #1919 (read-only find-duplicates tool) and #464 (auto-dedup on add) — this fixes the correctness of the existing destructive `dedup` CLI/module.
