### PR TITLE
fix(convo_miner): don't mine Claude Code tool-results/ dirs — raw tool dumps flood the palace

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -65,6 +65,16 @@ CONVO_EXTENSIONS = {
     ".jsonl",
 }
 
+# Directories inside conversation sources that never hold conversations.
+# ``tool-results``: Claude Code pages large tool outputs to
+# ``<session>/tool-results/*.txt`` inside ``~/.claude/projects/<slug>/``.
+# They are raw machine dumps referenced from the transcript JSONL — mining
+# them stores megabytes of command output as "memories" (field measurement:
+# 12.8k drawers from tool-results files on one palace; a single file
+# produced 3.6k). Extends the generic SKIP_DIRS set for the convo scanner
+# only — project mining semantics are unchanged.
+CONVO_SKIP_DIRS = SKIP_DIRS | {"tool-results"}
+
 MIN_CHUNK_SIZE = 30
 CHUNK_SIZE = 800  # chars per drawer — align with miner.py
 _LINE_GROUP_SIZE = 25  # lines per fallback group when no paragraph breaks
@@ -395,7 +405,7 @@ def scan_convos(convo_dir: str) -> list:
     convo_path = Path(convo_dir).expanduser().resolve()
     files = []
     for root, dirs, filenames in os.walk(convo_path):
-        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        dirs[:] = [d for d in dirs if d not in CONVO_SKIP_DIRS]
         for filename in filenames:
             if filename.endswith(".meta.json"):
                 continue

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -363,6 +363,32 @@ class TestScanConvos:
         files = scan_convos(str(tmp_path))
         assert files == []
 
+    def test_scan_skips_tool_results_dirs(self, tmp_path):
+        # Claude Code pages large tool outputs to <session>/tool-results/*.txt
+        # inside ~/.claude/projects/<slug>/. These are raw machine dumps
+        # referenced from the transcript JSONL, not conversations — mining
+        # them floods the palace (12.8k drawers measured in the field, one
+        # single file produced 3.6k). The scanner must not descend into them.
+        session_dir = tmp_path / "1234-5678-session"
+        tool_results = session_dir / "tool-results"
+        tool_results.mkdir(parents=True)
+        (tool_results / "bipc8jdx0.txt").write_text("raw tool dump " * 100, encoding="utf-8")
+        (tmp_path / "session.jsonl").write_text('{"type": "user"}', encoding="utf-8")
+        files = scan_convos(str(tmp_path))
+        names = [f.name for f in files]
+        assert "session.jsonl" in names
+        assert "bipc8jdx0.txt" not in names
+
+    def test_scan_keeps_regular_nested_dirs(self, tmp_path):
+        # The tool-results skip must not turn into a blanket nested-dir skip.
+        nested = tmp_path / "archive"
+        nested.mkdir()
+        (nested / "old-chat.md").write_text(
+            "> q\na\n> q2\na2\n> q3\na3", encoding="utf-8"
+        )
+        files = scan_convos(str(tmp_path))
+        assert [f.name for f in files] == ["old-chat.md"]
+
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="symlink creation requires elevated privileges on Windows",

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -383,9 +383,7 @@ class TestScanConvos:
         # The tool-results skip must not turn into a blanket nested-dir skip.
         nested = tmp_path / "archive"
         nested.mkdir()
-        (nested / "old-chat.md").write_text(
-            "> q\na\n> q2\na2\n> q3\na3", encoding="utf-8"
-        )
+        (nested / "old-chat.md").write_text("> q\na\n> q2\na2\n> q3\na3", encoding="utf-8")
         files = scan_convos(str(tmp_path))
         assert [f.name for f in files] == ["old-chat.md"]
 


### PR DESCRIPTION
## Summary

Claude Code pages large tool outputs to `<session>/tool-results/*.txt` inside `~/.claude/projects/<slug>/`. These are **raw machine dumps** — command output, MCP tool results, hook `additionalContext` — referenced from the transcript JSONL, not conversations. `scan_convos()` picks them up as plain `.txt` and mines them, so every transcript ingest stores megabytes of tool output as "memories."

Measured on one real palace: **12,825 drawers** traced back to `tool-results/*.txt`, with a single paged file (`bipc8jdx0.txt`) producing **3,611 drawers** on its own. These flood the embedding space, dominate similarity search, and are pure recall noise — the same tool output is already summarized/condensed inside the transcript itself via `normalize._format_tool_result`.

## What changed

- New module constant `CONVO_SKIP_DIRS = SKIP_DIRS | {"tool-results"}`, used **only** by `scan_convos`. Project-mining semantics (`miner.scan_project`) are unchanged.
- `scan_convos`'s directory walk now prunes on `CONVO_SKIP_DIRS` instead of the shared `SKIP_DIRS`.

Scoped deliberately narrow: only the `tool-results` directory name, only in the conversation scanner, so nothing legitimate is dropped. A companion test asserts that ordinary nested conversation dirs still scan.

## Tests

Two new cases in `tests/test_convo_miner_unit.py::TestScanConvos`:
- `test_scan_skips_tool_results_dirs` — a `tool-results/*.txt` alongside a `session.jsonl` is excluded; the session file still scans.
- `test_scan_keeps_regular_nested_dirs` — a regular nested `.md` conversation still scans (the skip isn't a blanket nested-dir skip).

Full convo-miner suites pass (103).

## Notes

Adjacent to #1722 (benchmark/test data polluting a user wing) but distinct: this is the transcript-ingest path silently vacuuming Claude Code's own tool-output sidecar files.
