### PR TITLE
feat: add async mining and tiered memory migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,10 +209,46 @@ Usage and tool reference:
 
 ## MCP server
 
-35 MCP tools cover palace reads/writes, knowledge-graph operations,
+37 MCP tools cover palace reads/writes, durable job inspection, knowledge-graph operations,
 cross-wing navigation, drawer management, and agent diaries. Installation
 and the full tool list:
 [mempalaceofficial.com/reference/mcp-tools](https://mempalaceofficial.com/reference/mcp-tools.html).
+
+### Durable MCP mining and writes
+
+Long mines do not need to keep an MCP request open. Start the local daemon,
+enable daemon-backed MCP writes in the MCP server environment, then submit a
+mine and poll its job ID:
+
+```bash
+mempalace daemon start
+export MEMPALACE_MCP_DAEMON_WRITES=1
+```
+
+`mempalace_mine` now returns an accepted receipt such as:
+
+```json
+{
+  "success": true,
+  "accepted": true,
+  "job_id": "<id>",
+  "state": "queued",
+  "deduplicated": false
+}
+```
+
+Use `mempalace_job_status` for progress and terminal results, or
+`mempalace_list_jobs` for recent safe summaries. Short MCP writes also use the
+single durable writer: they return their normal result when completed within
+250 ms, otherwise an accepted job receipt. While a mine is running, search
+continues through the read-only SQLite/BM25 index and reports
+`retrieval_mode: "bm25_sqlite"`.
+
+The daemon must already be running. When the flag is enabled, an unavailable
+daemon returns `DaemonUnavailable`; MemPalace never falls back to an unsafe
+direct write. To roll back during the compatibility window, unset
+`MEMPALACE_MCP_DAEMON_WRITES` and restart the MCP server; CLI mining remains
+synchronous in either mode.
 
 ## Agents
 

--- a/docs/superpowers/plans/2026-07-14-async-mcp-daemon-writes.md
+++ b/docs/superpowers/plans/2026-07-14-async-mcp-daemon-writes.md
@@ -1,0 +1,417 @@
+# Async MCP Daemon Writes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MCP mining and writes durable daemon jobs so long mines never hold an MCP request or block job status and maintenance-time search.
+
+**Architecture:** Add progress-aware daemon jobs and a focused `mcp_jobs` adapter. In daemon-write mode, MCP submits mutations to the existing single daemon worker, exposes safe job reads, and routes search to SQLite/BM25 while maintenance is active. Legacy direct mode remains behind the disabled feature flag during the compatibility window.
+
+**Tech Stack:** Python 3.9+, stdlib SQLite/HTTP/threading, ChromaDB, pytest.
+
+## Global Constraints
+
+- Preserve verbatim content and local-only operation.
+- `MEMPALACE_MCP_DAEMON_WRITES=1` enables the new writer lane; no direct-write fallback is allowed while enabled.
+- Warm mine submission p95 must stay below 500 ms; job reads below 100 ms.
+- CLI `mempalace mine` remains synchronous.
+- Daemon jobs remain serialized; do not add a second palace writer.
+- Queue payloads and job-list responses must not expose verbatim write content.
+
+---
+
+### Task 1: Progress-aware durable queue
+
+**Files:**
+- Modify: `mempalace/daemon.py:205-542`
+- Test: `tests/test_daemon.py`
+
+**Interfaces:**
+- Produces: `QueueStore.update_progress(job_id: str, progress: dict[str, Any]) -> Job`
+- Produces: `QueueStore.heartbeat(job_id: str) -> Job`
+- Produces: `QueueStore.active(kind: str | None = None) -> list[Job]`
+- Produces: `QueueStore.list(limit: int = 20, state: str | None = None, kind: str | None = None) -> list[Job]`
+- Produces: `QueueStore.enqueue_with_status(kind, payload, dedupe_key=None, priority=0) -> tuple[Job, bool]`, where the boolean reports active-job deduplication without changing legacy `enqueue()` callers.
+- Produces: `job_to_dict(job, include_payload=False, redact_payload=True)` with progress/timestamps.
+
+- [ ] **Step 1: Write failing queue schema/progress/filter/redaction tests**
+
+```python
+def test_queue_adds_progress_columns_to_existing_database(tmp_path):
+    store = QueueStore(tmp_path / "queue.sqlite3")
+    job = store.enqueue("mine", {"source": "/repo"})
+    updated = store.update_progress(job.id, {"phase": "scanning", "files_processed": 2})
+    assert updated.progress == {"phase": "scanning", "files_processed": 2}
+    assert updated.updated_at is not None
+
+def test_job_to_dict_redacts_write_payload(tmp_path):
+    store = QueueStore(tmp_path / "queue.sqlite3")
+    job = store.enqueue("mcp_tool", {"name": "mempalace_add_drawer", "arguments": {"content": "secret"}})
+    payload = job_to_dict(job, include_payload=True, redact_payload=True)
+    assert payload["payload"] == {"name": "mempalace_add_drawer", "arguments": "<redacted>"}
+```
+
+- [ ] **Step 2: Run tests and confirm the missing fields/methods fail**
+
+Run: `.venv/bin/pytest tests/test_daemon.py -k 'progress or filters or redact' -q`
+
+Expected: FAIL because `Job.progress`, `update_progress`, filtering, and redaction are absent.
+
+- [ ] **Step 3: Implement additive queue migration and methods**
+
+```python
+@dataclass
+class Job:
+    # existing fields stay unchanged
+    updated_at: str | None
+    heartbeat_at: str | None
+    progress: dict[str, Any] | None
+
+def _ensure_job_columns(conn: sqlite3.Connection) -> None:
+    present = {row[1] for row in conn.execute("PRAGMA table_info(jobs)")}
+    for name, ddl in (
+        ("updated_at", "TEXT"),
+        ("heartbeat_at", "TEXT"),
+        ("progress_json", "TEXT"),
+    ):
+        if name not in present:
+            conn.execute(f"ALTER TABLE jobs ADD COLUMN {name} {ddl}")
+
+def update_progress(self, job_id: str, progress: dict[str, Any]) -> Job:
+    now = _now()
+    with self._lock, self._connect() as conn:
+        conn.execute(
+            "UPDATE jobs SET progress_json = ?, updated_at = ?, heartbeat_at = ? WHERE id = ?",
+            (json.dumps(progress, ensure_ascii=False), now, now, job_id),
+        )
+        row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+        return self._row_to_job(row)
+```
+
+- [ ] **Step 4: Run daemon unit tests**
+
+Run: `.venv/bin/pytest tests/test_daemon.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mempalace/daemon.py tests/test_daemon.py
+git commit -m "feat: add daemon job progress and safe listing"
+```
+
+### Task 2: Heartbeat and progress execution context
+
+**Files:**
+- Modify: `mempalace/daemon.py:545-635`
+- Modify: `mempalace/service.py:104-231`
+- Modify: `mempalace/miner.py:1402-1900`
+- Modify: `mempalace/convo_miner.py:644-820`
+- Modify: `mempalace/format_miner.py:693-930`
+- Test: `tests/test_daemon.py`
+- Test: `tests/test_miner.py`
+
+**Interfaces:**
+- Produces: `ProgressCallback = Callable[[dict[str, Any]], None]`
+- Produces: `execute_job(kind, payload, progress_callback=None)` and `run_mine(payload, progress_callback=None)`.
+- Consumes: Task 1 `QueueStore.update_progress()` and `heartbeat()`.
+- Consumes: existing process-reentrant `mine_palace_lock()` so every daemon job owns the cross-process writer lease while nested miner/Chroma writes pass through safely.
+
+- [ ] **Step 1: Write failing heartbeat and miner callback tests**
+
+```python
+def test_runtime_heartbeats_while_job_is_blocked(tmp_path, monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+    monkeypatch.setattr(service, "execute_job", lambda kind, payload, progress_callback=None: (started.set(), release.wait(5), {"success": True})[-1])
+    runtime = DaemonRuntime(str(tmp_path / "palace"))
+    runtime.store = QueueStore(tmp_path / "queue.sqlite3")
+    job = runtime.store.enqueue("mine", {"source": str(tmp_path)})
+    runtime.start_worker()
+    assert started.wait(1)
+    first = runtime.store.get(job.id).heartbeat_at
+    assert first is not None
+    release.set()
+
+def test_mine_reports_scanning_and_post_processing(tmp_path, monkeypatch):
+    events = []
+    mine(str(tmp_path), str(tmp_path / "palace"), dry_run=True, progress_callback=events.append)
+    assert events[0]["phase"] == "scanning"
+    assert events[-1]["phase"] == "verifying"
+```
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+Run: `.venv/bin/pytest tests/test_daemon.py tests/test_miner.py -k 'heartbeat or reports_scanning' -q`
+
+Expected: FAIL on unsupported callback and missing heartbeat updates.
+
+- [ ] **Step 3: Add a throttled callback and daemon heartbeat thread**
+
+```python
+ProgressCallback = Callable[[dict[str, Any]], None]
+
+def _emit_progress(callback: ProgressCallback | None, **values: Any) -> None:
+    if callback is not None:
+        callback(values)
+
+def _heartbeat_until_stopped(store: QueueStore, job_id: str, stop: threading.Event) -> None:
+    while not stop.wait(5.0):
+        store.heartbeat(job_id)
+```
+
+Pass `progress_callback` through `execute_job` and `run_mine` into all three miners. Emit scanning, mining counters, post-processing, and verifying phases; throttle file-loop emission to one update per second. Wrap each daemon `execute_job` call in `with mine_palace_lock(self.palace_path):`; the existing process-wide re-entrant lock behavior permits nested miner and Chroma write acquisition while excluding direct writers in other processes.
+
+- [ ] **Step 4: Run miner and daemon tests**
+
+Run: `.venv/bin/pytest tests/test_daemon.py tests/test_miner.py tests/test_convo_miner.py tests/test_format_miner.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mempalace/daemon.py mempalace/service.py mempalace/miner.py mempalace/convo_miner.py mempalace/format_miner.py tests/
+git commit -m "feat: report mining progress through daemon jobs"
+```
+
+### Task 3: Async mine submission and worktree protection
+
+**Files:**
+- Create: `mempalace/mcp_jobs.py`
+- Modify: `mempalace/mcp_server.py:2741-2887`
+- Modify: `mempalace/mcp_server.py:4354-4406`
+- Test: `tests/test_mcp_jobs.py`
+- Modify: `tests/test_mcp_mine.py`
+
+**Interfaces:**
+- Produces: `daemon_writes_enabled() -> bool`
+- Produces: `detect_linked_worktree(source: str) -> tuple[bool, str | None]`
+- Produces: `mine_dedupe_key(palace_path: str, payload: dict[str, Any]) -> str`
+- Produces: `submit_mine(palace_path: str, payload: dict[str, Any]) -> dict[str, Any]`
+
+- [ ] **Step 1: Write failing canonicalization/dedupe/worktree/submit tests**
+
+```python
+def test_mine_dedupe_key_is_stable_for_symlinked_source(tmp_path):
+    source = tmp_path / "repo"
+    source.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(source)
+    assert mine_dedupe_key("/palace", {"source": str(source), "mode": "projects"}) == mine_dedupe_key("/palace", {"source": str(alias), "mode": "projects"})
+
+def test_detect_linked_worktree_rejects_git_worktrees(tmp_path):
+    primary = tmp_path / "primary"
+    linked = tmp_path / "linked"
+    subprocess.run(["git", "init", str(primary)], check=True)
+    subprocess.run(["git", "-C", str(primary), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(primary), "config", "user.name", "Test"], check=True)
+    (primary / "README.md").write_text("fixture\n")
+    subprocess.run(["git", "-C", str(primary), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(primary), "commit", "-m", "fixture"], check=True)
+    subprocess.run(["git", "-C", str(primary), "worktree", "add", str(linked)], check=True)
+    is_linked, canonical = detect_linked_worktree(str(linked))
+    assert is_linked is True
+    assert canonical == str(primary.resolve())
+
+def test_tool_mine_daemon_mode_returns_accepted_job(monkeypatch, config, tmp_dir):
+    monkeypatch.setenv("MEMPALACE_MCP_DAEMON_WRITES", "1")
+    monkeypatch.setattr(mcp_jobs, "submit_job", lambda *a, **k: {"id": "job-1", "state": "queued", "created_at": "now"})
+    result = tool_mine(source=tmp_dir)
+    assert result == {"success": True, "accepted": True, "job_id": "job-1", "state": "queued", "deduplicated": False, "source": os.path.realpath(tmp_dir), "mode": "projects", "wing": None, "submitted_at": "now"}
+```
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run: `.venv/bin/pytest tests/test_mcp_jobs.py tests/test_mcp_mine.py -q`
+
+Expected: FAIL because `mcp_jobs` and async branch do not exist.
+
+- [ ] **Step 3: Implement focused adapter and feature-flagged branch**
+
+```python
+DAEMON_WRITES_ENV = "MEMPALACE_MCP_DAEMON_WRITES"
+
+def daemon_writes_enabled() -> bool:
+    return os.environ.get(DAEMON_WRITES_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+def mine_dedupe_key(palace_path: str, payload: dict[str, Any]) -> str:
+    normalized = dict(payload)
+    normalized["source"] = os.path.realpath(os.path.expanduser(payload["source"]))
+    config_path = os.path.join(normalized["source"], "mempalace.yaml")
+    normalized["config_sha256"] = _file_sha256(config_path)
+    raw = json.dumps({"palace": canonical_palace_path(palace_path), "payload": normalized}, sort_keys=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+```
+
+`submit_mine()` must call existing `daemon.submit_job("mine", payload, wait=False, auto_start=False, dedupe_key=mine_dedupe_key(palace_path, payload))`, compare the returned active job with a newly generated request marker to set `deduplicated`, and translate `DaemonError` to `DaemonUnavailable` without direct fallback.
+
+- [ ] **Step 4: Run MCP mine tests**
+
+Run: `.venv/bin/pytest tests/test_mcp_jobs.py tests/test_mcp_mine.py -q`
+
+Expected: PASS for both legacy and daemon-backed modes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mempalace/mcp_jobs.py mempalace/mcp_server.py tests/test_mcp_jobs.py tests/test_mcp_mine.py
+git commit -m "feat: submit MCP mining as durable daemon jobs"
+```
+
+### Task 4: Job tools and daemon-backed short writes
+
+**Files:**
+- Modify: `mempalace/mcp_jobs.py`
+- Modify: `mempalace/mcp_server.py:4630-4820`
+- Modify: `mempalace/service.py:40-90`
+- Test: `tests/test_mcp_jobs.py`
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Produces: `tool_job_status(job_id: str) -> dict[str, Any]`
+- Produces: `tool_list_jobs(limit=20, state=None, kind=None) -> dict[str, Any]`
+- Produces: `dispatch_daemon_write(tool_name, arguments, fast_wait_ms=250) -> dict[str, Any]`
+
+- [ ] **Step 1: Write failing job-read, redaction, fast-path, and queued-path tests**
+
+```python
+def test_daemon_write_returns_accepted_when_not_done(monkeypatch):
+    fake = FakeClient(submitted={"id": "j1", "state": "queued"}, after_wait={"id": "j1", "state": "queued"})
+    monkeypatch.setattr(mcp_jobs, "get_client_if_running", lambda *a, **k: fake)
+    result = dispatch_daemon_write("mempalace_checkpoint", {"items": []}, fast_wait_ms=1)
+    assert result["delivery"] == "durable_queue"
+    assert result["job_id"] == "j1"
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run: `.venv/bin/pytest tests/test_mcp_jobs.py tests/test_mcp_server.py -k 'job_status or list_jobs or daemon_write' -q`
+
+Expected: FAIL on missing tools/dispatcher.
+
+- [ ] **Step 3: Implement read tools and dispatch routing**
+
+```python
+def dispatch_daemon_write(tool_name: str, arguments: dict[str, Any], fast_wait_ms: int = 250) -> dict[str, Any]:
+    client = require_running_client()
+    job = client.submit("mcp_tool", {"name": tool_name, "arguments": arguments}, dedupe_key=None, priority=0)
+    deadline = time.monotonic() + fast_wait_ms / 1000
+    while time.monotonic() < deadline:
+        current = client.get_job(job["id"])
+        if current["state"] in TERMINAL_STATES:
+            result = dict(current.get("result") or {})
+            result["delivery"] = "completed"
+            return result
+        time.sleep(0.02)
+    return {"success": True, "accepted": True, "job_id": job["id"], "state": current["state"], "delivery": "durable_queue"}
+```
+
+At MCP dispatch, keep read-only and integrity gates, skip lifetime peer-writer acquisition in daemon mode, and route write-classified tools other than the job-read tools through `dispatch_daemon_write`. The daemon's direct `run_mcp_tool()` continues to call handlers without entering MCP request dispatch, preventing recursion.
+
+- [ ] **Step 4: Run MCP and daemon suites**
+
+Run: `.venv/bin/pytest tests/test_mcp_jobs.py tests/test_mcp_server.py tests/test_daemon.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mempalace/mcp_jobs.py mempalace/mcp_server.py mempalace/service.py tests/
+git commit -m "feat: route MCP mutations through daemon writer"
+```
+
+### Task 5: Responsive maintenance search and HTTP lock scope
+
+**Files:**
+- Modify: `mempalace/mcp_jobs.py`
+- Modify: `mempalace/mcp_server.py:2011-2075`
+- Modify: `mempalace/mcp_server.py:5077-5435`
+- Test: `tests/test_mcp_http_transport.py`
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Produces: `active_maintenance_job() -> dict[str, Any] | None`
+- Consumes: existing `search_memories(query, palace_path=palace_path, vector_disabled=True)`.
+
+- [ ] **Step 1: Write blocked-mine concurrency tests**
+
+```python
+def test_job_status_and_search_respond_while_mine_request_is_blocked(http_server, monkeypatch):
+    # Block a fake maintenance job, issue concurrent JSON-RPC calls, and assert
+    # job status returns promptly and search calls search_memories(vector_disabled=True).
+    assert status_elapsed < 0.5
+    assert search_payload["index_state"] == "updating"
+    assert search_payload["retrieval_mode"] == "bm25_sqlite"
+```
+
+- [ ] **Step 2: Run the concurrency test and verify timeout/failure**
+
+Run: `.venv/bin/pytest tests/test_mcp_http_transport.py -k 'while_mine' -q`
+
+Expected: FAIL because the HTTP handler serializes the full request.
+
+- [ ] **Step 3: Move serialization to backend operations and mark fallback results**
+
+Remove `with _HTTP_REQUEST_LOCK: response = handle_request(request)` from HTTP/SSE framing. Introduce `_PALACE_READ_LOCK` only around direct Chroma handler execution. Job reads/submissions bypass it. If `active_maintenance_job()` returns a mine/sync job, call search with `vector_disabled=True` and add:
+
+```python
+result.update({
+    "index_state": "updating",
+    "active_job_id": active["id"],
+    "retrieval_mode": "bm25_sqlite",
+})
+```
+
+After terminal maintenance, call `_force_chroma_cache_reset()` before the next hybrid read and retain existing readiness/error fallback behavior.
+
+- [ ] **Step 4: Run focused and regression suites**
+
+Run: `.venv/bin/pytest tests/test_mcp_http_transport.py tests/test_mcp_server.py tests/test_mcp_mine.py tests/test_daemon.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mempalace/mcp_jobs.py mempalace/mcp_server.py tests/
+git commit -m "fix: keep MCP reads responsive during mining"
+```
+
+### Task 6: Runtime documentation and full verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md`
+- Test: full project suite
+
+**Interfaces:**
+- Documents: enabling/supervising daemon writes, async mine response, polling, failure behavior, and rollback flag.
+
+- [ ] **Step 1: Document exact operator flow**
+
+```bash
+mempalace daemon start
+export MEMPALACE_MCP_DAEMON_WRITES=1
+# call mempalace_mine, then mempalace_job_status(job_id)
+```
+
+- [ ] **Step 2: Run formatting and lint**
+
+Run: `.venv/bin/ruff format . && .venv/bin/ruff check .`
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run complete test suite**
+
+Run: `.venv/bin/pytest tests/ -v --ignore=tests/benchmarks`
+
+Expected: PASS with zero failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/ mempalace/ tests/
+git commit -m "docs: explain daemon-backed MCP mining"
+```

--- a/docs/superpowers/plans/2026-07-14-se-memory-migration-apply.md
+++ b/docs/superpowers/plans/2026-07-14-se-memory-migration-apply.md
@@ -1,0 +1,107 @@
+# Sales-Enablement Memory Migration Apply Plan
+
+> **Goal:** Build and verify a reduced migrated palace plus an owner-only rollback copy without mutating the active palace; keep final activation as an explicit atomic operation.
+
+## Safety invariants
+
+- Never update or delete a drawer in the active source palace.
+- Hold the cross-process palace read gate for the complete source copy.
+- Require the active SQLite+WAL snapshot to equal the reviewed physical snapshot,
+  or a version-2 semantic snapshot of every SQLite schema object and durable row
+  to match exactly when Chroma has only changed known bookkeeping.
+- Recompute inventory, actions, hashes, and duplicate evidence before applying.
+- Delete only IDs present in both `duplicate_candidate` actions and exact evidence.
+- Build into new, owner-only paths; publish with an OS-native atomic no-replace
+  rename so even a competing empty destination is never clobbered.
+- Publish a completed migrated copy only after integrity, counts, hashes, and vector readiness pass.
+- Keep activation separate, atomic, reversible, and explicit.
+
+## Task 1: Copy-only migration bundle
+
+- [x] Add a manifest reader/validator that rejects snapshot, count, hash, action, and evidence drift.
+- [x] Copy the full active palace to a rollback directory while holding a shared palace gate.
+- [x] Verify the source snapshot before/after and the rollback SQLite+WAL checksums.
+- [x] Clone the verified rollback copy into a separate staging directory.
+- [x] Enforce owner-only permissions, clean unpublished temporary destinations,
+      and retain any completed publication for explicit cleanup after a later failure.
+- [x] Cover source drift, symlinks, existing targets, and copy cleanup with tests.
+
+## Task 2: Apply reviewed actions to staging
+
+- [x] Recompute the migration plan from the rollback copy using the reviewed roots and hot-day cutoff.
+- [x] Reconcile every planned action and evidence row with the manifest before writes.
+- [x] Update retained drawer metadata in bounded batches, including destination wing and provenance/tier fields.
+- [x] Delete only exactly evidenced worktree duplicate IDs in bounded batches.
+- [x] Preserve all unique, uncertain, curated, session, and unclassified drawers verbatim.
+- [x] Invalidate/rebuild derived closets, graph artifacts, and vector indexes in staging.
+- [x] Remove only UUID HNSW directories no longer referenced by SQLite.
+- [x] Make retries idempotent and record an owner-only apply report with exact counts.
+
+## Task 3: Verify migrated copy
+
+- [x] Run SQLite integrity checks and persisted HNSW capacity plus reopen/query checks.
+- [x] Re-inventory staging and reconcile the expected 10,138 retained drawers.
+- [x] Prove retained content hashes match the rollback copy.
+- [x] Prove all 3,515 removals map one-to-one to reviewed duplicate evidence.
+- [x] Prove 59 unique, 14 uncertain, and 33 unclassified records remain.
+- [x] Verify default retrieval excludes cold records and explicit history includes them.
+- [x] Run representative decision, code, recent-session, and cold-session searches.
+
+## Task 4: Activation and rollback drill
+
+- [x] Add an atomic activation command that validates paths/snapshots and renames the active palace to a retained rollback slot before promoting staging.
+- [x] Add an atomic rollback command that reverses activation without deleting either palace.
+- [x] Exercise activation, crash recovery, and rollback against synthetic palaces in tests.
+- [x] Keep the user's live palace unchanged; activation remains pending explicit authorization.
+
+## Task 5: Performance evidence and completion gates
+
+- [x] Add/run async MCP benchmarks for mine submission, job status/listing, maintenance BM25, and post-maintenance hybrid search.
+- [x] Record p50/p95 results against the design budgets.
+- [x] Run the complete non-benchmark suite, Ruff, format check, migration verification, and an independent review.
+
+## Verified evidence
+
+The reviewed version-2 staging bundle at
+`/private/tmp/mempalace-se-migration-20260714-v5`
+was rebuilt after the final implementation changes. The active palace and
+rollback SQLite SHA-256 remain
+`7fe84a1a6641fecbd79b7000a682733b9f5963d2f1a6913e8429c7a695f7f2a5`.
+Their semantic SQLite snapshot also matches across 28 schema objects, 21
+tables, and 261,797 durable rows:
+`f2779368031fa034ceb7cdfae2e4213aa7565c45d991d3637ea719d4bb3b7d75`.
+The semantic snapshot normalizes Chroma's JSON serialization fields and omits
+only 47 append-only `acquire_write` lock-history rows, which Chroma adds merely
+by reopening collections. The `acquire_write` table schema and every other
+schema object and durable row remain hashed, so real data or schema drift
+blocks the operation. Repeated readiness reopens leave the semantic identity
+unchanged.
+The migrated report records 13,653 before, 10,138 after, 3,515 exact-evidence
+deletions, 10,137 reused embeddings, one safely re-embedded unreadable source
+vector, and two orphan HNSW directories removed. Its semantic identity is
+`a72e913546bc3ab32c1402e71aebb68a6505e1fc32c517f265cda925b9c38f2e`
+across 28 schema objects, 21 tables, and 226,304 durable rows. Only the two live
+vector segment directories remain.
+
+Synthetic enforced benchmark results (1,000 drawers, real loopback daemon):
+
+| Budget | p50 | p95 / ratio | Limit |
+|---|---:|---:|---:|
+| Async mine durable submission | 36.6 ms | 42.4 ms | < 500 ms |
+| Job status | 6.7 ms | 7.3 ms | < 100 ms |
+| Job listing | 7.4 ms | 19.6 ms | < 100 ms |
+| Maintenance BM25 | 12.8 ms | 14.8 ms | < 1,000 ms |
+| Post-maintenance hybrid | 20.5 ms | -5.36% | <= +10% |
+
+Real-copy search evidence (13,653-drawer rollback baseline versus
+10,138-drawer migrated copy, 240 queries per route):
+
+| Route | p50 | p95 | Median round p95 |
+|---|---:|---:|---:|
+| Baseline hybrid | 46.1 ms | 55.2 ms | 55.6 ms |
+| Migrated BM25 | 19.7 ms | 23.6 ms | 23.6 ms |
+| Migrated hybrid | 46.2 ms | 52.1 ms | 52.4 ms |
+
+The real-copy hybrid median p95 ratio is 0.9419 (-5.81%), within the 1.10
+budget. Representative decision, code, recent-session, default-hot, and
+explicit-cold retrieval checks all pass. Live activation was not run.

--- a/docs/superpowers/plans/2026-07-14-se-memory-migration.md
+++ b/docs/superpowers/plans/2026-07-14-se-memory-migration.md
@@ -232,4 +232,6 @@ Run with the active palace read-only and write the manifest under an owner-only 
 Completed against 13,653 drawers. The database SHA-256 remained
 `0e17be92a4cc7583054127ab4d295aa961ef8f06f565ffc6fd8a5958ebf9734b`.
 The manifest proves 3,515 duplicate candidates and preserves 59 unique plus 14
-uncertain worktree artifacts. No drawer was changed or deleted.
+uncertain worktree artifacts. It retains 59 source-free curated records and
+preserves 33 provenance-bearing records outside known roots as unclassified.
+No drawer was changed or deleted.

--- a/docs/superpowers/plans/2026-07-14-se-memory-migration.md
+++ b/docs/superpowers/plans/2026-07-14-se-memory-migration.md
@@ -29,7 +29,7 @@
 - Consumes: source-kind and worktree configuration from the metadata plan.
 - Produces canonical wing `se-code` and deterministic rooms/exclusions.
 
-- [ ] **Step 1: Add the checked-in configuration**
+- [x] **Step 1: Add the checked-in configuration**
 
 ```yaml
 wing: se-code
@@ -55,17 +55,21 @@ rooms:
 exclude_patterns: [node_modules/, .nx/, dist/, coverage/, "*.map", workflow-bundle.js, package-lock.json]
 ```
 
-- [ ] **Step 2: Update AGENTS usage routing**
+- [x] **Step 2: Update AGENTS usage routing**
 
 Document that decisions use `se`, canonical code uses `se-code`, sessions use `se-sessions`, ambiguous questions search `se` + `se-code`, and cold sessions require explicit historical lookup.
 
-- [ ] **Step 3: Validate config without mining**
+- [x] **Step 3: Validate config without mining**
 
 Run: `/private/tmp/mempalace-fix/.venv/bin/python -c "from mempalace.miner import load_config; print(load_config('.')['wing'])"`
 
 Expected: `se-code`.
 
-- [ ] **Step 4: Commit in sales-enablement repo**
+- [x] **Step 4: Commit in sales-enablement repo**
+
+The repository-local `AGENTS.md` is intentionally excluded by that checkout's
+`.git/info/exclude`, so the routing guidance remains local while the checked-in
+`mempalace.yaml` was committed as `deb1792`.
 
 ```bash
 git add mempalace.yaml AGENTS.md
@@ -83,7 +87,7 @@ git commit -m "chore: configure canonical MemPalace mining"
 - Produces: `inventory_palace(palace_path, canonical_root, worktree_roots, session_roots) -> list[InventoryRecord]`.
 - Produces: `plan_actions(records, hot_days=90, now=None) -> list[MigrationAction]`.
 
-- [ ] **Step 1: Write synthetic SQLite inventory/classification tests**
+- [x] **Step 1: Write synthetic SQLite inventory/classification tests**
 
 ```python
 def test_plan_classifies_canonical_sessions_and_worktree_candidates():
@@ -97,13 +101,13 @@ def test_plan_classifies_canonical_sessions_and_worktree_candidates():
     assert actions[2].metadata["memory_tier"] == "cold"
 ```
 
-- [ ] **Step 2: Run and verify missing module failure**
+- [x] **Step 2: Run and verify missing module failure**
 
 Run: `.venv/bin/pytest tests/test_reorganize.py -q`
 
 Expected: FAIL importing `mempalace.reorganize`.
 
-- [ ] **Step 3: Implement read-only SQLite extraction and pure classification**
+- [x] **Step 3: Implement read-only SQLite extraction and pure classification**
 
 ```python
 @dataclass(frozen=True)
@@ -121,7 +125,7 @@ def exact_hash(content: str) -> str:
 
 Open `chroma.sqlite3` with `mode=ro`, reconstruct each drawer's document and scalar metadata from Chroma tables, normalize source roots without mutating them, and return actions in stable drawer-ID order.
 
-- [ ] **Step 4: Run tests and commit**
+- [x] **Step 4: Run tests and commit**
 
 Run: `.venv/bin/pytest tests/test_reorganize.py -q`
 
@@ -142,7 +146,7 @@ git commit -m "feat: plan palace reorganization without mutations"
 - Produces: `prove_worktree_duplicate(worktree, canonical) -> DuplicateEvidence | None`.
 - Produces: `write_manifest(path, inventory, actions, evidence) -> None`.
 
-- [ ] **Step 1: Write evidence rejection and owner-only manifest tests**
+- [x] **Step 1: Write evidence rejection and owner-only manifest tests**
 
 ```python
 def test_duplicate_requires_same_relative_identity_chunk_and_content_hash():
@@ -155,17 +159,17 @@ def test_manifest_is_owner_only(tmp_path):
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
 ```
 
-- [ ] **Step 2: Run tests and confirm failure**
+- [x] **Step 2: Run tests and confirm failure**
 
 Run: `.venv/bin/pytest tests/test_reorganize.py -k 'duplicate or manifest' -q`
 
 Expected: FAIL on missing evidence/writer functions.
 
-- [ ] **Step 3: Implement strict proof and deterministic manifest**
+- [x] **Step 3: Implement strict proof and deterministic manifest**
 
 Evidence requires equal canonical relative path, source hash when both records have it, chunk index, and content SHA-256. If any required identity is missing or ambiguous, emit `preserve_uncertain`, not delete eligibility. Manifest includes version, palace path hash, snapshot SQLite size/mtime, counts, every action, and evidence IDs; write via `os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)`.
 
-- [ ] **Step 4: Run tests and commit**
+- [x] **Step 4: Run tests and commit**
 
 Run: `.venv/bin/pytest tests/test_reorganize.py -q`
 
@@ -188,7 +192,7 @@ git commit -m "feat: emit evidence-backed memory migration manifests"
 - Adds: `mempalace reorganize plan --canonical-root PATH --worktree-root PATH --session-root PATH --manifest PATH`.
 - No `--apply` option in this implementation checkpoint.
 
-- [ ] **Step 1: Write CLI no-mutation test**
+- [x] **Step 1: Write CLI no-mutation test**
 
 ```python
 def test_reorganize_plan_writes_manifest_without_changing_sqlite(tmp_path):
@@ -198,29 +202,34 @@ def test_reorganize_plan_writes_manifest_without_changing_sqlite(tmp_path):
     assert sha256_file(palace / "chroma.sqlite3") == before
 ```
 
-- [ ] **Step 2: Run and verify missing command failure**
+- [x] **Step 2: Run and verify missing command failure**
 
 Run: `.venv/bin/pytest tests/test_cli.py tests/test_reorganize.py -k 'reorganize' -q`
 
 Expected: FAIL because command is absent.
 
-- [ ] **Step 3: Add plan-only CLI and report summary**
+- [x] **Step 3: Add plan-only CLI and report summary**
 
 The command prints counts for canonical, session, worktree candidate, verified duplicate candidate, unique artifact, unclassified, hot, and cold. It exits non-zero on SQLite integrity failure and refuses a linked canonical root.
 
-- [ ] **Step 4: Run focused/full verification**
+- [x] **Step 4: Run focused/full verification**
 
 Run: `.venv/bin/pytest tests/test_cli.py tests/test_reorganize.py -q && .venv/bin/ruff check mempalace/reorganize.py tests/test_reorganize.py`
 
 Expected: PASS/exit 0.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add mempalace/cli.py mempalace/reorganize.py tests/
 git commit -m "feat: add dry-run palace reorganization command"
 ```
 
-- [ ] **Step 6: Run against a copied/current palace in dry-run mode**
+- [x] **Step 6: Run against a copied/current palace in dry-run mode**
 
 Run with the active palace read-only and write the manifest under an owner-only temporary directory. Confirm the database SHA-256 is identical before and after. Report exact projected counts to the user and stop before any mutation or deletion.
+
+Completed against 13,653 drawers. The database SHA-256 remained
+`0e17be92a4cc7583054127ab4d295aa961ef8f06f565ffc6fd8a5958ebf9734b`.
+The manifest proves 3,515 duplicate candidates and preserves 59 unique plus 14
+uncertain worktree artifacts. No drawer was changed or deleted.

--- a/docs/superpowers/plans/2026-07-14-se-memory-migration.md
+++ b/docs/superpowers/plans/2026-07-14-se-memory-migration.md
@@ -1,0 +1,226 @@
+# Sales-Enablement Memory Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Configure canonical sales-enablement mining and produce an auditable dry-run migration manifest that safely separates `se`, `se-code`, and `se-sessions` while identifying only exact duplicate deletion candidates.
+
+**Architecture:** Check in repository mining policy in the sales-enablement repo. Add a read-only-first migration planner to MemPalace that inventories Chroma SQLite without loading HNSW, classifies records, and writes an owner-only manifest. Apply/activation remains gated on review of the manifest and a verified palace copy.
+
+**Tech Stack:** YAML, Python stdlib SQLite/hashlib/json, Chroma metadata schema, pytest.
+
+## Global Constraints
+
+- Run against the canonical sales-enablement checkout, never a linked worktree.
+- Initial execution is dry-run only; do not delete or rewrite the active palace.
+- Delete eligibility requires canonical identity plus exact verbatim content evidence.
+- Preserve unique/uncertain worktree artifacts in `se-sessions` as cold.
+- Sessions older than 90 days are cold, not deleted; pinned sessions stay hot.
+- Backups/manifests are owner-only and remain local.
+
+---
+
+### Task 1: Canonical repository mining policy
+
+**Files (sales-enablement repository):**
+- Create: `mempalace.yaml`
+- Modify: `AGENTS.md`
+
+**Interfaces:**
+- Consumes: source-kind and worktree configuration from the metadata plan.
+- Produces canonical wing `se-code` and deterministic rooms/exclusions.
+
+- [ ] **Step 1: Add the checked-in configuration**
+
+```yaml
+wing: se-code
+source_kind: code
+reject_linked_worktrees: true
+rooms:
+  - name: backend
+    description: NestJS and Fastify API
+    keywords: [apps/sales-enablement-be, controller, service, dto]
+  - name: workers
+    description: Temporal workers, workflows, and activities
+    keywords: [apps/sales-enablement-workers, temporal, workflow, activity]
+  - name: helpers
+    description: Shared infrastructure and models
+    keywords: [libs/helpers, mongo, gcs, pubsub]
+  - name: architecture_docs
+    description: Architecture and operating documentation
+    source_kind: documentation
+    keywords: [docs, architecture, agents]
+  - name: tests_operations
+    description: Tests, migrations, scripts, and operations
+    keywords: [test, spec, scripts, migration, docker]
+exclude_patterns: [node_modules/, .nx/, dist/, coverage/, "*.map", workflow-bundle.js, package-lock.json]
+```
+
+- [ ] **Step 2: Update AGENTS usage routing**
+
+Document that decisions use `se`, canonical code uses `se-code`, sessions use `se-sessions`, ambiguous questions search `se` + `se-code`, and cold sessions require explicit historical lookup.
+
+- [ ] **Step 3: Validate config without mining**
+
+Run: `/private/tmp/mempalace-fix/.venv/bin/python -c "from mempalace.miner import load_config; print(load_config('.')['wing'])"`
+
+Expected: `se-code`.
+
+- [ ] **Step 4: Commit in sales-enablement repo**
+
+```bash
+git add mempalace.yaml AGENTS.md
+git commit -m "chore: configure canonical MemPalace mining"
+```
+
+### Task 2: Read-only inventory and classification engine
+
+**Files (MemPalace repository):**
+- Create: `mempalace/reorganize.py`
+- Create: `tests/test_reorganize.py`
+
+**Interfaces:**
+- Produces: `InventoryRecord` and `MigrationAction` dataclasses.
+- Produces: `inventory_palace(palace_path, canonical_root, worktree_roots, session_roots) -> list[InventoryRecord]`.
+- Produces: `plan_actions(records, hot_days=90, now=None) -> list[MigrationAction]`.
+
+- [ ] **Step 1: Write synthetic SQLite inventory/classification tests**
+
+```python
+def test_plan_classifies_canonical_sessions_and_worktree_candidates():
+    actions = plan_actions([
+        record("canonical", source="/repo/src/a.ts", content="A"),
+        record("worktree", source="/tmp/wt/src/a.ts", content="A"),
+        record("session", source="/codex/session.jsonl", content="talk", authored_at="2026-01-01"),
+    ], hot_days=90, now=date(2026, 7, 14))
+    assert actions[0].destination_wing == "se-code"
+    assert actions[1].action == "duplicate_candidate"
+    assert actions[2].metadata["memory_tier"] == "cold"
+```
+
+- [ ] **Step 2: Run and verify missing module failure**
+
+Run: `.venv/bin/pytest tests/test_reorganize.py -q`
+
+Expected: FAIL importing `mempalace.reorganize`.
+
+- [ ] **Step 3: Implement read-only SQLite extraction and pure classification**
+
+```python
+@dataclass(frozen=True)
+class MigrationAction:
+    drawer_id: str
+    action: str
+    destination_wing: str
+    reason: str
+    content_sha256: str
+    metadata: dict[str, Any]
+
+def exact_hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+```
+
+Open `chroma.sqlite3` with `mode=ro`, reconstruct each drawer's document and scalar metadata from Chroma tables, normalize source roots without mutating them, and return actions in stable drawer-ID order.
+
+- [ ] **Step 4: Run tests and commit**
+
+Run: `.venv/bin/pytest tests/test_reorganize.py -q`
+
+Expected: PASS.
+
+```bash
+git add mempalace/reorganize.py tests/test_reorganize.py
+git commit -m "feat: plan palace reorganization without mutations"
+```
+
+### Task 3: Exact duplicate evidence and manifest writer
+
+**Files:**
+- Modify: `mempalace/reorganize.py`
+- Modify: `tests/test_reorganize.py`
+
+**Interfaces:**
+- Produces: `prove_worktree_duplicate(worktree, canonical) -> DuplicateEvidence | None`.
+- Produces: `write_manifest(path, inventory, actions, evidence) -> None`.
+
+- [ ] **Step 1: Write evidence rejection and owner-only manifest tests**
+
+```python
+def test_duplicate_requires_same_relative_identity_chunk_and_content_hash():
+    assert prove_worktree_duplicate(worktree(content="A", chunk=0), canonical(content="B", chunk=0)) is None
+    assert prove_worktree_duplicate(worktree(content="A", chunk=1), canonical(content="A", chunk=0)) is None
+
+def test_manifest_is_owner_only(tmp_path):
+    path = tmp_path / "manifest.json"
+    write_manifest(path, [], [], [])
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+```
+
+- [ ] **Step 2: Run tests and confirm failure**
+
+Run: `.venv/bin/pytest tests/test_reorganize.py -k 'duplicate or manifest' -q`
+
+Expected: FAIL on missing evidence/writer functions.
+
+- [ ] **Step 3: Implement strict proof and deterministic manifest**
+
+Evidence requires equal canonical relative path, source hash when both records have it, chunk index, and content SHA-256. If any required identity is missing or ambiguous, emit `preserve_uncertain`, not delete eligibility. Manifest includes version, palace path hash, snapshot SQLite size/mtime, counts, every action, and evidence IDs; write via `os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)`.
+
+- [ ] **Step 4: Run tests and commit**
+
+Run: `.venv/bin/pytest tests/test_reorganize.py -q`
+
+Expected: PASS.
+
+```bash
+git add mempalace/reorganize.py tests/test_reorganize.py
+git commit -m "feat: emit evidence-backed memory migration manifests"
+```
+
+### Task 4: Dry-run CLI and current-palace report
+
+**Files:**
+- Modify: `mempalace/cli.py`
+- Modify: `mempalace/reorganize.py`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_reorganize.py`
+
+**Interfaces:**
+- Adds: `mempalace reorganize plan --canonical-root PATH --worktree-root PATH --session-root PATH --manifest PATH`.
+- No `--apply` option in this implementation checkpoint.
+
+- [ ] **Step 1: Write CLI no-mutation test**
+
+```python
+def test_reorganize_plan_writes_manifest_without_changing_sqlite(tmp_path):
+    before = sha256_file(palace / "chroma.sqlite3")
+    result = runner.invoke(app, ["reorganize", "plan", "--palace", str(palace), "--manifest", str(manifest)])
+    assert result.exit_code == 0
+    assert sha256_file(palace / "chroma.sqlite3") == before
+```
+
+- [ ] **Step 2: Run and verify missing command failure**
+
+Run: `.venv/bin/pytest tests/test_cli.py tests/test_reorganize.py -k 'reorganize' -q`
+
+Expected: FAIL because command is absent.
+
+- [ ] **Step 3: Add plan-only CLI and report summary**
+
+The command prints counts for canonical, session, worktree candidate, verified duplicate candidate, unique artifact, unclassified, hot, and cold. It exits non-zero on SQLite integrity failure and refuses a linked canonical root.
+
+- [ ] **Step 4: Run focused/full verification**
+
+Run: `.venv/bin/pytest tests/test_cli.py tests/test_reorganize.py -q && .venv/bin/ruff check mempalace/reorganize.py tests/test_reorganize.py`
+
+Expected: PASS/exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mempalace/cli.py mempalace/reorganize.py tests/
+git commit -m "feat: add dry-run palace reorganization command"
+```
+
+- [ ] **Step 6: Run against a copied/current palace in dry-run mode**
+
+Run with the active palace read-only and write the manifest under an owner-only temporary directory. Confirm the database SHA-256 is identical before and after. Report exact projected counts to the user and stop before any mutation or deletion.

--- a/docs/superpowers/plans/2026-07-14-source-metadata-search-scopes.md
+++ b/docs/superpowers/plans/2026-07-14-source-metadata-search-scopes.md
@@ -1,0 +1,244 @@
+# Source Metadata and Search Scopes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stamp deterministic source/tier metadata on new drawers and let callers search multiple wings while excluding cold history by default.
+
+**Architecture:** Centralize scalar metadata construction in a small module shared by all miners, extend room config with optional source-kind overrides, and extend both vector and SQLite search paths with identical filters. Missing legacy tier metadata is treated as hot.
+
+**Tech Stack:** Python, YAML, Chroma metadata filters, SQLite FTS, pytest.
+
+## Global Constraints
+
+- Drawer content remains exact verbatim source content.
+- Metadata values must be Chroma-compatible scalars.
+- Existing singular `wing` input remains compatible; `wing` and `wings` are mutually exclusive.
+- Missing `memory_tier` is treated as hot.
+- Cold history is never deleted by search filtering.
+
+---
+
+### Task 1: Canonical source metadata builder
+
+**Files:**
+- Create: `mempalace/source_metadata.py`
+- Modify: `mempalace/miner.py`
+- Modify: `mempalace/convo_miner.py`
+- Modify: `mempalace/format_miner.py`
+- Test: `tests/test_source_metadata.py`
+
+**Interfaces:**
+- Produces: `SourceContext` dataclass.
+- Produces: `build_source_metadata(context, content, chunk_index) -> dict[str, str]`.
+- Produces fields: `source_kind`, `memory_tier`, `source_root`, `source_identity`, `source_revision`, `source_sha256`, `content_sha256`, `source_canonicality` when values are available.
+
+- [ ] **Step 1: Write failing deterministic hash/identity tests**
+
+```python
+def test_build_source_metadata_is_scalar_and_deterministic(tmp_path):
+    source = tmp_path / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text("print('x')\n")
+    ctx = SourceContext(root=str(tmp_path), source_file=str(source), source_kind="code", memory_tier="hot")
+    meta = build_source_metadata(ctx, "print('x')\n", 0)
+    assert meta["source_identity"].endswith(":src/app.py")
+    assert meta["content_sha256"] == hashlib.sha256(b"print('x')\n").hexdigest()
+    assert all(isinstance(value, (str, int, float, bool)) for value in meta.values())
+```
+
+- [ ] **Step 2: Run tests and verify missing module failure**
+
+Run: `.venv/bin/pytest tests/test_source_metadata.py -q`
+
+Expected: FAIL importing `mempalace.source_metadata`.
+
+- [ ] **Step 3: Implement builder and merge it into existing drawer metadata**
+
+```python
+@dataclass(frozen=True)
+class SourceContext:
+    root: str
+    source_file: str
+    source_kind: str
+    memory_tier: str = "hot"
+    source_revision: str | None = None
+    source_canonicality: str = "canonical"
+
+def build_source_metadata(context: SourceContext, content: str, chunk_index: int) -> dict[str, str]:
+    relative = os.path.relpath(os.path.realpath(context.source_file), os.path.realpath(context.root))
+    return {
+        "source_kind": context.source_kind,
+        "memory_tier": context.memory_tier,
+        "source_root": os.path.realpath(context.root),
+        "source_identity": f"{context.source_kind}:{relative}",
+        "content_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        "source_canonicality": context.source_canonicality,
+    }
+```
+
+- [ ] **Step 4: Run miner suites**
+
+Run: `.venv/bin/pytest tests/test_source_metadata.py tests/test_miner.py tests/test_convo_miner.py tests/test_format_miner.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mempalace/source_metadata.py mempalace/miner.py mempalace/convo_miner.py mempalace/format_miner.py tests/
+git commit -m "feat: stamp canonical source metadata on drawers"
+```
+
+### Task 2: Configuration validation and room overrides
+
+**Files:**
+- Modify: `mempalace/miner.py:483-535`
+- Modify: `mempalace/room_detector_local.py:282-305`
+- Test: `tests/test_miner.py`
+- Test: `tests/test_room_detector_local.py`
+
+**Interfaces:**
+- Consumes: Task 1 `SourceContext`.
+- Produces validated config keys `source_kind`, `reject_linked_worktrees`, and per-room `source_kind`.
+
+- [ ] **Step 1: Write invalid-enum and documentation-room tests**
+
+```python
+def test_load_config_rejects_unknown_source_kind(tmp_path):
+    (tmp_path / "mempalace.yaml").write_text("wing: x\nsource_kind: mystery\nrooms: []\n")
+    with pytest.raises(ValueError, match="source_kind"):
+        load_config(str(tmp_path))
+
+def test_room_source_kind_overrides_project_default(tmp_path):
+    config = {"source_kind": "code", "rooms": [{"name": "docs", "source_kind": "documentation"}]}
+    assert source_kind_for_room(config, "docs") == "documentation"
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `.venv/bin/pytest tests/test_miner.py tests/test_room_detector_local.py -k 'source_kind' -q`
+
+Expected: FAIL because config is not validated or routed.
+
+- [ ] **Step 3: Implement strict additive validation**
+
+```python
+SOURCE_KINDS = frozenset({"curated", "code", "documentation", "session", "worktree-artifact"})
+
+def source_kind_for_room(config: dict, room_name: str) -> str:
+    default = config.get("source_kind", "code")
+    room = next((item for item in config.get("rooms", []) if item.get("name") == room_name), {})
+    value = room.get("source_kind", default)
+    if value not in SOURCE_KINDS:
+        raise ValueError(f"invalid source_kind: {value!r}")
+    return value
+```
+
+- [ ] **Step 4: Run config/miner tests and commit**
+
+Run: `.venv/bin/pytest tests/test_miner.py tests/test_room_detector_local.py -q`
+
+Expected: PASS.
+
+```bash
+git add mempalace/miner.py mempalace/room_detector_local.py tests/
+git commit -m "feat: configure source kinds by memory room"
+```
+
+### Task 3: Multi-wing and tier filters in both search paths
+
+**Files:**
+- Modify: `mempalace/searcher.py:240-735`
+- Modify: `mempalace/searcher.py:1049-1310`
+- Test: `tests/test_searcher.py`
+
+**Interfaces:**
+- Produces: `build_where_filter(wing=None, wings=None, room=None, source_file=None, source_kinds=None, include_cold=False)`.
+- Produces matching optional parameters on `search_memories()` and `_bm25_only_via_sqlite()`.
+
+- [ ] **Step 1: Write vector-filter and SQLite fallback parity tests**
+
+```python
+def test_build_where_filter_combines_wings_source_kind_and_hot_default():
+    where = build_where_filter(wings=["se", "se-code"], source_kinds=["code", "curated"])
+    assert {"wing": {"$in": ["se", "se-code"]}} in where["$and"]
+    assert {"source_kind": {"$in": ["code", "curated"]}} in where["$and"]
+
+def test_legacy_missing_tier_is_hot_in_sqlite_fallback(palace_path, seeded_collection):
+    result = _bm25_only_via_sqlite("legacy", str(palace_path), include_cold=False)
+    assert any(hit["text"] == "legacy" for hit in result["results"])
+```
+
+- [ ] **Step 2: Run focused tests and verify signature/filter failures**
+
+Run: `.venv/bin/pytest tests/test_searcher.py -k 'wings or tier or source_kind' -q`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement common filter semantics**
+
+```python
+def _validate_scope(wing, wings):
+    if wing and wings:
+        raise ValueError("wing and wings are mutually exclusive")
+    return [wing] if wing else list(wings or [])
+
+def _tier_visible(meta: dict, include_cold: bool) -> bool:
+    return include_cold or meta.get("memory_tier", "hot") != "cold"
+```
+
+Use Chroma `$in` for multiple wings/source kinds. Apply missing-as-hot logic in vector candidate post-filtering where a `missing OR hot` Chroma expression is unavailable, and in SQLite metadata grouping before BM25 ranking. Fetch enough candidates to fill the requested result count after filtering.
+
+- [ ] **Step 4: Run search tests and commit**
+
+Run: `.venv/bin/pytest tests/test_searcher.py -q`
+
+Expected: PASS.
+
+```bash
+git add mempalace/searcher.py tests/test_searcher.py
+git commit -m "feat: filter memory search by wings and tiers"
+```
+
+### Task 4: MCP search contract and verification
+
+**Files:**
+- Modify: `mempalace/mcp_server.py:2011-2075`
+- Modify: `mempalace/mcp_server.py` search tool schema
+- Test: `tests/test_mcp_server.py`
+- Test: `tests/test_searcher.py`
+
+**Interfaces:**
+- Adds MCP arguments `wings: list[str]`, `source_kinds: list[str]`, `include_cold: bool`.
+
+- [ ] **Step 1: Write failing MCP argument and compatibility tests**
+
+```python
+def test_tool_search_forwards_multiwing_hot_scope(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(mcp, "search_memories", lambda *a, **kw: seen.update(kw) or {"results": []})
+    mcp.tool_search("why OCR", wings=["se", "se-code"], source_kinds=["curated", "code"])
+    assert seen["wings"] == ["se", "se-code"]
+    assert seen["include_cold"] is False
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k 'multiwing_hot_scope' -q`
+
+Expected: FAIL on unsupported arguments.
+
+- [ ] **Step 3: Add schema, sanitization, mutual-exclusion error, and forwarding**
+
+Sanitize every wing/source kind, keep existing `wing` callers unchanged, and return a structured error if both singular and plural arguments are supplied.
+
+- [ ] **Step 4: Run tests, lint, and commit**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py tests/test_searcher.py -q && .venv/bin/ruff check mempalace tests`
+
+Expected: PASS/exit 0.
+
+```bash
+git add mempalace/mcp_server.py mempalace/searcher.py tests/
+git commit -m "feat: expose scoped memory retrieval over MCP"
+```

--- a/docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md
+++ b/docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md
@@ -1,6 +1,6 @@
 # Async MCP Mining and Tiered Project Memory Design
 
-- **Status:** Runtime implemented; source metadata and sales migration pending
+- **Status:** Runtime, source metadata, scoped retrieval, sales policy, and migration dry run implemented; copy/apply/activation pending
 - **Date:** 2026-07-14
 - **Target:** MemPalace MCP/daemon runtime plus the sales-enablement `se` rollout
 - **Baseline:** MemPalace `develop` at the start of this design
@@ -11,6 +11,13 @@
 > `MEMPALACE_MCP_DAEMON_WRITES=1`. The daemon must be started separately. Unset
 > the flag and restart MCP to restore legacy direct mode; enabled mode never
 > falls back to direct writes.
+>
+> **Migration implementation note (2026-07-14):** New mines stamp canonical
+> source metadata, retrieval supports wing/source-kind/hot-cold scopes, and the
+> canonical sales repository has an `se-code` mining policy. A SQLite-only,
+> plan-only command produced an owner-only manifest from the active palace
+> without changing its SHA-256. Applying the reviewed manifest to a copied
+> palace and activation remain separate gated work.
 
 ## Summary
 
@@ -35,15 +42,15 @@ The existing daemon already provides the primitives needed for a better executio
 
 The MCP mine tool does not currently use those primitives. It also competes with the MCP process's lifetime peer-writer lease, so simply wrapping the current function in a thread would not solve ownership or responsiveness.
 
-The current `se` palace also mixes distinct retrieval concerns. A read-only inventory measured 13,649 active drawers:
+The current `se` palace also mixes distinct retrieval concerns. The implemented read-only inventory measured 13,653 active drawers:
 
 | Category | Drawers | Intended destination |
 |---|---:|---|
-| Codex/session transcripts | 5,249 | `se-sessions` |
+| Codex/session transcripts | 5,306 | `se-sessions` |
 | Canonical current repository | 4,667 | `se-code` |
 | Temporary linked-worktree copy | 3,588 | delete if equivalent; otherwise preserve as artifacts |
-| Curated records without a mined source | 55 | `se` |
-| Other/unclassified | 90 | manual classification |
+| Curated records without a mined source | 92 | `se` |
+| Other/unclassified | 0 | preserve if found by a future inventory |
 
 The linked-worktree copy alone accounts for 26.3% of the current records. Default retrieval is therefore paying for duplicate and historical material that should not compete with current decisions and code.
 
@@ -340,7 +347,7 @@ Apply the migration to a second full palace copy, leaving the active palace and 
 5. Delete a worktree drawer only when canonical source identity, full-source hash where available, chunk index, and exact verbatim content hash prove equivalence.
 6. Preserve non-equivalent worktree content in `se-sessions` as `worktree-artifact`, cold by default, with its original source path and revision.
 7. Collapse repeated transcript imports only when session/import identity and exact content hash match. Identical words from unrelated legitimate sources are not deduplicated.
-8. Leave the 90 unclassified records untouched until each is assigned or explicitly approved for removal.
+8. Leave any unclassified records untouched until each is assigned or explicitly approved for removal. The current dry run found none after all known roots were supplied.
 9. Rebuild derived closets, hallways, tunnels, and vector indexes in the migrated copy.
 
 The migration manifest records every old drawer ID, action, destination, reason, and checksum. It is resumable and idempotent.
@@ -363,7 +370,7 @@ Pause writers, confirm the active source palace did not change since the migrati
 
 ### Expected reduction
 
-The 3,588 known worktree records are the initial upper-bound candidate set, not an unconditional delete count. If all prove equivalent, removing them would reduce the current drawer count by approximately 26%; any record without exact evidence is preserved. Generated/lock/cache exclusions and repeated-import dedup may reduce the total further after measured dry-run results.
+The dry run classified all 3,588 known worktree records and proved 3,515 exact duplicate candidates. Removing only those reviewed candidates would reduce the current drawer count by 25.7%, from 13,653 to 10,138. The remaining 59 unique and 14 uncertain worktree records are preserved cold in `se-sessions`. Generated/lock/cache exclusions may reduce future mine growth; no repeated-session deletion is proposed by this checkpoint.
 
 Cold session classification reduces the default search set but not total storage. Reports always distinguish `records_deleted_as_verified_duplicates`, `records_preserved_cold`, and `records_excluded_from_future_mines`.
 

--- a/docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md
+++ b/docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md
@@ -1,6 +1,6 @@
 # Async MCP Mining and Tiered Project Memory Design
 
-- **Status:** Runtime, source metadata, scoped retrieval, sales policy, and migration dry run implemented; copy/apply/activation pending
+- **Status:** Runtime, source metadata, scoped retrieval, sales policy, copied migration, and synthetic activation/rollback drill implemented; live activation pending explicit authorization
 - **Date:** 2026-07-14
 - **Target:** MemPalace MCP/daemon runtime plus the sales-enablement `se` rollout
 - **Baseline:** MemPalace `develop` at the start of this design
@@ -16,8 +16,18 @@
 > source metadata, retrieval supports wing/source-kind/hot-cold scopes, and the
 > canonical sales repository has an `se-code` mining policy. A SQLite-only,
 > plan-only command produced an owner-only manifest from the active palace
-> without changing its SHA-256. Applying the reviewed manifest to a copied
-> palace and activation remain separate gated work.
+> without changing its SHA-256. The reviewed manifest was applied to a separate
+> copied palace, which passed integrity, count, content-retention, retrieval,
+> and vector-readiness checks. Atomic activation/rollback and crash recovery
+> were exercised with synthetic palaces. The user's live palace remains
+> unchanged; live activation is a separate explicitly authorized operation.
+> Reviewed manifests are versioned. Version 2 adds a semantic SQLite snapshot
+> over every schema object and durable row. It normalizes Chroma's JSON
+> serialization fields and omits only append-only `acquire_write` lock-history
+> rows that are created by collection reopen. The lock table schema remains
+> hashed. This permits harmless Chroma bookkeeping while still rejecting real
+> schema or durable-row changes. Version-1 manifests retain strict
+> physical-snapshot behavior.
 
 ## Summary
 
@@ -333,7 +343,7 @@ Cleanup is a separate, one-time, project-specific operation. It is not hidden in
 
 1. Record palace, daemon, backend, and MemPalace versions.
 2. Produce a read-only JSON/Markdown inventory by wing, source root, source kind, age, and exact-content hash.
-3. Stop/suspend writers briefly, checkpoint SQLite WAL, and copy the full palace, daemon queue, hallways/tunnels, and configuration to an owner-only rollback directory.
+3. Stop/suspend writers briefly, checkpoint SQLite WAL, and copy the full palace, daemon queue, hallways/tunnels, and configuration to an owner-only rollback directory. Capture both the physical SQLite+WAL snapshot and the version-2 semantic SQLite snapshot.
 4. Verify SQLite integrity and checksums on the rollback copy before continuing.
 
 ### Phase 2: build a migrated copy
@@ -347,10 +357,14 @@ Apply the migration to a second full palace copy, leaving the active palace and 
 5. Delete a worktree drawer only when canonical source identity, full-source hash where available, chunk index, and exact verbatim content hash prove equivalence.
 6. Preserve non-equivalent worktree content in `se-sessions` as `worktree-artifact`, cold by default, with its original source path and revision.
 7. Collapse repeated transcript imports only when session/import identity and exact content hash match. Identical words from unrelated legitimate sources are not deduplicated.
-8. Leave any unclassified records untouched until each is assigned or explicitly approved for removal. The current dry run found none after all known roots were supplied.
+8. Leave any unclassified records untouched until each is assigned or explicitly approved for removal. The reviewed inventory retained 33 provenance-bearing records outside the known roots as unclassified.
 9. Rebuild derived closets, hallways, tunnels, and vector indexes in the migrated copy.
 
 The migration manifest records every old drawer ID, action, destination, reason, and checksum. It is resumable and idempotent.
+Completed rollback and staging copies are published with an OS-native atomic
+no-replace rename; a destination that appears after preflight is never
+overwritten, including when it is an empty directory. Unsupported platforms or
+filesystems fail closed instead of falling back to clobbering rename semantics.
 
 ### Phase 3: verify and activate
 
@@ -366,7 +380,17 @@ Before activation:
 - default searches exclude cold sessions;
 - explicit historical searches include them.
 
-Pause writers, confirm the active source palace did not change since the migration manifest snapshot, and atomically activate the migrated copy. Keep the previous palace for a defined rollback window. Rollback switches the active path back; old data is not deleted during activation.
+Pause writers, confirm the active source palace still matches the reviewed
+manifest, and atomically activate the migrated copy. Exact physical equality is
+accepted immediately. If only the physical checksum changed, version-2
+manifests require an exact semantic snapshot match across every SQLite schema
+object and durable row. Only JSON key-order/whitespace differences in Chroma's
+configuration fields and append-only `acquire_write` lock-history rows are
+normalized; the lock table schema is still hashed. Capture the current physical
+snapshot immediately before the swap so any concurrent durable change still
+aborts.
+Keep the previous palace for a defined rollback window. Rollback switches the
+active path back; old data is not deleted during activation.
 
 ### Expected reduction
 
@@ -409,6 +433,21 @@ Measured on a warm local daemon and a palace comparable to the current 13.6k-dra
 - No MCP request remains open for repository mining duration.
 - Progress writes are throttled to at most one per second; heartbeat gap is at most five seconds while healthy.
 - Hybrid-search latency after maintenance does not regress by more than 10% from the pre-change warm baseline.
+
+### Measured evidence (2026-07-14)
+
+The enforced synthetic benchmark used 1,000 drawers and the real loopback
+daemon with an actively blocked maintenance job. It measured mine submission
+p95 at 42.4 ms, job status p95 at 7.3 ms, job listing p95 at 19.6 ms,
+maintenance BM25 p95 at 14.8 ms, and post-maintenance hybrid median-round-p95
+improvement at 5.36%.
+
+The copied-palace benchmark compared the 13,653-drawer rollback baseline with
+the 10,138-drawer migrated copy over 240 queries per route. Baseline hybrid
+median round p95 was 55.6 ms and migrated hybrid median round p95 was 52.4 ms,
+a 0.9419 ratio (-5.81%). Migrated BM25 median round p95 was 23.6 ms. These
+results meet every performance budget above. Detailed evidence is recorded in
+`docs/superpowers/plans/2026-07-14-se-memory-migration-apply.md`.
 
 ## Test strategy
 
@@ -464,7 +503,7 @@ The sales-enablement rollout additionally validates the migration manifest/count
 3. Enable it in the local sales-enablement MemPalace service and soak async mine, queued checkpoints, and maintenance search fallback.
 4. Add source metadata/filtering and the repository `mempalace.yaml`.
 5. Run cleanup inventory and migration dry-run; review the manifest and exact projected counts.
-6. Create/verify rollback copy, build migrated copy, run acceptance searches, and activate.
+6. Create/verify rollback copy, build migrated copy, and run acceptance searches. Activate only after separate explicit authorization.
 7. Retain the old palace through the rollback window and monitor job/search errors.
 8. After upstream compatibility feedback, make daemon-backed MCP writes the default in an appropriate release and retain an explicit legacy escape hatch for one deprecation cycle.
 
@@ -491,4 +530,4 @@ The work is complete only when:
 7. `se`, `se-code`, and `se-sessions` follow the approved retrieval policy.
 8. No unique verbatim record is lost in cleanup.
 9. Every removed record is backed by exact duplicate evidence in the migration manifest.
-10. The migrated palace passes integrity, count, duplicate, representative retrieval, activation, and rollback checks.
+10. The migrated palace passes integrity, count, duplicate, and representative retrieval checks; atomic activation, rollback, and crash recovery pass against synthetic palaces. Live activation is an operational rollout step requiring separate explicit authorization.

--- a/docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md
+++ b/docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md
@@ -1,9 +1,16 @@
 # Async MCP Mining and Tiered Project Memory Design
 
-- **Status:** Approved design; implementation pending
+- **Status:** Runtime implemented; source metadata and sales migration pending
 - **Date:** 2026-07-14
 - **Target:** MemPalace MCP/daemon runtime plus the sales-enablement `se` rollout
 - **Baseline:** MemPalace `develop` at the start of this design
+
+> **Runtime implementation note (2026-07-14):** Daemon progress, asynchronous
+> MCP mine submission, durable short writes, job inspection, linked-worktree
+> protection, and maintenance-time BM25 search are implemented behind
+> `MEMPALACE_MCP_DAEMON_WRITES=1`. The daemon must be started separately. Unset
+> the flag and restart MCP to restore legacy direct mode; enabled mode never
+> falls back to direct writes.
 
 ## Summary
 

--- a/docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md
+++ b/docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md
@@ -49,8 +49,8 @@ The current `se` palace also mixes distinct retrieval concerns. The implemented 
 | Codex/session transcripts | 5,306 | `se-sessions` |
 | Canonical current repository | 4,667 | `se-code` |
 | Temporary linked-worktree copy | 3,588 | delete if equivalent; otherwise preserve as artifacts |
-| Curated records without a mined source | 92 | `se` |
-| Other/unclassified | 0 | preserve if found by a future inventory |
+| Curated records without source provenance | 59 | `se` |
+| Provenance-bearing records outside known roots | 33 | preserve unclassified for review |
 
 The linked-worktree copy alone accounts for 26.3% of the current records. Default retrieval is therefore paying for duplicate and historical material that should not compete with current decisions and code.
 
@@ -370,7 +370,7 @@ Pause writers, confirm the active source palace did not change since the migrati
 
 ### Expected reduction
 
-The dry run classified all 3,588 known worktree records and proved 3,515 exact duplicate candidates. Removing only those reviewed candidates would reduce the current drawer count by 25.7%, from 13,653 to 10,138. The remaining 59 unique and 14 uncertain worktree records are preserved cold in `se-sessions`. Generated/lock/cache exclusions may reduce future mine growth; no repeated-session deletion is proposed by this checkpoint.
+The dry run classified all 3,588 known worktree records and proved 3,515 exact duplicate candidates. Removing only those reviewed candidates would reduce the current drawer count by 25.7%, from 13,653 to 10,138. The remaining 59 unique and 14 uncertain worktree records are preserved cold in `se-sessions`; 33 provenance-bearing records outside known roots remain explicitly unclassified for review. Generated/lock/cache exclusions may reduce future mine growth; no repeated-session deletion is proposed by this checkpoint.
 
 Cold session classification reduces the default search set but not total storage. Reports always distinguish `records_deleted_as_verified_duplicates`, `records_preserved_cold`, and `records_excluded_from_future_mines`.
 

--- a/docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md
+++ b/docs/superpowers/specs/2026-07-14-async-mcp-mining-memory-tiers-design.md
@@ -1,0 +1,480 @@
+# Async MCP Mining and Tiered Project Memory Design
+
+- **Status:** Approved design; implementation pending
+- **Date:** 2026-07-14
+- **Target:** MemPalace MCP/daemon runtime plus the sales-enablement `se` rollout
+- **Baseline:** MemPalace `develop` at the start of this design
+
+## Summary
+
+Move long-running MCP mining out of the MCP request process and into the existing durable MemPalace daemon queue. An MCP mine call validates and submits work, returns a job ID, and never waits for the repository scan or index rebuild. Job/status requests stay responsive, and search falls back to the existing read-only SQLite/BM25 path while a maintenance job is changing the vector index.
+
+For the sales-enablement repository, separate curated memory, canonical code, and session history into `se`, `se-code`, and `se-sessions`. Remove verified worktree duplicates, retain unique worktree artifacts, mark old sessions cold without summarizing or deleting their verbatim content, and add source metadata that makes future cleanup deterministic.
+
+This is a targeted evolution of the current MCP and daemon architecture. It reuses the durable queue, incremental miners, Chroma SQLite fallback, and existing palace structures. It does not introduce an external service, remote storage, lossy summaries, or a second workflow engine.
+
+## Problem and evidence
+
+The MCP HTTP server uses `ThreadingHTTPServer`, but every POST wraps the whole `handle_request()` call in `_HTTP_REQUEST_LOCK`. `mempalace_mine` invokes the miner synchronously inside that lock. If a client times out or disconnects, the Python handler continues mining and retains the lock. All later MCP POSTs, including search and status, queue behind the abandoned request.
+
+The existing daemon already provides the primitives needed for a better execution model:
+
+- durable SQLite-backed jobs;
+- `queued`, `running`, `succeeded`, `failed`, and `cancelled` states;
+- active-job deduplication;
+- retry and restart recovery;
+- authenticated loopback job and health APIs;
+- `mine`, `sync`, and allowlisted MCP-write job execution.
+
+The MCP mine tool does not currently use those primitives. It also competes with the MCP process's lifetime peer-writer lease, so simply wrapping the current function in a thread would not solve ownership or responsiveness.
+
+The current `se` palace also mixes distinct retrieval concerns. A read-only inventory measured 13,649 active drawers:
+
+| Category | Drawers | Intended destination |
+|---|---:|---|
+| Codex/session transcripts | 5,249 | `se-sessions` |
+| Canonical current repository | 4,667 | `se-code` |
+| Temporary linked-worktree copy | 3,588 | delete if equivalent; otherwise preserve as artifacts |
+| Curated records without a mined source | 55 | `se` |
+| Other/unclassified | 90 | manual classification |
+
+The linked-worktree copy alone accounts for 26.3% of the current records. Default retrieval is therefore paying for duplicate and historical material that should not compete with current decisions and code.
+
+## Goals
+
+1. Return from `mempalace_mine` after durable submission, not after mining.
+2. Keep job status and search usable throughout a mine.
+3. Ensure client timeout or disconnect never cancels accepted mining work.
+4. Serialize writes through the existing daemon when daemon-backed MCP mode is enabled.
+5. Deduplicate equivalent queued/running mine requests.
+6. Expose useful job progress without requiring a conversation or UI to wait.
+7. Reject accidental mining of linked Git worktrees by default.
+8. Separate current decisions, canonical code, and session history for precise retrieval.
+9. Reduce duplicate and low-value records while preserving unique verbatim content.
+10. Provide an auditable, dry-run-first migration with a complete rollback copy.
+
+## Non-goals
+
+- Replacing Temporal, adding a distributed queue, or adding remote workers.
+- Running multiple concurrent writers against one palace.
+- Making every Chroma/HNSW operation safe during maintenance.
+- Providing a transactionally frozen search snapshot during mining. SQLite fallback returns a committed point-in-time view and labels it as updating.
+- Summarizing, paraphrasing, or otherwise reducing verbatim user content.
+- Deleting old sessions merely because they are old.
+- Automatically deleting unique worktree content.
+- Changing synchronous CLI `mempalace mine` semantics in this work.
+- Building a general-purpose retention-policy language in the first release.
+
+## Architecture
+
+### 1. One durable writer lane
+
+When daemon-backed MCP mode is enabled, the daemon is the only MCP mutation executor for a palace:
+
+- read tools continue to execute in the MCP process;
+- `mempalace_mine` submits a daemon `mine` job;
+- write-classified tools submit daemon `mcp_tool` jobs;
+- maintenance jobs and short writes execute serially in the daemon worker;
+- the MCP process does not retain the lifetime peer-writer lease in this mode.
+
+The daemon worker acquires the per-palace writer lease before executing a job. Lock acquisition becomes re-entrant within that daemon process so the outer job lease and existing miner-internal lock cannot deadlock each other. The cross-process lease remains exclusive; direct CLI or legacy MCP writers still receive the existing structured lock error.
+
+This mode is introduced behind `MEMPALACE_MCP_DAEMON_WRITES=1` for safe rollout. The sales-enablement installation enables it immediately. Legacy direct-write behavior remains available while upstream compatibility is evaluated; it is not used as a fallback when daemon mode is enabled.
+
+### 2. Async MCP mine contract
+
+`mempalace_mine` keeps its existing mining arguments and adds:
+
+- `allow_linked_worktree: boolean = false`
+- `priority: integer = 0`
+
+In daemon-backed mode it performs only:
+
+1. schema and mode validation;
+2. source existence and canonical-path validation;
+3. linked-worktree protection;
+4. construction of the daemon payload and dedupe key;
+5. durable submission with `wait=False`;
+6. return of the accepted job.
+
+Successful submission returns:
+
+```json
+{
+  "success": true,
+  "accepted": true,
+  "job_id": "<id>",
+  "state": "queued",
+  "deduplicated": false,
+  "source": "<canonical source>",
+  "mode": "projects",
+  "wing": "se-code",
+  "submitted_at": "<UTC ISO-8601>"
+}
+```
+
+If an equivalent active request already exists, `job_id` identifies that job and `deduplicated` is `true`. There is no in-process or synchronous fallback. If daemon health/submission fails, the tool returns a structured `DaemonUnavailable` error quickly with the command needed to start or inspect the daemon.
+
+The dedupe key is a SHA-256 of the canonical palace path, canonical source path, mode, wing, agent, limit, dry-run flag, extraction strategy, relevant mining options, and `mempalace.yaml` checksum. Only `queued` and `running` jobs participate; a later request may run after a terminal job.
+
+This is an intentional MCP behavior change: callers that previously consumed the final `output` must poll job status. The CLI remains synchronous unless its existing background option is used.
+
+### 3. MCP job tools
+
+Add read-classified tools that do not open Chroma and never take the palace request lock:
+
+#### `mempalace_job_status`
+
+Input: `job_id`.
+
+Returns identity, kind, state, attempts, timestamps, progress, result, and structured error. Result/output is present only for a terminal job.
+
+#### `mempalace_list_jobs`
+
+Inputs: `limit` (default 20, capped), optional `state`, and optional `kind`.
+
+Returns recent jobs and aggregate counts. Payloads containing verbatim write content are never returned; source paths and safe operational fields are returned for mine jobs.
+
+The existing daemon bearer token, loopback binding, owner-only queue permissions, body caps, and retention policy remain mandatory.
+
+### 4. Progress and heartbeat
+
+Extend the daemon queue schema additively with `updated_at`, `heartbeat_at`, and `progress_json`. Queue startup performs an idempotent schema migration for existing databases.
+
+Mine progress has this stable shape:
+
+```json
+{
+  "phase": "scanning|mining|post_processing|verifying",
+  "files_total": 4667,
+  "files_processed": 1200,
+  "files_changed": 14,
+  "files_skipped": 1186,
+  "files_failed": 0,
+  "current_source": "apps/.../file.ts",
+  "message": "optional safe status"
+}
+```
+
+Miner callbacks update progress at phase boundaries and no more than once per second during file loops. The daemon refreshes `heartbeat_at` at least every five seconds while a job is running, independently of client polling.
+
+The heartbeat is operational evidence that the daemon worker is alive; it does not keep an MCP request open and it is not a user-facing wait loop. A stale heartbeat is reported by status, but it does not by itself mutate the job state. Restart recovery remains the authority for re-queuing an interrupted `running` job.
+
+### 5. Short writes during maintenance
+
+All write-classified MCP calls enter the durable daemon queue in daemon-backed mode. The MCP dispatcher waits for at most 250 ms for an idle-daemon fast path:
+
+- if the write finishes, return its normal tool result plus `delivery: "completed"`;
+- if it remains queued or running, return `accepted`, `job_id`, and `delivery: "durable_queue"`;
+- if submission fails, return `DaemonUnavailable`; never execute directly.
+
+Therefore a curated checkpoint made during a large mine is accepted immediately and executes after the maintenance job. No person or MCP connection has to wait. Queue order remains deterministic; this design does not preempt a miner mid-file or introduce a second writer.
+
+### 6. Responsive reads and transport lock scope
+
+Remove the whole-request `_HTTP_REQUEST_LOCK` critical section. Replace it with operation-level protection:
+
+- protocol initialization, tool listing, health, and daemon job reads do not take a palace lock;
+- daemon submissions only use the daemon client and queue database;
+- direct cached Chroma reads remain serialized where the backend requires it;
+- when a maintenance job is active, `mempalace_search` sets `vector_disabled=True` and uses the existing read-only SQLite/BM25 path;
+- other HNSW-dependent reads may return a structured `IndexUpdating` response rather than block behind the mine.
+
+Searches served during maintenance include:
+
+```json
+{
+  "index_state": "updating",
+  "active_job_id": "<id>",
+  "retrieval_mode": "bm25_sqlite"
+}
+```
+
+The fallback sees SQLite commits that completed before its read transaction. It is not described as a stable pre-mine snapshot. After a successful maintenance job, the MCP process invalidates cached clients, verifies SQLite/HNSW readiness, and resumes hybrid search. If post-mine verification fails, vector search stays disabled and the terminal job reports the integrity error while BM25 remains available.
+
+### 7. Daemon availability
+
+Daemon-backed MCP mode expects the local daemon to be supervised and already running. MCP tool calls use short health/submission timeouts and do not silently start a long-lived process or fall back to unsafe direct writes. Sales-enablement local setup starts the daemon with the existing MemPalace daemon command as part of the developer service bootstrap.
+
+This keeps latency predictable and makes missing supervision visible. A cold or failed daemon is a configuration/health error, not a reason to put long work back inside an MCP request.
+
+## Source identity and linked-worktree protection
+
+### Canonical source identity
+
+Newly mined drawers receive scalar metadata compatible with Chroma:
+
+| Field | Purpose |
+|---|---|
+| `source_kind` | `curated`, `code`, `documentation`, `session`, or `worktree-artifact` |
+| `memory_tier` | `hot` or `cold` |
+| `source_root` | canonical real path of the mining root |
+| `source_identity` | stable kind/repository/relative-path or kind/session identity |
+| `source_revision` | Git commit, session ID, or importer revision when available |
+| `source_sha256` | hash of the full source bytes when available |
+| `content_sha256` | hash of this exact verbatim drawer content |
+| `source_canonicality` | `canonical` or `linked-worktree` |
+
+Missing fields on legacy drawers are treated compatibly: missing `memory_tier` means hot, and existing `source_file` continues to work.
+
+### Git worktree rule
+
+For `projects` mode, source validation detects a linked worktree by resolving its Git directory and checking whether it lives below the common Git directory's `worktrees/` area. This avoids confusing ordinary repositories or submodules with linked worktrees.
+
+If linked, submission fails with `LinkedWorktreeRejected` unless `allow_linked_worktree=true`. The error reports the detected canonical repository root when available. Explicitly allowed content is stamped `source_canonicality=linked-worktree`; it never masquerades as canonical code.
+
+The sales-enablement repository keeps `allow_linked_worktree` false. Worktree-specific conversation or design artifacts belong in `se-sessions`, not `se-code`.
+
+## Tiered `se` memory model
+
+### Wings
+
+#### `se`
+
+Small, curated, durable knowledge:
+
+- decisions and their rationale;
+- architecture boundaries;
+- incidents and root causes;
+- release/check-in facts;
+- repository policy and operating conventions.
+
+These records are immediately checkpointed, permanently hot unless explicitly retired, and not created by repository mining.
+
+#### `se-code`
+
+The canonical repository's current code, tests, and useful documentation. It is populated only from the canonical checkout using checked-in `mempalace.yaml`. Re-mining is incremental; changed source replaces that source's older mined drawers according to existing miner semantics.
+
+#### `se-sessions`
+
+Verbatim Codex/conversation history and preserved worktree-only artifacts. Sessions authored in the last 90 days are hot by default. Older sessions are marked cold, not deleted. Pinned sessions stay hot regardless of age.
+
+Cross-wing tunnels connect curated architecture/decision rooms to relevant code rooms and session history without merging the three retrieval concerns.
+
+### Retrieval policy
+
+| Question | First search | Fallback |
+|---|---|---|
+| Why was this decided? | `se` | hot `se-sessions` |
+| What is implemented now? | `se-code` | `se`, then hot sessions |
+| What did we discuss? | hot `se-sessions` | cold sessions |
+| Ambiguous project question | `se` + `se-code` | hot sessions, then cold sessions |
+
+Search accepts optional `wings`, `source_kinds`, and `include_cold` filters while preserving the existing singular `wing` argument. `wing` and `wings` are mutually exclusive. Legacy records without tier metadata remain visible. Cold records are included only when requested or when a caller intentionally performs the historical fallback.
+
+This policy reduces the default semantic candidate set; it does not discard historical words.
+
+### Repository configuration
+
+The sales-enablement canonical checkout gains a checked-in `mempalace.yaml` with:
+
+- `wing: se-code`;
+- rooms for backend, workers, shared helpers, architecture/docs, and tests/operations;
+- `source_kind: code` and linked-worktree rejection;
+- exclusions for dependency directories, build output, coverage, caches, generated bundles/maps, lockfiles, and other reproducible low-value artifacts;
+- normal Git ignore behavior enabled.
+
+Source files, tests, migrations, hand-written documentation, and repository agent instructions remain included.
+
+The configuration extension is additive. A representative shape is:
+
+```yaml
+wing: se-code
+source_kind: code
+reject_linked_worktrees: true
+rooms:
+  - name: backend
+    description: NestJS API code
+    keywords: [apps/sales-enablement-be, controller, service, dto]
+  - name: workers
+    description: Temporal worker and workflow code
+    keywords: [apps/sales-enablement-workers, workflow, activity, temporal]
+  - name: helpers
+    description: Shared libraries and infrastructure
+    keywords: [libs/helpers, mongo, gcs, pubsub]
+  - name: architecture_docs
+    description: Hand-written architecture and operating documentation
+    source_kind: documentation
+    keywords: [docs, architecture, agents]
+  - name: tests_operations
+    description: Tests, migrations, scripts, and operational configuration
+    keywords: [test, spec, scripts, migration, docker]
+exclude_patterns:
+  - node_modules/
+  - .nx/
+  - dist/
+  - coverage/
+  - "*.map"
+  - workflow-bundle.js
+  - package-lock.json
+```
+
+The implementation validates new scalar fields and per-room `source_kind`; older configuration files retain their current behavior.
+
+## Cleanup and migration
+
+Cleanup is a separate, one-time, project-specific operation. It is not hidden inside ordinary mining and does not make broad deletion available through MCP.
+
+### Phase 1: inventory and backup
+
+1. Record palace, daemon, backend, and MemPalace versions.
+2. Produce a read-only JSON/Markdown inventory by wing, source root, source kind, age, and exact-content hash.
+3. Stop/suspend writers briefly, checkpoint SQLite WAL, and copy the full palace, daemon queue, hallways/tunnels, and configuration to an owner-only rollback directory.
+4. Verify SQLite integrity and checksums on the rollback copy before continuing.
+
+### Phase 2: build a migrated copy
+
+Apply the migration to a second full palace copy, leaving the active palace and rollback copy untouched:
+
+1. Reclassify curated records into `se`.
+2. Reclassify canonical repository records into `se-code` with canonical source identities.
+3. Reclassify transcripts into `se-sessions` and apply the 90-day hot/cold rule.
+4. Map each temporary-worktree source to the canonical repository relative path.
+5. Delete a worktree drawer only when canonical source identity, full-source hash where available, chunk index, and exact verbatim content hash prove equivalence.
+6. Preserve non-equivalent worktree content in `se-sessions` as `worktree-artifact`, cold by default, with its original source path and revision.
+7. Collapse repeated transcript imports only when session/import identity and exact content hash match. Identical words from unrelated legitimate sources are not deduplicated.
+8. Leave the 90 unclassified records untouched until each is assigned or explicitly approved for removal.
+9. Rebuild derived closets, hallways, tunnels, and vector indexes in the migrated copy.
+
+The migration manifest records every old drawer ID, action, destination, reason, and checksum. It is resumable and idempotent.
+
+### Phase 3: verify and activate
+
+Before activation:
+
+- SQLite `integrity_check` passes;
+- HNSW/collection readiness checks pass;
+- retained content hashes match the source palace;
+- expected category counts reconcile with the manifest;
+- no verified duplicate worktree records remain;
+- unique worktree artifacts are still retrievable;
+- representative decision, code, recent-session, and cold-session searches return expected verbatim drawers;
+- default searches exclude cold sessions;
+- explicit historical searches include them.
+
+Pause writers, confirm the active source palace did not change since the migration manifest snapshot, and atomically activate the migrated copy. Keep the previous palace for a defined rollback window. Rollback switches the active path back; old data is not deleted during activation.
+
+### Expected reduction
+
+The 3,588 known worktree records are the initial upper-bound candidate set, not an unconditional delete count. If all prove equivalent, removing them would reduce the current drawer count by approximately 26%; any record without exact evidence is preserved. Generated/lock/cache exclusions and repeated-import dedup may reduce the total further after measured dry-run results.
+
+Cold session classification reduces the default search set but not total storage. Reports always distinguish `records_deleted_as_verified_duplicates`, `records_preserved_cold`, and `records_excluded_from_future_mines`.
+
+## Failure handling
+
+| Failure | Behavior |
+|---|---|
+| Daemon unavailable | Fast structured error; no direct fallback |
+| Client disconnects after submission | Job continues; caller can recover by listing jobs |
+| Duplicate submission | Existing active job returned |
+| Daemon exits during job | Existing recovery re-queues until max attempts, then fails visibly |
+| Mine fails | Job stores structured error/output; prior incremental data remains |
+| Post-mine integrity fails | Job fails; vector stays disabled; BM25 remains available |
+| Write arrives during mine | Durable queued acceptance; executes after maintenance |
+| Search arrives during mine | SQLite/BM25 result marked `index_state=updating` |
+| Migration equivalence uncertain | Preserve and classify; never guess-delete |
+| Active palace changes before swap | Abort activation and rebuild migrated copy |
+
+## Observability
+
+- Job status exposes state, attempts, phase progress, timestamps, and heartbeat age.
+- `mempalace_list_jobs` provides recent failures without exposing verbatim queued payloads.
+- Mine completion includes changed/skipped/failed counts and post-processing results.
+- Search responses identify hybrid versus maintenance fallback mode.
+- Structured logs include job ID and palace key but avoid drawer content.
+- Optional desktop notification may announce terminal mine state; it is not required for correctness.
+- Terminal queue records retain the existing bounded retention window.
+
+## Performance budgets
+
+Measured on a warm local daemon and a palace comparable to the current 13.6k-drawer `se` palace:
+
+- MCP mine validation and durable submission: p95 under 500 ms.
+- Job status and recent-job listing: p95 under 100 ms.
+- Search during maintenance via SQLite/BM25: p95 under 1 second for ordinary queries.
+- No MCP request remains open for repository mining duration.
+- Progress writes are throttled to at most one per second; heartbeat gap is at most five seconds while healthy.
+- Hybrid-search latency after maintenance does not regress by more than 10% from the pre-change warm baseline.
+
+## Test strategy
+
+### Unit tests
+
+- canonical source and linked-worktree detection, including submodules;
+- deterministic mine dedupe keys and config-checksum changes;
+- additive queue schema migration;
+- progress throttling and heartbeat serialization;
+- job response redaction;
+- metadata defaults and hot/cold filtering;
+- single- and multi-wing filter validation;
+- exact source/session dedup predicates.
+
+### Integration tests
+
+- block a fake mine indefinitely and prove health, job status, job listing, and BM25 search remain responsive;
+- disconnect/time out the submitting MCP client and prove the job reaches a terminal state;
+- submit the same mine concurrently and prove only one active job executes;
+- restart the daemon during a mine and prove recovery/attempt limits;
+- queue a curated write behind a mine and prove immediate accepted response plus eventual execution;
+- prove daemon-backed mode never invokes direct-write fallback;
+- prove MCP and daemon writer ownership cannot deadlock;
+- prove cached HNSW clients are invalidated and hybrid resumes only after readiness checks;
+- prove linked worktrees are rejected unless explicitly allowed.
+
+### Migration tests
+
+- run the full migration against a synthetic copy with canonical duplicates, unique worktree artifacts, repeated transcript imports, and ambiguous records;
+- verify dry-run makes no changes;
+- interrupt and resume without duplicate actions;
+- verify every deletion has exact-equivalence evidence;
+- verify cold records are verbatim and explicitly retrievable;
+- exercise activation and rollback;
+- run SQLite and vector-index integrity checks before and after.
+
+### Baseline and completion gates
+
+Before implementation, the current focused suite must pass. Before completion:
+
+```bash
+uv run pytest tests/ -v --ignore=tests/benchmarks
+uv run ruff check .
+uv run ruff format --check .
+```
+
+The sales-enablement rollout additionally validates the migration manifest/counts and representative retrieval queries against the copied palace before activation.
+
+## Rollout
+
+1. Land daemon progress/status and lock-scope tests without changing defaults.
+2. Add daemon-backed MCP routing behind `MEMPALACE_MCP_DAEMON_WRITES=1`.
+3. Enable it in the local sales-enablement MemPalace service and soak async mine, queued checkpoints, and maintenance search fallback.
+4. Add source metadata/filtering and the repository `mempalace.yaml`.
+5. Run cleanup inventory and migration dry-run; review the manifest and exact projected counts.
+6. Create/verify rollback copy, build migrated copy, run acceptance searches, and activate.
+7. Retain the old palace through the rollback window and monitor job/search errors.
+8. After upstream compatibility feedback, make daemon-backed MCP writes the default in an appropriate release and retain an explicit legacy escape hatch for one deprecation cycle.
+
+## Security and privacy
+
+- All processing remains local.
+- Daemon endpoints stay loopback-only and bearer-token protected.
+- Palace, token, queue, logs, manifests, and backups are owner-only.
+- Job tools redact verbatim write payloads.
+- Logs and progress use relative/safe source labels and never drawer content.
+- Migration copies and rollback data receive the same protections as the active palace.
+- No telemetry, cloud service, or external embedding/LLM provider is introduced.
+
+## Acceptance criteria
+
+The work is complete only when:
+
+1. An MCP mine call returns an accepted durable job without waiting for mining.
+2. Search and job status meet their responsiveness budgets during a blocked mine.
+3. Client timeout/disconnect does not stop accepted work.
+4. Only one writer lane mutates a palace in daemon-backed mode.
+5. Curated writes made during mining are durably accepted and eventually visible.
+6. Linked-worktree project mining is rejected by default.
+7. `se`, `se-code`, and `se-sessions` follow the approved retrieval policy.
+8. No unique verbatim record is lost in cleanup.
+9. Every removed record is backed by exact duplicate evidence in the migration manifest.
+10. The migrated palace passes integrity, count, duplicate, representative retrieval, activation, and rollback checks.

--- a/mempalace/backends/base.py
+++ b/mempalace/backends/base.py
@@ -403,6 +403,23 @@ class BaseCollection(ABC):
         include: Optional[list[str]] = None,
     ) -> GetResult: ...
 
+    def get_source_chunks(
+        self,
+        source_file: str,
+        *,
+        parent_drawer_id: Optional[str] = None,
+    ) -> GetResult:
+        """Fetch all chunks for one logical source group.
+
+        Backends may override this for an indexed source lookup.  The default
+        preserves behavior through the ordinary metadata-filtered ``get``.
+        """
+        clauses = [{"source_file": source_file}]
+        if parent_drawer_id:
+            clauses.append({"parent_drawer_id": parent_drawer_id})
+        where = clauses[0] if len(clauses) == 1 else {"$and": clauses}
+        return self.get(where=where, include=["documents", "metadatas"])
+
     @abstractmethod
     def delete(
         self,

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -966,7 +966,7 @@ def _sqlite_wing_room_counts(
     return total, wing_rooms
 
 
-def _pin_hnsw_threads(collection) -> None:
+def _pin_hnsw_threads(collection) -> bool:
     """Best-effort retrofit: pin ``hnsw:num_threads=1`` on an existing collection.
 
     Fresh collections set this via ``metadata=`` at creation. Legacy palaces
@@ -975,9 +975,10 @@ def _pin_hnsw_threads(collection) -> None:
     ``collection.modify(configuration=...)`` lets us re-apply ``num_threads=1``
     in memory at load time so every new process is protected.
 
-    Note: in chromadb 1.5.x the modified ``configuration_json["hnsw"]`` does
-    not persist to disk across ``PersistentClient`` reopens, so this must
-    run on every ``get_collection`` call, not just once.
+    In chromadb 1.5.x the modification does not persist across
+    ``PersistentClient`` reopens. The backend therefore pins once per cached
+    client/collection and retries on later ``get_collection`` calls until the
+    first successful pin; replacing the client clears that success cache.
     """
     try:
         from chromadb.api.collection_configuration import (
@@ -986,13 +987,15 @@ def _pin_hnsw_threads(collection) -> None:
         )
     except ImportError:
         logger.debug("_pin_hnsw_threads skipped: chromadb too old", exc_info=True)
-        return
+        return False
     try:
         collection.modify(
             configuration=UpdateCollectionConfiguration(hnsw=UpdateHNSWConfiguration(num_threads=1))
         )
     except Exception:
         logger.debug("_pin_hnsw_threads modify failed", exc_info=True)
+        return False
+    return True
 
 
 _BLOB_FIX_MARKER = ".blob_seq_ids_migrated"
@@ -1594,6 +1597,102 @@ class ChromaCollection(BaseCollection):
             embeddings=[list(v) for v in out_embeds] if out_embeds is not None else None,
         )
 
+    def get_source_chunks(
+        self,
+        source_file: str,
+        *,
+        parent_drawer_id: Optional[str] = None,
+    ) -> GetResult:
+        """Fetch source chunks directly from Chroma's SQLite metadata index."""
+        fast = self._get_source_chunks_via_sqlite(source_file, parent_drawer_id)
+        if fast is not None:
+            return fast
+        return super().get_source_chunks(
+            source_file,
+            parent_drawer_id=parent_drawer_id,
+        )
+
+    def _get_source_chunks_via_sqlite(
+        self,
+        source_file: str,
+        parent_drawer_id: Optional[str],
+    ) -> Optional[GetResult]:
+        if not self._palace_path:
+            return None
+        collection_name = self._collection_name()
+        db_path = os.path.join(self._palace_path, "chroma.sqlite3")
+        if not collection_name or not os.path.isfile(db_path):
+            return None
+
+        parent_clause = ""
+        parameters: list[Any] = [source_file, collection_name]
+        if parent_drawer_id:
+            parent_clause = """
+                AND EXISTS (
+                    SELECT 1
+                    FROM embedding_metadata parent
+                    WHERE parent.id = e.id
+                      AND parent.key = 'parent_drawer_id'
+                      AND parent.string_value = ?
+                )
+            """
+            parameters.append(parent_drawer_id)
+
+        try:
+            conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+            conn.row_factory = sqlite3.Row
+        except sqlite3.Error:
+            logger.debug("Chroma source-chunk sqlite open failed", exc_info=True)
+            return None
+
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT
+                    e.embedding_id,
+                    document.string_value AS document,
+                    chunk.int_value AS chunk_index
+                FROM embeddings e
+                JOIN segments s ON e.segment_id = s.id
+                JOIN collections c ON s.collection = c.id
+                JOIN embedding_metadata source
+                 ON source.id = e.id
+                 AND source.key = 'source_file'
+                 AND source.string_value = ?
+                LEFT JOIN embedding_metadata document
+                  ON document.id = e.id
+                 AND document.key = 'chroma:document'
+                LEFT JOIN embedding_metadata chunk
+                  ON chunk.id = e.id
+                 AND chunk.key = 'chunk_index'
+                WHERE c.name = ?
+                {parent_clause}
+                ORDER BY chunk.int_value, e.id
+                """,
+                parameters,
+            ).fetchall()
+        except sqlite3.Error:
+            logger.debug("Chroma source-chunk sqlite read failed", exc_info=True)
+            return None
+        finally:
+            conn.close()
+
+        metadatas = []
+        for row in rows:
+            metadata = {"source_file": source_file}
+            if row["chunk_index"] is not None:
+                metadata["chunk_index"] = int(row["chunk_index"])
+            if parent_drawer_id:
+                metadata["parent_drawer_id"] = parent_drawer_id
+            metadatas.append(metadata)
+
+        return GetResult(
+            ids=[str(row["embedding_id"]) for row in rows],
+            documents=[str(row["document"] or "") for row in rows],
+            metadatas=metadatas,
+            embeddings=None,
+        )
+
     def delete(self, *, ids=None, where=None):
         _validate_where(where)
         kwargs: dict[str, Any] = {}
@@ -1931,7 +2030,15 @@ class ChromaBackend(BaseBackend):
         self._clients: dict[str, Any] = {}
         # palace_path -> (inode, mtime) of chroma.sqlite3 at cache time.
         self._freshness: dict[str, tuple[int, float]] = {}
+        # ``collection.modify(num_threads=1)`` is needed once per collection
+        # for each fresh client, not on every hot-path lookup.
+        self._pinned_collections: set[tuple[str, str]] = set()
         self._closed = False
+
+    def _forget_pinned_collections(self, palace_path: str) -> None:
+        self._pinned_collections = {
+            key for key in self._pinned_collections if key[0] != palace_path
+        }
 
     @staticmethod
     def _resolve_embedding_function():
@@ -2054,6 +2161,7 @@ class ChromaBackend(BaseBackend):
                 or (mtime_appeared and palace_path in self._freshness)
             ):
                 ChromaBackend._quarantined_paths.discard(palace_path)
+            self._forget_pinned_collections(palace_path)
             ChromaBackend._prepare_palace_for_open(palace_path)
             cached = chromadb.PersistentClient(path=palace_path)
             self._clients[palace_path] = cached
@@ -2208,7 +2316,14 @@ class ChromaBackend(BaseBackend):
                 if explanation:
                     raise ValueError(explanation) from e
                 raise
-        _pin_hnsw_threads(collection)
+        pin_key = (palace_path, collection_name)
+        if pin_key not in self._pinned_collections:
+            if _pin_hnsw_threads(collection):
+                self._pinned_collections.add(pin_key)
+                # ``_pin_hnsw_threads`` intentionally calls ``collection.modify``
+                # and advances chroma.sqlite3's mtime. Record that self-authored
+                # change so the next lookup does not treat it as an external write.
+                self._freshness[palace_path] = self._db_stat(palace_path)
         return ChromaCollection(collection, palace_path=palace_path)
 
     def close_palace(self, palace) -> None:
@@ -2224,12 +2339,14 @@ class ChromaBackend(BaseBackend):
             return
         _close_client(self._clients.pop(path, None))
         self._freshness.pop(path, None)
+        self._forget_pinned_collections(path)
 
     def close(self) -> None:
         for client in self._clients.values():
             _close_client(client)
         self._clients.clear()
         self._freshness.clear()
+        self._pinned_collections.clear()
         self._closed = True
 
     def health(self, palace: Optional[PalaceRef] = None) -> HealthStatus:
@@ -2271,6 +2388,8 @@ class ChromaBackend(BaseBackend):
     def delete_collection(self, palace_path: str, collection_name: str) -> None:
         """Delete ``collection_name`` from the palace at ``palace_path``."""
         self._client(palace_path).delete_collection(collection_name)
+        self._pinned_collections.discard((palace_path, collection_name))
+        self._freshness[palace_path] = self._db_stat(palace_path)
 
     def create_collection(
         self, palace_path: str, collection_name: str, hnsw_space: str = "cosine"
@@ -2287,6 +2406,8 @@ class ChromaBackend(BaseBackend):
             },
             **ef_kwargs,
         )
+        self._pinned_collections.add((palace_path, collection_name))
+        self._freshness[palace_path] = self._db_stat(palace_path)
         return ChromaCollection(collection, palace_path=palace_path)
 
 

--- a/mempalace/backends/embedding_wrapper.py
+++ b/mempalace/backends/embedding_wrapper.py
@@ -179,6 +179,20 @@ class EmbeddingCollection(BaseCollection):
         # ``lexical_search`` above.
         return self._inner.get_all_metadata(where=where)
 
+    def get_source_chunks(
+        self,
+        source_file: str,
+        *,
+        parent_drawer_id: Optional[str] = None,
+    ):
+        # Preserve backend-specific indexed source hydration. Without this
+        # explicit forwarder, BaseCollection's concrete fallback shadows the
+        # wrapped collection through normal MRO resolution.
+        return self._inner.get_source_chunks(
+            source_file,
+            parent_drawer_id=parent_drawer_id,
+        )
+
     def update(self, *, ids, documents=None, metadatas=None, embeddings=None):
         ids = _as_list(ids)
         if documents is not None:

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1007,7 +1007,17 @@ def cmd_migrate_wings(args):
 
 
 def cmd_reorganize(args):
-    """Build an auditable reorganization manifest without mutating the palace."""
+    """Plan, build, activate, or roll back a reviewed palace migration."""
+    action = getattr(args, "reorganize_action", None)
+    if action == "prepare":
+        return _cmd_reorganize_prepare(args)
+    if action == "apply":
+        return _cmd_reorganize_apply(args)
+    if action == "activate":
+        return _cmd_reorganize_activate(args)
+    if action == "rollback":
+        return _cmd_reorganize_rollback(args)
+
     import sqlite3
     from collections import Counter
 
@@ -1126,6 +1136,108 @@ def cmd_reorganize(args):
     print(f"  Manifest: {os.path.abspath(os.path.expanduser(args.manifest))}")
     print(f"  SQLite SHA-256: {before['sha256']} (unchanged)")
     print("  Dry run only — no drawers were changed or deleted.")
+
+
+def _reorganize_palace_path(args) -> str:
+    palace_path = (
+        getattr(args, "reorganize_palace", None)
+        or getattr(args, "palace", None)
+        or MempalaceConfig().palace_path
+    )
+    return os.path.abspath(os.path.expanduser(palace_path))
+
+
+def _migration_scope_kwargs(args) -> dict:
+    return {
+        "source_palace": _reorganize_palace_path(args),
+        "reviewed_manifest": args.manifest,
+        "rollback_root": args.rollback_root,
+        "migrated_root": args.migrated_root,
+        "canonical_root": args.canonical_root,
+        "worktree_roots": args.worktree_root,
+        "session_roots": args.session_root,
+        "hot_days": args.hot_days,
+    }
+
+
+def _cmd_reorganize_prepare(args):
+    from .migration_bundle import prepare_migration_copies
+
+    try:
+        report = prepare_migration_copies(**_migration_scope_kwargs(args))
+    except Exception as exc:  # noqa: BLE001 - user-facing migration boundary
+        print(f"  Could not prepare migration copies: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print("\n  Rollback copy ready")
+    print(f"  Inventory: {report['inventory_total']:,}")
+    print(f"  Verified duplicate candidates: {report['duplicate_candidates']:,}")
+    print(f"  Rollback: {os.path.abspath(os.path.expanduser(args.rollback_root))}")
+    print(f"  Staging: {os.path.abspath(os.path.expanduser(args.migrated_root))}")
+
+
+def _cmd_reorganize_apply(args):
+    from .migration_bundle import apply_reviewed_migration
+
+    try:
+        report = apply_reviewed_migration(
+            **_migration_scope_kwargs(args),
+            batch_size=args.batch_size,
+        )
+    except Exception as exc:  # noqa: BLE001 - user-facing migration boundary
+        print(f"  Could not apply reviewed migration: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print("\n  Migrated copy verified")
+    print(f"  Before: {report['records_before']:,}")
+    print(f"  After: {report['records_expected_after']:,}")
+    print(f"  Removed with exact evidence: {report['records_deleted_as_verified_duplicates']:,}")
+    print(f"  Report: {os.path.abspath(os.path.expanduser(args.migrated_root))}/apply-report.json")
+
+
+def _require_explicit_activation(args, operation: str) -> None:
+    if getattr(args, "yes", False):
+        return
+    print(
+        f"  Refusing to {operation} without --yes; stop the daemon and review the paths first.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+def _cmd_reorganize_activate(args):
+    from .migration_bundle import activate_migrated_palace
+
+    _require_explicit_activation(args, "activate the migrated palace")
+    try:
+        report = activate_migrated_palace(
+            active_palace=_reorganize_palace_path(args),
+            reviewed_manifest=args.manifest,
+            migrated_root=args.migrated_root,
+            previous_root=args.previous_root,
+        )
+    except Exception as exc:  # noqa: BLE001 - user-facing migration boundary
+        print(f"  Could not activate migration: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print("\n  Migration activated")
+    print(f"  Active palace: {report['active_palace']}")
+    print(f"  Previous palace retained at: {report['previous_root']}")
+
+
+def _cmd_reorganize_rollback(args):
+    from .migration_bundle import rollback_activated_palace
+
+    _require_explicit_activation(args, "roll back the migrated palace")
+    try:
+        report = rollback_activated_palace(
+            active_palace=_reorganize_palace_path(args),
+            migrated_root=args.migrated_root,
+            previous_root=args.previous_root,
+        )
+    except Exception as exc:  # noqa: BLE001 - user-facing migration boundary
+        print(f"  Could not roll back migration: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print("\n  Migration rolled back")
+    print(f"  Active palace: {report['active_palace']}")
+    print(f"  Migrated palace retained at: {report['migrated_root']}/palace")
 
 
 def cmd_hallways(args):
@@ -2343,6 +2455,127 @@ def main():
         help="Owner-only JSON manifest output path",
     )
 
+    def add_reviewed_migration_scope(parser, *, include_batch_size=False):
+        parser.add_argument(
+            "--palace",
+            dest="reorganize_palace",
+            default=None,
+            help="Active palace path (default: global --palace or configured palace)",
+        )
+        parser.add_argument(
+            "--canonical-root",
+            required=True,
+            help="Primary repository checkout used by the reviewed manifest",
+        )
+        parser.add_argument(
+            "--worktree-root",
+            action="append",
+            default=[],
+            help="Reviewed linked-worktree root; repeat for multiple roots",
+        )
+        parser.add_argument(
+            "--session-root",
+            action="append",
+            default=[],
+            help="Reviewed session root; repeat for multiple roots",
+        )
+        parser.add_argument(
+            "--hot-days",
+            type=int,
+            default=90,
+            help="Reviewed session hot-window in days (default: 90)",
+        )
+        parser.add_argument(
+            "--manifest",
+            required=True,
+            help="Previously reviewed owner-only manifest",
+        )
+        parser.add_argument(
+            "--rollback-root",
+            required=True,
+            help="Verified rollback bundle directory",
+        )
+        parser.add_argument(
+            "--migrated-root",
+            required=True,
+            help="Migrated staging bundle directory",
+        )
+        if include_batch_size:
+            parser.add_argument(
+                "--batch-size",
+                type=int,
+                default=250,
+                help="Bounded Chroma update/delete batch size (default: 250)",
+            )
+
+    p_reorganize_prepare = reorganize_sub.add_parser(
+        "prepare",
+        help="Create verified rollback and staging copies without changing the active palace",
+    )
+    add_reviewed_migration_scope(p_reorganize_prepare)
+    p_reorganize_apply = reorganize_sub.add_parser(
+        "apply",
+        help="Apply the exact reviewed actions to the staging copy and verify it",
+    )
+    add_reviewed_migration_scope(p_reorganize_apply, include_batch_size=True)
+
+    p_reorganize_activate = reorganize_sub.add_parser(
+        "activate",
+        help="Explicitly swap a completed staging palace into the stable active path",
+    )
+    p_reorganize_activate.add_argument(
+        "--palace",
+        dest="reorganize_palace",
+        default=None,
+        help="Stable active palace path",
+    )
+    p_reorganize_activate.add_argument(
+        "--manifest",
+        required=True,
+        help="Previously reviewed owner-only manifest",
+    )
+    p_reorganize_activate.add_argument(
+        "--migrated-root",
+        required=True,
+        help="Completed migrated staging bundle",
+    )
+    p_reorganize_activate.add_argument(
+        "--previous-root",
+        required=True,
+        help="New private slot that will retain the previous active palace",
+    )
+    p_reorganize_activate.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm the explicit activation swap",
+    )
+
+    p_reorganize_rollback = reorganize_sub.add_parser(
+        "rollback",
+        help="Reverse a reviewed activation without deleting either palace",
+    )
+    p_reorganize_rollback.add_argument(
+        "--palace",
+        dest="reorganize_palace",
+        default=None,
+        help="Stable active palace path",
+    )
+    p_reorganize_rollback.add_argument(
+        "--migrated-root",
+        required=True,
+        help="Migrated bundle that will receive the deactivated palace",
+    )
+    p_reorganize_rollback.add_argument(
+        "--previous-root",
+        required=True,
+        help="Retained previous-palace slot from activation",
+    )
+    p_reorganize_rollback.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm the explicit rollback swap",
+    )
+
     p_hallways = sub.add_parser("hallways", help="List entity hallways (associative graph)")
     p_hallways.add_argument("--wing", default=None, help="Filter to one wing")
     p_hallways.add_argument("--limit", type=int, default=50, help="Max hallways to show")
@@ -2417,7 +2650,7 @@ def main():
         return
 
     if args.command == "reorganize":
-        if getattr(args, "reorganize_action", None) != "plan":
+        if not getattr(args, "reorganize_action", None):
             p_reorganize.print_help()
             return
         cmd_reorganize(args)

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -33,6 +33,7 @@ import os
 import sys
 import shlex
 import argparse
+import tempfile
 from pathlib import Path
 
 from .config import MempalaceConfig
@@ -581,6 +582,7 @@ def cmd_mine(args):
         )
 
     from .palace import MineAlreadyRunning, MineValidationError
+    from .source_metadata import LinkedWorktreeRejected
 
     try:
         if args.mode == "convos":
@@ -625,6 +627,9 @@ def cmd_mine(args):
         # palace. Surface the holder identity so the operator knows what
         # to wait for (or stop), and exit non-zero so wrappers like
         # nohup / scripts can detect the contention.
+        print(f"mempalace: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except LinkedWorktreeRejected as exc:
         print(f"mempalace: {exc}", file=sys.stderr)
         sys.exit(1)
     except MineValidationError as exc:
@@ -1065,9 +1070,19 @@ def cmd_reorganize(args):
         )
         sys.exit(1)
 
+    manifest_path = Path(os.path.abspath(os.path.expanduser(args.manifest)))
+    manifest_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temporary_manifest: Path | None = None
     try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{manifest_path.name}.",
+            suffix=".tmp",
+            dir=manifest_path.parent,
+        )
+        os.close(descriptor)
+        temporary_manifest = Path(temporary_name)
         write_manifest(
-            args.manifest,
+            temporary_manifest,
             records,
             actions,
             evidence,
@@ -1076,15 +1091,21 @@ def cmd_reorganize(args):
         )
         after_manifest = palace_snapshot(palace_path)
     except (OSError, RuntimeError, ValueError) as exc:
+        if temporary_manifest is not None:
+            temporary_manifest.unlink(missing_ok=True)
         print(f"  Could not write reorganization manifest: {exc}", file=sys.stderr)
         sys.exit(1)
 
+    assert temporary_manifest is not None
     if before != after_manifest:
+        temporary_manifest.unlink(missing_ok=True)
         print(
-            "  Palace changed before the manifest completed; discard it and retry when mining is idle.",
+            "  Palace changed before the manifest completed; no manifest was published.",
             file=sys.stderr,
         )
         sys.exit(1)
+
+    os.replace(temporary_manifest, manifest_path)
 
     origin_counts = Counter(record.origin for record in records)
     action_counts = Counter(action.action for action in actions)

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1001,6 +1001,112 @@ def cmd_migrate_wings(args):
     )
 
 
+def cmd_reorganize(args):
+    """Build an auditable reorganization manifest without mutating the palace."""
+    import sqlite3
+    from collections import Counter
+
+    from .mcp_jobs import detect_linked_worktree
+    from .reorganize import (
+        collect_duplicate_evidence,
+        inventory_palace,
+        palace_snapshot,
+        plan_actions,
+        write_manifest,
+    )
+    from .repair import sqlite_integrity_errors
+
+    palace_path = (
+        getattr(args, "reorganize_palace", None)
+        or getattr(args, "palace", None)
+        or MempalaceConfig().palace_path
+    )
+    palace_path = os.path.abspath(os.path.expanduser(palace_path))
+    canonical_root = os.path.abspath(os.path.expanduser(args.canonical_root))
+    if not os.path.isdir(canonical_root):
+        print(f"  Canonical root is not a directory: {canonical_root}", file=sys.stderr)
+        sys.exit(1)
+
+    linked, primary_root = detect_linked_worktree(canonical_root)
+    if linked:
+        suffix = f"; primary checkout: {primary_root}" if primary_root else ""
+        print(
+            f"  Refusing linked worktree as canonical root: {canonical_root}{suffix}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    integrity_errors = sqlite_integrity_errors(palace_path)
+    if integrity_errors:
+        print("  SQLite integrity check failed; no manifest was written:", file=sys.stderr)
+        for error in integrity_errors[:5]:
+            print(f"    {error}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        before = palace_snapshot(palace_path)
+        records = inventory_palace(
+            palace_path,
+            canonical_root=canonical_root,
+            worktree_roots=args.worktree_root,
+            session_roots=args.session_root,
+        )
+        actions = plan_actions(records, hot_days=args.hot_days)
+        evidence = collect_duplicate_evidence(records, actions)
+        after_inventory = palace_snapshot(palace_path)
+    except (FileNotFoundError, OSError, RuntimeError, sqlite3.Error, ValueError) as exc:
+        print(f"  Could not build reorganization plan: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if before != after_inventory:
+        print(
+            "  Palace changed while it was being inventoried; retry when mining is idle.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        write_manifest(
+            args.manifest,
+            records,
+            actions,
+            evidence,
+            palace_path=palace_path,
+            sqlite_snapshot=before,
+        )
+        after_manifest = palace_snapshot(palace_path)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"  Could not write reorganization manifest: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if before != after_manifest:
+        print(
+            "  Palace changed before the manifest completed; discard it and retry when mining is idle.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    origin_counts = Counter(record.origin for record in records)
+    action_counts = Counter(action.action for action in actions)
+    tier_counts = Counter(
+        str(action.metadata.get("memory_tier") or "unspecified") for action in actions
+    )
+    print("\n  Reorganization plan")
+    print(f"  Inventory: {len(records):,}")
+    print(f"  Canonical: {origin_counts['canonical']:,}")
+    print(f"  Sessions: {origin_counts['session']:,}")
+    print(f"  Worktree artifacts: {origin_counts['worktree']:,}")
+    print(f"  Verified duplicate candidates: {len(evidence):,}")
+    print(f"  Unique worktree artifacts: {action_counts['preserve_unique']:,}")
+    print(f"  Uncertain worktree artifacts: {action_counts['preserve_uncertain']:,}")
+    print(f"  Unclassified: {origin_counts['unclassified']:,}")
+    print(f"  Hot: {tier_counts['hot']:,}")
+    print(f"  Cold: {tier_counts['cold']:,}")
+    print(f"  Manifest: {os.path.abspath(os.path.expanduser(args.manifest))}")
+    print(f"  SQLite SHA-256: {before['sha256']} (unchanged)")
+    print("  Dry run only — no drawers were changed or deleted.")
+
+
 def cmd_hallways(args):
     """List within-wing entity hallways (the auto-built associative graph)."""
     from .hallways import list_hallways
@@ -2172,6 +2278,50 @@ def main():
     )
     p_migrate_wings.add_argument("--yes", action="store_true", help="Skip the confirmation prompt")
 
+    p_reorganize = sub.add_parser(
+        "reorganize",
+        help="Plan a read-only palace reorganization and write an audit manifest",
+    )
+    reorganize_sub = p_reorganize.add_subparsers(dest="reorganize_action")
+    p_reorganize_plan = reorganize_sub.add_parser(
+        "plan",
+        help="Inventory Chroma SQLite and write a dry-run manifest",
+    )
+    p_reorganize_plan.add_argument(
+        "--palace",
+        dest="reorganize_palace",
+        default=None,
+        help="Palace path (default: global --palace or configured palace)",
+    )
+    p_reorganize_plan.add_argument(
+        "--canonical-root",
+        required=True,
+        help="Primary repository checkout that owns canonical code memories",
+    )
+    p_reorganize_plan.add_argument(
+        "--worktree-root",
+        action="append",
+        default=[],
+        help="Linked worktree source root to classify; repeat for multiple roots",
+    )
+    p_reorganize_plan.add_argument(
+        "--session-root",
+        action="append",
+        default=[],
+        help="Conversation/session source root to classify; repeat for multiple roots",
+    )
+    p_reorganize_plan.add_argument(
+        "--hot-days",
+        type=int,
+        default=90,
+        help="Keep unpinned sessions hot for this many days (default: 90)",
+    )
+    p_reorganize_plan.add_argument(
+        "--manifest",
+        required=True,
+        help="Owner-only JSON manifest output path",
+    )
+
     p_hallways = sub.add_parser("hallways", help="List entity hallways (associative graph)")
     p_hallways.add_argument("--wing", default=None, help="Filter to one wing")
     p_hallways.add_argument("--limit", type=int, default=50, help="Max hallways to show")
@@ -2243,6 +2393,13 @@ def main():
             p_daemon.print_help()
             return
         cmd_daemon(args)
+        return
+
+    if args.command == "reorganize":
+        if getattr(args, "reorganize_action", None) != "plan":
+            p_reorganize.print_help()
+            return
+        cmd_reorganize(args)
         return
 
     dispatch = {

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -649,6 +649,7 @@ def mine_convos(
     limit: int = 0,
     dry_run: bool = False,
     extract_mode: str = "exchange",
+    progress_callback=None,
 ):
     """Mine a directory of conversation files into the palace.
 
@@ -681,6 +682,7 @@ def mine_convos(
             limit=limit,
             dry_run=dry_run,
             extract_mode=extract_mode,
+            progress_callback=progress_callback,
         )
 
     with mine_palace_lock(palace_path):
@@ -692,6 +694,7 @@ def mine_convos(
             limit=limit,
             dry_run=dry_run,
             extract_mode=extract_mode,
+            progress_callback=progress_callback,
         )
 
 
@@ -719,8 +722,10 @@ def _mine_convos_impl(
     limit: int = 0,
     dry_run: bool = False,
     extract_mode: str = "exchange",
+    progress_callback=None,
 ):
     from .config import MempalaceConfig
+    from .progress import ProgressReporter
 
     palace_config = MempalaceConfig()
     cfg_chunk_size = palace_config.chunk_size
@@ -738,7 +743,19 @@ def _mine_convos_impl(
     convo_path = Path(convo_dir).expanduser().resolve()
     wing = _resolve_wing(convo_path, wing)
 
+    reporter = ProgressReporter(progress_callback)
+    reporter.emit(
+        force=True,
+        phase="scanning",
+        files_total=0,
+        files_processed=0,
+        files_changed=0,
+        files_skipped=0,
+        files_failed=0,
+        current_source="",
+    )
     files = scan_convos(convo_dir)
+    reporter.emit(force=True, phase="mining", files_total=len(files))
 
     print(f"\n{'=' * 55}")
     print("  MemPalace Mine — Conversations")
@@ -773,6 +790,12 @@ def _mine_convos_impl(
     for i, filepath in enumerate(files, 1):
         files_processed = i
         source_file = str(filepath)
+        reporter.emit(
+            files_processed=files_processed,
+            files_changed=files_mined,
+            files_skipped=files_skipped,
+            current_source=str(filepath.relative_to(convo_path)),
+        )
 
         # Skip only if already filed at the current NORMALIZE_VERSION AND
         # unchanged on disk since. Transcripts are NOT assumed immutable:
@@ -875,12 +898,22 @@ def _mine_convos_impl(
         if limit > 0 and files_mined >= limit:
             break
 
+    reporter.emit(
+        force=True,
+        phase="post_processing",
+        files_processed=files_processed,
+        files_changed=files_mined,
+        files_skipped=files_skipped,
+    )
     if not dry_run:
         # Compute hallways before the FTS5 validation: the latter opens a direct sqlite
         # connection to the Chroma DB, which can invalidate the live collection handle on
         # some Chroma builds and make the hallway fetch fail.
         _compute_hallways_for_wing_safe(wing, collection, total_drawers)
+        reporter.emit(force=True, phase="verifying")
         _validate_palace_fts5_after_mine(palace_path)
+    else:
+        reporter.emit(force=True, phase="verifying")
 
     print(f"\n{'=' * 55}")
     print("  Done.")
@@ -893,6 +926,13 @@ def _mine_convos_impl(
             print(f"    {room:20} {count} files")
     print('\n  Next: mempalace search "what you\'re looking for"')
     print(f"{'=' * 55}\n")
+    reporter.emit(
+        force=True,
+        phase="verifying",
+        files_processed=files_processed,
+        files_changed=files_mined,
+        files_skipped=files_skipped,
+    )
 
 
 if __name__ == "__main__":

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -22,6 +22,7 @@ from .collision_scan import assert_no_collisions
 from .ids import ID_RECIPE, make_convo_drawer_id, make_convo_sentinel_id
 from .normalize import normalize
 from .entities import entities_metadata
+from .source_metadata import SourceContext, build_source_metadata, sha256_file
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
@@ -107,7 +108,14 @@ def _is_regular_source_file(filepath: Path, root: Path) -> bool:
                 pass
 
 
-def _register_file(collection, source_file: str, wing: str, agent: str, extract_mode: str):
+def _register_file(
+    collection,
+    source_file: str,
+    wing: str,
+    agent: str,
+    extract_mode: str,
+    source_root: str = None,
+):
     """Write a sentinel so file_already_mined() returns True for 0-chunk files.
 
     Without this, files that normalize to nothing or produce zero chunks are
@@ -124,6 +132,13 @@ def _register_file(collection, source_file: str, wing: str, agent: str, extract_
     except OSError:
         source_mtime = None
     sentinel_id = make_convo_sentinel_id(source_file, extract_mode)
+    content = f"[registry] {source_file}"
+    source_context = SourceContext(
+        root=source_root or os.path.dirname(source_file),
+        source_file=source_file,
+        source_kind="session",
+        source_sha256=sha256_file(source_file),
+    )
     meta = {
         "wing": wing,
         "room": "_registry",
@@ -135,10 +150,11 @@ def _register_file(collection, source_file: str, wing: str, agent: str, extract_
         "normalize_version": NORMALIZE_VERSION,
         "id_recipe": ID_RECIPE,
     }
+    meta.update(build_source_metadata(source_context, content, -1))
     if source_mtime is not None:
         meta["source_mtime"] = source_mtime
     collection.upsert(
-        documents=[f"[registry] {source_file}"],
+        documents=[content],
         ids=[sentinel_id],
         metadatas=[meta],
     )
@@ -477,7 +493,15 @@ def _extract_authored_at(filepath):
 
 
 def _file_chunks_locked(
-    collection, source_file, chunks, wing, room, agent, extract_mode, authored_at=None
+    collection,
+    source_file,
+    chunks,
+    wing,
+    room,
+    agent,
+    extract_mode,
+    authored_at=None,
+    source_root=None,
 ):
     """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
@@ -520,6 +544,12 @@ def _file_chunks_locked(
             source_mtime = os.path.getmtime(source_file)
         except OSError:
             source_mtime = None
+        source_context = SourceContext(
+            root=source_root or os.path.dirname(source_file),
+            source_file=source_file,
+            source_kind="session",
+            source_sha256=sha256_file(source_file),
+        )
         for batch_start in range(0, len(chunks), DRAWER_UPSERT_BATCH_SIZE):
             batch_docs: list = []
             batch_ids: list = []
@@ -550,6 +580,9 @@ def _file_chunks_locked(
                 }
                 if source_mtime is not None:
                     meta["source_mtime"] = source_mtime
+                meta.update(
+                    build_source_metadata(source_context, chunk["content"], chunk["chunk_index"])
+                )
                 batch_metas.append(meta)
             assert_no_collisions(list(zip(batch_ids, batch_metas)), collection)
             try:
@@ -818,12 +851,16 @@ def _mine_convos_impl(
             content = normalize(str(filepath))
         except (OSError, ValueError):
             if not dry_run:
-                _register_file(collection, source_file, wing, agent, extract_mode)
+                _register_file(
+                    collection, source_file, wing, agent, extract_mode, source_root=str(convo_path)
+                )
             continue
 
         if not content or len(content.strip()) < cfg_min_chunk_size:
             if not dry_run:
-                _register_file(collection, source_file, wing, agent, extract_mode)
+                _register_file(
+                    collection, source_file, wing, agent, extract_mode, source_root=str(convo_path)
+                )
             continue
 
         # Chunk — either exchange pairs or general extraction
@@ -841,7 +878,9 @@ def _mine_convos_impl(
 
         if not chunks:
             if not dry_run:
-                _register_file(collection, source_file, wing, agent, extract_mode)
+                _register_file(
+                    collection, source_file, wing, agent, extract_mode, source_root=str(convo_path)
+                )
             continue
 
         # Detect room from content (general mode uses memory_type instead)
@@ -885,6 +924,7 @@ def _mine_convos_impl(
             agent,
             extract_mode,
             authored_at=_extract_authored_at(filepath),
+            source_root=str(convo_path),
         )
         if skipped:
             files_skipped += 1

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -216,6 +216,9 @@ class Job:
     result: dict[str, Any] | None
     error: dict[str, Any] | None
     attempts: int
+    updated_at: str | None
+    heartbeat_at: str | None
+    progress: dict[str, Any] | None
 
 
 class QueueStore:
@@ -263,10 +266,17 @@ class QueueStore:
                     finished_at TEXT,
                     result_json TEXT,
                     error_json TEXT,
-                    attempts INTEGER NOT NULL DEFAULT 0
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    updated_at TEXT,
+                    heartbeat_at TEXT,
+                    progress_json TEXT
                 )
                 """
             )
+            present = {str(row[1]) for row in conn.execute("PRAGMA table_info(jobs)")}
+            for name in ("updated_at", "heartbeat_at", "progress_json"):
+                if name not in present:
+                    conn.execute(f"ALTER TABLE jobs ADD COLUMN {name} TEXT")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_state ON jobs(state, priority)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_dedupe ON jobs(dedupe_key, state)")
             # Unique partial index: at most one queued/running job per dedupe_key.
@@ -348,14 +358,14 @@ class QueueStore:
             )
             return int(cur.rowcount or 0)
 
-    def enqueue(
+    def enqueue_with_status(
         self,
         kind: str,
         payload: dict[str, Any],
         *,
         dedupe_key: str | None = None,
         priority: int = 0,
-    ) -> Job:
+    ) -> tuple[Job, bool]:
         payload_json = json.dumps(payload, ensure_ascii=False, sort_keys=True)
         with self._lock, self._connect() as conn:
             if dedupe_key:
@@ -369,17 +379,19 @@ class QueueStore:
                     (dedupe_key,),
                 ).fetchone()
                 if row is not None:
-                    return self._row_to_job(row)
+                    return self._row_to_job(row), True
 
             job_id = uuid.uuid4().hex
+            created_at = _now()
             try:
                 conn.execute(
                     """
                     INSERT INTO jobs (
-                        id, kind, payload_json, state, priority, dedupe_key, created_at, attempts
-                    ) VALUES (?, ?, ?, 'queued', ?, ?, ?, 0)
+                        id, kind, payload_json, state, priority, dedupe_key,
+                        created_at, attempts, updated_at
+                    ) VALUES (?, ?, ?, 'queued', ?, ?, ?, 0, ?)
                     """,
-                    (job_id, kind, payload_json, int(priority), dedupe_key, _now()),
+                    (job_id, kind, payload_json, int(priority), dedupe_key, created_at, created_at),
                 )
             except sqlite3.IntegrityError:
                 # Unique partial index beat us in a cross-process race — return the
@@ -401,15 +413,41 @@ class QueueStore:
                     conn.execute(
                         """
                         INSERT INTO jobs (
-                            id, kind, payload_json, state, priority, dedupe_key, created_at, attempts
-                        ) VALUES (?, ?, ?, 'queued', ?, ?, ?, 0)
+                            id, kind, payload_json, state, priority, dedupe_key,
+                            created_at, attempts, updated_at
+                        ) VALUES (?, ?, ?, 'queued', ?, ?, ?, 0, ?)
                         """,
-                        (job_id, kind, payload_json, int(priority), dedupe_key, _now()),
+                        (
+                            job_id,
+                            kind,
+                            payload_json,
+                            int(priority),
+                            dedupe_key,
+                            created_at,
+                            created_at,
+                        ),
                     )
                     row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
-                return self._row_to_job(row)
+                    return self._row_to_job(row), False
+                return self._row_to_job(row), True
             row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
-            return self._row_to_job(row)
+            return self._row_to_job(row), False
+
+    def enqueue(
+        self,
+        kind: str,
+        payload: dict[str, Any],
+        *,
+        dedupe_key: str | None = None,
+        priority: int = 0,
+    ) -> Job:
+        job, _deduplicated = self.enqueue_with_status(
+            kind,
+            payload,
+            dedupe_key=dedupe_key,
+            priority=priority,
+        )
+        return job
 
     def claim_next(self) -> Job | None:
         # Atomic across processes: the UPDATE only fires if the row is still
@@ -432,10 +470,11 @@ class QueueStore:
             cur = conn.execute(
                 """
                 UPDATE jobs
-                SET state = 'running', started_at = ?, attempts = attempts + 1
+                SET state = 'running', started_at = ?, attempts = attempts + 1,
+                    updated_at = ?, heartbeat_at = ?
                 WHERE id = ? AND state = 'queued'
                 """,
-                (_now(), row["id"]),
+                (_now(), _now(), _now(), row["id"]),
             )
             if cur.rowcount != 1:
                 # Lost the race to another process — nothing to run this iteration.
@@ -463,7 +502,8 @@ class QueueStore:
             conn.execute(
                 f"""
                 UPDATE jobs
-                SET state = ?, finished_at = ?, result_json = ?, error_json = ?
+                SET state = ?, finished_at = ?, result_json = ?, error_json = ?,
+                    updated_at = ?, heartbeat_at = ?
                 {where}
                 """,
                 (
@@ -471,6 +511,8 @@ class QueueStore:
                     _now(),
                     json.dumps(result or {}, ensure_ascii=False),
                     json.dumps(error or {}, ensure_ascii=False) if error else None,
+                    _now(),
+                    _now(),
                     job_id,
                 ),
             )
@@ -484,11 +526,69 @@ class QueueStore:
                 raise DaemonError(f"unknown job id: {job_id}")
             return self._row_to_job(row)
 
-    def list(self, limit: int = 20) -> list[Job]:
+    def update_progress(self, job_id: str, progress: dict[str, Any]) -> Job:
+        now = _now()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE jobs
+                SET progress_json = ?, updated_at = ?, heartbeat_at = ?
+                WHERE id = ?
+                """,
+                (json.dumps(progress, ensure_ascii=False), now, now, job_id),
+            )
+            row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+            if row is None:
+                raise DaemonError(f"unknown job id: {job_id}")
+            return self._row_to_job(row)
+
+    def heartbeat(self, job_id: str) -> Job:
+        now = _now()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                "UPDATE jobs SET heartbeat_at = ?, updated_at = ? WHERE id = ?",
+                (now, now, job_id),
+            )
+            row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+            if row is None:
+                raise DaemonError(f"unknown job id: {job_id}")
+            return self._row_to_job(row)
+
+    def list(
+        self,
+        limit: int = 20,
+        *,
+        state: str | None = None,
+        kind: str | None = None,
+    ) -> list[Job]:
+        clauses = []
+        params: list[Any] = []
+        if state:
+            clauses.append("state = ?")
+            params.append(state)
+        if kind:
+            clauses.append("kind = ?")
+            params.append(kind)
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(max(1, int(limit)))
         with self._lock, self._connect() as conn:
             rows = conn.execute(
-                "SELECT * FROM jobs ORDER BY created_at DESC LIMIT ?",
-                (max(1, int(limit)),),
+                f"SELECT * FROM jobs{where} ORDER BY created_at DESC LIMIT ?",
+                params,
+            ).fetchall()
+            return [self._row_to_job(row) for row in rows]
+
+    def active(self, *, kind: str | None = None) -> list[Job]:
+        clauses = ["state IN ('queued', 'running')"]
+        params: list[Any] = []
+        if kind:
+            clauses.append("kind = ?")
+            params.append(kind)
+        with self._lock, self._connect() as conn:
+            rows = conn.execute(
+                f"SELECT * FROM jobs WHERE {' AND '.join(clauses)} "
+                "ORDER BY priority DESC, created_at ASC",
+                params,
             ).fetchall()
             return [self._row_to_job(row) for row in rows]
 
@@ -520,10 +620,18 @@ class QueueStore:
             result=_loads(row["result_json"]),
             error=_loads(row["error_json"]),
             attempts=int(row["attempts"]),
+            updated_at=row["updated_at"],
+            heartbeat_at=row["heartbeat_at"],
+            progress=_loads(row["progress_json"]),
         )
 
 
-def job_to_dict(job: Job, *, include_payload: bool = True) -> dict[str, Any]:
+def job_to_dict(
+    job: Job,
+    *,
+    include_payload: bool = True,
+    redact_payload: bool = False,
+) -> dict[str, Any]:
     out = {
         "id": job.id,
         "kind": job.kind,
@@ -536,9 +644,20 @@ def job_to_dict(job: Job, *, include_payload: bool = True) -> dict[str, Any]:
         "result": job.result,
         "error": job.error,
         "attempts": job.attempts,
+        "updated_at": job.updated_at,
+        "heartbeat_at": job.heartbeat_at,
+        "progress": job.progress,
     }
     if include_payload:
-        out["payload"] = job.payload
+        payload: Any = job.payload
+        if redact_payload and job.kind == "mcp_tool":
+            payload = {
+                "name": job.payload.get("name"),
+                "arguments": "<redacted>",
+            }
+        elif redact_payload and job.kind not in {"mine", "sync"}:
+            payload = "<redacted>"
+        out["payload"] = payload
     return out
 
 

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -41,6 +41,7 @@ TERMINAL_STATES = {"succeeded", "failed", "cancelled"}
 MAX_ATTEMPTS = 3
 MAX_BODY_BYTES = 1 << 20  # 1 MiB cap on request bodies (auth-gated DoS guard)
 SHUTDOWN_DRAIN_SECONDS = 10.0
+DAEMON_HEARTBEAT_SECONDS = 5.0
 # Terminal jobs are kept for diagnostics then pruned so the queue DB (which
 # holds verbatim payloads) doesn't grow without bound across a long-lived
 # daemon. Override via env for operators who want a longer/shorter window.
@@ -698,6 +699,25 @@ class DaemonRuntime:
         except Exception:  # noqa: BLE001 - a finish failure must not kill the worker
             pass
 
+    def _heartbeat_loop(self, job_id: str, stop: threading.Event) -> None:
+        while not stop.wait(DAEMON_HEARTBEAT_SECONDS):
+            try:
+                self.store.heartbeat(job_id)
+            except Exception:  # noqa: BLE001 - observability cannot kill useful work
+                pass
+
+    @staticmethod
+    def _execute_with_progress(execute_job, kind: str, payload: dict, progress_callback):
+        import inspect
+
+        try:
+            accepts_progress = "progress_callback" in inspect.signature(execute_job).parameters
+        except (TypeError, ValueError):
+            accepts_progress = True
+        if accepts_progress:
+            return execute_job(kind, payload, progress_callback=progress_callback)
+        return execute_job(kind, payload)
+
     def _worker_loop(self) -> None:
         from .service import execute_job
 
@@ -712,6 +732,14 @@ class DaemonRuntime:
                 self.worker_wake.clear()
                 continue
             self.active_job_id = job.id
+            heartbeat_stop = threading.Event()
+            heartbeat_thread = threading.Thread(
+                target=self._heartbeat_loop,
+                args=(job.id, heartbeat_stop),
+                name=f"mempalace-heartbeat-{job.id[:8]}",
+                daemon=True,
+            )
+            heartbeat_thread.start()
             try:
                 payload = dict(job.payload)
                 # Override, never trust the client: an authenticated request for
@@ -719,7 +747,19 @@ class DaemonRuntime:
                 payload["palace_path"] = self.palace_path
                 if self.backend:
                     payload["backend"] = self.backend
-                result = execute_job(job.kind, payload)
+
+                def progress_callback(progress: dict[str, Any]) -> None:
+                    self.store.update_progress(job.id, progress)
+
+                from .palace import mine_palace_lock
+
+                with mine_palace_lock(self.palace_path):
+                    result = self._execute_with_progress(
+                        execute_job,
+                        job.kind,
+                        payload,
+                        progress_callback,
+                    )
                 ok = bool(result.get("success", True))
                 state = "succeeded" if ok else "failed"
                 error = None if ok else {"message": result.get("error", "job failed")}
@@ -738,6 +778,8 @@ class DaemonRuntime:
                     error={"error_class": type(exc).__name__, "message": str(exc)},
                 )
             finally:
+                heartbeat_stop.set()
+                heartbeat_thread.join(timeout=1.0)
                 self.active_job_id = None
 
 

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -903,7 +903,7 @@ def run_server(palace_path: str, *, backend: str | None = None, port: int = 0) -
             if parsed.path == "/jobs":
                 try:
                     body = self._read_json()
-                    job = runtime.store.enqueue(
+                    job, deduplicated = runtime.store.enqueue_with_status(
                         str(body.get("kind") or ""),
                         body.get("payload") or {},
                         dedupe_key=body.get("dedupe_key"),
@@ -913,7 +913,14 @@ def run_server(palace_path: str, *, backend: str | None = None, port: int = 0) -
                 except Exception as exc:  # noqa: BLE001 - client gets structured failure
                     _json_response(self, 400, {"error": str(exc)})
                     return
-                _json_response(self, 202, {"job": job_to_dict(job)})
+                _json_response(
+                    self,
+                    202,
+                    {
+                        "job": job_to_dict(job, redact_payload=True),
+                        "deduplicated": deduplicated,
+                    },
+                )
                 return
             if parsed.path == "/shutdown":
                 _json_response(self, 200, {"ok": True})
@@ -1084,11 +1091,14 @@ class DaemonClient:
         dedupe_key: str | None = None,
         priority: int = 0,
     ) -> dict[str, Any]:
-        return self.request(
+        response = self.request(
             "POST",
             "/jobs",
             {"kind": kind, "payload": payload, "dedupe_key": dedupe_key, "priority": priority},
-        )["job"]
+        )
+        job = response["job"]
+        job["deduplicated"] = bool(response.get("deduplicated", False))
+        return job
 
     def get_job(self, job_id: str) -> dict[str, Any]:
         return self.request("GET", f"/jobs/{job_id}")["job"]

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -747,6 +747,10 @@ class DaemonRuntime:
                 # Override, never trust the client: an authenticated request for
                 # palace A must not be able to retarget the daemon at palace B.
                 payload["palace_path"] = self.palace_path
+                # Stable across crash recovery/retry. Write handlers use this
+                # private key to derive deterministic storage IDs without
+                # exposing queue internals through their public MCP schemas.
+                payload["operation_id"] = job.id
                 if self.backend:
                     payload["backend"] = self.backend
 
@@ -755,7 +759,11 @@ class DaemonRuntime:
 
                 from .palace import mine_palace_lock
 
-                with mine_palace_lock(self.palace_path):
+                # Block briefly behind an in-flight shared vector-read gate.
+                # The durable job is already accepted, so failing it merely
+                # because one search won the transition race would violate the
+                # daemon contract.
+                with mine_palace_lock(self.palace_path, blocking=True):
                     result = self._execute_with_progress(
                         execute_job,
                         job.kind,
@@ -854,12 +862,13 @@ def run_server(palace_path: str, *, backend: str | None = None, port: int = 0) -
         def _handle_get(self):
             parsed = urlparse(self.path)
             if parsed.path == "/health":
+                worker_alive = runtime.worker_alive()
                 _json_response(
                     self,
                     200,
                     {
-                        "ok": True,
-                        "worker_alive": runtime.worker_alive(),
+                        "ok": worker_alive,
+                        "worker_alive": worker_alive,
                         "pid": os.getpid(),
                         "palace_path": runtime.palace_path,
                         "backend": runtime.backend,
@@ -877,7 +886,7 @@ def run_server(palace_path: str, *, backend: str | None = None, port: int = 0) -
                     job_to_dict(job, include_payload=False, include_result=False)
                     for job in runtime.store.list(limit, state=state, kind=kind)
                 ]
-                _json_response(self, 200, {"jobs": jobs})
+                _json_response(self, 200, {"jobs": jobs, "counts": runtime.store.counts()})
                 return
             if parsed.path.startswith("/jobs/"):
                 job_id = parsed.path.rsplit("/", 1)[-1]
@@ -1095,31 +1104,48 @@ class DaemonClient:
         *,
         dedupe_key: str | None = None,
         priority: int = 0,
+        timeout: float = 5.0,
     ) -> dict[str, Any]:
         response = self.request(
             "POST",
             "/jobs",
             {"kind": kind, "payload": payload, "dedupe_key": dedupe_key, "priority": priority},
+            timeout=timeout,
         )
         job = response["job"]
         job["deduplicated"] = bool(response.get("deduplicated", False))
         return job
 
-    def get_job(self, job_id: str) -> dict[str, Any]:
-        return self.request("GET", f"/jobs/{job_id}")["job"]
+    def get_job(self, job_id: str, *, timeout: float = 5.0) -> dict[str, Any]:
+        return self.request("GET", f"/jobs/{job_id}", timeout=timeout)["job"]
 
     def list_jobs(
         self,
         limit: int = 20,
         state: str | None = None,
         kind: str | None = None,
+        timeout: float = 5.0,
     ) -> list[dict[str, Any]]:
+        return self.list_jobs_summary(
+            limit=limit,
+            state=state,
+            kind=kind,
+            timeout=timeout,
+        )["jobs"]
+
+    def list_jobs_summary(
+        self,
+        limit: int = 20,
+        state: str | None = None,
+        kind: str | None = None,
+        timeout: float = 5.0,
+    ) -> dict[str, Any]:
         query: dict[str, Any] = {"limit": int(limit)}
         if state:
             query["state"] = state
         if kind:
             query["kind"] = kind
-        return self.request("GET", f"/jobs?{urlencode(query)}")["jobs"]
+        return self.request("GET", f"/jobs?{urlencode(query)}", timeout=timeout)
 
     def wait(self, job_id: str, *, timeout: float = DEFAULT_WAIT_TIMEOUT) -> dict[str, Any]:
         deadline = time.monotonic() + timeout
@@ -1142,7 +1168,9 @@ def get_client_if_running(palace_path: str, *, health_timeout: float = 5.0) -> D
     # hook for the default 5s before it falls back to the direct path.
     try:
         client = DaemonClient(palace_path)
-        client.health(timeout=health_timeout)
+        health = client.health(timeout=health_timeout)
+        if not health.get("ok") or health.get("worker_alive") is not True:
+            return None
         return client
     except DaemonError:
         return None
@@ -1284,10 +1312,14 @@ def start_daemon(
 
 
 def ensure_client(
-    palace_path: str, *, backend: str | None = None, auto_start: bool = True
+    palace_path: str,
+    *,
+    backend: str | None = None,
+    auto_start: bool = True,
+    health_timeout: float = 5.0,
 ) -> DaemonClient:
     palace_path = canonical_palace_path(palace_path)
-    client = get_client_if_running(palace_path)
+    client = get_client_if_running(palace_path, health_timeout=health_timeout)
     if client is not None:
         return client
     if not auto_start:
@@ -1306,6 +1338,8 @@ def submit_job(
     wait: bool = True,
     auto_start: bool = False,
     timeout: float = DEFAULT_WAIT_TIMEOUT,
+    health_timeout: float = 5.0,
+    request_timeout: float = 5.0,
 ) -> dict[str, Any]:
     # Strictly opt-in: callers that want the daemon auto-started must say so
     # explicitly (the CLI --daemon path passes auto_start=True). The default
@@ -1315,8 +1349,19 @@ def submit_job(
     payload["palace_path"] = resolved_palace  # override, never trust client input
     if backend:
         payload["backend"] = backend
-    client = ensure_client(resolved_palace, backend=backend, auto_start=auto_start)
-    job = client.submit(kind, payload, dedupe_key=dedupe_key, priority=priority)
+    client = ensure_client(
+        resolved_palace,
+        backend=backend,
+        auto_start=auto_start,
+        health_timeout=health_timeout,
+    )
+    job = client.submit(
+        kind,
+        payload,
+        dedupe_key=dedupe_key,
+        priority=priority,
+        timeout=request_timeout,
+    )
     if not wait:
         return job
     return client.wait(job["id"], timeout=timeout)

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Any
 from urllib import error as urlerror
 from urllib import request as urlrequest
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from .config import MempalaceConfig
 
@@ -631,6 +631,7 @@ def job_to_dict(
     job: Job,
     *,
     include_payload: bool = True,
+    include_result: bool = True,
     redact_payload: bool = False,
 ) -> dict[str, Any]:
     out = {
@@ -642,13 +643,14 @@ def job_to_dict(
         "created_at": job.created_at,
         "started_at": job.started_at,
         "finished_at": job.finished_at,
-        "result": job.result,
         "error": job.error,
         "attempts": job.attempts,
         "updated_at": job.updated_at,
         "heartbeat_at": job.heartbeat_at,
         "progress": job.progress,
     }
+    if include_result:
+        out["result"] = job.result
     if include_payload:
         payload: Any = job.payload
         if redact_payload and job.kind == "mcp_tool":
@@ -869,8 +871,11 @@ def run_server(palace_path: str, *, backend: str | None = None, port: int = 0) -
             if parsed.path == "/jobs":
                 qs = parse_qs(parsed.query)
                 limit = int((qs.get("limit") or ["20"])[0])
+                state = (qs.get("state") or [None])[0]
+                kind = (qs.get("kind") or [None])[0]
                 jobs = [
-                    job_to_dict(job, include_payload=False) for job in runtime.store.list(limit)
+                    job_to_dict(job, include_payload=False, include_result=False)
+                    for job in runtime.store.list(limit, state=state, kind=kind)
                 ]
                 _json_response(self, 200, {"jobs": jobs})
                 return
@@ -1103,8 +1108,18 @@ class DaemonClient:
     def get_job(self, job_id: str) -> dict[str, Any]:
         return self.request("GET", f"/jobs/{job_id}")["job"]
 
-    def list_jobs(self, limit: int = 20) -> list[dict[str, Any]]:
-        return self.request("GET", f"/jobs?limit={int(limit)}")["jobs"]
+    def list_jobs(
+        self,
+        limit: int = 20,
+        state: str | None = None,
+        kind: str | None = None,
+    ) -> list[dict[str, Any]]:
+        query: dict[str, Any] = {"limit": int(limit)}
+        if state:
+            query["state"] = state
+        if kind:
+            query["kind"] = kind
+        return self.request("GET", f"/jobs?{urlencode(query)}")["jobs"]
 
     def wait(self, job_id: str, *, timeout: float = DEFAULT_WAIT_TIMEOUT) -> dict[str, Any]:
         deadline = time.monotonic() + timeout

--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -83,6 +83,7 @@ from .palace import (
 # expose these as attributes of this module, breaking the test seams.
 from .config import MempalaceConfig, normalize_wing_name
 from .collision_scan import assert_no_collisions
+from .source_metadata import SourceContext, build_source_metadata, sha256_file
 from .ids import ID_RECIPE, make_drawer_id_from_chunk
 from .miner import (
     _compute_topic_tunnels_for_wing,
@@ -536,7 +537,12 @@ def _print_mine_summary(
 
 
 def _register_skip_sentinel_if_appropriate(
-    collection, source_file: str, wing: str, agent: str, status: ExtractionStatus
+    collection,
+    source_file: str,
+    wing: str,
+    agent: str,
+    status: ExtractionStatus,
+    source_root: str = None,
 ) -> None:
     """Write the ``file_already_mined`` sentinel ONLY when the skip is durable.
 
@@ -548,10 +554,12 @@ def _register_skip_sentinel_if_appropriate(
     """
     if status in _TRANSIENT_MISSING_DEP_STATUSES:
         return
-    _register_file(collection, source_file, wing, agent)
+    _register_file(collection, source_file, wing, agent, source_root=source_root)
 
 
-def _register_file(collection, source_file: str, wing: str, agent: str) -> None:
+def _register_file(
+    collection, source_file: str, wing: str, agent: str, source_root: str = None
+) -> None:
     """Write a sentinel so file_already_mined() returns True for 0-chunk files.
 
     Without this, files that extract to nothing (or hit a SKIP status) get
@@ -559,24 +567,31 @@ def _register_file(collection, source_file: str, wing: str, agent: str) -> None:
     Mirrors the helper of the same name in convo_miner.py.
     """
     sentinel_id = f"sentinel_{wing}_{hashlib.sha256(source_file.encode()).hexdigest()[:24]}"
+    content = "[empty]"
+    source_context = SourceContext(
+        root=source_root or os.path.dirname(source_file),
+        source_file=source_file,
+        source_kind="documentation",
+        source_sha256=sha256_file(source_file),
+    )
+    metadata = {
+        "wing": wing,
+        "room": "documents",
+        "source_file": source_file,
+        "chunk_index": -1,
+        "added_by": agent,
+        "filed_at": datetime.now().isoformat(),
+        "ingest_mode": "extract",
+        "extract_mode": "format",
+        "normalize_version": NORMALIZE_VERSION,
+        "is_sentinel": True,
+    }
+    metadata.update(build_source_metadata(source_context, content, -1))
     try:
         collection.upsert(
-            documents=["[empty]"],
+            documents=[content],
             ids=[sentinel_id],
-            metadatas=[
-                {
-                    "wing": wing,
-                    "room": "documents",
-                    "source_file": source_file,
-                    "chunk_index": -1,
-                    "added_by": agent,
-                    "filed_at": datetime.now().isoformat(),
-                    "ingest_mode": "extract",
-                    "extract_mode": "format",
-                    "normalize_version": NORMALIZE_VERSION,
-                    "is_sentinel": True,
-                }
-            ],
+            metadatas=[metadata],
         )
     except Exception:
         logger.debug("Sentinel write failed for %s", source_file, exc_info=True)
@@ -591,6 +606,7 @@ def _file_chunks_locked(
     agent,
     source_mtime: Optional[float] = None,
     content: Optional[str] = None,
+    source_root: Optional[str] = None,
 ):
     """Lock the source file, purge stale drawers, and upsert fresh chunks.
 
@@ -615,6 +631,12 @@ def _file_chunks_locked(
     # the binary source). Caller may pass ``content`` (full extracted text) for
     # the body-scan branch; if absent, the helper still uses filename + mtime.
     file_content_date = _extract_content_date(source_file, content or "")
+    source_context = SourceContext(
+        root=source_root or os.path.dirname(source_file),
+        source_file=source_file,
+        source_kind="documentation",
+        source_sha256=sha256_file(source_file),
+    )
 
     drawers_added = 0
     with mine_lock(source_file):
@@ -673,6 +695,7 @@ def _file_chunks_locked(
                 entities = _extract_entities_for_metadata(content)
                 if entities:
                     meta["entities"] = entities
+                meta.update(build_source_metadata(source_context, content, chunk["chunk_index"]))
                 batch_docs.append(content)
                 batch_ids.append(drawer_id)
                 batch_metas.append(meta)
@@ -871,7 +894,12 @@ def mine_formats(
                 if status != ExtractionStatus.OK or not text:
                     if not dry_run:
                         _register_skip_sentinel_if_appropriate(
-                            collection, source_file, wing, agent, status
+                            collection,
+                            source_file,
+                            wing,
+                            agent,
+                            status,
+                            source_root=str(format_path),
                         )
                     print(f"  - [{i:4}/{len(files)}] {filepath.name[:50]:50} {status.name}")
                     continue
@@ -888,7 +916,13 @@ def mine_formats(
                 )
                 if not chunks:
                     if not dry_run:
-                        _register_file(collection, source_file, wing, agent)
+                        _register_file(
+                            collection,
+                            source_file,
+                            wing,
+                            agent,
+                            source_root=str(format_path),
+                        )
                     print(f"  - [{i:4}/{len(files)}] {filepath.name[:50]:50} EMPTY_AFTER_CHUNK")
                     continue
 
@@ -915,6 +949,7 @@ def mine_formats(
                     agent,
                     source_mtime=source_mtime,
                     content=text,
+                    source_root=str(format_path),
                 )
                 if skipped:
                     files_skipped += 1

--- a/mempalace/format_miner.py
+++ b/mempalace/format_miner.py
@@ -697,6 +697,7 @@ def mine_formats(
     agent: str = "mempalace",
     limit: int = 0,
     dry_run: bool = False,
+    progress_callback=None,
 ) -> None:
     """Mine a directory of binary office-format files into the palace.
 
@@ -745,6 +746,20 @@ def mine_formats(
     # tests can patch ``mempalace.format_miner.MempalaceConfig`` and
     # ``mempalace.format_miner.chunk_text`` directly. Hoisted as part of the
     # PR #1555 polish PR (Gemini #3).
+
+    from .progress import ProgressReporter
+
+    reporter = ProgressReporter(progress_callback)
+    reporter.emit(
+        force=True,
+        phase="scanning",
+        files_total=0,
+        files_processed=0,
+        files_changed=0,
+        files_skipped=0,
+        files_failed=0,
+        current_source="",
+    )
 
     # Load palace-wide config. Chunk parameters (chunk_size, chunk_overlap,
     # min_chunk_size) are now threaded through chunk_text below, so users
@@ -801,6 +816,7 @@ def mine_formats(
         # ``~/docs`` and relative inputs work consistently. Per PR #1555 review
         # (Copilot #10).
         files = scan_formats(format_path)
+        reporter.emit(force=True, phase="mining", files_total=len(files))
 
         print(f"\n{'=' * 55}")
         print("  MemPalace Mine — Format extraction")
@@ -819,6 +835,13 @@ def mine_formats(
         for i, filepath in enumerate(files, 1):
             files_processed = i
             source_file = str(filepath)
+            reporter.emit(
+                files_processed=files_processed,
+                files_changed=files_mined,
+                files_skipped=files_skipped,
+                files_failed=files_errored,
+                current_source=str(filepath.relative_to(format_path)),
+            )
 
             # Per-file try/except so one bad file can't crash the whole mine.
             # Mirrors miner.py's robustness pattern.
@@ -938,6 +961,14 @@ def mine_formats(
             file=sys.stderr,
         )
     else:
+        reporter.emit(
+            force=True,
+            phase="post_processing",
+            files_processed=files_processed,
+            files_changed=files_mined,
+            files_skipped=files_skipped,
+            files_failed=files_errored,
+        )
         # All files processed without interruption — compute cross-wing topic
         # tunnels linking this wing to others that share confirmed topics.
         # Mirrors the post-loop tunnel block in miner._mine_impl: tunnel-compute
@@ -965,7 +996,10 @@ def mine_formats(
             # exit Done on the --mode extract path that bypasses _mine_impl.
             # Sits outside the per-file try/except in the for-loop body, so
             # caught per-file errors do not mask the integrity result.
+            reporter.emit(force=True, phase="verifying")
             _validate_palace_fts5_after_mine(palace_path)
+        else:
+            reporter.emit(force=True, phase="verifying")
     finally:
         # Hook-spawned mines write a PID file that miner.py's
         # _cleanup_mine_pid_file() clears; we mirror that so format-mode
@@ -987,4 +1021,12 @@ def mine_formats(
         files_errored=files_errored,
         total_drawers=total_drawers,
         status_counts=status_counts,
+    )
+    reporter.emit(
+        force=True,
+        phase="verifying",
+        files_processed=files_processed,
+        files_changed=files_mined,
+        files_skipped=files_skipped,
+        files_failed=files_errored,
     )

--- a/mempalace/mcp_jobs.py
+++ b/mempalace/mcp_jobs.py
@@ -6,12 +6,20 @@ import hashlib
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
-from .daemon import DaemonError, canonical_palace_path, submit_job
+from .daemon import (
+    TERMINAL_STATES,
+    DaemonError,
+    canonical_palace_path,
+    get_client_if_running,
+    submit_job,
+)
 
 DAEMON_WRITES_ENV = "MEMPALACE_MCP_DAEMON_WRITES"
+DAEMON_PROBE_TIMEOUT_SECONDS = 0.2
 
 
 def daemon_writes_enabled() -> bool:
@@ -146,3 +154,105 @@ def submit_mine(palace_path: str, payload: dict[str, Any]) -> dict[str, Any]:
         "wing": request.get("wing"),
         "submitted_at": job.get("created_at"),
     }
+
+
+def _daemon_unavailable(error: Exception | None = None) -> dict[str, Any]:
+    message = str(error) if error is not None else "daemon is not running"
+    return {
+        "success": False,
+        "error": message,
+        "error_class": "DaemonUnavailable",
+        "hint": "Run `mempalace daemon start` and retry.",
+    }
+
+
+def _running_client(palace_path: str | None):
+    return get_client_if_running(
+        canonical_palace_path(palace_path),
+        health_timeout=DAEMON_PROBE_TIMEOUT_SECONDS,
+    )
+
+
+def dispatch_daemon_write(
+    tool_name: str,
+    arguments: dict[str, Any],
+    *,
+    palace_path: str | None = None,
+    fast_wait_ms: int = 250,
+    priority: int = 0,
+) -> dict[str, Any]:
+    """Durably queue an MCP mutation and briefly wait for a fast completion."""
+    client = _running_client(palace_path)
+    if client is None:
+        return _daemon_unavailable()
+
+    try:
+        job = client.submit(
+            "mcp_tool",
+            {"name": tool_name, "arguments": arguments},
+            dedupe_key=None,
+            priority=priority,
+        )
+        current = job
+        deadline = time.monotonic() + max(0, fast_wait_ms) / 1000
+        while time.monotonic() < deadline:
+            current = client.get_job(job["id"])
+            if current.get("state") in TERMINAL_STATES:
+                result = dict(current.get("result") or {})
+                result.setdefault("success", current.get("state") == "succeeded")
+                if current.get("state") != "succeeded" and "error" not in result:
+                    error = current.get("error") or {}
+                    result["error"] = error.get("message") or "daemon write failed"
+                result["job_id"] = job["id"]
+                result["delivery"] = "completed"
+                return result
+            time.sleep(0.02)
+    except DaemonError as exc:
+        return _daemon_unavailable(exc)
+
+    return {
+        "success": True,
+        "accepted": True,
+        "job_id": job["id"],
+        "state": current.get("state", job.get("state", "queued")),
+        "delivery": "durable_queue",
+    }
+
+
+def tool_job_status(job_id: str, *, palace_path: str | None = None) -> dict[str, Any]:
+    client = _running_client(palace_path)
+    if client is None:
+        return _daemon_unavailable()
+    try:
+        return {"success": True, "job": client.get_job(job_id)}
+    except DaemonError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_class": "DaemonJobError",
+        }
+
+
+def tool_list_jobs(
+    limit: int = 20,
+    state: str | None = None,
+    kind: str | None = None,
+    *,
+    palace_path: str | None = None,
+) -> dict[str, Any]:
+    client = _running_client(palace_path)
+    if client is None:
+        return _daemon_unavailable()
+    try:
+        jobs = client.list_jobs(
+            limit=max(1, min(int(limit), 100)),
+            state=state or None,
+            kind=kind or None,
+        )
+        return {"success": True, "jobs": jobs}
+    except (DaemonError, ValueError, TypeError) as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_class": "DaemonJobError",
+        }

--- a/mempalace/mcp_jobs.py
+++ b/mempalace/mcp_jobs.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import subprocess
 import time
-from pathlib import Path
 from typing import Any
 
 from .daemon import (
@@ -17,6 +15,7 @@ from .daemon import (
     get_client_if_running,
     submit_job,
 )
+from .source_metadata import detect_linked_worktree
 
 DAEMON_WRITES_ENV = "MEMPALACE_MCP_DAEMON_WRITES"
 DAEMON_PROBE_TIMEOUT_SECONDS = 0.2
@@ -62,49 +61,6 @@ def mine_dedupe_key(palace_path: str, payload: dict[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _git_output(source: str, *args: str) -> str | None:
-    try:
-        result = subprocess.run(
-            ["git", "-C", source, *args],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=3,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return result.stdout.strip()
-
-
-def _primary_worktree(source: str) -> str | None:
-    listing = _git_output(source, "worktree", "list", "--porcelain")
-    if not listing:
-        return None
-    for line in listing.splitlines():
-        if line.startswith("worktree "):
-            return os.path.realpath(line.removeprefix("worktree ").strip())
-    return None
-
-
-def detect_linked_worktree(source: str) -> tuple[bool, str | None]:
-    source = os.path.realpath(os.path.expanduser(source))
-    git_dir_raw = _git_output(source, "rev-parse", "--absolute-git-dir")
-    common_raw = _git_output(source, "rev-parse", "--path-format=absolute", "--git-common-dir")
-    if not git_dir_raw or not common_raw:
-        return False, None
-
-    git_dir = Path(git_dir_raw).resolve()
-    common_dir = Path(common_raw).resolve()
-    linked_root = common_dir / "worktrees"
-    try:
-        linked = git_dir.is_relative_to(linked_root)
-    except ValueError:
-        linked = False
-    return linked, _primary_worktree(source)
-
-
 def submit_mine(palace_path: str, payload: dict[str, Any]) -> dict[str, Any]:
     request = dict(payload)
     source = os.path.realpath(os.path.expanduser(str(request.get("source") or "")))
@@ -134,6 +90,8 @@ def submit_mine(palace_path: str, payload: dict[str, Any]) -> dict[str, Any]:
             priority=priority,
             wait=False,
             auto_start=False,
+            health_timeout=DAEMON_PROBE_TIMEOUT_SECONDS,
+            request_timeout=DAEMON_PROBE_TIMEOUT_SECONDS,
         )
     except DaemonError as exc:
         return {
@@ -192,11 +150,12 @@ def dispatch_daemon_write(
             {"name": tool_name, "arguments": arguments},
             dedupe_key=None,
             priority=priority,
+            timeout=DAEMON_PROBE_TIMEOUT_SECONDS,
         )
         current = job
         deadline = time.monotonic() + max(0, fast_wait_ms) / 1000
         while time.monotonic() < deadline:
-            current = client.get_job(job["id"])
+            current = client.get_job(job["id"], timeout=DAEMON_PROBE_TIMEOUT_SECONDS)
             if current.get("state") in TERMINAL_STATES:
                 result = dict(current.get("result") or {})
                 result.setdefault("success", current.get("state") == "succeeded")
@@ -224,7 +183,10 @@ def tool_job_status(job_id: str, *, palace_path: str | None = None) -> dict[str,
     if client is None:
         return _daemon_unavailable()
     try:
-        return {"success": True, "job": client.get_job(job_id)}
+        return {
+            "success": True,
+            "job": client.get_job(job_id, timeout=DAEMON_PROBE_TIMEOUT_SECONDS),
+        }
     except DaemonError as exc:
         return {
             "success": False,
@@ -244,12 +206,17 @@ def tool_list_jobs(
     if client is None:
         return _daemon_unavailable()
     try:
-        jobs = client.list_jobs(
+        page = client.list_jobs_summary(
             limit=max(1, min(int(limit), 100)),
             state=state or None,
             kind=kind or None,
+            timeout=DAEMON_PROBE_TIMEOUT_SECONDS,
         )
-        return {"success": True, "jobs": jobs}
+        return {
+            "success": True,
+            "jobs": page.get("jobs", []),
+            "counts": page.get("counts", {}),
+        }
     except (DaemonError, ValueError, TypeError) as exc:
         return {
             "success": False,
@@ -266,7 +233,12 @@ def active_maintenance_job(*, palace_path: str | None = None) -> dict[str, Any] 
     if client is None:
         return None
     try:
-        jobs = client.list_jobs(limit=10, state="running", kind=None)
+        jobs = client.list_jobs(
+            limit=10,
+            state="running",
+            kind=None,
+            timeout=DAEMON_PROBE_TIMEOUT_SECONDS,
+        )
     except DaemonError:
         return None
     return next((job for job in jobs if job.get("kind") in {"mine", "sync"}), None)

--- a/mempalace/mcp_jobs.py
+++ b/mempalace/mcp_jobs.py
@@ -1,0 +1,148 @@
+"""Daemon-backed MCP job submission without palace/backend side effects."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .daemon import DaemonError, canonical_palace_path, submit_job
+
+DAEMON_WRITES_ENV = "MEMPALACE_MCP_DAEMON_WRITES"
+
+
+def daemon_writes_enabled() -> bool:
+    return os.environ.get(DAEMON_WRITES_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _file_sha256(path: str) -> str | None:
+    if not os.path.isfile(path):
+        return None
+    digest = hashlib.sha256()
+    try:
+        with open(path, "rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def mine_dedupe_key(palace_path: str, payload: dict[str, Any]) -> str:
+    normalized = dict(payload)
+    source = os.path.realpath(os.path.expanduser(str(payload.get("source") or "")))
+    normalized["source"] = source
+    normalized.pop("priority", None)
+    normalized["config_sha256"] = _file_sha256(os.path.join(source, "mempalace.yaml"))
+    encoded = json.dumps(
+        {
+            "palace": canonical_palace_path(palace_path),
+            "payload": normalized,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _git_output(source: str, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", source, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _primary_worktree(source: str) -> str | None:
+    listing = _git_output(source, "worktree", "list", "--porcelain")
+    if not listing:
+        return None
+    for line in listing.splitlines():
+        if line.startswith("worktree "):
+            return os.path.realpath(line.removeprefix("worktree ").strip())
+    return None
+
+
+def detect_linked_worktree(source: str) -> tuple[bool, str | None]:
+    source = os.path.realpath(os.path.expanduser(source))
+    git_dir_raw = _git_output(source, "rev-parse", "--absolute-git-dir")
+    common_raw = _git_output(source, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    if not git_dir_raw or not common_raw:
+        return False, None
+
+    git_dir = Path(git_dir_raw).resolve()
+    common_dir = Path(common_raw).resolve()
+    linked_root = common_dir / "worktrees"
+    try:
+        linked = git_dir.is_relative_to(linked_root)
+    except ValueError:
+        linked = False
+    return linked, _primary_worktree(source)
+
+
+def submit_mine(palace_path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    request = dict(payload)
+    source = os.path.realpath(os.path.expanduser(str(request.get("source") or "")))
+    request["source"] = source
+    allow_linked = bool(request.pop("allow_linked_worktree", False))
+    priority = int(request.pop("priority", 0) or 0)
+
+    if request.get("mode", "projects") == "projects":
+        linked, canonical_root = detect_linked_worktree(source)
+        if linked and not allow_linked:
+            return {
+                "success": False,
+                "error": "linked Git worktree mining is disabled; mine the canonical checkout",
+                "error_class": "LinkedWorktreeRejected",
+                "source": source,
+                "canonical_root": canonical_root,
+            }
+        request["source_canonicality"] = "linked-worktree" if linked else "canonical"
+
+    dedupe_key = mine_dedupe_key(palace_path, request)
+    try:
+        job = submit_job(
+            "mine",
+            request,
+            palace_path=palace_path,
+            dedupe_key=dedupe_key,
+            priority=priority,
+            wait=False,
+            auto_start=False,
+        )
+    except DaemonError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_class": "DaemonUnavailable",
+            "hint": "Run `mempalace daemon start` and retry.",
+        }
+
+    return {
+        "success": True,
+        "accepted": True,
+        "job_id": job["id"],
+        "state": job["state"],
+        "deduplicated": bool(job.get("deduplicated", False)),
+        "source": source,
+        "mode": request.get("mode", "projects"),
+        "wing": request.get("wing"),
+        "submitted_at": job.get("created_at"),
+    }

--- a/mempalace/mcp_jobs.py
+++ b/mempalace/mcp_jobs.py
@@ -256,3 +256,17 @@ def tool_list_jobs(
             "error": str(exc),
             "error_class": "DaemonJobError",
         }
+
+
+def active_maintenance_job(*, palace_path: str | None = None) -> dict[str, Any] | None:
+    """Return a running mine/sync summary, without reading queued payloads."""
+    if not daemon_writes_enabled():
+        return None
+    client = _running_client(palace_path)
+    if client is None:
+        return None
+    try:
+        jobs = client.list_jobs(limit=10, state="running", kind=None)
+    except DaemonError:
+        return None
+    return next((job for job in jobs if job.get("kind") in {"mine", "sync"}), None)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -382,6 +382,25 @@ _MCP_ALLOW_PEER_WRITER_ENV = "MEMPALACE_MCP_ALLOW_PEER_WRITER"
 # search can therefore use SQLite/BM25 while a direct operation is blocked.
 _PALACE_READ_LOCK = threading.RLock()
 _JOB_READ_TOOLS = frozenset({"mempalace_job_status", "mempalace_list_jobs"})
+_CHROMA_READ_TOOLS = frozenset(
+    {
+        "mempalace_status",
+        "mempalace_list_wings",
+        "mempalace_list_rooms",
+        "mempalace_get_taxonomy",
+        "mempalace_traverse",
+        "mempalace_find_tunnels",
+        "mempalace_graph_stats",
+        "mempalace_list_tunnels",
+        "mempalace_list_hallways",
+        "mempalace_follow_tunnels",
+        "mempalace_check_duplicate",
+        "mempalace_get_drawer",
+        "mempalace_list_drawers",
+        "mempalace_diary_read",
+        "mempalace_memories_filed_away",
+    }
+)
 _last_active_maintenance_job_id: str | None = None
 
 _MUTATING_TOOLS = frozenset(
@@ -2106,6 +2125,7 @@ def tool_search(
             collection_name=_config.collection_name,
         )
 
+    writer_gate_busy = False
     if active is not None:
         _last_active_maintenance_job_id = active.get("id")
         # The daemon owns the writer lease. Avoid Chroma entirely and use the
@@ -2114,31 +2134,48 @@ def tool_search(
         result = _search(vector_disabled=True)
     else:
         with _PALACE_READ_LOCK:
-            if _last_active_maintenance_job_id is not None:
-                _force_chroma_cache_reset()
-                _last_active_maintenance_job_id = None
-            # Ensure the vector-disabled probe has been run via the safe
-            # sqlite/pickle path before we touch chromadb. Calling _get_client()
-            # here would defeat the fallback — it constructs a PersistentClient
-            # which can segfault on segment load in the #1222 failure mode.
-            _refresh_vector_disabled_flag()
-            result = _search(vector_disabled=_vector_disabled)
-            if _is_transient_index_error(result):
+            from .palace import palace_read_lock
+
+            with palace_read_lock(_config.palace_path) as vector_safe:
+                if not vector_safe:
+                    # A writer won the transition race after the daemon-status
+                    # check. Never open Chroma/HNSW in this branch.
+                    writer_gate_busy = True
+                    active = active_maintenance_job(palace_path=_config.palace_path)
+                    if active is not None:
+                        _last_active_maintenance_job_id = active.get("id")
+                    result = _search(vector_disabled=True)
+                else:
+                    if _last_active_maintenance_job_id is not None:
+                        _force_chroma_cache_reset()
+                        _last_active_maintenance_job_id = None
+                    # Ensure the vector-disabled probe has been run via the safe
+                    # sqlite/pickle path before we touch chromadb. Calling
+                    # _get_client() here would defeat the fallback.
+                    _refresh_vector_disabled_flag()
+                    result = _search(vector_disabled=_vector_disabled)
+            if not writer_gate_busy and _is_transient_index_error(result):
                 # Post-bulk-write HNSW flush window (#1315): drop caches, give
-                # the segment a moment to settle, retry once. Caller never sees
-                # the transient unless the second attempt also fails.
+                # the segment a moment to settle, retry once under a fresh
+                # cross-process read gate.
                 _force_chroma_cache_reset()
                 time.sleep(2)
                 _refresh_vector_disabled_flag()
-                result = _search(vector_disabled=_vector_disabled)
-                if not _is_transient_index_error(result):
-                    result["index_recovered"] = True
+                with palace_read_lock(_config.palace_path) as vector_safe:
+                    if vector_safe:
+                        result = _search(vector_disabled=_vector_disabled)
+                        if not _is_transient_index_error(result):
+                            result["index_recovered"] = True
+                    else:
+                        writer_gate_busy = True
+                        active = active_maintenance_job(palace_path=_config.palace_path)
+                        result = _search(vector_disabled=True)
 
-    if active is not None:
+    if active is not None or writer_gate_busy:
         result.update(
             {
                 "index_state": "updating",
-                "active_job_id": active.get("id"),
+                "active_job_id": active.get("id") if active is not None else None,
                 "retrieval_mode": "bm25_sqlite",
             }
         )
@@ -3559,7 +3596,13 @@ def tool_kg_stats():
 # ==================== AGENT DIARY ====================
 
 
-def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: str = ""):
+def tool_diary_write(
+    agent_name: str,
+    entry: str,
+    topic: str = "general",
+    wing: str = "",
+    _operation_id: str | None = None,
+):
     """
     Write a diary entry for this agent. Entries are timestamped and
     accumulate over time in a diary room.
@@ -3588,10 +3631,46 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
         return _collection_error_or_no_palace()
 
     now = datetime.now()
-    entry_id = (
-        f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S%f')}_"
-        f"{hashlib.sha256(entry.encode()).hexdigest()[:12]}"
-    )
+    content_hash = hashlib.sha256(entry.encode()).hexdigest()[:12]
+    if _operation_id:
+        operation_hash = hashlib.sha256(str(_operation_id).encode()).hexdigest()[:24]
+        entry_id = f"diary_{wing}_job_{operation_hash}_{content_hash}"
+    else:
+        entry_id = f"diary_{wing}_{now.strftime('%Y%m%d_%H%M%S%f')}_{content_hash}"
+
+    chunk_size = _config.chunk_size
+    if len(entry) <= chunk_size:
+        expected_ids = [entry_id]
+    else:
+        expected_ids = [
+            f"{entry_id}_chunk_{index:06d}"
+            for index in range((len(entry) + chunk_size - 1) // chunk_size)
+        ]
+
+    if _operation_id:
+        try:
+            existing = set(col.get(ids=expected_ids, include=[]).get("ids") or [])
+        except Exception as exc:
+            logger.warning("Diary idempotency pre-check failed for %s", entry_id, exc_info=True)
+            return {"success": False, "error": f"diary idempotency check failed: {exc}"}
+        if existing == set(expected_ids):
+            result = {
+                "success": True,
+                "reason": "already_exists",
+                "entry_id": entry_id,
+                "agent": agent_name,
+                "topic": topic,
+                "chunks": len(expected_ids),
+            }
+            if len(expected_ids) > 1:
+                result["chunk_ids"] = expected_ids
+            return result
+        if existing:
+            return {
+                "success": False,
+                "error": "partial diary operation exists; refusing a duplicate retry",
+                "entry_id": entry_id,
+            }
 
     _wal_log(
         "diary_write",
@@ -3618,7 +3697,6 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
             "filed_at": now.isoformat(),
             "date": now.strftime("%Y-%m-%d"),
         }
-        chunk_size = _config.chunk_size
         if len(entry) <= chunk_size:
             col.add(
                 ids=[entry_id],
@@ -3978,7 +4056,7 @@ def tool_reconnect():
         return {"success": False, "error": str(e)}
 
 
-def tool_checkpoint(items, diary=None, dedup_threshold=0.9):
+def tool_checkpoint(items, diary=None, dedup_threshold=0.9, _operation_id: str | None = None):
     """Batch session save in a single call.
 
     Semantic-dedups each item, files the non-duplicates as drawers, then
@@ -4047,6 +4125,7 @@ def tool_checkpoint(items, diary=None, dedup_threshold=0.9):
                     entry=entry,
                     topic=diary.get("topic", "session-checkpoint"),
                     wing=diary.get("wing", ""),
+                    _operation_id=_operation_id,
                 )
     return out
 
@@ -4851,6 +4930,27 @@ def _invoke_direct_tool(tool_name: str, tool_args: dict):
     if daemon_writes_enabled() and tool_name == "mempalace_mine":
         return handler(**tool_args)
     with _PALACE_READ_LOCK:
+        if daemon_writes_enabled() and tool_name in _CHROMA_READ_TOOLS:
+            from .mcp_jobs import active_maintenance_job
+            from .palace import palace_read_lock
+
+            active = active_maintenance_job(palace_path=_config.palace_path)
+            if active is not None:
+                return {
+                    "success": False,
+                    "error": "vector index is updating; retry after maintenance",
+                    "error_class": "IndexUpdating",
+                    "active_job_id": active.get("id"),
+                }
+            with palace_read_lock(_config.palace_path) as vector_safe:
+                if not vector_safe:
+                    return {
+                        "success": False,
+                        "error": "vector index is updating; retry after maintenance",
+                        "error_class": "IndexUpdating",
+                        "active_job_id": None,
+                    }
+                return handler(**tool_args)
         return handler(**tool_args)
 
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1481,6 +1481,25 @@ def _filed_at_in_window(
 # ==================== READ TOOLS ====================
 
 
+def tool_job_status(job_id: str):
+    """Return durable daemon job state and progress without touching the palace."""
+    from .mcp_jobs import tool_job_status as read_job_status
+
+    return read_job_status(job_id, palace_path=_config.palace_path)
+
+
+def tool_list_jobs(limit: int = 20, state: str = None, kind: str = None):
+    """List safe daemon job summaries without payloads or write results."""
+    from .mcp_jobs import tool_list_jobs as read_jobs
+
+    return read_jobs(
+        limit=limit,
+        state=state,
+        kind=kind,
+        palace_path=_config.palace_path,
+    )
+
+
 def _tool_status_via_sqlite() -> dict:
     """Pure-sqlite status reader for the #1222 fallback path.
 
@@ -3984,6 +4003,39 @@ TOOLS = {
         "input_schema": {"type": "object", "properties": {}},
         "handler": tool_status,
     },
+    "mempalace_job_status": {
+        "description": "Get durable daemon job state, progress, and terminal result by ID.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "job_id": {"type": "string", "description": "Daemon job ID."},
+            },
+            "required": ["job_id"],
+        },
+        "handler": tool_job_status,
+    },
+    "mempalace_list_jobs": {
+        "description": "List safe daemon job summaries without queued write payloads.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum jobs to return (1-100). Default: 20.",
+                },
+                "state": {
+                    "type": "string",
+                    "enum": ["queued", "running", "succeeded", "failed", "cancelled"],
+                    "description": "Optional state filter.",
+                },
+                "kind": {
+                    "type": "string",
+                    "description": "Optional job-kind filter, such as mine or mcp_tool.",
+                },
+            },
+        },
+        "handler": tool_list_jobs,
+    },
     "mempalace_list_wings": {
         "description": "List all wings with drawer counts",
         "input_schema": {"type": "object", "properties": {}},
@@ -4689,6 +4741,11 @@ def _mcp_tool_preflight_refusal(req_id, tool_name: str):
     if sqlite_integrity_error is not None:
         return sqlite_integrity_error
 
+    from .mcp_jobs import daemon_writes_enabled
+
+    if daemon_writes_enabled():
+        return None
+
     return _mcp_peer_writer_refusal(req_id, tool_name)
 
 
@@ -4838,7 +4895,18 @@ def handle_request(request):
             if "entry" not in tool_args or tool_args["entry"] is None:
                 tool_args["entry"] = content_val
         try:
-            result = _decorate_mcp_tool_result(tool_name, TOOLS[tool_name]["handler"](**tool_args))
+            from . import mcp_jobs
+            from .service import classify_tool
+
+            if mcp_jobs.daemon_writes_enabled() and classify_tool(tool_name) == "write":
+                result = mcp_jobs.dispatch_daemon_write(
+                    tool_name,
+                    tool_args,
+                    palace_path=_config.palace_path,
+                )
+            else:
+                result = TOOLS[tool_name]["handler"](**tool_args)
+            result = _decorate_mcp_tool_result(tool_name, result)
 
             return {
                 "jsonrpc": "2.0",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2043,14 +2043,40 @@ def tool_search(
     max_distance: float = 1.5,
     min_similarity: float = None,
     context: str = None,
+    wings: list = None,
+    source_kinds: list = None,
+    include_cold: bool = False,
 ):
     global _last_active_maintenance_job_id
 
     limit = max(1, min(limit, _MAX_RESULTS))
     try:
+        if wing and wings:
+            raise ValueError("wing and wings are mutually exclusive")
         wing = _sanitize_optional_name(wing, "wing")
+        if wings is not None and not isinstance(wings, list):
+            raise ValueError("wings must be a list of strings")
+        sanitized_wings = []
+        for value in wings or []:
+            if not isinstance(value, str):
+                raise ValueError("wings must contain non-empty strings")
+            sanitized = _sanitize_optional_name(value, "wing")
+            if sanitized is None:
+                raise ValueError("wings must contain non-empty strings")
+            if sanitized not in sanitized_wings:
+                sanitized_wings.append(sanitized)
         room = _sanitize_optional_name(room, "room")
         source_file = _sanitize_optional_source_file(source_file)
+        if source_kinds is not None and not isinstance(source_kinds, list):
+            raise ValueError("source_kinds must be a list of strings")
+        from .source_metadata import SOURCE_KINDS
+
+        sanitized_source_kinds = []
+        for value in source_kinds or []:
+            if not isinstance(value, str) or value not in SOURCE_KINDS:
+                raise ValueError(f"invalid source_kind: {value!r}")
+            if value not in sanitized_source_kinds:
+                sanitized_source_kinds.append(value)
     except ValueError as e:
         return {"error": str(e)}
     # Backwards compat: accept old name
@@ -2071,6 +2097,9 @@ def tool_search(
             wing=wing,
             room=room,
             source_file=source_file,
+            wings=sanitized_wings,
+            source_kinds=sanitized_source_kinds,
+            include_cold=include_cold,
             n_results=limit,
             max_distance=dist,
             vector_disabled=vector_disabled,
@@ -4336,7 +4365,34 @@ TOOLS = {
                     "maximum": 100,
                 },
                 "wing": {"type": "string", "description": "Filter by wing (optional)"},
+                "wings": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Filter across multiple wings (optional). Mutually exclusive with wing."
+                    ),
+                },
                 "room": {"type": "string", "description": "Filter by room (optional)"},
+                "source_kinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "curated",
+                            "code",
+                            "documentation",
+                            "session",
+                            "worktree-artifact",
+                        ],
+                    },
+                    "description": "Filter by one or more source provenance kinds.",
+                },
+                "include_cold": {
+                    "type": "boolean",
+                    "description": (
+                        "Include cold history. Default false; legacy missing tiers remain hot."
+                    ),
+                },
                 "source_file": {
                     "type": "string",
                     "description": (

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2746,6 +2746,8 @@ def tool_mine(
     limit: int = 0,
     dry_run: bool = False,
     extract: str = "exchange",
+    allow_linked_worktree: bool = False,
+    priority: int = 0,
 ):
     """Mine a directory into the palace — the MCP equivalent of ``mempalace mine``.
 
@@ -2767,7 +2769,9 @@ def tool_mine(
     extract: convos extraction strategy — ``"exchange"`` (default) or
              ``"general"``; ignored by the other modes.
 
-    Runs synchronously and mirrors the :func:`tool_sync` contract: success
+    When ``MEMPALACE_MCP_DAEMON_WRITES`` is enabled, submits a durable daemon
+    job and immediately returns its ID. Otherwise runs synchronously and
+    mirrors the :func:`tool_sync` contract: success
     returns ``{success: True, mode, dry_run, output[, output_truncated]}`` where ``output`` is
     the miner's human-readable summary (captured so it cannot corrupt the
     JSON-RPC stream); failure returns ``{success: False, error[, error_class]}``.
@@ -2792,6 +2796,24 @@ def tool_mine(
     src = os.path.expanduser(source) if source else ""
     if not src or not os.path.isdir(src):
         return {"success": False, "error": f"source directory not found: {source!r}"}
+
+    from . import mcp_jobs
+
+    if mcp_jobs.daemon_writes_enabled():
+        return mcp_jobs.submit_mine(
+            _config.palace_path,
+            {
+                "source": src,
+                "mode": mode,
+                "wing": wing,
+                "agent": agent,
+                "limit": limit,
+                "dry_run": dry_run,
+                "extract": extract,
+                "allow_linked_worktree": allow_linked_worktree,
+                "priority": priority,
+            },
+        )
 
     def _run():
         if mode == "convos":
@@ -4356,10 +4378,10 @@ TOOLS = {
             "Mine a directory into the palace — the MCP equivalent of `mempalace mine`. "
             "mode='projects' (default) ingests code/docs; mode='convos' ingests chat "
             "transcripts; mode='extract' ingests office documents (PDF/DOCX/RTF, requires "
-            "the mempalace[extract] extra). Runs synchronously and returns the miner's "
-            "summary as `output`. The palace write lock is automatic; a concurrent mine "
-            "returns a structured already-running error. Orphan cleanup is separate — use "
-            "mempalace_sync."
+            "the mempalace[extract] extra). With MEMPALACE_MCP_DAEMON_WRITES enabled, "
+            "submits a durable asynchronous job and returns its ID; otherwise it runs "
+            "synchronously. Project mining rejects linked Git worktrees by default to avoid "
+            "duplicate indexing. Orphan cleanup is separate — use mempalace_sync."
         ),
         "input_schema": {
             "type": "object",
@@ -4399,6 +4421,16 @@ TOOLS = {
                         "Convos extraction strategy: exchange (default) or general. "
                         "Ignored by other modes."
                     ),
+                },
+                "allow_linked_worktree": {
+                    "type": "boolean",
+                    "description": (
+                        "Allow projects mode to mine a linked Git worktree. Default: false."
+                    ),
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "Daemon queue priority (higher runs first). Default: 0.",
                 },
             },
             "required": ["source"],

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -377,6 +377,13 @@ _MCP_WRITER_LOCK_FAILED = False
 _MCP_WRITER_LOCK_ERROR = ""
 _MCP_ALLOW_PEER_WRITER_ENV = "MEMPALACE_MCP_ALLOW_PEER_WRITER"
 
+# Serialize direct Chroma/KG operations without serializing the whole HTTP
+# request. Daemon submissions and job reads never take this lock; maintenance
+# search can therefore use SQLite/BM25 while a direct operation is blocked.
+_PALACE_READ_LOCK = threading.RLock()
+_JOB_READ_TOOLS = frozenset({"mempalace_job_status", "mempalace_list_jobs"})
+_last_active_maintenance_job_id: str | None = None
+
 _MUTATING_TOOLS = frozenset(
     {
         "mempalace_kg_add",
@@ -2037,6 +2044,8 @@ def tool_search(
     min_similarity: float = None,
     context: str = None,
 ):
+    global _last_active_maintenance_job_id
+
     limit = max(1, min(limit, _MAX_RESULTS))
     try:
         wing = _sanitize_optional_name(wing, "wing")
@@ -2050,30 +2059,13 @@ def tool_search(
     dist = (1.0 - min_similarity) if min_similarity is not None else max_distance
     # Mitigate system prompt contamination (Issue #333)
     sanitized = sanitize_query(query)
-    # Ensure the vector-disabled probe has been run via the safe
-    # sqlite/pickle path before we touch chromadb. Calling _get_client()
-    # here would defeat the fallback — it constructs a PersistentClient
-    # which can segfault on segment load in the #1222 failure mode.
-    _refresh_vector_disabled_flag()
-    result = search_memories(
-        sanitized["clean_query"],
-        palace_path=_config.palace_path,
-        wing=wing,
-        room=room,
-        source_file=source_file,
-        n_results=limit,
-        max_distance=dist,
-        vector_disabled=_vector_disabled,
-        collection_name=_config.collection_name,
-    )
-    if _is_transient_index_error(result):
-        # Post-bulk-write HNSW flush window (#1315): drop caches, give
-        # the segment a moment to settle, retry once. Caller never sees
-        # the transient unless the second attempt also fails.
-        _force_chroma_cache_reset()
-        time.sleep(2)
-        _refresh_vector_disabled_flag()
-        result = search_memories(
+
+    from .mcp_jobs import active_maintenance_job
+
+    active = active_maintenance_job(palace_path=_config.palace_path)
+
+    def _search(*, vector_disabled: bool):
+        return search_memories(
             sanitized["clean_query"],
             palace_path=_config.palace_path,
             wing=wing,
@@ -2081,12 +2073,47 @@ def tool_search(
             source_file=source_file,
             n_results=limit,
             max_distance=dist,
-            vector_disabled=_vector_disabled,
+            vector_disabled=vector_disabled,
             collection_name=_config.collection_name,
         )
-        if not _is_transient_index_error(result):
-            result["index_recovered"] = True
-    if _vector_disabled:
+
+    if active is not None:
+        _last_active_maintenance_job_id = active.get("id")
+        # The daemon owns the writer lease. Avoid Chroma entirely and use the
+        # read-only SQLite/BM25 path, which observes committed rows without
+        # waiting for the maintenance job or the in-process palace lock.
+        result = _search(vector_disabled=True)
+    else:
+        with _PALACE_READ_LOCK:
+            if _last_active_maintenance_job_id is not None:
+                _force_chroma_cache_reset()
+                _last_active_maintenance_job_id = None
+            # Ensure the vector-disabled probe has been run via the safe
+            # sqlite/pickle path before we touch chromadb. Calling _get_client()
+            # here would defeat the fallback — it constructs a PersistentClient
+            # which can segfault on segment load in the #1222 failure mode.
+            _refresh_vector_disabled_flag()
+            result = _search(vector_disabled=_vector_disabled)
+            if _is_transient_index_error(result):
+                # Post-bulk-write HNSW flush window (#1315): drop caches, give
+                # the segment a moment to settle, retry once. Caller never sees
+                # the transient unless the second attempt also fails.
+                _force_chroma_cache_reset()
+                time.sleep(2)
+                _refresh_vector_disabled_flag()
+                result = _search(vector_disabled=_vector_disabled)
+                if not _is_transient_index_error(result):
+                    result["index_recovered"] = True
+
+    if active is not None:
+        result.update(
+            {
+                "index_state": "updating",
+                "active_job_id": active.get("id"),
+                "retrieval_mode": "bm25_sqlite",
+            }
+        )
+    elif _vector_disabled:
         result["vector_disabled"] = True
         result["vector_disabled_reason"] = _vector_disabled_reason
     # Attach sanitizer metadata for transparency
@@ -4758,6 +4785,19 @@ def _decorate_mcp_tool_result(tool_name: str, result):
     return result
 
 
+def _invoke_direct_tool(tool_name: str, tool_args: dict):
+    """Run a non-queued handler with the narrowest safe palace lock scope."""
+    from .mcp_jobs import daemon_writes_enabled
+
+    handler = TOOLS[tool_name]["handler"]
+    if tool_name in _JOB_READ_TOOLS or tool_name == "mempalace_search":
+        return handler(**tool_args)
+    if daemon_writes_enabled() and tool_name == "mempalace_mine":
+        return handler(**tool_args)
+    with _PALACE_READ_LOCK:
+        return handler(**tool_args)
+
+
 def handle_request(request):
     global _last_request_time
     if not isinstance(request, dict):
@@ -4905,7 +4945,7 @@ def handle_request(request):
                     palace_path=_config.palace_path,
                 )
             else:
-                result = TOOLS[tool_name]["handler"](**tool_args)
+                result = _invoke_direct_tool(tool_name, tool_args)
             result = _decorate_mcp_tool_result(tool_name, result)
 
             return {
@@ -5174,7 +5214,6 @@ def _json_rpc_parse_error(req_id=None):
 # Module-level constants for the HTTP transport.
 # Defined here (not inside main()) so _serve_http() / _build_http_server()
 # can reference them as free names without a NameError.
-_HTTP_REQUEST_LOCK = threading.Lock()
 _HTTP_MAX_REQUEST_BYTES = 16 * 1024 * 1024
 # Host literals that always denote this machine. Used both to decide whether a
 # bind is loopback (skip the network-exposure warning) and to pin the Host
@@ -5380,11 +5419,10 @@ def _build_http_server(host: str, port: int):
                 self._send_json(400, _json_rpc_parse_error())
                 return
 
-            # Preserve the single-process / single-palace-handle behavior that
-            # stdio deployments rely on. HTTP gives us a safer transport, not
-            # concurrent Chroma/HNSW mutation.
-            with _HTTP_REQUEST_LOCK:
-                response = handle_request(request)
+            # Request framing is concurrent. Individual palace operations are
+            # serialized by _PALACE_READ_LOCK; daemon submissions, job reads,
+            # and maintenance-time SQLite/BM25 search bypass that lock.
+            response = handle_request(request)
 
             if response is None:
                 # JSON-RPC notifications intentionally have no response body.
@@ -5527,7 +5565,7 @@ def _run_http_loop() -> None:
     if raw_warmup in _WARMUP_TRUTHY:
 
         def _warmup_with_lock():
-            with _HTTP_REQUEST_LOCK:
+            with _PALACE_READ_LOCK:
                 _maybe_eager_warmup_embedder()
 
         threading.Thread(

--- a/mempalace/migration_bundle.py
+++ b/mempalace/migration_bundle.py
@@ -1,0 +1,1726 @@
+"""Offline, copy-only migration bundle construction for reviewed palace plans."""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import stat
+import sys
+import uuid
+from collections import defaultdict
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+from typing import Any, Iterable
+
+from .daemon import state_dir
+from .palace import mine_palace_lock, palace_read_lock
+from .reorganize import (
+    collect_duplicate_evidence,
+    exact_hash,
+    inventory_palace,
+    palace_semantic_snapshot,
+    palace_snapshot,
+    plan_actions,
+    read_manifest,
+    sha256_file,
+    validate_reviewed_manifest,
+)
+
+_SIDECAR_NAMES = ("config.json", "hallways.json", "tunnels.json")
+_ACTIVATION_SIDECAR_NAMES = ("hallways.json", "tunnels.json")
+_ACTIVATION_REPORT = "activation-report.json"
+
+
+def _expanded(path: os.PathLike[str] | str) -> Path:
+    return Path(path).expanduser().absolute()
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_new_bundle_path(path: Path, source_palace: Path) -> None:
+    if path.exists() or path.is_symlink():
+        raise ValueError(f"migration destination already exists: {path}")
+    source = source_palace.resolve()
+    destination = path.resolve(strict=False)
+    if _is_within(destination, source) or _is_within(source, destination):
+        raise ValueError("migration destination must not overlap the active palace")
+
+
+def _reject_symlinks(root: Path) -> None:
+    if root.is_symlink():
+        raise ValueError(f"migration source must not be a symlink: {root}")
+    for current, directories, files in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        for name in [*directories, *files]:
+            candidate = current_path / name
+            if candidate.is_symlink():
+                raise ValueError(f"migration source contains a symlink: {candidate}")
+
+
+def _make_owner_only(root: Path) -> None:
+    for current, directories, files in os.walk(root):
+        current_path = Path(current)
+        os.chmod(current_path, 0o700)
+        for name in directories:
+            os.chmod(current_path / name, 0o700)
+        for name in files:
+            os.chmod(current_path / name, 0o600)
+
+
+def _copy_bundle_source(source_palace: Path, destination_root: Path) -> None:
+    destination_root.mkdir(mode=0o700, parents=False, exist_ok=False)
+    shutil.copytree(
+        source_palace,
+        destination_root / "palace",
+        copy_function=shutil.copy2,
+        ignore=shutil.ignore_patterns("*-shm"),
+    )
+    source_config_root = source_palace.parent
+    for name in _SIDECAR_NAMES:
+        source = source_config_root / name
+        if source.is_file() and not source.is_symlink():
+            shutil.copy2(source, destination_root / name)
+    daemon_source = state_dir(str(source_palace))
+    if daemon_source.is_dir() and not daemon_source.is_symlink():
+        _reject_symlinks(daemon_source)
+        shutil.copytree(daemon_source, destination_root / "daemon", copy_function=shutil.copy2)
+    _make_owner_only(destination_root)
+
+
+def _temporary_sibling(destination: Path) -> Path:
+    return destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+
+
+def _ensure_bundle_parent(path: Path) -> None:
+    parent = path.parent
+    try:
+        parent.mkdir(mode=0o700, parents=True, exist_ok=False)
+    except FileExistsError:
+        if parent.is_symlink() or not parent.is_dir():
+            raise ValueError(f"migration destination parent is not a directory: {parent}")
+    else:
+        os.chmod(parent, 0o700)
+
+
+def _raise_posix_rename_error(error: int, destination: Path) -> None:
+    if error in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise FileExistsError(error, os.strerror(error), str(destination))
+    raise OSError(error, os.strerror(error), str(destination))
+
+
+def _publish_directory_no_replace(source: Path, destination: Path) -> None:
+    """Atomically rename a directory only when ``destination`` is absent."""
+    if os.name == "nt":
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        move_file = kernel32.MoveFileExW
+        move_file.argtypes = [ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32]
+        move_file.restype = ctypes.c_int
+        if not move_file(str(source), str(destination), 0):
+            error = ctypes.get_last_error()
+            if error in {80, 183}:  # ERROR_FILE_EXISTS / ERROR_ALREADY_EXISTS
+                raise FileExistsError(error, ctypes.FormatError(error), str(destination))
+            raise OSError(error, ctypes.FormatError(error), str(destination))
+        return
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    source_bytes = os.fsencode(source)
+    destination_bytes = os.fsencode(destination)
+    if sys.platform == "darwin":
+        rename_exclusive = libc.renamex_np
+        rename_exclusive.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint]
+        rename_exclusive.restype = ctypes.c_int
+        result = rename_exclusive(source_bytes, destination_bytes, 0x00000004)
+    elif sys.platform.startswith("linux"):
+        try:
+            rename_exclusive = libc.renameat2
+        except AttributeError as exc:
+            raise RuntimeError(
+                "atomic no-replace migration publication is unavailable on this Linux runtime"
+            ) from exc
+        rename_exclusive.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        rename_exclusive.restype = ctypes.c_int
+        result = rename_exclusive(
+            -100,  # AT_FDCWD
+            source_bytes,
+            -100,
+            destination_bytes,
+            0x00000001,  # RENAME_NOREPLACE
+        )
+    else:
+        raise RuntimeError(
+            f"atomic no-replace migration publication is unsupported on {sys.platform}"
+        )
+    if result != 0:
+        _raise_posix_rename_error(ctypes.get_errno(), destination)
+    _fsync_directory(destination.parent)
+
+
+def _validated_source_snapshot(
+    reviewed: dict[str, Any],
+    palace_path: Path,
+    *,
+    label: str,
+    current_snapshot: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Accept exact physical state or version-2 semantic equivalence."""
+    expected_physical = reviewed.get("sqlite_snapshot")
+    if not isinstance(expected_physical, dict):
+        raise ValueError("reviewed manifest is missing its SQLite snapshot")
+    current = current_snapshot or palace_snapshot(palace_path)
+    if current == expected_physical:
+        return current
+
+    expected_semantic = reviewed.get("source_semantic_snapshot")
+    if reviewed.get("version") != 2 or not isinstance(expected_semantic, dict):
+        raise ValueError(f"{label} no longer matches the reviewed manifest snapshot")
+    if palace_semantic_snapshot(palace_path) != expected_semantic:
+        raise ValueError(
+            f"{label} no longer matches the reviewed manifest; semantic state no longer matches"
+        )
+    return current
+
+
+def prepare_migration_copies(
+    *,
+    source_palace: os.PathLike[str] | str,
+    reviewed_manifest: os.PathLike[str] | str,
+    rollback_root: os.PathLike[str] | str,
+    migrated_root: os.PathLike[str] | str,
+    canonical_root: os.PathLike[str] | str,
+    worktree_roots: Iterable[os.PathLike[str] | str],
+    session_roots: Iterable[os.PathLike[str] | str],
+    hot_days: int = 90,
+) -> dict[str, Any]:
+    """Create verified rollback and migrated copies without touching source.
+
+    Both destinations are published by same-filesystem rename only after the
+    active SQLite+WAL snapshot and reviewed manifest have been reconciled. If
+    rollback publishes but staging publication fails, the completed rollback
+    is deliberately retained for explicit cleanup; automatic path deletion
+    cannot safely distinguish a concurrently replaced destination.
+    """
+
+    source = _expanded(source_palace)
+    rollback = _expanded(rollback_root)
+    migrated = _expanded(migrated_root)
+    if rollback == migrated:
+        raise ValueError("rollback and migrated destinations must differ")
+    _validate_new_bundle_path(rollback, source)
+    _validate_new_bundle_path(migrated, source)
+    _ensure_bundle_parent(rollback)
+    _ensure_bundle_parent(migrated)
+
+    reviewed = read_manifest(reviewed_manifest)
+    rollback_tmp = _temporary_sibling(rollback)
+    migrated_tmp = _temporary_sibling(migrated)
+    try:
+        _reject_symlinks(source)
+        with palace_read_lock(str(source)) as acquired:
+            if not acquired:
+                raise RuntimeError("active palace is being written; retry when maintenance is idle")
+            before = palace_snapshot(source)
+            _validated_source_snapshot(
+                reviewed,
+                source,
+                label="active palace",
+                current_snapshot=before,
+            )
+            inventory = inventory_palace(
+                source,
+                canonical_root=canonical_root,
+                worktree_roots=worktree_roots,
+                session_roots=session_roots,
+            )
+            actions = plan_actions(inventory, hot_days=hot_days)
+            evidence = collect_duplicate_evidence(inventory, actions)
+            validate_reviewed_manifest(
+                reviewed,
+                inventory,
+                actions,
+                evidence,
+                palace_path=source,
+                sqlite_snapshot=reviewed["sqlite_snapshot"],
+            )
+            _copy_bundle_source(source, rollback_tmp)
+            after = palace_snapshot(source)
+            if before != after:
+                raise RuntimeError("active palace changed during rollback copy")
+
+        rollback_snapshot = palace_snapshot(rollback_tmp / "palace")
+        if rollback_snapshot != before:
+            raise RuntimeError("rollback copy SQLite+WAL checksum does not match source")
+        shutil.copytree(rollback_tmp, migrated_tmp, copy_function=shutil.copy2)
+        _make_owner_only(migrated_tmp)
+        if palace_snapshot(migrated_tmp / "palace") != before:
+            raise RuntimeError("migrated staging copy does not match rollback source")
+
+        _publish_directory_no_replace(rollback_tmp, rollback)
+        _publish_directory_no_replace(migrated_tmp, migrated)
+        return {
+            "success": True,
+            "source_palace": str(source),
+            "rollback_root": str(rollback),
+            "migrated_root": str(migrated),
+            "snapshot": before,
+            "inventory_total": len(inventory),
+            "duplicate_candidates": len(evidence),
+        }
+    except Exception:
+        shutil.rmtree(rollback_tmp, ignore_errors=True)
+        shutil.rmtree(migrated_tmp, ignore_errors=True)
+        raise
+
+
+def bundle_permissions(root: os.PathLike[str] | str) -> list[tuple[str, int]]:
+    """Return non-private bundle paths for verification/reporting."""
+    bundle = _expanded(root)
+    violations: list[tuple[str, int]] = []
+    for current, directories, files in os.walk(bundle):
+        current_path = Path(current)
+        for candidate in [current_path, *(current_path / name for name in directories)]:
+            mode = stat.S_IMODE(candidate.stat().st_mode)
+            if mode != 0o700:
+                violations.append((str(candidate), mode))
+        for name in files:
+            candidate = current_path / name
+            mode = stat.S_IMODE(candidate.stat().st_mode)
+            if mode != 0o600:
+                violations.append((str(candidate), mode))
+    return violations
+
+
+def _chunk_index(metadata: dict[str, Any]) -> int:
+    value = metadata.get("chunk_index", 0)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def apply_actions_to_collection(
+    collection,
+    inventory,
+    actions,
+    evidence,
+    *,
+    batch_size: int = 250,
+) -> dict[str, int]:
+    """Idempotently update retained metadata and delete evidenced duplicates."""
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    records_by_id = {record.drawer_id: record for record in inventory}
+    actions_by_id = {action.drawer_id: action for action in actions}
+    evidence_ids = {item.worktree_drawer_id for item in evidence}
+    candidate_ids = {
+        action.drawer_id for action in actions if action.action == "duplicate_candidate"
+    }
+    if candidate_ids != evidence_ids:
+        raise ValueError("duplicate candidates and exact evidence do not reconcile")
+    if set(records_by_id) != set(actions_by_id):
+        raise ValueError("inventory and migration actions do not reconcile")
+
+    retained_actions = [
+        action
+        for action in sorted(actions, key=lambda item: item.drawer_id)
+        if action.drawer_id not in candidate_ids
+    ]
+    for start in range(0, len(retained_actions), batch_size):
+        batch = retained_actions[start : start + batch_size]
+        metadatas = []
+        for action in batch:
+            metadata = {key: value for key, value in action.metadata.items() if value is not None}
+            metadata["wing"] = action.destination_wing
+            metadatas.append(metadata)
+        collection.update(
+            ids=[action.drawer_id for action in batch],
+            metadatas=metadatas,
+        )
+
+    ordered_candidates = sorted(candidate_ids)
+    for start in range(0, len(ordered_candidates), batch_size):
+        collection.delete(ids=ordered_candidates[start : start + batch_size])
+
+    return {
+        "records_before": len(records_by_id),
+        "records_updated": len(retained_actions),
+        "records_deleted_as_verified_duplicates": len(candidate_ids),
+        "records_expected_after": len(retained_actions),
+    }
+
+
+def verify_retained_records(collection, inventory, actions, evidence) -> dict[str, int]:
+    """Prove exact retained content and destination metadata after apply."""
+    evidence_ids = {item.worktree_drawer_id for item in evidence}
+    records_by_id = {record.drawer_id: record for record in inventory}
+    expected_ids = sorted(set(records_by_id) - evidence_ids)
+    expected_actions = {action.drawer_id: action for action in actions}
+    observed_ids: set[str] = set()
+    checked = 0
+    for start in range(0, len(expected_ids), 500):
+        batch_ids = expected_ids[start : start + 500]
+        result = collection.get(ids=batch_ids, include=["documents", "metadatas"])
+        documents = result.get("documents") or []
+        metadatas = result.get("metadatas") or []
+        for drawer_id, document, metadata in zip(result.get("ids") or [], documents, metadatas):
+            observed_ids.add(drawer_id)
+            expected_record = records_by_id[drawer_id]
+            expected_action = expected_actions[drawer_id]
+            if exact_hash(document or "") != exact_hash(expected_record.content):
+                raise RuntimeError(f"retained content hash mismatch: {drawer_id}")
+            metadata = metadata or {}
+            if metadata.get("wing") != expected_action.destination_wing:
+                raise RuntimeError(f"destination wing mismatch: {drawer_id}")
+            for key in ("memory_tier", "source_kind", "source_canonicality"):
+                expected_value = expected_action.metadata.get(key)
+                if expected_value is not None and metadata.get(key) != expected_value:
+                    raise RuntimeError(f"retained metadata mismatch for {drawer_id}: {key}")
+            checked += 1
+    missing = set(expected_ids) - observed_ids
+    if missing:
+        raise RuntimeError(f"retained drawers missing after migration: {len(missing)}")
+    if collection.count() != len(expected_ids):
+        raise RuntimeError("migrated collection contains unexpected drawer IDs")
+
+    for start in range(0, len(evidence_ids), 500):
+        candidate_batch = sorted(evidence_ids)[start : start + 500]
+        remaining = collection.get(ids=candidate_batch, include=[]).get("ids") or []
+        if remaining:
+            raise RuntimeError(
+                f"verified duplicate drawers remain after migration: {len(remaining)}"
+            )
+    return {
+        "retained_records_verified": checked,
+        "verified_duplicates_absent": len(evidence_ids),
+    }
+
+
+def rebuild_closets_for_retained_records(
+    *,
+    backend,
+    palace_path: str,
+    inventory,
+    actions,
+    evidence,
+) -> int:
+    """Rebuild the derived regex closet index from retained verbatim drawers."""
+    from .palace import build_closet_lines, get_closets_collection, upsert_closet_lines
+
+    evidence_ids = {item.worktree_drawer_id for item in evidence}
+    actions_by_id = {action.drawer_id: action for action in actions}
+    groups: dict[tuple[str, str, str], list[Any]] = defaultdict(list)
+    for record in inventory:
+        if record.drawer_id in evidence_ids:
+            continue
+        action = actions_by_id[record.drawer_id]
+        room = str(action.metadata.get("room") or "general")
+        source_file = str(action.metadata.get("source_file") or f"drawer:{record.drawer_id}")
+        groups[(source_file, action.destination_wing, room)].append(record)
+
+    try:
+        backend.delete_collection(palace_path, "mempalace_closets")
+    except Exception:
+        pass
+    closets = get_closets_collection(palace_path, create=True)
+    written = 0
+    for (source_file, wing, room), records in sorted(groups.items()):
+        ordered = sorted(
+            records,
+            key=lambda record: (_chunk_index(record.metadata), record.drawer_id),
+        )
+        drawer_ids = [record.drawer_id for record in ordered]
+        content = "\n".join(record.content for record in ordered)
+        drawer_metas = [
+            {**actions_by_id[record.drawer_id].metadata, "wing": wing} for record in ordered
+        ]
+        lines = build_closet_lines(
+            source_file,
+            drawer_ids,
+            content,
+            wing,
+            room,
+            drawer_metas=drawer_metas,
+        )
+        identity = f"{wing}\0{room}\0{source_file}".encode("utf-8", errors="surrogatepass")
+        closet_id_base = f"closet_{wing}_{room}_{hashlib.sha256(identity).hexdigest()[:24]}"
+        written += upsert_closet_lines(
+            closets,
+            closet_id_base,
+            lines,
+            {
+                "wing": wing,
+                "room": room,
+                "source_file": source_file,
+                "drawer_count": len(drawer_ids),
+                "memory_tier": drawer_metas[0].get("memory_tier", "hot"),
+            },
+        )
+    return written
+
+
+def _optional_collection(backend, palace_path: str, collection_name: str):
+    from .backends.base import CollectionNotInitializedError
+
+    try:
+        return backend.get_collection(
+            palace_path,
+            collection_name=collection_name,
+            create=False,
+        )
+    except CollectionNotInitializedError:
+        return None
+
+
+def _result_values(result, name: str):
+    value = getattr(result, name, None)
+    if value is None and hasattr(result, "get"):
+        value = result.get(name)
+    return [] if value is None else list(value)
+
+
+def _read_available_embeddings(collection, drawer_ids: list[str]) -> dict[str, list[float]]:
+    if not drawer_ids:
+        return {}
+    try:
+        result = collection.get(ids=drawer_ids, include=["embeddings"])
+        observed = dict(
+            zip(
+                _result_values(result, "ids"),
+                _result_values(result, "embeddings"),
+            )
+        )
+    except Exception:
+        if len(drawer_ids) == 1:
+            return {}
+        midpoint = len(drawer_ids) // 2
+        return {
+            **_read_available_embeddings(collection, drawer_ids[:midpoint]),
+            **_read_available_embeddings(collection, drawer_ids[midpoint:]),
+        }
+    missing = [drawer_id for drawer_id in drawer_ids if drawer_id not in observed]
+    if missing and len(missing) < len(drawer_ids):
+        observed.update(_read_available_embeddings(collection, missing))
+    return observed
+
+
+def rebuild_drawers_vector_index(
+    *,
+    backend,
+    palace_path: str,
+    inventory,
+    actions,
+    evidence,
+    batch_size: int,
+) -> tuple[Any, int]:
+    """Rebuild retained drawers into a fresh HNSW collection without re-embedding."""
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    collection_name = "mempalace_drawers"
+    temporary_name = f"{collection_name}__migration_tmp"
+    records_by_id = {record.drawer_id: record for record in inventory}
+    actions_by_id = {action.drawer_id: action for action in actions}
+    removed_ids = {item.worktree_drawer_id for item in evidence}
+    retained_ids = sorted(set(records_by_id) - removed_ids)
+
+    original = _optional_collection(backend, palace_path, collection_name)
+    temporary = _optional_collection(backend, palace_path, temporary_name)
+    reembedded = 0
+    if original is not None:
+        if temporary is not None:
+            backend.delete_collection(palace_path, temporary_name)
+        metric = getattr(original, "distance_metric", "cosine")
+        identity = original.get_stored_embedder_identity()
+        temporary = backend.create_collection(
+            palace_path,
+            temporary_name,
+            hnsw_space=metric,
+        )
+        for start in range(0, len(retained_ids), batch_size):
+            batch_ids = retained_ids[start : start + batch_size]
+            embeddings_by_id = _read_available_embeddings(original, batch_ids)
+
+            def metadata_for(drawer_id: str) -> dict[str, Any]:
+                action = actions_by_id[drawer_id]
+                metadata = {
+                    key: value for key, value in action.metadata.items() if value is not None
+                }
+                metadata["wing"] = action.destination_wing
+                return metadata
+
+            reusable_ids = [drawer_id for drawer_id in batch_ids if drawer_id in embeddings_by_id]
+            if reusable_ids:
+                temporary.upsert(
+                    ids=reusable_ids,
+                    documents=[records_by_id[drawer_id].content for drawer_id in reusable_ids],
+                    metadatas=[metadata_for(drawer_id) for drawer_id in reusable_ids],
+                    embeddings=[embeddings_by_id[drawer_id] for drawer_id in reusable_ids],
+                )
+            missing_ids = [
+                drawer_id for drawer_id in batch_ids if drawer_id not in embeddings_by_id
+            ]
+            if missing_ids:
+                temporary.upsert(
+                    ids=missing_ids,
+                    documents=[records_by_id[drawer_id].content for drawer_id in missing_ids],
+                    metadatas=[metadata_for(drawer_id) for drawer_id in missing_ids],
+                )
+                reembedded += len(missing_ids)
+        if identity is not None:
+            temporary.set_embedder_identity(identity)
+        verify_retained_records(temporary, inventory, actions, evidence)
+    elif temporary is None:
+        raise RuntimeError(
+            "drawer vector rebuild has neither a live nor recoverable temporary collection"
+        )
+    else:
+        verify_retained_records(temporary, inventory, actions, evidence)
+
+    if original is not None:
+        backend.delete_collection(palace_path, collection_name)
+    raw_collection = getattr(temporary, "_collection", None)
+    if raw_collection is None or not hasattr(raw_collection, "modify"):
+        raise RuntimeError("Chroma collection rename is unavailable for vector rebuild")
+    raw_collection.modify(name=collection_name)
+    backend.close_palace(palace_path)
+
+    rebuilt = _optional_collection(backend, palace_path, collection_name)
+    if rebuilt is None:
+        raise RuntimeError("rebuilt drawer collection was not published")
+    verify_retained_records(rebuilt, inventory, actions, evidence)
+    if _optional_collection(backend, palace_path, temporary_name) is not None:
+        raise RuntimeError("temporary drawer collection still exists after vector rebuild")
+    return rebuilt, reembedded
+
+
+def _write_private_json(path: Path, payload: dict[str, Any]) -> None:
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = -1
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_atomic_private_json(path: Path, payload: dict[str, Any]) -> None:
+    temporary = _temporary_sibling(path)
+    try:
+        _write_private_json(temporary, payload)
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _replace_and_sync(source: Path, destination: Path) -> None:
+    os.replace(source, destination)
+    _fsync_directory(destination.parent)
+    if source.parent != destination.parent:
+        _fsync_directory(source.parent)
+
+
+def _configure_migrated_bundle(bundle_root: Path) -> None:
+    config_path = bundle_root / "config.json"
+    config: dict[str, Any] = {}
+    if config_path.is_file() and not config_path.is_symlink():
+        with config_path.open("r", encoding="utf-8") as handle:
+            loaded = json.load(handle)
+        if isinstance(loaded, dict):
+            config = loaded
+    config["palace_path"] = str(bundle_root / "palace")
+    config["backend"] = "chroma"
+    _write_private_json(config_path, config)
+
+
+def _sqlite_integrity_errors(palace_path: Path) -> list[str]:
+    sqlite_path = palace_path / "chroma.sqlite3"
+    uri = f"file:{sqlite_path.as_posix()}?mode=ro"
+    with sqlite3.connect(uri, uri=True) as connection:
+        rows = connection.execute("PRAGMA integrity_check").fetchall()
+    return [str(row[0]) for row in rows if str(row[0]).lower() != "ok"]
+
+
+def prune_orphan_hnsw_directories(palace_path: os.PathLike[str] | str) -> int:
+    """Remove UUID segment directories no longer referenced by Chroma SQLite."""
+    palace = _expanded(palace_path)
+    sqlite_path = palace / "chroma.sqlite3"
+    with sqlite3.connect(f"file:{sqlite_path.as_posix()}?mode=ro", uri=True) as connection:
+        live_segment_ids = {str(row[0]) for row in connection.execute("SELECT id FROM segments")}
+
+    removed = 0
+    for child in palace.iterdir():
+        if child.is_symlink() or not child.is_dir() or child.name in live_segment_ids:
+            continue
+        try:
+            parsed = uuid.UUID(child.name)
+        except ValueError:
+            continue
+        if str(parsed) != child.name.lower() or not (child / "index_metadata.pickle").is_file():
+            continue
+        shutil.rmtree(child)
+        removed += 1
+    return removed
+
+
+def _artifact_snapshot(path: Path) -> dict[str, int | str]:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"migration artifact must be a regular file: {path}")
+    stat_result = path.stat()
+    return {
+        "size": stat_result.st_size,
+        "sha256": sha256_file(path),
+    }
+
+
+def drawer_logical_snapshot(palace_path: os.PathLike[str] | str) -> dict[str, int | str]:
+    """Hash stable drawer content and metadata, independent of Chroma bookkeeping."""
+    palace = _expanded(palace_path)
+    records = inventory_palace(
+        palace,
+        canonical_root=palace,
+        worktree_roots=[],
+        session_roots=[],
+    )
+    digest = hashlib.sha256()
+    for record in records:
+        row = json.dumps(
+            [record.drawer_id, exact_hash(record.content), record.metadata],
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8", errors="surrogatepass")
+        digest.update(len(row).to_bytes(8, "big"))
+        digest.update(row)
+    return {"count": len(records), "sha256": digest.hexdigest()}
+
+
+def _derived_sidecar_snapshots(bundle_root: Path) -> dict[str, dict[str, int | str]]:
+    return {
+        name: _artifact_snapshot(bundle_root / name)
+        for name in _ACTIVATION_SIDECAR_NAMES
+        if (bundle_root / name).exists()
+    }
+
+
+def _rebuild_graph_sidecars(bundle_root: Path, collection, wings: list[str]) -> dict[str, int]:
+    from .hallways import compute_hallways_for_wing, list_hallways
+    from .palace_graph import entity_tunnels_for_wing
+
+    hallway_path = bundle_root / "hallways.json"
+    tunnel_path = bundle_root / "tunnels.json"
+    hallway_path.unlink(missing_ok=True)
+    tunnel_path.unlink(missing_ok=True)
+    previous = os.environ.get("MEMPALACE_PALACE_PATH")
+    os.environ["MEMPALACE_PALACE_PATH"] = str(bundle_root / "palace")
+    try:
+        hallways_created = 0
+        for wing in wings:
+            hallways_created += len(compute_hallways_for_wing(wing, col=collection))
+        hallways = list_hallways()
+        tunnels_created = 0
+        for wing in wings:
+            tunnels_created += len(entity_tunnels_for_wing(wing, hallways))
+    finally:
+        if previous is None:
+            os.environ.pop("MEMPALACE_PALACE_PATH", None)
+        else:
+            os.environ["MEMPALACE_PALACE_PATH"] = previous
+    return {
+        "hallways_created": hallways_created,
+        "entity_tunnels_created": tunnels_created,
+    }
+
+
+def apply_reviewed_migration(
+    *,
+    source_palace: os.PathLike[str] | str,
+    reviewed_manifest: os.PathLike[str] | str,
+    rollback_root: os.PathLike[str] | str,
+    migrated_root: os.PathLike[str] | str,
+    canonical_root: os.PathLike[str] | str,
+    worktree_roots: Iterable[os.PathLike[str] | str],
+    session_roots: Iterable[os.PathLike[str] | str],
+    hot_days: int = 90,
+    batch_size: int = 250,
+) -> dict[str, Any]:
+    """Apply a reviewed plan to the migrated copy and verify it end-to-end."""
+    source = _expanded(source_palace)
+    rollback = _expanded(rollback_root)
+    migrated = _expanded(migrated_root)
+    rollback_palace = rollback / "palace"
+    migrated_palace = migrated / "palace"
+    if not rollback_palace.is_dir() or not migrated_palace.is_dir():
+        raise ValueError("rollback and migrated bundle copies must already exist")
+    reviewed = read_manifest(reviewed_manifest)
+    reviewed_snapshot = reviewed.get("sqlite_snapshot")
+    if not isinstance(reviewed_snapshot, dict):
+        raise ValueError("reviewed manifest is missing its SQLite snapshot")
+    _validated_source_snapshot(reviewed, rollback_palace, label="rollback copy")
+
+    inventory = inventory_palace(
+        rollback_palace,
+        canonical_root=canonical_root,
+        worktree_roots=worktree_roots,
+        session_roots=session_roots,
+    )
+    actions = plan_actions(inventory, hot_days=hot_days)
+    evidence = collect_duplicate_evidence(inventory, actions)
+    validate_reviewed_manifest(
+        reviewed,
+        inventory,
+        actions,
+        evidence,
+        palace_path=source,
+        sqlite_snapshot=reviewed_snapshot,
+    )
+
+    from .palace import get_backend_for_palace, get_collection
+
+    _configure_migrated_bundle(migrated)
+    backend = get_backend_for_palace(str(migrated_palace), explicit="chroma")
+    collection, vectors_reembedded = rebuild_drawers_vector_index(
+        backend=backend,
+        palace_path=str(migrated_palace),
+        inventory=inventory,
+        actions=actions,
+        evidence=evidence,
+        batch_size=batch_size,
+    )
+    duplicate_count = len(evidence)
+    apply_counts = {
+        "records_before": len(inventory),
+        "records_updated": len(inventory) - duplicate_count,
+        "records_deleted_as_verified_duplicates": duplicate_count,
+        "records_expected_after": len(inventory) - duplicate_count,
+    }
+    verification = verify_retained_records(collection, inventory, actions, evidence)
+
+    closets_written = rebuild_closets_for_retained_records(
+        backend=backend,
+        palace_path=str(migrated_palace),
+        inventory=inventory,
+        actions=actions,
+        evidence=evidence,
+    )
+    graph_counts = _rebuild_graph_sidecars(
+        migrated,
+        collection,
+        sorted(
+            {
+                action.destination_wing
+                for action in actions
+                if action.drawer_id not in {item.worktree_drawer_id for item in evidence}
+            }
+        ),
+    )
+    backend.close_palace(str(migrated_palace))
+    orphan_hnsw_removed = prune_orphan_hnsw_directories(migrated_palace)
+
+    integrity_errors = _sqlite_integrity_errors(migrated_palace)
+    if integrity_errors:
+        raise RuntimeError(f"migrated SQLite integrity_check failed: {integrity_errors[:3]}")
+    from .service import _verify_chroma_readiness
+
+    drawer_readiness = _verify_chroma_readiness(
+        str(migrated_palace),
+        "mempalace_drawers",
+    )
+    closet_readiness = _verify_chroma_readiness(
+        str(migrated_palace),
+        "mempalace_closets",
+    )
+    if not drawer_readiness.get("ready") or not closet_readiness.get("ready"):
+        raise RuntimeError("migrated vector collections did not pass persisted readiness checks")
+
+    collection = get_collection(
+        str(migrated_palace),
+        collection_name="mempalace_drawers",
+        create=False,
+        backend="chroma",
+    )
+    verification = verify_retained_records(collection, inventory, actions, evidence)
+    get_backend_for_palace(str(migrated_palace), explicit="chroma").close_palace(
+        str(migrated_palace)
+    )
+
+    cold_preserved = sum(
+        1
+        for action in actions
+        if action.drawer_id not in {item.worktree_drawer_id for item in evidence}
+        and action.metadata.get("memory_tier") == "cold"
+    )
+    report = {
+        "version": 1,
+        "status": "complete",
+        "source_palace_sha256": hashlib.sha256(str(source).encode()).hexdigest(),
+        "reviewed_manifest_sha256": hashlib.sha256(
+            Path(reviewed_manifest).expanduser().read_bytes()
+        ).hexdigest(),
+        **apply_counts,
+        **verification,
+        "records_preserved_cold": cold_preserved,
+        "records_preserved_unclassified": sum(
+            1 for action in actions if action.action == "preserve_unclassified"
+        ),
+        "closets_rebuilt": closets_written,
+        "drawer_vectors_reused": len(inventory) - duplicate_count - vectors_reembedded,
+        "drawer_vectors_reembedded": vectors_reembedded,
+        "orphan_hnsw_directories_removed": orphan_hnsw_removed,
+        **graph_counts,
+        "sqlite_integrity": "ok",
+        "drawer_vector_readiness": drawer_readiness,
+        "closet_vector_readiness": closet_readiness,
+        "derived_sidecars": _derived_sidecar_snapshots(migrated),
+        "migrated_logical_snapshot": drawer_logical_snapshot(migrated_palace),
+        "migrated_semantic_snapshot": palace_semantic_snapshot(migrated_palace),
+        "migrated_snapshot": palace_snapshot(migrated_palace),
+    }
+    _write_private_json(migrated / "apply-report.json", report)
+    _make_owner_only(migrated)
+    return report
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    if path.is_symlink():
+        raise ValueError(f"{label} must not be a symlink: {path}")
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read {label}: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must contain a JSON object")
+    return payload
+
+
+def _require_real_directory(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise ValueError(f"{label} must not be a symlink: {path}")
+    if not path.is_dir():
+        raise ValueError(f"{label} is not a directory: {path}")
+
+
+def _paths_overlap(left: Path, right: Path) -> bool:
+    resolved_left = left.resolve(strict=False)
+    resolved_right = right.resolve(strict=False)
+    return _is_within(resolved_left, resolved_right) or _is_within(resolved_right, resolved_left)
+
+
+def _validate_activation_paths(
+    *,
+    active_palace: Path,
+    migrated_root: Path,
+    previous_root: Path,
+) -> Path:
+    staged_palace = migrated_root / "palace"
+    _require_real_directory(active_palace, label="active palace")
+    _require_real_directory(migrated_root, label="migrated bundle")
+    _require_real_directory(staged_palace, label="migrated palace")
+    if previous_root.exists() or previous_root.is_symlink():
+        raise ValueError(f"previous activation slot already exists: {previous_root}")
+    for left, right in (
+        (active_palace, migrated_root),
+        (active_palace, previous_root),
+        (migrated_root, previous_root),
+    ):
+        if _paths_overlap(left, right):
+            raise ValueError("activation paths must not overlap")
+
+    previous_root.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    devices = {
+        active_palace.parent.stat().st_dev,
+        migrated_root.stat().st_dev,
+        previous_root.parent.stat().st_dev,
+    }
+    if len(devices) != 1:
+        raise ValueError("activation paths must be on the same filesystem")
+    return staged_palace
+
+
+def _validate_reviewed_activation(
+    *,
+    active_palace: Path,
+    reviewed_manifest: os.PathLike[str] | str,
+    migrated_root: Path,
+    staged_palace: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    reviewed = read_manifest(reviewed_manifest)
+    expected_path_hash = exact_hash(str(active_palace.resolve()))
+    if reviewed.get("palace_path_sha256") != expected_path_hash:
+        raise ValueError("reviewed manifest belongs to a different active palace")
+    reviewed_snapshot = reviewed.get("sqlite_snapshot")
+    if not isinstance(reviewed_snapshot, dict):
+        raise ValueError("reviewed manifest is missing its SQLite snapshot")
+    active_snapshot = _validated_source_snapshot(
+        reviewed,
+        active_palace,
+        label="active palace",
+    )
+
+    apply_report = _read_json_object(
+        migrated_root / "apply-report.json",
+        label="migration apply report",
+    )
+    if apply_report.get("version") != 1 or apply_report.get("status") != "complete":
+        raise ValueError("migrated bundle does not have a completed apply report")
+    manifest_digest = sha256_file(reviewed_manifest)
+    if apply_report.get("reviewed_manifest_sha256") != manifest_digest:
+        raise ValueError("migration apply report belongs to a different reviewed manifest")
+    if apply_report.get("source_palace_sha256") != expected_path_hash:
+        raise ValueError("migration apply report belongs to a different source palace")
+    if apply_report.get("sqlite_integrity") != "ok":
+        raise ValueError("migration apply report does not attest SQLite integrity")
+    if not (apply_report.get("drawer_vector_readiness") or {}).get("ready"):
+        raise ValueError("migration apply report does not attest drawer vector readiness")
+    if not (apply_report.get("closet_vector_readiness") or {}).get("ready"):
+        raise ValueError("migration apply report does not attest closet vector readiness")
+    counts = reviewed.get("counts") or {}
+    inventory_total = counts.get("inventory_total")
+    duplicate_total = counts.get("verified_duplicate_candidates")
+    if not isinstance(inventory_total, int) or not isinstance(duplicate_total, int):
+        raise ValueError("reviewed manifest is missing migration counts")
+    expected_after = inventory_total - duplicate_total
+    expected_report_counts = {
+        "records_before": inventory_total,
+        "records_expected_after": expected_after,
+        "records_deleted_as_verified_duplicates": duplicate_total,
+        "retained_records_verified": expected_after,
+        "verified_duplicates_absent": duplicate_total,
+    }
+    if any(apply_report.get(key) != value for key, value in expected_report_counts.items()):
+        raise ValueError("migration apply report counts do not match the reviewed manifest")
+    migrated_snapshot = apply_report.get("migrated_snapshot")
+    if not isinstance(migrated_snapshot, dict):
+        raise ValueError("migration apply report is missing the migrated snapshot")
+    logical_snapshot = apply_report.get("migrated_logical_snapshot")
+    if not isinstance(logical_snapshot, dict):
+        raise ValueError("migration apply report is missing the migrated logical snapshot")
+    if drawer_logical_snapshot(staged_palace) != logical_snapshot:
+        raise ValueError("migrated drawers no longer match the completed apply report")
+    semantic_snapshot = apply_report.get("migrated_semantic_snapshot")
+    if not isinstance(semantic_snapshot, dict):
+        raise ValueError("migration apply report is missing the migrated semantic snapshot")
+    if palace_semantic_snapshot(staged_palace) != semantic_snapshot:
+        raise ValueError("migrated palace no longer matches the completed semantic snapshot")
+    expected_sidecars = apply_report.get("derived_sidecars")
+    if not isinstance(expected_sidecars, dict):
+        raise ValueError("migration apply report is missing derived sidecar snapshots")
+    if _derived_sidecar_snapshots(migrated_root) != expected_sidecars:
+        raise ValueError("migrated sidecars no longer match the completed apply report")
+    return reviewed, apply_report, active_snapshot
+
+
+def _require_daemons_stopped(palace_paths: Iterable[Path]) -> None:
+    from .daemon import _pid_alive, endpoint_path, get_client_if_running, pid_path
+
+    for palace_path in palace_paths:
+        palace_string = str(palace_path)
+        if get_client_if_running(palace_string, health_timeout=0.2) is not None:
+            raise RuntimeError(
+                f"MemPalace daemon must be stopped before activation or rollback: {palace_path}"
+            )
+        pid_marker = pid_path(palace_string)
+        endpoint_marker = endpoint_path(palace_string)
+        if pid_marker.exists():
+            try:
+                pid = int(pid_marker.read_text(encoding="utf-8").strip())
+            except (OSError, ValueError) as exc:
+                raise RuntimeError(
+                    f"cannot prove MemPalace daemon is stopped for {palace_path}"
+                ) from exc
+            if _pid_alive(pid):
+                raise RuntimeError(f"MemPalace daemon PID {pid} is still alive for {palace_path}")
+        elif endpoint_marker.exists():
+            raise RuntimeError(
+                f"cannot prove MemPalace daemon is stopped for {palace_path}: stale endpoint state"
+            )
+
+
+@contextmanager
+def _exclusive_palace_locks(palace_paths: Iterable[Path]):
+    ordered = sorted({str(path.absolute()) for path in palace_paths})
+    with ExitStack() as stack:
+        for palace_path in ordered:
+            stack.enter_context(mine_palace_lock(palace_path, blocking=False))
+        yield
+
+
+def _close_palace_handles(*palace_paths: Path) -> None:
+    from .palace import get_backend_for_palace
+
+    backend = get_backend_for_palace(str(palace_paths[0]), explicit="chroma")
+    for palace_path in palace_paths:
+        backend.close_palace(str(palace_path))
+
+
+def _validate_sidecars(
+    root: Path,
+    names: Iterable[str],
+    *,
+    expected: dict[str, dict[str, int | str]] | None = None,
+) -> dict[str, dict[str, int | str]]:
+    present: dict[str, dict[str, int | str]] = {}
+    names_to_check = set(names)
+    if expected is not None:
+        names_to_check.update(_ACTIVATION_SIDECAR_NAMES)
+    for name in sorted(names_to_check):
+        path = root / name
+        if path.is_symlink():
+            raise ValueError(f"activation sidecar must not be a symlink: {path}")
+        if path.exists():
+            if not path.is_file():
+                raise ValueError(f"activation sidecar must be a file: {path}")
+            present[name] = _artifact_snapshot(path)
+    if expected is not None and present != expected:
+        raise ValueError(f"activation sidecars changed under {root}")
+    return present
+
+
+def _verify_staging_readiness(staged_palace: Path) -> None:
+    integrity_errors = _sqlite_integrity_errors(staged_palace)
+    if integrity_errors:
+        raise RuntimeError(f"migrated SQLite integrity_check failed: {integrity_errors[:3]}")
+    from .service import _verify_chroma_readiness
+
+    for collection_name in ("mempalace_drawers", "mempalace_closets"):
+        readiness = _verify_chroma_readiness(str(staged_palace), collection_name)
+        if not readiness.get("ready"):
+            raise RuntimeError(
+                f"migrated {collection_name} failed persisted readiness before activation"
+            )
+
+
+def _journal_path(previous_root: Path) -> Path:
+    return previous_root.parent / f".{previous_root.name}.activation-journal.json"
+
+
+def _remove_journal(path: Path) -> None:
+    path.unlink(missing_ok=True)
+    _fsync_directory(path.parent)
+
+
+def _palace_matches(path: Path, expected: dict[str, Any]) -> bool:
+    try:
+        return path.is_dir() and not path.is_symlink() and palace_snapshot(path) == expected
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _semantic_palace_matches(path: Path, expected: dict[str, Any]) -> bool:
+    try:
+        return (
+            path.is_dir() and not path.is_symlink() and palace_semantic_snapshot(path) == expected
+        )
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _sidecar_matches(path: Path, expected: dict[str, int | str]) -> bool:
+    try:
+        return _artifact_snapshot(path) == expected
+    except (OSError, ValueError):
+        return False
+
+
+def _validated_journal(
+    *,
+    journal_path: Path,
+    expected_operation: str,
+    active: Path,
+    migrated: Path,
+    previous: Path,
+) -> dict[str, Any] | None:
+    if not journal_path.exists() and not journal_path.is_symlink():
+        return None
+    payload = _read_json_object(journal_path, label="activation journal")
+    if payload.get("version") != 1 or payload.get("operation") != expected_operation:
+        raise RuntimeError(
+            f"unfinished {payload.get('operation', 'unknown')} operation requires matching recovery"
+        )
+    expected_paths = {
+        "active_palace": str(active),
+        "migrated_root": str(migrated),
+        "previous_root": str(previous),
+    }
+    if payload.get("paths") != expected_paths:
+        raise RuntimeError("activation journal paths do not match this request")
+    return payload
+
+
+def _recover_activation_swap(
+    *,
+    journal_path: Path,
+    journal: dict[str, Any],
+    active: Path,
+    migrated: Path,
+    previous: Path,
+) -> dict[str, Any] | None:
+    report = journal.get("report")
+    if not isinstance(report, dict):
+        raise RuntimeError("activation journal is missing its recovery report")
+    previous_tmp = Path(str(journal.get("previous_tmp") or ""))
+    if (
+        previous_tmp.parent != previous.parent
+        or not previous_tmp.name.startswith(f".{previous.name}.")
+        or not previous_tmp.name.endswith(".tmp")
+        or previous_tmp.is_symlink()
+    ):
+        raise RuntimeError("activation journal contains an unsafe temporary path")
+    staged = migrated / "palace"
+    old_snapshot = report.get("reviewed_snapshot")
+    new_snapshot = report.get("migrated_semantic_snapshot")
+    old_sidecars = report.get("active_sidecars")
+    new_sidecars = report.get("migrated_sidecars")
+    if not all(
+        isinstance(value, dict)
+        for value in (old_snapshot, new_snapshot, old_sidecars, new_sidecars)
+    ):
+        raise RuntimeError("activation journal is missing snapshot evidence")
+
+    lock_paths = [active, staged, previous / "palace"]
+    _require_daemons_stopped(lock_paths)
+    with _exclusive_palace_locks(lock_paths):
+        _require_daemons_stopped(lock_paths)
+        if (
+            _semantic_palace_matches(active, new_snapshot)
+            and not staged.exists()
+            and _palace_matches(previous / "palace", old_snapshot)
+        ):
+            _validate_sidecars(active.parent, new_sidecars, expected=new_sidecars)
+            _validate_sidecars(previous, old_sidecars, expected=old_sidecars)
+            _remove_journal(journal_path)
+            return report
+        if previous.exists() or previous.is_symlink():
+            raise RuntimeError("cannot safely recover a partially published activation")
+        if active.exists():
+            if _semantic_palace_matches(active, new_snapshot) and not staged.exists():
+                _replace_and_sync(active, staged)
+            elif not _palace_matches(active, old_snapshot):
+                raise RuntimeError("cannot identify the active palace during activation recovery")
+        for name, snapshot in new_sidecars.items():
+            active_sidecar = active.parent / name
+            staged_sidecar = migrated / name
+            if _sidecar_matches(active_sidecar, snapshot):
+                if staged_sidecar.exists() or staged_sidecar.is_symlink():
+                    raise RuntimeError(f"ambiguous migrated sidecar during recovery: {name}")
+                _replace_and_sync(active_sidecar, staged_sidecar)
+            elif not _sidecar_matches(staged_sidecar, snapshot):
+                raise RuntimeError(f"cannot identify migrated sidecar during recovery: {name}")
+        for name, snapshot in old_sidecars.items():
+            active_sidecar = active.parent / name
+            saved_sidecar = previous_tmp / name
+            if _sidecar_matches(active_sidecar, snapshot):
+                continue
+            if not _sidecar_matches(saved_sidecar, snapshot):
+                raise RuntimeError(f"cannot identify previous sidecar during recovery: {name}")
+            if active_sidecar.exists() or active_sidecar.is_symlink():
+                raise RuntimeError(
+                    f"active sidecar destination is occupied during recovery: {name}"
+                )
+            _replace_and_sync(saved_sidecar, active_sidecar)
+        if not _palace_matches(active, old_snapshot):
+            saved_palace = previous_tmp / "palace"
+            if not _palace_matches(saved_palace, old_snapshot) or active.exists():
+                raise RuntimeError("cannot restore the previous active palace")
+            _replace_and_sync(saved_palace, active)
+        if not _semantic_palace_matches(staged, new_snapshot):
+            raise RuntimeError("migrated palace was not restored during activation recovery")
+        _validate_sidecars(active.parent, old_sidecars, expected=old_sidecars)
+        _validate_sidecars(migrated, new_sidecars, expected=new_sidecars)
+        shutil.rmtree(previous_tmp)
+        _fsync_directory(previous_tmp.parent)
+        _remove_journal(journal_path)
+    return None
+
+
+def _recover_rollback_swap(
+    *,
+    journal_path: Path,
+    journal: dict[str, Any],
+    active: Path,
+    migrated: Path,
+    previous: Path,
+) -> dict[str, Any] | None:
+    state = journal.get("report")
+    rolled_back = journal.get("rolled_back_report")
+    if not isinstance(state, dict) or not isinstance(rolled_back, dict):
+        raise RuntimeError("rollback journal is missing its recovery report")
+    staged = migrated / "palace"
+    old_snapshot = state.get("reviewed_snapshot")
+    new_snapshot = state.get("migrated_semantic_snapshot")
+    old_sidecars = state.get("active_sidecars")
+    new_sidecars = state.get("migrated_sidecars")
+    if not all(
+        isinstance(value, dict)
+        for value in (old_snapshot, new_snapshot, old_sidecars, new_sidecars)
+    ):
+        raise RuntimeError("rollback journal is missing snapshot evidence")
+    old_palace = previous / "palace"
+    lock_paths = [active, staged, old_palace]
+    _require_daemons_stopped(lock_paths)
+    with _exclusive_palace_locks(lock_paths):
+        _require_daemons_stopped(lock_paths)
+        if (
+            _palace_matches(active, old_snapshot)
+            and _semantic_palace_matches(staged, new_snapshot)
+            and not old_palace.exists()
+        ):
+            _validate_sidecars(active.parent, old_sidecars, expected=old_sidecars)
+            _validate_sidecars(migrated, new_sidecars, expected=new_sidecars)
+            _write_atomic_private_json(previous / _ACTIVATION_REPORT, rolled_back)
+            _remove_journal(journal_path)
+            return rolled_back
+        if active.exists() and _palace_matches(active, old_snapshot) and not old_palace.exists():
+            _replace_and_sync(active, old_palace)
+        elif active.exists() and not _semantic_palace_matches(active, new_snapshot):
+            raise RuntimeError("cannot identify the active palace during rollback recovery")
+        for name, snapshot in old_sidecars.items():
+            active_sidecar = active.parent / name
+            saved_sidecar = previous / name
+            if _sidecar_matches(active_sidecar, snapshot):
+                if saved_sidecar.exists() or saved_sidecar.is_symlink():
+                    raise RuntimeError(f"ambiguous previous sidecar during recovery: {name}")
+                _replace_and_sync(active_sidecar, saved_sidecar)
+            elif not _sidecar_matches(saved_sidecar, snapshot):
+                raise RuntimeError(f"cannot identify previous sidecar during recovery: {name}")
+        for name, snapshot in new_sidecars.items():
+            active_sidecar = active.parent / name
+            staged_sidecar = migrated / name
+            if _sidecar_matches(active_sidecar, snapshot):
+                continue
+            if not _sidecar_matches(staged_sidecar, snapshot):
+                raise RuntimeError(f"cannot identify migrated sidecar during recovery: {name}")
+            if active_sidecar.exists() or active_sidecar.is_symlink():
+                raise RuntimeError(
+                    f"active sidecar destination is occupied during recovery: {name}"
+                )
+            _replace_and_sync(staged_sidecar, active_sidecar)
+        if not _semantic_palace_matches(active, new_snapshot):
+            if not _semantic_palace_matches(staged, new_snapshot) or active.exists():
+                raise RuntimeError("cannot restore the migrated active palace")
+            _replace_and_sync(staged, active)
+        if not _palace_matches(old_palace, old_snapshot):
+            raise RuntimeError("previous palace was not restored during rollback recovery")
+        _validate_sidecars(active.parent, new_sidecars, expected=new_sidecars)
+        _validate_sidecars(previous, old_sidecars, expected=old_sidecars)
+        _remove_journal(journal_path)
+    return None
+
+
+def _recover_interrupted_swap(
+    *,
+    expected_operation: str,
+    active: Path,
+    migrated: Path,
+    previous: Path,
+) -> dict[str, Any] | None:
+    journal_path = _journal_path(previous)
+    journal = _validated_journal(
+        journal_path=journal_path,
+        expected_operation=expected_operation,
+        active=active,
+        migrated=migrated,
+        previous=previous,
+    )
+    if journal is None:
+        return None
+    if expected_operation == "activate":
+        return _recover_activation_swap(
+            journal_path=journal_path,
+            journal=journal,
+            active=active,
+            migrated=migrated,
+            previous=previous,
+        )
+    return _recover_rollback_swap(
+        journal_path=journal_path,
+        journal=journal,
+        active=active,
+        migrated=migrated,
+        previous=previous,
+    )
+
+
+def _restore_activation_failure(
+    *,
+    active_palace: Path,
+    migrated_root: Path,
+    previous_tmp: Path,
+    active_moved: bool,
+    staged_promoted: bool,
+    old_sidecars_moved: list[str],
+    new_sidecars_moved: list[str],
+) -> list[str]:
+    errors: list[str] = []
+
+    def restore(source: Path, destination: Path) -> None:
+        try:
+            _replace_and_sync(source, destination)
+        except OSError as exc:
+            errors.append(f"{source} -> {destination}: {exc}")
+
+    if staged_promoted:
+        restore(active_palace, migrated_root / "palace")
+    for name in reversed(new_sidecars_moved):
+        restore(active_palace.parent / name, migrated_root / name)
+    for name in reversed(old_sidecars_moved):
+        restore(previous_tmp / name, active_palace.parent / name)
+    if active_moved:
+        restore(previous_tmp / "palace", active_palace)
+    if not errors:
+        shutil.rmtree(previous_tmp, ignore_errors=True)
+    return errors
+
+
+def activate_migrated_palace(
+    *,
+    active_palace: os.PathLike[str] | str,
+    reviewed_manifest: os.PathLike[str] | str,
+    migrated_root: os.PathLike[str] | str,
+    previous_root: os.PathLike[str] | str,
+) -> dict[str, Any]:
+    """Promote a verified staging palace while retaining the previous palace."""
+    active = _expanded(active_palace)
+    migrated = _expanded(migrated_root)
+    previous = _expanded(previous_root)
+    recovered = _recover_interrupted_swap(
+        expected_operation="activate",
+        active=active,
+        migrated=migrated,
+        previous=previous,
+    )
+    if recovered is not None:
+        return recovered
+    staged = _validate_activation_paths(
+        active_palace=active,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+    reviewed, apply_report, active_snapshot = _validate_reviewed_activation(
+        active_palace=active,
+        reviewed_manifest=reviewed_manifest,
+        migrated_root=migrated,
+        staged_palace=staged,
+    )
+    active_sidecars = _validate_sidecars(active.parent, _ACTIVATION_SIDECAR_NAMES)
+    migrated_sidecars = _validate_sidecars(
+        migrated,
+        _ACTIVATION_SIDECAR_NAMES,
+        expected=apply_report["derived_sidecars"],
+    )
+    config_path = active.parent / "config.json"
+    if config_path.is_symlink():
+        raise ValueError(f"active config must not be a symlink: {config_path}")
+    _require_daemons_stopped([active, staged])
+
+    previous_tmp = _temporary_sibling(previous)
+    report = {
+        "version": 1,
+        "status": "active",
+        "active_palace": str(active),
+        "migrated_root": str(migrated),
+        "previous_root": str(previous),
+        "reviewed_snapshot": active_snapshot,
+        "migrated_snapshot": apply_report["migrated_snapshot"],
+        "migrated_logical_snapshot": apply_report["migrated_logical_snapshot"],
+        "migrated_semantic_snapshot": apply_report["migrated_semantic_snapshot"],
+        "active_sidecars": active_sidecars,
+        "migrated_sidecars": migrated_sidecars,
+    }
+    try:
+        previous_tmp.mkdir(mode=0o700, parents=False, exist_ok=False)
+        if config_path.is_file():
+            shutil.copy2(config_path, previous_tmp / "config.json")
+        _write_private_json(previous_tmp / _ACTIVATION_REPORT, report)
+        _reject_symlinks(active)
+        _reject_symlinks(migrated)
+        _make_owner_only(active)
+        _make_owner_only(migrated)
+        _make_owner_only(previous_tmp)
+        for name in active_sidecars:
+            os.chmod(active.parent / name, 0o600)
+    except Exception:
+        shutil.rmtree(previous_tmp, ignore_errors=True)
+        raise
+
+    active_moved = False
+    staged_promoted = False
+    old_sidecars_moved: list[str] = []
+    new_sidecars_moved: list[str] = []
+    journal_path = _journal_path(previous)
+    try:
+        with _exclusive_palace_locks([active, staged]):
+            _require_daemons_stopped([active, staged])
+            _validate_sidecars(
+                active.parent,
+                active_sidecars,
+                expected=active_sidecars,
+            )
+            _validate_sidecars(
+                migrated,
+                migrated_sidecars,
+                expected=migrated_sidecars,
+            )
+            _verify_staging_readiness(staged)
+            _close_palace_handles(active, staged)
+            if palace_snapshot(active) != active_snapshot:
+                raise ValueError("active palace no longer matches the reviewed manifest")
+            if palace_semantic_snapshot(staged) != apply_report["migrated_semantic_snapshot"]:
+                raise ValueError("migrated palace changed before activation")
+
+            _write_atomic_private_json(
+                journal_path,
+                {
+                    "version": 1,
+                    "operation": "activate",
+                    "paths": {
+                        "active_palace": str(active),
+                        "migrated_root": str(migrated),
+                        "previous_root": str(previous),
+                    },
+                    "previous_tmp": str(previous_tmp),
+                    "report": report,
+                },
+            )
+            _replace_and_sync(active, previous_tmp / "palace")
+            active_moved = True
+            for name in active_sidecars:
+                _replace_and_sync(active.parent / name, previous_tmp / name)
+                old_sidecars_moved.append(name)
+            for name in migrated_sidecars:
+                _replace_and_sync(migrated / name, active.parent / name)
+                new_sidecars_moved.append(name)
+            _replace_and_sync(staged, active)
+            staged_promoted = True
+            _replace_and_sync(previous_tmp, previous)
+    except Exception as exc:
+        errors = _restore_activation_failure(
+            active_palace=active,
+            migrated_root=migrated,
+            previous_tmp=previous_tmp,
+            active_moved=active_moved,
+            staged_promoted=staged_promoted,
+            old_sidecars_moved=old_sidecars_moved,
+            new_sidecars_moved=new_sidecars_moved,
+        )
+        if errors:
+            raise RuntimeError(
+                "activation failed and automatic restoration was incomplete: " + "; ".join(errors)
+            ) from exc
+        _remove_journal(journal_path)
+        raise
+
+    _remove_journal(journal_path)
+    return report
+
+
+def _validate_rollback_state(
+    *,
+    active: Path,
+    migrated: Path,
+    previous: Path,
+) -> tuple[
+    dict[str, Any],
+    dict[str, dict[str, int | str]],
+    dict[str, dict[str, int | str]],
+]:
+    _require_real_directory(active, label="active palace")
+    _require_real_directory(migrated, label="migrated bundle")
+    _require_real_directory(previous, label="previous activation slot")
+    state = _read_json_object(previous / _ACTIVATION_REPORT, label="activation report")
+    expected_paths = {
+        "active_palace": str(active),
+        "migrated_root": str(migrated),
+        "previous_root": str(previous),
+    }
+    if state.get("version") != 1 or state.get("status") != "active":
+        raise ValueError("activation report is not in an active state")
+    if any(state.get(key) != value for key, value in expected_paths.items()):
+        raise ValueError("activation report paths do not match this rollback request")
+    old_palace = previous / "palace"
+    _require_real_directory(old_palace, label="retained previous palace")
+    if (migrated / "palace").exists() or (migrated / "palace").is_symlink():
+        raise ValueError("migrated bundle palace destination must be empty for rollback")
+    if palace_semantic_snapshot(active) != state.get("migrated_semantic_snapshot"):
+        raise ValueError("active migrated palace changed after activation")
+    if palace_snapshot(old_palace) != state.get("reviewed_snapshot"):
+        raise ValueError("retained previous palace changed after activation")
+    active_sidecars = state.get("active_sidecars")
+    migrated_sidecars = state.get("migrated_sidecars")
+    if not isinstance(active_sidecars, dict) or not isinstance(migrated_sidecars, dict):
+        raise ValueError("activation report is missing sidecar snapshots")
+    sidecar_names = [*active_sidecars, *migrated_sidecars]
+    if any(name not in _ACTIVATION_SIDECAR_NAMES for name in sidecar_names):
+        raise ValueError("activation report contains an unsupported sidecar")
+    for name in migrated_sidecars:
+        if (migrated / name).exists() or (migrated / name).is_symlink():
+            raise ValueError(f"migrated sidecar destination is not empty: {name}")
+    return state, active_sidecars, migrated_sidecars
+
+
+def _restore_rollback_failure(
+    *,
+    active: Path,
+    migrated: Path,
+    previous: Path,
+    active_moved: bool,
+    previous_promoted: bool,
+    old_sidecars_promoted: list[str],
+    new_sidecars_moved: list[str],
+) -> list[str]:
+    errors: list[str] = []
+
+    def restore(source: Path, destination: Path) -> None:
+        try:
+            _replace_and_sync(source, destination)
+        except OSError as exc:
+            errors.append(f"{source} -> {destination}: {exc}")
+
+    if previous_promoted:
+        restore(active, previous / "palace")
+    for name in reversed(old_sidecars_promoted):
+        restore(active.parent / name, previous / name)
+    for name in reversed(new_sidecars_moved):
+        restore(migrated / name, active.parent / name)
+    if active_moved:
+        restore(migrated / "palace", active)
+    return errors
+
+
+def rollback_activated_palace(
+    *,
+    active_palace: os.PathLike[str] | str,
+    migrated_root: os.PathLike[str] | str,
+    previous_root: os.PathLike[str] | str,
+) -> dict[str, Any]:
+    """Reverse one reviewed activation without deleting either palace."""
+    active = _expanded(active_palace)
+    migrated = _expanded(migrated_root)
+    previous = _expanded(previous_root)
+    recovered = _recover_interrupted_swap(
+        expected_operation="rollback",
+        active=active,
+        migrated=migrated,
+        previous=previous,
+    )
+    if recovered is not None:
+        return recovered
+    state, active_sidecars, migrated_sidecars = _validate_rollback_state(
+        active=active,
+        migrated=migrated,
+        previous=previous,
+    )
+    old_palace = previous / "palace"
+    staged_palace = migrated / "palace"
+    _require_daemons_stopped([active, old_palace, staged_palace])
+    _reject_symlinks(active)
+    _reject_symlinks(previous)
+    _reject_symlinks(migrated)
+    _make_owner_only(active)
+    _make_owner_only(previous)
+    _make_owner_only(migrated)
+    for name in migrated_sidecars:
+        os.chmod(active.parent / name, 0o600)
+    rolled_back = {**state, "status": "rolled_back"}
+
+    active_moved = False
+    previous_promoted = False
+    old_sidecars_promoted: list[str] = []
+    new_sidecars_moved: list[str] = []
+    journal_path = _journal_path(previous)
+    try:
+        with _exclusive_palace_locks([active, old_palace, staged_palace]):
+            _require_daemons_stopped([active, old_palace, staged_palace])
+            _validate_sidecars(
+                active.parent,
+                migrated_sidecars,
+                expected=migrated_sidecars,
+            )
+            _validate_sidecars(
+                previous,
+                active_sidecars,
+                expected=active_sidecars,
+            )
+            _close_palace_handles(active, old_palace)
+            if palace_semantic_snapshot(active) != state["migrated_semantic_snapshot"]:
+                raise ValueError("active migrated palace changed before rollback")
+            if palace_snapshot(previous / "palace") != state["reviewed_snapshot"]:
+                raise ValueError("retained previous palace changed before rollback")
+
+            _write_atomic_private_json(
+                journal_path,
+                {
+                    "version": 1,
+                    "operation": "rollback",
+                    "paths": {
+                        "active_palace": str(active),
+                        "migrated_root": str(migrated),
+                        "previous_root": str(previous),
+                    },
+                    "report": state,
+                    "rolled_back_report": rolled_back,
+                },
+            )
+            _replace_and_sync(active, migrated / "palace")
+            active_moved = True
+            for name in migrated_sidecars:
+                _replace_and_sync(active.parent / name, migrated / name)
+                new_sidecars_moved.append(name)
+            for name in active_sidecars:
+                _replace_and_sync(previous / name, active.parent / name)
+                old_sidecars_promoted.append(name)
+            _replace_and_sync(previous / "palace", active)
+            previous_promoted = True
+            _write_atomic_private_json(previous / _ACTIVATION_REPORT, rolled_back)
+    except Exception as exc:
+        errors = _restore_rollback_failure(
+            active=active,
+            migrated=migrated,
+            previous=previous,
+            active_moved=active_moved,
+            previous_promoted=previous_promoted,
+            old_sidecars_promoted=old_sidecars_promoted,
+            new_sidecars_moved=new_sidecars_moved,
+        )
+        if errors:
+            raise RuntimeError(
+                "rollback failed and automatic restoration was incomplete: " + "; ".join(errors)
+            ) from exc
+        _remove_journal(journal_path)
+        raise
+
+    _remove_journal(journal_path)
+    return rolled_back

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -1707,6 +1707,7 @@ def mine(
     include_ignored: list = None,
     files: list = None,
     max_chunks_per_file: Optional[int] = None,
+    progress_callback=None,
 ):
     """Mine a project directory into the palace.
 
@@ -1733,6 +1734,7 @@ def mine(
             include_ignored=include_ignored,
             files=files,
             max_chunks_per_file=max_chunks_per_file,
+            progress_callback=progress_callback,
         )
 
     # MineAlreadyRunning propagates so the CLI can render a clear holder-aware
@@ -1750,6 +1752,7 @@ def mine(
             include_ignored=include_ignored,
             files=files,
             max_chunks_per_file=max_chunks_per_file,
+            progress_callback=progress_callback,
         )
 
 
@@ -1764,10 +1767,23 @@ def _mine_impl(
     include_ignored: list = None,
     files: list = None,
     max_chunks_per_file: Optional[int] = None,
+    progress_callback=None,
 ):
     from .config import MempalaceConfig
+    from .progress import ProgressReporter
 
     project_path = Path(project_dir).expanduser().resolve()
+    reporter = ProgressReporter(progress_callback)
+    reporter.emit(
+        force=True,
+        phase="scanning",
+        files_total=0,
+        files_processed=0,
+        files_changed=0,
+        files_skipped=0,
+        files_failed=0,
+        current_source="",
+    )
     config = load_config(project_dir)
     palace_config = MempalaceConfig()
 
@@ -1790,6 +1806,8 @@ def _mine_impl(
         files = _apply_exclude_patterns_to_prescanned_files(
             files, project_path, exclude_patterns, include_ignored
         )
+
+    reporter.emit(force=True, phase="mining", files_total=len(files))
 
     from .embedding import describe_device
 
@@ -1870,8 +1888,29 @@ def _mine_impl(
                 if not dry_run:
                     print(f"  + [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")
                 if limit > 0 and files_mined >= limit:
+                    reporter.emit(
+                        force=True,
+                        files_processed=files_processed,
+                        files_changed=files_mined,
+                        files_skipped=files_skipped,
+                        current_source=str(filepath.relative_to(project_path)),
+                    )
                     break
+            reporter.emit(
+                files_processed=files_processed,
+                files_changed=files_mined,
+                files_skipped=files_skipped,
+                current_source=str(filepath.relative_to(project_path)),
+            )
 
+        reporter.emit(
+            force=True,
+            phase="post_processing",
+            files_processed=files_processed,
+            files_changed=files_mined,
+            files_skipped=files_skipped,
+        )
+        reporter.emit(force=True, phase="verifying")
         if not dry_run:
             # Cross-wing topic tunnels: after every file in this wing has been
             # processed, link this wing to any other wing that shares a
@@ -1950,6 +1989,14 @@ def _mine_impl(
             print(f"    {room:20} {count} files")
         print('\n  Next: mempalace search "what you\'re looking for"')
         print(f"{'=' * 55}\n")
+        reporter.emit(
+            force=True,
+            phase="verifying",
+            files_processed=files_processed,
+            files_changed=files_mined,
+            files_skipped=files_skipped,
+            current_source=last_file or "",
+        )
     except KeyboardInterrupt:
         # Idempotent re-mine: deterministic drawer IDs mean already-filed
         # drawers upsert to the same row on next run, so partial progress

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -46,10 +46,12 @@ from .collision_scan import assert_no_collisions
 from .hallways import compute_hallways_for_wing
 from .ids import ID_RECIPE, make_drawer_id_from_chunk
 from .source_metadata import (
+    SOURCE_KINDS,
     SourceContext,
     build_source_metadata,
     git_revision,
     sha256_file,
+    source_kind_for_room,
 )
 
 logger = logging.getLogger("mempalace_mcp")
@@ -516,6 +518,8 @@ def load_config(project_dir: str) -> dict:
             )
             return {
                 "wing": wing_name,
+                "source_kind": "code",
+                "reject_linked_worktrees": True,
                 "rooms": [
                     {
                         "name": "general",
@@ -525,7 +529,24 @@ def load_config(project_dir: str) -> dict:
                 ],
             }
     with open(config_path) as f:
-        return yaml.safe_load(f)
+        config = yaml.safe_load(f)
+    if not isinstance(config, dict):
+        raise ValueError(f"invalid project config in {config_path}: expected a mapping")
+    source_kind = config.setdefault("source_kind", "code")
+    if source_kind not in SOURCE_KINDS:
+        raise ValueError(f"invalid source_kind: {source_kind!r}")
+    reject_linked = config.setdefault("reject_linked_worktrees", True)
+    if not isinstance(reject_linked, bool):
+        raise ValueError("reject_linked_worktrees must be a boolean")
+    rooms = config.get("rooms", [])
+    if not isinstance(rooms, list):
+        raise ValueError("rooms must be a list")
+    for room in rooms:
+        if not isinstance(room, dict):
+            raise ValueError("each room must be a mapping")
+        if "source_kind" in room and room["source_kind"] not in SOURCE_KINDS:
+            raise ValueError(f"invalid source_kind: {room['source_kind']!r}")
+    return config
 
 
 # =============================================================================
@@ -1435,6 +1456,7 @@ def process_file(
     max_chunks_per_file: Optional[int] = None,
     source_revision: Optional[str] = None,
     source_canonicality: str = "canonical",
+    source_kind: str = "code",
 ) -> tuple:
     """Read, chunk, route, and file one file.
 
@@ -1464,7 +1486,10 @@ def process_file(
     source_context = SourceContext(
         root=str(project_path),
         source_file=source_file,
-        source_kind="code",
+        source_kind=source_kind_for_room(
+            {"source_kind": source_kind, "rooms": rooms},
+            room,
+        ),
         source_revision=source_revision,
         source_canonicality=source_canonicality,
         source_sha256=sha256_file(source_file),
@@ -1903,6 +1928,7 @@ def _mine_impl(
                     max_chunks_per_file=effective_chunk_cap,
                     source_revision=project_revision,
                     source_canonicality=source_canonicality,
+                    source_kind=config.get("source_kind", "code"),
                 )
             except KeyboardInterrupt:
                 # Re-raise so the outer handler prints the summary; we

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -65,7 +65,7 @@ def _path_within_root(path: Path, root: Path) -> bool:
         return False
 
 
-def _read_text_no_follow(filepath: Path, root: Path) -> Optional[str]:
+def _read_source_no_follow(filepath: Path, root: Path) -> Optional[tuple[str, str]]:
     if not _path_within_root(filepath, root):
         return None
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
@@ -75,9 +75,13 @@ def _read_text_no_follow(filepath: Path, root: Path) -> Optional[str]:
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode) or st.st_size > MAX_FILE_SIZE:
             return None
-        with os.fdopen(fd, "r", encoding="utf-8", errors="replace") as f:
+        with os.fdopen(fd, "rb") as f:
             fd = -1
-            return f.read()
+            source_bytes = f.read()
+            return (
+                source_bytes.decode("utf-8", errors="replace"),
+                hashlib.sha256(source_bytes).hexdigest(),
+            )
     except OSError:
         return None
     finally:
@@ -86,6 +90,12 @@ def _read_text_no_follow(filepath: Path, root: Path) -> Optional[str]:
                 os.close(fd)
             except OSError:
                 pass
+
+
+def _read_text_no_follow(filepath: Path, root: Path) -> Optional[str]:
+    """Backward-compatible text-only view of the single-read source helper."""
+    result = _read_source_no_follow(filepath, root)
+    return result[0] if result is not None else None
 
 
 PHP_EXTENSIONS = {
@@ -1474,10 +1484,11 @@ def process_file(
     if not dry_run and file_already_mined(collection, source_file, check_mtime=True):
         return 0, "general", None
 
-    content = _read_text_no_follow(filepath, project_path)
-    if content is None:
+    source = _read_source_no_follow(filepath, project_path)
+    if source is None:
         return 0, "general", None
 
+    content, source_sha256 = source
     content = content.strip()
     if len(content) < effective_min:
         return 0, "general", None
@@ -1492,7 +1503,7 @@ def process_file(
         ),
         source_revision=source_revision,
         source_canonicality=source_canonicality,
-        source_sha256=sha256_file(source_file),
+        source_sha256=source_sha256,
     )
     chunks = chunk_text(
         content,
@@ -1846,6 +1857,13 @@ def _mine_impl(
         current_source="",
     )
     config = load_config(project_dir)
+    from .source_metadata import enforce_worktree_policy
+
+    source_canonicality = enforce_worktree_policy(
+        str(project_path),
+        config,
+        source_canonicality,
+    )
     palace_config = MempalaceConfig()
 
     cfg_chunk_size = palace_config.chunk_size

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -45,6 +45,12 @@ from .palace import (
 from .collision_scan import assert_no_collisions
 from .hallways import compute_hallways_for_wing
 from .ids import ID_RECIPE, make_drawer_id_from_chunk
+from .source_metadata import (
+    SourceContext,
+    build_source_metadata,
+    git_revision,
+    sha256_file,
+)
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -1328,6 +1334,7 @@ def _build_drawer_metadata(
     line_start: Optional[int] = None,
     line_end: Optional[int] = None,
     content_date: Optional[str] = None,
+    source_context: Optional[SourceContext] = None,
 ) -> dict:
     """Build the metadata dict for one drawer without upserting.
 
@@ -1362,6 +1369,8 @@ def _build_drawer_metadata(
         metadata["line_end"] = line_end
     if content_date:
         metadata["content_date"] = content_date
+    if source_context is not None:
+        metadata.update(build_source_metadata(source_context, content, chunk_index))
     metadata["hall"] = detect_hall(content)
     entities = _extract_entities_for_metadata(content)
     if entities:
@@ -1384,7 +1393,19 @@ def add_drawer(
     except OSError:
         source_mtime = None
     metadata = _build_drawer_metadata(
-        wing, room, source_file, chunk_index, agent, content, source_mtime
+        wing,
+        room,
+        source_file,
+        chunk_index,
+        agent,
+        content,
+        source_mtime,
+        source_context=SourceContext(
+            root=os.path.dirname(source_file),
+            source_file=source_file,
+            source_kind="code",
+            source_sha256=sha256_file(source_file),
+        ),
     )
     collection.upsert(
         documents=[content],
@@ -1412,6 +1433,8 @@ def process_file(
     chunk_overlap: int = None,
     min_chunk_size: int = None,
     max_chunks_per_file: Optional[int] = None,
+    source_revision: Optional[str] = None,
+    source_canonicality: str = "canonical",
 ) -> tuple:
     """Read, chunk, route, and file one file.
 
@@ -1438,6 +1461,14 @@ def process_file(
         return 0, "general", None
 
     room = detect_room(filepath, content, rooms, project_path)
+    source_context = SourceContext(
+        root=str(project_path),
+        source_file=source_file,
+        source_kind="code",
+        source_revision=source_revision,
+        source_canonicality=source_canonicality,
+        source_sha256=sha256_file(source_file),
+    )
     chunks = chunk_text(
         content,
         source_file,
@@ -1525,6 +1556,7 @@ def process_file(
                         line_start=chunk.get("line_start"),
                         line_end=chunk.get("line_end"),
                         content_date=file_content_date,
+                        source_context=source_context,
                     )
                 )
             assert_no_collisions(list(zip(batch_ids, batch_metas)), collection)
@@ -1708,6 +1740,7 @@ def mine(
     files: list = None,
     max_chunks_per_file: Optional[int] = None,
     progress_callback=None,
+    source_canonicality: str = "canonical",
 ):
     """Mine a project directory into the palace.
 
@@ -1735,6 +1768,7 @@ def mine(
             files=files,
             max_chunks_per_file=max_chunks_per_file,
             progress_callback=progress_callback,
+            source_canonicality=source_canonicality,
         )
 
     # MineAlreadyRunning propagates so the CLI can render a clear holder-aware
@@ -1753,6 +1787,7 @@ def mine(
             files=files,
             max_chunks_per_file=max_chunks_per_file,
             progress_callback=progress_callback,
+            source_canonicality=source_canonicality,
         )
 
 
@@ -1768,6 +1803,7 @@ def _mine_impl(
     files: list = None,
     max_chunks_per_file: Optional[int] = None,
     progress_callback=None,
+    source_canonicality: str = "canonical",
 ):
     from .config import MempalaceConfig
     from .progress import ProgressReporter
@@ -1843,6 +1879,7 @@ def _mine_impl(
     last_file = None
     room_counts = defaultdict(int)
     effective_chunk_cap = _resolve_max_chunks_per_file(max_chunks_per_file)
+    project_revision = git_revision(str(project_path))
 
     try:
         for i, filepath in enumerate(files, 1):
@@ -1864,6 +1901,8 @@ def _mine_impl(
                     # otherwise a malformed env var would emit its warning
                     # per file.
                     max_chunks_per_file=effective_chunk_cap,
+                    source_revision=project_revision,
+                    source_canonicality=source_canonicality,
                 )
             except KeyboardInterrupt:
                 # Re-raise so the outer handler prints the summary; we

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -961,8 +961,8 @@ def _validate_palace_fts5_after_mine(palace_path: str) -> None:
 # different worker thread. A thread-local guard makes those handlers fail to see
 # the process-held lease, re-acquire the flock, and self-conflict
 # ("palace ... is held by PID <self>"). flock is per-process and HTTP writes are
-# serialized by `_HTTP_REQUEST_LOCK`, so the process is the correct re-entrancy
-# boundary.
+# serialized at the palace-operation boundary by the MCP server (or by the
+# daemon's single worker), so the process is the correct re-entrancy boundary.
 #
 # The holder set is tagged with ``pid`` so that a forked child does NOT inherit
 # re-entrant credit from its parent: the OS-level flock IS NOT inherited as a

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -1040,6 +1040,25 @@ def _format_lock_holder(content: str) -> str:
 _LOCK_SENTINEL_BYTES = 1
 
 
+def _palace_lock_details(palace_path: str) -> tuple[str, str, str]:
+    lock_dir = os.path.join(os.path.expanduser("~"), ".mempalace", "locks")
+    os.makedirs(lock_dir, exist_ok=True)
+    resolved = os.path.realpath(os.path.expanduser(palace_path))
+    lock_key_source = os.path.normcase(resolved)
+    palace_key = hashlib.sha256(lock_key_source.encode()).hexdigest()[:16]
+    return resolved, palace_key, os.path.join(lock_dir, f"mine_palace_{palace_key}.lock")
+
+
+def _ensure_palace_lock_file(lock_path: str) -> None:
+    if os.path.exists(lock_path):
+        return
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
+        os.close(fd)
+    except FileExistsError:
+        pass
+
+
 def _read_lock_holder(lock_file) -> str:
     """Read the prior holder's identity from the lock-file body, best-effort."""
     try:
@@ -1074,8 +1093,12 @@ def _write_lock_holder(lock_file) -> None:
 
 
 @contextlib.contextmanager
-def mine_palace_lock(palace_path: str):
-    """Per-palace non-blocking lock around the full `mine` pipeline.
+def mine_palace_lock(palace_path: str, *, blocking: bool = False):
+    """Per-palace lock around the full ``mine`` pipeline.
+
+    Direct callers fail fast by default.  The durable daemon worker may pass
+    ``blocking=True`` after accepting a job so it waits for any short-lived
+    vector readers that entered immediately before maintenance began.
 
     The per-file `mine_lock` only protects delete+insert interleave for a
     single source; it does not prevent N copies of `mempalace mine <dir>`
@@ -1106,12 +1129,7 @@ def mine_palace_lock(palace_path: str):
     lets the threaded MCP HTTP transport write from a worker thread while the
     long-lived writer-lease is held on another thread of the same process.
     """
-    lock_dir = os.path.join(os.path.expanduser("~"), ".mempalace", "locks")
-    os.makedirs(lock_dir, exist_ok=True)
-    resolved = os.path.realpath(os.path.expanduser(palace_path))
-    lock_key_source = os.path.normcase(resolved)
-    palace_key = hashlib.sha256(lock_key_source.encode()).hexdigest()[:16]
-    lock_path = os.path.join(lock_dir, f"mine_palace_{palace_key}.lock")
+    resolved, palace_key, lock_path = _palace_lock_details(palace_path)
 
     if _held_by_this_process(palace_key):
         # This process already holds the lock for this palace — pass through.
@@ -1125,14 +1143,7 @@ def mine_palace_lock(palace_path: str):
     # *current* position, so two contenders end up locking different bytes
     # and silently both acquire — observed as Windows-CI lock test
     # failures during #1264 development).
-    if not os.path.exists(lock_path):
-        # Touch atomically: O_CREAT|O_EXCL would fail if a concurrent
-        # contender just created it, which is fine — we proceed to open.
-        try:
-            fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
-            os.close(fd)
-        except FileExistsError:
-            pass
+    _ensure_palace_lock_file(lock_path)
     lf = open(lock_path, "r+b")
     acquired = False
     try:
@@ -1143,7 +1154,8 @@ def mine_palace_lock(palace_path: str):
             import msvcrt
 
             try:
-                msvcrt.locking(lf.fileno(), msvcrt.LK_NBLCK, 1)
+                mode = msvcrt.LK_LOCK if blocking else msvcrt.LK_NBLCK
+                msvcrt.locking(lf.fileno(), mode, 1)
                 acquired = True
             except OSError as exc:
                 holder = _read_lock_holder(lf)
@@ -1155,7 +1167,8 @@ def mine_palace_lock(palace_path: str):
             import fcntl
 
             try:
-                fcntl.flock(lf, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+                fcntl.flock(lf, flags)
                 acquired = True
             except BlockingIOError as exc:
                 holder = _read_lock_holder(lf)
@@ -1186,6 +1199,65 @@ def mine_palace_lock(palace_path: str):
             except Exception:
                 pass
         lf.close()
+
+
+@contextlib.contextmanager
+def palace_read_lock(palace_path: str):
+    """Try to hold a cross-process read gate for one vector operation.
+
+    On POSIX this is a shared, non-blocking flock. A daemon writer takes the
+    matching exclusive lock in blocking mode, which closes the gap between an
+    MCP maintenance-status check and opening Chroma. Windows byte-range locks
+    have no shared mode, so readers use a short exclusive non-blocking gate.
+
+    Yields ``True`` when vector access is safe and ``False`` when a writer owns
+    the gate. Callers must use their SQLite-only fallback on ``False``.
+    """
+
+    _, palace_key, lock_path = _palace_lock_details(palace_path)
+    if _held_by_this_process(palace_key):
+        # Legacy/direct MCP mode deliberately holds the writer lease for the
+        # process lifetime.  Its own handlers are serialized in-process, so a
+        # same-process read is safe while peer processes remain excluded.
+        yield True
+        return
+    _ensure_palace_lock_file(lock_path)
+    lock_file = open(lock_path, "r+b")
+    acquired = False
+    try:
+        lock_file.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            try:
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+                acquired = True
+            except OSError:
+                acquired = False
+        else:
+            import fcntl
+
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_SH | fcntl.LOCK_NB)
+                acquired = True
+            except BlockingIOError:
+                acquired = False
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+            except Exception:
+                pass
+        lock_file.close()
 
 
 # Backward-compatible alias (previous patch iteration used a single global

--- a/mempalace/progress.py
+++ b/mempalace/progress.py
@@ -34,9 +34,11 @@ class ProgressReporter:
             and now - self._last_emitted_at < self.min_interval
         ):
             return
+        # Throttle delivery attempts as well as successes. A broken queue or
+        # callback must not turn per-file progress into an exception hot loop.
+        self._last_emitted_at = now
         try:
             self.callback(dict(self.state))
         except Exception:
             # Progress is observability only; it must never fail useful work.
             return
-        self._last_emitted_at = now

--- a/mempalace/progress.py
+++ b/mempalace/progress.py
@@ -1,0 +1,42 @@
+"""Small, failure-isolated progress reporting for background operations."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+ProgressCallback = Callable[[dict[str, Any]], None]
+
+
+class ProgressReporter:
+    """Merge progress fields and throttle non-forced callback delivery."""
+
+    def __init__(
+        self,
+        callback: ProgressCallback | None,
+        *,
+        min_interval: float = 1.0,
+    ) -> None:
+        self.callback = callback
+        self.min_interval = max(0.0, float(min_interval))
+        self.state: dict[str, Any] = {}
+        self._last_emitted_at: float | None = None
+
+    def emit(self, *, force: bool = False, **updates: Any) -> None:
+        self.state.update(updates)
+        if self.callback is None:
+            return
+        now = time.monotonic()
+        if (
+            not force
+            and self._last_emitted_at is not None
+            and now - self._last_emitted_at < self.min_interval
+        ):
+            return
+        try:
+            self.callback(dict(self.state))
+        except Exception:
+            # Progress is observability only; it must never fail useful work.
+            return
+        self._last_emitted_at = now

--- a/mempalace/reorganize.py
+++ b/mempalace/reorganize.py
@@ -1,0 +1,358 @@
+"""Read-only inventory and reorganization planning for Chroma palaces.
+
+This module deliberately reads Chroma's SQLite source of truth directly. It
+does not construct a ``PersistentClient`` and therefore never opens or repairs
+the HNSW index while producing a migration plan.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from .config import sqlite_read_uri
+
+
+DRAWERS_COLLECTION = "mempalace_drawers"
+_PIN_KEYS = ("pinned", "memory_pinned", "is_pinned")
+
+
+@dataclass(frozen=True)
+class InventoryRecord:
+    """One drawer reconstructed from SQLite plus its inferred source scope."""
+
+    drawer_id: str
+    content: str
+    metadata: dict[str, Any]
+    origin: str
+    relative_identity: str | None
+    source_path: str | None
+
+
+@dataclass(frozen=True)
+class MigrationAction:
+    """A non-mutating recommendation for one drawer."""
+
+    drawer_id: str
+    action: str
+    destination_wing: str
+    reason: str
+    content_sha256: str
+    metadata: dict[str, Any]
+
+
+def exact_hash(content: str) -> str:
+    """Hash the exact drawer text, including whitespace and line endings."""
+
+    return hashlib.sha256(content.encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
+def _expanded_path(value: os.PathLike[str] | str) -> Path:
+    return Path(os.path.abspath(os.path.expanduser(os.fspath(value))))
+
+
+def _normalized_roots(values: Iterable[os.PathLike[str] | str]) -> tuple[Path, ...]:
+    return tuple(_expanded_path(value) for value in values)
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _metadata_source_path(metadata: dict[str, Any]) -> Path | None:
+    source = metadata.get("source_file") or metadata.get("source_path")
+    source_root = metadata.get("source_root")
+    if source:
+        source_path = Path(os.path.expanduser(str(source)))
+        if not source_path.is_absolute() and source_root:
+            source_path = Path(os.path.expanduser(str(source_root))) / source_path
+        if source_path.is_absolute():
+            return _expanded_path(source_path)
+    if source_root:
+        root_path = Path(os.path.expanduser(str(source_root)))
+        if root_path.is_absolute():
+            return _expanded_path(root_path)
+    return None
+
+
+def _identity_from_metadata(metadata: dict[str, Any]) -> str | None:
+    identity = metadata.get("source_identity")
+    if not identity:
+        return None
+    normalized = str(identity).replace("\\", "/")
+    prefix, separator, suffix = normalized.partition(":")
+    if separator and prefix in {
+        "code",
+        "documentation",
+        "session",
+        "worktree-artifact",
+        "curated",
+    }:
+        normalized = suffix
+    normalized = normalized.lstrip("./")
+    return normalized or None
+
+
+def _classify_source(
+    metadata: dict[str, Any],
+    *,
+    canonical_root: Path,
+    worktree_roots: tuple[Path, ...],
+    session_roots: tuple[Path, ...],
+) -> tuple[str, Path | None, str | None]:
+    source_path = _metadata_source_path(metadata)
+    relative_identity = _identity_from_metadata(metadata)
+
+    if source_path is not None:
+        for root in worktree_roots:
+            if _is_within(source_path, root):
+                relative = source_path.relative_to(root).as_posix()
+                return "worktree", source_path, relative_identity or relative or None
+        for root in session_roots:
+            if _is_within(source_path, root):
+                relative = source_path.relative_to(root).as_posix()
+                return "session", source_path, relative_identity or relative or None
+        if _is_within(source_path, canonical_root):
+            relative = source_path.relative_to(canonical_root).as_posix()
+            return "canonical", source_path, relative_identity or relative or None
+
+    source_kind = str(metadata.get("source_kind") or "")
+    canonicality = str(metadata.get("source_canonicality") or "")
+    if source_kind == "session":
+        return "session", source_path, relative_identity
+    if source_kind == "worktree-artifact" or canonicality == "linked-worktree":
+        return "worktree", source_path, relative_identity
+    if source_kind in {"code", "documentation"} and canonicality == "canonical":
+        return "canonical", source_path, relative_identity
+    if source_kind == "curated" or metadata.get("wing") == "se":
+        return "curated", source_path, relative_identity
+    return "unclassified", source_path, relative_identity
+
+
+def _metadata_value(row: sqlite3.Row, value_columns: tuple[str, ...]) -> Any:
+    for column in value_columns:
+        value = row[column]
+        if value is not None:
+            if column == "bool_value":
+                return bool(value)
+            return value
+    return None
+
+
+def inventory_palace(
+    palace_path: os.PathLike[str] | str,
+    canonical_root: os.PathLike[str] | str,
+    worktree_roots: Iterable[os.PathLike[str] | str],
+    session_roots: Iterable[os.PathLike[str] | str],
+    *,
+    collection_name: str = DRAWERS_COLLECTION,
+) -> list[InventoryRecord]:
+    """Reconstruct drawers from Chroma SQLite in stable ID order.
+
+    The database is opened with ``mode=ro`` and this function never imports or
+    initializes ChromaDB.
+    """
+
+    palace = _expanded_path(palace_path)
+    sqlite_path = palace / "chroma.sqlite3"
+    if not sqlite_path.is_file():
+        raise FileNotFoundError(f"Chroma SQLite database not found: {sqlite_path}")
+
+    canonical = _expanded_path(canonical_root)
+    worktrees = _normalized_roots(worktree_roots)
+    sessions = _normalized_roots(session_roots)
+
+    with sqlite3.connect(sqlite_read_uri(str(sqlite_path)), uri=True) as conn:
+        conn.row_factory = sqlite3.Row
+        columns = {
+            str(row["name"])
+            for row in conn.execute("PRAGMA table_info(embedding_metadata)").fetchall()
+        }
+        value_columns = tuple(
+            column
+            for column in ("string_value", "int_value", "float_value", "bool_value")
+            if column in columns
+        )
+        if not value_columns:
+            raise RuntimeError("Chroma embedding_metadata has no scalar value columns")
+
+        rows = conn.execute(
+            f"""
+            SELECT e.id, e.embedding_id, em.key, {", ".join(f"em.{c}" for c in value_columns)}
+            FROM embeddings e
+            JOIN segments s ON e.segment_id = s.id
+            JOIN collections c ON s.collection = c.id
+            LEFT JOIN embedding_metadata em ON em.id = e.id
+            WHERE c.name = ?
+            ORDER BY e.embedding_id, em.key
+            """,
+            (collection_name,),
+        ).fetchall()
+
+    reconstructed: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        internal_id = int(row["id"])
+        item = reconstructed.setdefault(
+            internal_id,
+            {
+                "drawer_id": str(row["embedding_id"]),
+                "content": "",
+                "metadata": {},
+            },
+        )
+        key = row["key"]
+        if key is None:
+            continue
+        value = _metadata_value(row, value_columns)
+        if key == "chroma:document":
+            item["content"] = "" if value is None else str(value)
+        else:
+            item["metadata"][str(key)] = value
+
+    records: list[InventoryRecord] = []
+    for item in reconstructed.values():
+        metadata = item["metadata"]
+        origin, source_path, relative_identity = _classify_source(
+            metadata,
+            canonical_root=canonical,
+            worktree_roots=worktrees,
+            session_roots=sessions,
+        )
+        records.append(
+            InventoryRecord(
+                drawer_id=item["drawer_id"],
+                content=item["content"],
+                metadata=metadata,
+                origin=origin,
+                relative_identity=relative_identity,
+                source_path=str(source_path) if source_path is not None else None,
+            )
+        )
+    return sorted(records, key=lambda record: record.drawer_id)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "pinned"}
+    return bool(value)
+
+
+def _session_tier(metadata: dict[str, Any], *, hot_days: int, now: date) -> str:
+    if any(_truthy(metadata.get(key)) for key in _PIN_KEYS):
+        return "hot"
+    raw_date = metadata.get("authored_at") or metadata.get("filed_at")
+    if not raw_date:
+        return "hot"
+    try:
+        authored = date.fromisoformat(str(raw_date)[:10])
+    except ValueError:
+        return "hot"
+    return "cold" if (now - authored).days > hot_days else "hot"
+
+
+def _as_date(value: date | datetime | None) -> date:
+    if value is None:
+        return datetime.now().date()
+    if isinstance(value, datetime):
+        return value.date()
+    return value
+
+
+def plan_actions(
+    records: Iterable[InventoryRecord],
+    hot_days: int = 90,
+    now: date | datetime | None = None,
+) -> list[MigrationAction]:
+    """Classify records without changing the palace."""
+
+    if hot_days < 0:
+        raise ValueError("hot_days must be non-negative")
+    today = _as_date(now)
+    ordered = sorted(records, key=lambda record: record.drawer_id)
+    canonical_matches: dict[tuple[str, str], list[InventoryRecord]] = {}
+    for record in ordered:
+        if record.origin == "canonical" and record.relative_identity:
+            key = (record.relative_identity, exact_hash(record.content))
+            canonical_matches.setdefault(key, []).append(record)
+
+    actions: list[MigrationAction] = []
+    for record in ordered:
+        metadata = dict(record.metadata)
+        content_sha256 = exact_hash(record.content)
+        if record.origin == "canonical":
+            metadata.update(
+                {
+                    "memory_tier": "hot",
+                    "source_canonicality": "canonical",
+                    "source_kind": metadata.get("source_kind") or "code",
+                }
+            )
+            action = "reclassify_canonical"
+            destination = "se-code"
+            reason = "source is inside the canonical repository"
+        elif record.origin == "session":
+            metadata.update(
+                {
+                    "memory_tier": _session_tier(metadata, hot_days=hot_days, now=today),
+                    "source_kind": "session",
+                }
+            )
+            action = "retain_session"
+            destination = "se-sessions"
+            reason = "session memory is retained and tiered by age"
+        elif record.origin == "worktree":
+            metadata.update(
+                {
+                    "memory_tier": "cold",
+                    "source_kind": "worktree-artifact",
+                    "source_canonicality": "linked-worktree",
+                }
+            )
+            key = (record.relative_identity or "", content_sha256)
+            matches = canonical_matches.get(key, []) if record.relative_identity else []
+            if len(matches) == 1:
+                action = "duplicate_candidate"
+                reason = "one canonical drawer has the same relative identity and content"
+            elif matches:
+                action = "preserve_uncertain"
+                reason = "multiple canonical drawers match; deletion identity is ambiguous"
+            else:
+                action = "preserve_unique"
+                reason = "no canonical drawer has the same relative identity and content"
+            destination = "se-sessions"
+        elif record.origin == "curated":
+            metadata.update(
+                {
+                    "memory_tier": metadata.get("memory_tier") or "hot",
+                    "source_kind": metadata.get("source_kind") or "curated",
+                }
+            )
+            action = "retain_curated"
+            destination = "se"
+            reason = "curated project memory stays in the decision wing"
+        else:
+            metadata["memory_tier"] = metadata.get("memory_tier") or "hot"
+            action = "preserve_unclassified"
+            destination = str(metadata.get("wing") or "se")
+            reason = "source scope is unknown; preserve without guessing"
+
+        actions.append(
+            MigrationAction(
+                drawer_id=record.drawer_id,
+                action=action,
+                destination_wing=destination,
+                reason=reason,
+                content_sha256=content_sha256,
+                metadata=metadata,
+            )
+        )
+    return actions

--- a/mempalace/reorganize.py
+++ b/mempalace/reorganize.py
@@ -8,8 +8,10 @@ the HNSW index while producing a migration plan.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import sqlite3
+from collections import Counter
 from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
@@ -44,6 +46,18 @@ class MigrationAction:
     reason: str
     content_sha256: str
     metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class DuplicateEvidence:
+    """Exact identity evidence linking a worktree drawer to a canonical one."""
+
+    worktree_drawer_id: str
+    canonical_drawer_id: str
+    relative_identity: str
+    chunk_index: int
+    content_sha256: str
+    source_sha256: str | None
 
 
 def exact_hash(content: str) -> str:
@@ -267,6 +281,65 @@ def _as_date(value: date | datetime | None) -> date:
     return value
 
 
+def _chunk_index(record: InventoryRecord) -> int | None:
+    value = record.metadata.get("chunk_index")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def prove_worktree_duplicate(
+    worktree: InventoryRecord,
+    canonical: InventoryRecord,
+) -> DuplicateEvidence | None:
+    """Return strict duplicate evidence or ``None`` when proof is incomplete.
+
+    Legacy pairs where neither drawer has a file-level source hash can still be
+    proven by relative source identity, chunk coordinate, and an exact content
+    hash. If only one side has a source hash, or both hashes disagree, the pair
+    remains uncertain.
+    """
+
+    if worktree.origin != "worktree" or canonical.origin != "canonical":
+        return None
+    if not worktree.relative_identity or not canonical.relative_identity:
+        return None
+    if worktree.relative_identity != canonical.relative_identity:
+        return None
+
+    worktree_chunk = _chunk_index(worktree)
+    canonical_chunk = _chunk_index(canonical)
+    if worktree_chunk is None or canonical_chunk is None or worktree_chunk != canonical_chunk:
+        return None
+
+    worktree_content_hash = exact_hash(worktree.content)
+    if worktree_content_hash != exact_hash(canonical.content):
+        return None
+
+    worktree_source_hash = worktree.metadata.get("source_sha256")
+    canonical_source_hash = canonical.metadata.get("source_sha256")
+    if bool(worktree_source_hash) != bool(canonical_source_hash):
+        return None
+    if worktree_source_hash and str(worktree_source_hash) != str(canonical_source_hash):
+        return None
+
+    return DuplicateEvidence(
+        worktree_drawer_id=worktree.drawer_id,
+        canonical_drawer_id=canonical.drawer_id,
+        relative_identity=worktree.relative_identity,
+        chunk_index=worktree_chunk,
+        content_sha256=worktree_content_hash,
+        source_sha256=str(worktree_source_hash) if worktree_source_hash else None,
+    )
+
+
 def plan_actions(
     records: Iterable[InventoryRecord],
     hot_days: int = 90,
@@ -320,8 +393,12 @@ def plan_actions(
             key = (record.relative_identity or "", content_sha256)
             matches = canonical_matches.get(key, []) if record.relative_identity else []
             if len(matches) == 1:
-                action = "duplicate_candidate"
-                reason = "one canonical drawer has the same relative identity and content"
+                if prove_worktree_duplicate(record, matches[0]) is not None:
+                    action = "duplicate_candidate"
+                    reason = "one canonical drawer has strict exact-duplicate evidence"
+                else:
+                    action = "preserve_uncertain"
+                    reason = "candidate identity is incomplete or source hashes are asymmetric"
             elif matches:
                 action = "preserve_uncertain"
                 reason = "multiple canonical drawers match; deletion identity is ambiguous"
@@ -356,3 +433,174 @@ def plan_actions(
             )
         )
     return actions
+
+
+def collect_duplicate_evidence(
+    records: Iterable[InventoryRecord],
+    actions: Iterable[MigrationAction] | None = None,
+) -> list[DuplicateEvidence]:
+    """Collect evidence only for unambiguous ``duplicate_candidate`` actions."""
+
+    ordered = sorted(records, key=lambda record: record.drawer_id)
+    candidate_ids = (
+        {action.drawer_id for action in actions if action.action == "duplicate_candidate"}
+        if actions is not None
+        else {record.drawer_id for record in ordered if record.origin == "worktree"}
+    )
+    canonical_by_key: dict[tuple[str, str], list[InventoryRecord]] = {}
+    for record in ordered:
+        if record.origin != "canonical" or not record.relative_identity:
+            continue
+        key = (record.relative_identity, exact_hash(record.content))
+        canonical_by_key.setdefault(key, []).append(record)
+
+    evidence: list[DuplicateEvidence] = []
+    for record in ordered:
+        if record.drawer_id not in candidate_ids or record.origin != "worktree":
+            continue
+        key = (record.relative_identity or "", exact_hash(record.content))
+        matches = canonical_by_key.get(key, []) if record.relative_identity else []
+        if len(matches) != 1:
+            continue
+        proof = prove_worktree_duplicate(record, matches[0])
+        if proof is not None:
+            evidence.append(proof)
+    return sorted(evidence, key=lambda item: item.worktree_drawer_id)
+
+
+def sha256_file(path: os.PathLike[str] | str) -> str:
+    """Hash a file without loading it into memory."""
+
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def palace_snapshot(palace_path: os.PathLike[str] | str) -> dict[str, int | str]:
+    """Capture the read-only SQLite facts needed to audit a plan."""
+
+    sqlite_path = _expanded_path(palace_path) / "chroma.sqlite3"
+    stat_result = sqlite_path.stat()
+    return {
+        "size": stat_result.st_size,
+        "mtime_ns": stat_result.st_mtime_ns,
+        "sha256": sha256_file(sqlite_path),
+    }
+
+
+def _manifest_counts(
+    inventory: list[InventoryRecord],
+    actions: list[MigrationAction],
+    evidence: list[DuplicateEvidence],
+) -> dict[str, Any]:
+    origins = Counter(record.origin for record in inventory)
+    action_types = Counter(action.action for action in actions)
+    tiers = Counter(str(action.metadata.get("memory_tier") or "unspecified") for action in actions)
+    return {
+        "inventory_total": len(inventory),
+        "inventory_by_origin": dict(sorted(origins.items())),
+        "actions_by_type": dict(sorted(action_types.items())),
+        "memory_tiers": dict(sorted(tiers.items())),
+        "verified_duplicate_candidates": len(evidence),
+    }
+
+
+def _manifest_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    allowed = {
+        "chunk_index",
+        "content_sha256",
+        "memory_tier",
+        "source_canonicality",
+        "source_identity",
+        "source_kind",
+        "source_revision",
+        "source_sha256",
+    }
+    return {key: metadata[key] for key in sorted(allowed & metadata.keys())}
+
+
+def write_manifest(
+    path: os.PathLike[str] | str,
+    inventory: Iterable[InventoryRecord],
+    actions: Iterable[MigrationAction],
+    evidence: Iterable[DuplicateEvidence],
+    *,
+    palace_path: os.PathLike[str] | str | None = None,
+    sqlite_snapshot: dict[str, int | str] | None = None,
+) -> None:
+    """Write a deterministic, owner-only migration manifest.
+
+    Drawer text and source paths are intentionally excluded. The manifest
+    records stable IDs, relative identities, hashes, proposed metadata, and
+    duplicate evidence so it can be reviewed without duplicating the corpus.
+    """
+
+    inventory_list = sorted(inventory, key=lambda record: record.drawer_id)
+    action_list = sorted(actions, key=lambda action: action.drawer_id)
+    evidence_list = sorted(evidence, key=lambda item: item.worktree_drawer_id)
+    palace_string = str(_expanded_path(palace_path)) if palace_path is not None else "unspecified"
+    snapshot = (
+        dict(sqlite_snapshot)
+        if sqlite_snapshot is not None
+        else palace_snapshot(palace_string)
+        if palace_path is not None
+        else {}
+    )
+    payload = {
+        "version": 1,
+        "palace_path_sha256": exact_hash(palace_string),
+        "sqlite_snapshot": snapshot,
+        "counts": _manifest_counts(inventory_list, action_list, evidence_list),
+        "inventory": [
+            {
+                "drawer_id": record.drawer_id,
+                "origin": record.origin,
+                "relative_identity": record.relative_identity,
+                "content_sha256": exact_hash(record.content),
+                "source_path_sha256": (
+                    exact_hash(record.source_path) if record.source_path is not None else None
+                ),
+            }
+            for record in inventory_list
+        ],
+        "actions": [
+            {
+                "drawer_id": action.drawer_id,
+                "action": action.action,
+                "destination_wing": action.destination_wing,
+                "reason": action.reason,
+                "content_sha256": action.content_sha256,
+                "metadata": _manifest_metadata(action.metadata),
+            }
+            for action in action_list
+        ],
+        "duplicate_evidence": [
+            {
+                "worktree_drawer_id": item.worktree_drawer_id,
+                "canonical_drawer_id": item.canonical_drawer_id,
+                "relative_identity": item.relative_identity,
+                "chunk_index": item.chunk_index,
+                "content_sha256": item.content_sha256,
+                "source_sha256": item.source_sha256,
+            }
+            for item in evidence_list
+        ],
+    }
+    encoded = (json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n").encode(
+        "utf-8", errors="surrogatepass"
+    )
+
+    manifest_path = Path(path)
+    manifest_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    file_descriptor = os.open(manifest_path, flags, 0o600)
+    try:
+        os.fchmod(file_descriptor, 0o600)
+        with os.fdopen(file_descriptor, "wb") as handle:
+            file_descriptor = -1
+            handle.write(encoded)
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)

--- a/mempalace/reorganize.py
+++ b/mempalace/reorganize.py
@@ -22,6 +22,12 @@ from .config import sqlite_read_uri
 
 DRAWERS_COLLECTION = "mempalace_drawers"
 _PIN_KEYS = ("pinned", "memory_pinned", "is_pinned")
+_SEMANTIC_JSON_COLUMNS = {
+    ("collections", "config_json_str"),
+    ("collections", "schema_str"),
+    ("embeddings_queue_config", "config_json_str"),
+}
+_SEMANTIC_EPHEMERAL_ROW_TABLES = {"acquire_write"}
 
 
 @dataclass(frozen=True)
@@ -560,6 +566,116 @@ def palace_snapshot(palace_path: os.PathLike[str] | str) -> dict[str, Any]:
     return snapshot
 
 
+def _semantic_sqlite_value(table: str, column: str, value: Any) -> Any:
+    """Return a type-stable, JSON-serializable SQLite value."""
+    if isinstance(value, bytes):
+        return ["blob", value.hex()]
+    if isinstance(value, float):
+        return ["float", value.hex()]
+    if isinstance(value, str) and (table, column) in _SEMANTIC_JSON_COLUMNS:
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            pass
+        else:
+            canonical = json.dumps(
+                parsed,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            return ["json", canonical]
+    if value is None:
+        return ["null", None]
+    return [type(value).__name__, value]
+
+
+def palace_semantic_snapshot(palace_path: os.PathLike[str] | str) -> dict[str, Any]:
+    """Hash SQLite schema and durable rows while normalizing Chroma bookkeeping.
+
+    Chroma may rewrite collection JSON with different whitespace or key order
+    when a collection is opened. That changes the physical database checksum
+    without changing its meaning. This snapshot remains stable across that
+    bookkeeping, but any schema, durable row, or non-equivalent JSON change
+    changes the digest. Chroma's append-only ``acquire_write`` lock history is
+    excluded because merely reopening a collection adds rows to it; its table
+    schema remains covered by the schema-object hash.
+    """
+    sqlite_path = _expanded_path(palace_path) / "chroma.sqlite3"
+    if not sqlite_path.is_file():
+        raise FileNotFoundError(f"Chroma SQLite database not found: {sqlite_path}")
+
+    digest = hashlib.sha256()
+    table_count = 0
+    schema_object_count = 0
+    row_count = 0
+    with sqlite3.connect(sqlite_read_uri(str(sqlite_path)), uri=True) as connection:
+        schema_objects = connection.execute(
+            """
+            SELECT type, name, tbl_name, sql
+            FROM sqlite_master
+            WHERE type IN ('table', 'index', 'trigger', 'view')
+              AND name NOT LIKE 'sqlite_%'
+            ORDER BY type, name
+            """
+        ).fetchall()
+        for object_type, object_name, table_name, schema_sql in schema_objects:
+            descriptor = json.dumps(
+                [
+                    "schema",
+                    str(object_type),
+                    str(object_name),
+                    str(table_name),
+                    str(schema_sql or ""),
+                ],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8", errors="surrogatepass")
+            digest.update(len(descriptor).to_bytes(8, "big"))
+            digest.update(descriptor)
+            schema_object_count += 1
+
+        tables = [item for item in schema_objects if item[0] == "table"]
+        for _object_type, table_name, _owning_table, _schema_sql in tables:
+            table = str(table_name)
+            quoted = table.replace('"', '""')
+            cursor = connection.execute(f'SELECT * FROM "{quoted}"')
+            columns = [str(item[0]) for item in (cursor.description or [])]
+            descriptor = json.dumps(
+                ["rows", table, columns],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8", errors="surrogatepass")
+            digest.update(len(descriptor).to_bytes(8, "big"))
+            digest.update(descriptor)
+
+            row_digests: list[bytes] = []
+            if table not in _SEMANTIC_EPHEMERAL_ROW_TABLES:
+                for row in cursor:
+                    encoded = json.dumps(
+                        [
+                            _semantic_sqlite_value(table, column, value)
+                            for column, value in zip(columns, row)
+                        ],
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ).encode("utf-8", errors="surrogatepass")
+                    row_digests.append(hashlib.sha256(encoded).digest())
+            row_digests.sort()
+            digest.update(len(row_digests).to_bytes(8, "big"))
+            for row_digest in row_digests:
+                digest.update(row_digest)
+            table_count += 1
+            row_count += len(row_digests)
+
+    return {
+        "schema_object_count": schema_object_count,
+        "table_count": table_count,
+        "row_count": row_count,
+        "sha256": digest.hexdigest(),
+    }
+
+
 def _manifest_counts(
     inventory: list[InventoryRecord],
     actions: list[MigrationAction],
@@ -591,22 +707,16 @@ def _manifest_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
     return {key: metadata[key] for key in sorted(allowed & metadata.keys())}
 
 
-def write_manifest(
-    path: os.PathLike[str] | str,
+def build_manifest_payload(
     inventory: Iterable[InventoryRecord],
     actions: Iterable[MigrationAction],
     evidence: Iterable[DuplicateEvidence],
     *,
     palace_path: os.PathLike[str] | str | None = None,
     sqlite_snapshot: dict[str, Any] | None = None,
-) -> None:
-    """Write a deterministic, owner-only migration manifest.
-
-    Drawer text and source paths are intentionally excluded. The manifest
-    records stable IDs, relative identities, hashes, proposed metadata, and
-    duplicate evidence so it can be reviewed without duplicating the corpus.
-    """
-
+    source_semantic_snapshot: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the deterministic reviewed-manifest payload without writing it."""
     inventory_list = sorted(inventory, key=lambda record: record.drawer_id)
     action_list = sorted(actions, key=lambda action: action.drawer_id)
     evidence_list = sorted(evidence, key=lambda item: item.worktree_drawer_id)
@@ -618,10 +728,18 @@ def write_manifest(
         if palace_path is not None
         else {}
     )
-    payload = {
-        "version": 1,
+    semantic_snapshot = (
+        dict(source_semantic_snapshot)
+        if source_semantic_snapshot is not None
+        else palace_semantic_snapshot(palace_string)
+        if palace_path is not None
+        else {}
+    )
+    return {
+        "version": 2,
         "palace_path_sha256": exact_hash(palace_string),
         "sqlite_snapshot": snapshot,
+        "source_semantic_snapshot": semantic_snapshot,
         "counts": _manifest_counts(inventory_list, action_list, evidence_list),
         "inventory": [
             {
@@ -658,6 +776,71 @@ def write_manifest(
             for item in evidence_list
         ],
     }
+
+
+def read_manifest(path: os.PathLike[str] | str) -> dict[str, Any]:
+    """Read a reviewed manifest and reject non-object or unsupported payloads."""
+    manifest_path = Path(path).expanduser()
+    if manifest_path.is_symlink():
+        raise ValueError(f"manifest must not be a symlink: {manifest_path}")
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict) or payload.get("version") not in {1, 2}:
+        raise ValueError("unsupported or malformed reorganization manifest")
+    return payload
+
+
+def validate_reviewed_manifest(
+    reviewed: dict[str, Any],
+    inventory: Iterable[InventoryRecord],
+    actions: Iterable[MigrationAction],
+    evidence: Iterable[DuplicateEvidence],
+    *,
+    palace_path: os.PathLike[str] | str,
+    sqlite_snapshot: dict[str, Any],
+    source_semantic_snapshot: dict[str, Any] | None = None,
+) -> None:
+    """Require exact equality with the plan that would be generated now."""
+    expected = build_manifest_payload(
+        inventory,
+        actions,
+        evidence,
+        palace_path=palace_path,
+        sqlite_snapshot=sqlite_snapshot,
+        source_semantic_snapshot=source_semantic_snapshot,
+    )
+    if reviewed.get("version") == 1:
+        expected["version"] = 1
+        expected.pop("source_semantic_snapshot", None)
+    if reviewed != expected:
+        raise ValueError("reviewed manifest does not match the current palace migration plan")
+
+
+def write_manifest(
+    path: os.PathLike[str] | str,
+    inventory: Iterable[InventoryRecord],
+    actions: Iterable[MigrationAction],
+    evidence: Iterable[DuplicateEvidence],
+    *,
+    palace_path: os.PathLike[str] | str | None = None,
+    sqlite_snapshot: dict[str, Any] | None = None,
+    source_semantic_snapshot: dict[str, Any] | None = None,
+) -> None:
+    """Write a deterministic, owner-only migration manifest.
+
+    Drawer text and source paths are intentionally excluded. The manifest
+    records stable IDs, relative identities, hashes, proposed metadata, and
+    duplicate evidence so it can be reviewed without duplicating the corpus.
+    """
+
+    payload = build_manifest_payload(
+        inventory,
+        actions,
+        evidence,
+        palace_path=palace_path,
+        sqlite_snapshot=sqlite_snapshot,
+        source_semantic_snapshot=source_semantic_snapshot,
+    )
     encoded = (json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n").encode(
         "utf-8", errors="surrogatepass"
     )

--- a/mempalace/reorganize.py
+++ b/mempalace/reorganize.py
@@ -14,7 +14,7 @@ import sqlite3
 from collections import Counter
 from dataclasses import dataclass
 from datetime import date, datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Iterable
 
 from .config import sqlite_read_uri
@@ -67,7 +67,7 @@ def exact_hash(content: str) -> str:
 
 
 def _expanded_path(value: os.PathLike[str] | str) -> Path:
-    return Path(os.path.abspath(os.path.expanduser(os.fspath(value))))
+    return Path(os.path.realpath(os.path.abspath(os.path.expanduser(os.fspath(value)))))
 
 
 def _normalized_roots(values: Iterable[os.PathLike[str] | str]) -> tuple[Path, ...]:
@@ -112,8 +112,25 @@ def _identity_from_metadata(metadata: dict[str, Any]) -> str | None:
         "curated",
     }:
         normalized = suffix
-    normalized = normalized.lstrip("./")
-    return normalized or None
+    return _safe_relative_identity(normalized)
+
+
+def _safe_relative_identity(identity: str) -> str | None:
+    normalized = str(identity).replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    path = PurePosixPath(normalized)
+    windows_path = PureWindowsPath(normalized)
+    if (
+        not normalized
+        or normalized == "."
+        or path.is_absolute()
+        or windows_path.drive
+        or windows_path.is_absolute()
+        or ".." in path.parts
+    ):
+        return None
+    return path.as_posix()
 
 
 def _classify_source(
@@ -147,7 +164,20 @@ def _classify_source(
         return "worktree", source_path, relative_identity
     if source_kind in {"code", "documentation"} and canonicality == "canonical":
         return "canonical", source_path, relative_identity
-    if source_kind == "curated" or metadata.get("wing") == "se":
+    if source_kind == "curated":
+        return "curated", source_path, relative_identity
+    provenance_keys = {
+        "source_file",
+        "source_path",
+        "source_root",
+        "source_identity",
+        "source_kind",
+        "source_canonicality",
+        "source_revision",
+        "source_sha256",
+    }
+    has_provenance = any(metadata.get(key) not in (None, "") for key in provenance_keys)
+    if metadata.get("wing") == "se" and not has_provenance:
         return "curated", source_path, relative_identity
     return "unclassified", source_path, relative_identity
 
@@ -309,9 +339,17 @@ def prove_worktree_duplicate(
 
     if worktree.origin != "worktree" or canonical.origin != "canonical":
         return None
-    if not worktree.relative_identity or not canonical.relative_identity:
+    worktree_identity = (
+        _safe_relative_identity(worktree.relative_identity) if worktree.relative_identity else None
+    )
+    canonical_identity = (
+        _safe_relative_identity(canonical.relative_identity)
+        if canonical.relative_identity
+        else None
+    )
+    if not worktree_identity or not canonical_identity:
         return None
-    if worktree.relative_identity != canonical.relative_identity:
+    if worktree_identity != canonical_identity:
         return None
 
     worktree_chunk = _chunk_index(worktree)
@@ -333,7 +371,7 @@ def prove_worktree_duplicate(
     return DuplicateEvidence(
         worktree_drawer_id=worktree.drawer_id,
         canonical_drawer_id=canonical.drawer_id,
-        relative_identity=worktree.relative_identity,
+        relative_identity=worktree_identity,
         chunk_index=worktree_chunk,
         content_sha256=worktree_content_hash,
         source_sha256=str(worktree_source_hash) if worktree_source_hash else None,
@@ -478,16 +516,48 @@ def sha256_file(path: os.PathLike[str] | str) -> str:
     return digest.hexdigest()
 
 
-def palace_snapshot(palace_path: os.PathLike[str] | str) -> dict[str, int | str]:
+def _stable_file_snapshot(path: Path) -> dict[str, int | str]:
+    before = path.stat()
+    digest = sha256_file(path)
+    after = path.stat()
+    before_identity = (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
+    after_identity = (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+    if before_identity != after_identity:
+        raise RuntimeError(f"file changed while hashing: {path}")
+    return {
+        "size": after.st_size,
+        "mtime_ns": after.st_mtime_ns,
+        "sha256": digest,
+    }
+
+
+def palace_snapshot(palace_path: os.PathLike[str] | str) -> dict[str, Any]:
     """Capture the read-only SQLite facts needed to audit a plan."""
 
     sqlite_path = _expanded_path(palace_path) / "chroma.sqlite3"
-    stat_result = sqlite_path.stat()
-    return {
-        "size": stat_result.st_size,
-        "mtime_ns": stat_result.st_mtime_ns,
-        "sha256": sha256_file(sqlite_path),
-    }
+    snapshot: dict[str, Any] = _stable_file_snapshot(sqlite_path)
+    wal_path = Path(f"{sqlite_path}-wal")
+    try:
+        wal_snapshot = _stable_file_snapshot(wal_path)
+    except FileNotFoundError:
+        snapshot.update(
+            {
+                "wal_present": False,
+                "wal_size": None,
+                "wal_mtime_ns": None,
+                "wal_sha256": None,
+            }
+        )
+    else:
+        snapshot.update(
+            {
+                "wal_present": True,
+                "wal_size": wal_snapshot["size"],
+                "wal_mtime_ns": wal_snapshot["mtime_ns"],
+                "wal_sha256": wal_snapshot["sha256"],
+            }
+        )
+    return snapshot
 
 
 def _manifest_counts(
@@ -528,7 +598,7 @@ def write_manifest(
     evidence: Iterable[DuplicateEvidence],
     *,
     palace_path: os.PathLike[str] | str | None = None,
-    sqlite_snapshot: dict[str, int | str] | None = None,
+    sqlite_snapshot: dict[str, Any] | None = None,
 ) -> None:
     """Write a deterministic, owner-only migration manifest.
 

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -644,7 +644,10 @@ def print_sqlite_integrity_abort(palace_path: str, errors: list[str]) -> None:
 # intact ``embedding_fulltext_search_content`` shadow table, so rebuilding it
 # restores full-text search without touching any drawer rows. Concurrent
 # killed-mid-write mines are the usual cause (#1596).
-_FTS5_MALFORMED_RE = re.compile(r"malformed inverted index for FTS5 table", re.IGNORECASE)
+_FTS5_MALFORMED_RE = re.compile(
+    r"(?:malformed inverted index for FTS5 table|fts5:\s*corruption found reading blob)",
+    re.IGNORECASE,
+)
 
 
 def _errors_are_isolated_fts5(errors: list[str]) -> bool:

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -282,11 +282,18 @@ def get_user_approval(rooms: list) -> list:
 def save_config(project_dir: str, project_name: str, rooms: list):
     config = {
         "wing": project_name,
+        "source_kind": "code",
+        "reject_linked_worktrees": True,
         "rooms": [
             {
                 "name": r["name"],
                 "description": r["description"],
                 "keywords": r.get("keywords", [r["name"]]),
+                **(
+                    {"source_kind": r.get("source_kind", "documentation")}
+                    if r["name"] == "documentation" or r.get("source_kind")
+                    else {}
+                ),
             }
             for r in rooms
         ],

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -14,6 +14,7 @@ import math
 import os
 import re
 import sqlite3
+from itertools import islice
 from pathlib import Path
 from typing import List, Optional
 
@@ -302,6 +303,53 @@ def _vector_candidate_limit(n_results: int, include_cold: bool) -> int:
     # which was both slower and incomplete when the first hot hit ranked 501.
     _ = include_cold
     return n_results * 3
+
+
+_DEFAULT_HOT_TIER_FILTER = {"memory_tier": {"$ne": "cold"}}
+_SPARSE_COLD_OVERFETCH_LIMIT = 256
+
+
+def _default_tier_query_plan(
+    collection, where: dict, candidate_limit: int
+) -> tuple[dict, int, int | None]:
+    """Avoid a near-full HNSW allow-list when only a few cold rows exist.
+
+    Chroma implements ``$ne`` vector filters as an allowed-ID set.  When almost
+    every drawer is hot, constructing and applying that large set costs more
+    than querying the unfiltered index.  Fetching ``candidate_limit + cold``
+    rows is complete for the requested hot candidate window: even if every cold
+    row ranks first, ``candidate_limit`` hot rows remain for the Python-side
+    visibility check.  The caller caps visible rows back to the original
+    candidate window before ranking.  Dense cold palaces keep the metadata
+    pushdown.
+    """
+    if where != _DEFAULT_HOT_TIER_FILTER:
+        return where, candidate_limit, None
+    try:
+        cold_result = collection.get(
+            where={"memory_tier": "cold"},
+            limit=_SPARSE_COLD_OVERFETCH_LIMIT + 1,
+            include=[],
+        )
+        cold_ids = cold_result.get("ids", [])
+        if not isinstance(cold_ids, list) or len(cold_ids) > _SPARSE_COLD_OVERFETCH_LIMIT:
+            return where, candidate_limit, None
+        total = collection.count()
+        if not isinstance(total, int) or total <= 0:
+            return where, candidate_limit, None
+    except Exception:
+        logger.debug("Cold-tier cardinality probe unavailable; retaining metadata filter")
+        return where, candidate_limit, None
+    query_limit = min(total, candidate_limit + min(len(cold_ids), candidate_limit))
+    safe_limit = min(total, candidate_limit + len(cold_ids))
+    return {}, query_limit, safe_limit if safe_limit > query_limit else None
+
+
+def _hot_result_count(result) -> int:
+    return sum(
+        (metadata or {}).get("memory_tier") != "cold"
+        for metadata in _first_or_empty(result, "metadatas")
+    )
 
 
 def build_where_filter(
@@ -1255,6 +1303,56 @@ def _visible_query_rows(
             yield doc, meta, dist
 
 
+def _hydrate_source_for_query(
+    drawers_col,
+    full_source: str,
+    parent_drawer_id: str | None,
+    query: str,
+    *,
+    max_chars: int = 10000,
+) -> tuple[str, int, int] | None:
+    """Return keyword-best neighboring chunks for one logical source group."""
+    try:
+        source_drawers = drawers_col.get_source_chunks(
+            full_source,
+            parent_drawer_id=parent_drawer_id,
+        )
+    except Exception:
+        logger.debug("Neighbor fetch failed for %s", full_source, exc_info=True)
+        return None
+    docs = source_drawers.documents
+    metadatas = source_drawers.metadatas
+    if len(docs) <= 1:
+        return None
+
+    indexed = []
+    for index, (document, metadata) in enumerate(zip(docs, metadatas)):
+        chunk_index = metadata.get("chunk_index", index) if isinstance(metadata, dict) else index
+        if not isinstance(chunk_index, int):
+            chunk_index = index
+        indexed.append((chunk_index, document))
+    indexed.sort(key=lambda pair: pair[0])
+    ordered_documents = [document for _, document in indexed]
+
+    query_terms = set(_tokenize(query))
+    best_index, best_score = 0, -1
+    for index, document in enumerate(ordered_documents):
+        lowered = document.lower()
+        score = sum(1 for term in query_terms if term in lowered)
+        if score > best_score:
+            best_score, best_index = score, index
+
+    start = max(0, best_index - 1)
+    end = min(len(ordered_documents), best_index + 2)
+    expanded = "\n\n".join(ordered_documents[start:end])
+    if len(expanded) > max_chars:
+        expanded = (
+            expanded[:max_chars] + f"\n\n[...truncated. {len(ordered_documents)} total drawers. "
+            "Use mempalace_get_drawer for full content.]"
+        )
+    return expanded, best_index, len(ordered_documents)
+
+
 def search_memories(
     query: str,
     palace_path: str,
@@ -1350,15 +1448,19 @@ def search_memories(
     # produces low-signal closets (regex extraction matches few topics)
     # and closet-first routing hides drawers that direct search would find.
     try:
+        drawer_candidate_limit = _vector_candidate_limit(n_results, include_cold)
+        drawer_where, drawer_limit, drawer_safe_limit = _default_tier_query_plan(
+            drawers_col,
+            where,
+            drawer_candidate_limit,
+        )
         dkwargs = {
             "query_texts": [query],
-            # Metadata filtering removes cold rows inside Chroma before ANN
-            # ranking; over-fetch only for later distance/closet ranking.
-            "n_results": _vector_candidate_limit(n_results, include_cold),
+            "n_results": drawer_limit,
             "include": ["documents", "metadatas", "distances"],
         }
-        if where:
-            dkwargs["where"] = where
+        if drawer_where:
+            dkwargs["where"] = drawer_where
         drawer_results = _query_drawers_with_filter_fallback(
             drawers_col,
             dkwargs,
@@ -1371,6 +1473,23 @@ def search_memories(
             source_kinds=kinds,
             include_cold=include_cold,
         )
+        if (
+            drawer_safe_limit is not None
+            and _hot_result_count(drawer_results) < drawer_candidate_limit
+        ):
+            dkwargs["n_results"] = drawer_safe_limit
+            drawer_results = _query_drawers_with_filter_fallback(
+                drawers_col,
+                dkwargs,
+                query,
+                n_results,
+                wing,
+                room,
+                source_file,
+                wings=wings,
+                source_kinds=kinds,
+                include_cold=include_cold,
+            )
     except Exception as e:
         return {"error": f"Search error: {e}"}
 
@@ -1378,25 +1497,49 @@ def search_memories(
     closet_boost_by_source: dict = {}  # source_file -> (rank, closet_dist, preview)
     try:
         closets_col = get_closets_collection(palace_path, create=False)
+        closet_candidate_limit = n_results * 2
+        closet_where, closet_limit, closet_safe_limit = _default_tier_query_plan(
+            closets_col,
+            where,
+            closet_candidate_limit,
+        )
         ckwargs = {
             "query_texts": [query],
-            "n_results": n_results * 2,
+            "n_results": closet_limit,
             "include": ["documents", "metadatas", "distances"],
         }
-        if where:
-            ckwargs["where"] = where
+        if closet_where:
+            ckwargs["where"] = closet_where
         closet_results = closets_col.query(**ckwargs)
-        for rank, (cdoc, cmeta, cdist) in enumerate(
-            zip(
-                _first_or_empty(closet_results, "documents"),
-                _first_or_empty(closet_results, "metadatas"),
-                _first_or_empty(closet_results, "distances"),
-            )
+        if (
+            closet_safe_limit is not None
+            and _hot_result_count(closet_results) < closet_candidate_limit
         ):
+            ckwargs["n_results"] = closet_safe_limit
+            closet_results = closets_col.query(**ckwargs)
+        closet_rows = zip(
+            _first_or_empty(closet_results, "documents"),
+            _first_or_empty(closet_results, "metadatas"),
+            _first_or_empty(closet_results, "distances"),
+        )
+        visible_rank = 0
+        for cdoc, cmeta, cdist in closet_rows:
             cmeta = cmeta or {}
+            if not _metadata_visible(
+                cmeta,
+                scoped_wings=scoped_wings,
+                room=room,
+                source_file=source_file,
+                source_kinds=kinds,
+                include_cold=include_cold,
+            ):
+                continue
+            if visible_rank >= n_results * 2:
+                break
             source = cmeta.get("source_file", "")
             if source and source not in closet_boost_by_source:
-                closet_boost_by_source[source] = (rank, cdist, cdoc[:200])
+                closet_boost_by_source[source] = (visible_rank, cdist, cdoc[:200])
+            visible_rank += 1
     except Exception:
         # No closets yet — hybrid degrades to pure drawer search.
         logger.debug("Closet collection unavailable; using drawer-only search", exc_info=True)
@@ -1408,13 +1551,17 @@ def search_memories(
     CLOSET_DISTANCE_CAP = 1.5  # cosine dist > 1.5 = too weak to use as signal
 
     scored: list = []
-    for doc, meta, dist in _visible_query_rows(
+    visible_drawers = _visible_query_rows(
         drawer_results,
         scoped_wings=scoped_wings,
         room=room,
         source_file=source_file,
         source_kinds=kinds,
         include_cold=include_cold,
+    )
+    for doc, meta, dist in islice(
+        visible_drawers,
+        _vector_candidate_limit(n_results, include_cold),
     ):
         doc = doc or ""
         # Filter on raw distance before rounding to avoid precision loss.
@@ -1475,58 +1622,29 @@ def search_memories(
     # neighbors instead of just the drawer vector search landed on. The
     # closet said "this source is relevant"; vector may have picked the
     # wrong chunk within it; grep picks the right one.
-    MAX_HYDRATION_CHARS = 10000
+    hydration_cache: dict[tuple[str, str | None], tuple[str, int, int] | None] = {}
     for h in hits:
         if h["matched_via"] == "drawer":
             continue
         full_source = h.get("_source_file_full") or ""
         if not full_source:
             continue
-        # Narrow by ``parent_drawer_id`` when present so unrelated
-        # chunked drawers sharing ``source_file`` do not stitch (#1580).
-        try:
-            source_drawers = drawers_col.get(
-                where=_scoped_source_filter(full_source, h.get("_parent_drawer_id")),
-                include=["documents", "metadatas"],
+        parent_drawer_id = h.get("_parent_drawer_id")
+        cache_key = (full_source, parent_drawer_id)
+        if cache_key not in hydration_cache:
+            # Narrow by ``parent_drawer_id`` when present so unrelated
+            # chunked drawers sharing ``source_file`` do not stitch (#1580).
+            hydration_cache[cache_key] = _hydrate_source_for_query(
+                drawers_col,
+                full_source,
+                parent_drawer_id,
+                query,
             )
-        except Exception:
-            logger.debug("Neighbor fetch failed for %s", full_source, exc_info=True)
+
+        hydrated = hydration_cache[cache_key]
+        if hydrated is None:
             continue
-        docs = source_drawers.documents
-        metas_ = source_drawers.metadatas
-        if len(docs) <= 1:
-            continue
-
-        # Sort by chunk_index so best_idx + neighbors are positional.
-        indexed = []
-        for idx, (d, m) in enumerate(zip(docs, metas_)):
-            ci = m.get("chunk_index", idx) if isinstance(m, dict) else idx
-            if not isinstance(ci, int):
-                ci = idx
-            indexed.append((ci, d))
-        indexed.sort(key=lambda p: p[0])
-        ordered_docs = [d for _, d in indexed]
-
-        query_terms = set(_tokenize(query))
-        best_idx, best_score = 0, -1
-        for idx, d in enumerate(ordered_docs):
-            d_lower = d.lower()
-            s = sum(1 for t in query_terms if t in d_lower)
-            if s > best_score:
-                best_score, best_idx = s, idx
-
-        start = max(0, best_idx - 1)
-        end = min(len(ordered_docs), best_idx + 2)
-        expanded = "\n\n".join(ordered_docs[start:end])
-        if len(expanded) > MAX_HYDRATION_CHARS:
-            expanded = (
-                expanded[:MAX_HYDRATION_CHARS]
-                + f"\n\n[...truncated. {len(ordered_docs)} total drawers. "
-                "Use mempalace_get_drawer for full content.]"
-            )
-        h["text"] = expanded
-        h["drawer_index"] = best_idx
-        h["total_drawers"] = len(ordered_docs)
+        h["text"], h["drawer_index"], h["total_drawers"] = hydrated
 
     # Candidate strategy hook: optionally widen the rerank pool's *source*
     # before ranking. Default ("vector") is a no-op; "union" merges top-K

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -15,6 +15,7 @@ import os
 import re
 import sqlite3
 from pathlib import Path
+from typing import List, Optional
 
 from .backends import (
     BackendError,
@@ -24,6 +25,7 @@ from .backends import (
     UnsupportedCapabilityError,
 )
 from .config import sqlite_read_uri
+from .source_metadata import SOURCE_KINDS
 from .palace import (
     _open_collection_or_explain,
     get_closets_collection,
@@ -237,19 +239,97 @@ def _hybrid_rank(
     return results
 
 
-def build_where_filter(wing: str = None, room: str = None, source_file: str = None) -> dict:
-    """Build a ChromaDB where filter from optional wing/room/source_file.
+def _validate_scope(wing: Optional[str], wings: Optional[List[str]]) -> List[str]:
+    if wing and wings:
+        raise ValueError("wing and wings are mutually exclusive")
+    values = [wing] if wing else list(wings or [])
+    if any(not isinstance(value, str) or not value for value in values):
+        raise ValueError("wings must contain non-empty strings")
+    return list(dict.fromkeys(values))
+
+
+def _validate_source_kinds(source_kinds: Optional[List[str]]) -> List[str]:
+    values = list(source_kinds or [])
+    invalid = [value for value in values if value not in SOURCE_KINDS]
+    if invalid:
+        raise ValueError(f"invalid source_kind: {invalid[0]!r}")
+    return list(dict.fromkeys(values))
+
+
+def _metadata_visible(
+    meta: dict,
+    *,
+    scoped_wings: List[str],
+    room: Optional[str],
+    source_file: Optional[str],
+    source_kinds: List[str],
+    include_cold: bool,
+) -> bool:
+    if scoped_wings and meta.get("wing") not in scoped_wings:
+        return False
+    if room and meta.get("room") != room:
+        return False
+    if source_file and meta.get("source_file") != source_file:
+        return False
+    if source_kinds and meta.get("source_kind") not in source_kinds:
+        return False
+    return include_cold or meta.get("memory_tier", "hot") != "cold"
+
+
+def _filter_envelope(
+    *,
+    wing=None,
+    wings=None,
+    room=None,
+    source_file=None,
+    source_kinds=None,
+    include_cold=False,
+) -> dict:
+    return {
+        "wing": wing,
+        "wings": list(wings or []),
+        "room": room,
+        "source_file": source_file,
+        "source_kinds": list(source_kinds or []),
+        "include_cold": bool(include_cold),
+    }
+
+
+def _vector_candidate_limit(n_results: int, include_cold: bool) -> int:
+    multiplier = 3 if include_cold else 15
+    return min(n_results * multiplier, 500)
+
+
+def build_where_filter(
+    wing: str = None,
+    room: str = None,
+    source_file: str = None,
+    *,
+    wings: List[str] = None,
+    source_kinds: List[str] = None,
+    include_cold: bool = False,
+) -> dict:
+    """Build a ChromaDB where filter from optional source scopes.
 
     ChromaDB needs a ``$and`` only when ≥2 clauses are present; a single
     clause is returned bare and zero clauses yield an empty filter (#1815).
+    Tier visibility is post-filtered because Chroma cannot express
+    ``memory_tier is missing OR memory_tier != cold`` portably.
     """
+    scoped_wings = _validate_scope(wing, wings)
+    kinds = _validate_source_kinds(source_kinds)
     clauses = []
     if wing:
         clauses.append({"wing": wing})
+    elif scoped_wings:
+        clauses.append({"wing": {"$in": scoped_wings}})
     if room:
         clauses.append({"room": room})
     if source_file:
         clauses.append({"source_file": source_file})
+    if kinds:
+        clauses.append({"source_kind": {"$in": kinds}})
+    _ = include_cold
     if not clauses:
         return {}
     if len(clauses) == 1:
@@ -501,6 +581,9 @@ def _bm25_only_via_sqlite(
     max_candidates: int = 500,
     _include_internal: bool = False,
     collection_name: str = None,
+    wings: List[str] = None,
+    source_kinds: List[str] = None,
+    include_cold: bool = False,
 ) -> dict:
     """BM25-only search reading drawers directly from chroma.sqlite3.
 
@@ -528,11 +611,21 @@ def _bm25_only_via_sqlite(
         from .config import get_configured_collection_name
 
         collection_name = get_configured_collection_name()
+    scoped_wings = _validate_scope(wing, wings)
+    kinds = _validate_source_kinds(source_kinds)
+    filters = _filter_envelope(
+        wing=wing,
+        wings=wings,
+        room=room,
+        source_file=source_file,
+        source_kinds=kinds,
+        include_cold=include_cold,
+    )
 
     def _metadata_filter_sql(row_id_expr: str) -> tuple[str, list[str]]:
         clauses = []
         params = []
-        for key, value in (("wing", wing), ("room", room), ("source_file", source_file)):
+        for key, value in (("room", room), ("source_file", source_file)):
             if not value:
                 continue
             clauses.append(
@@ -552,6 +645,34 @@ def _bm25_only_via_sqlite(
                 """
             )
             params.extend([key, value])
+        for key, values in (("wing", scoped_wings), ("source_kind", kinds)):
+            if not values:
+                continue
+            placeholders = ",".join("?" for _ in values)
+            clauses.append(
+                f"""
+                AND EXISTS (
+                    SELECT 1
+                    FROM embedding_metadata mf
+                    WHERE mf.id = {row_id_expr}
+                      AND mf.key = ?
+                      AND mf.string_value IN ({placeholders})
+                )
+                """
+            )
+            params.extend([key, *values])
+        if not include_cold:
+            clauses.append(
+                f"""
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM embedding_metadata mt
+                    WHERE mt.id = {row_id_expr}
+                      AND mt.key = 'memory_tier'
+                      AND mt.string_value = 'cold'
+                )
+                """
+            )
         return "".join(clauses), params
 
     try:
@@ -645,7 +766,7 @@ def _bm25_only_via_sqlite(
         if not candidate_ids:
             return {
                 "query": query,
-                "filters": {"wing": wing, "room": room, "source_file": source_file},
+                "filters": filters,
                 "total_before_filter": 0,
                 "results": [],
                 "fallback": "bm25_only_via_sqlite",
@@ -677,11 +798,14 @@ def _bm25_only_via_sqlite(
     candidates = []
     for d in drawers.values():
         meta = d["metadata"]
-        if wing and meta.get("wing") != wing:
-            continue
-        if room and meta.get("room") != room:
-            continue
-        if source_file and meta.get("source_file") != source_file:
+        if not _metadata_visible(
+            meta,
+            scoped_wings=scoped_wings,
+            room=room,
+            source_file=source_file,
+            source_kinds=kinds,
+            include_cold=include_cold,
+        ):
             continue
         full_source = meta.get("source_file", "") or ""
         candidates.append(
@@ -727,7 +851,7 @@ def _bm25_only_via_sqlite(
 
     return {
         "query": query,
-        "filters": {"wing": wing, "room": room, "source_file": source_file},
+        "filters": filters,
         "total_before_filter": len(candidates),
         "results": hits,
         "fallback": "bm25_only_via_sqlite",
@@ -744,6 +868,9 @@ def _merge_bm25_union_candidates(
     n_results: int,
     max_distance: float = 0.0,
     source_file: str = None,
+    wings=None,
+    source_kinds=None,
+    include_cold=False,
 ) -> None:
     """Append top-K backend lexical candidates into ``hits`` in place.
 
@@ -770,7 +897,16 @@ def _merge_bm25_union_candidates(
     if max_distance > 0.0:
         return
 
-    where = build_where_filter(wing, room, source_file)
+    scoped_wings = _validate_scope(wing, wings)
+    kinds = _validate_source_kinds(source_kinds)
+    where = build_where_filter(
+        wing,
+        room,
+        source_file,
+        wings=wings,
+        source_kinds=kinds,
+        include_cold=include_cold,
+    )
     try:
         lexical = drawers_col.lexical_search(
             query=query,
@@ -786,6 +922,15 @@ def _merge_bm25_union_candidates(
     bm25_extra = []
     for hit in lexical.hits:
         meta = hit.metadata or {}
+        if not _metadata_visible(
+            meta,
+            scoped_wings=scoped_wings,
+            room=room,
+            source_file=source_file,
+            source_kinds=kinds,
+            include_cold=include_cold,
+        ):
+            continue
         full_source = meta.get("source_file", "") or ""
         bm25_extra.append(
             {
@@ -861,6 +1006,9 @@ def _apply_candidate_strategy(
     n_results: int,
     max_distance: float = 0.0,
     source_file: str = None,
+    wings=None,
+    source_kinds=None,
+    include_cold=False,
 ) -> None:
     """Dispatch to the registered merger for ``strategy``.
 
@@ -878,6 +1026,9 @@ def _apply_candidate_strategy(
             n_results,
             max_distance=max_distance,
             source_file=source_file,
+            wings=wings,
+            source_kinds=source_kinds,
+            include_cold=include_cold,
         )
 
 
@@ -892,6 +1043,9 @@ def _finalize_candidate_hits(
     n_results: int,
     max_distance: float,
     source_file: str = None,
+    wings=None,
+    source_kinds=None,
+    include_cold=False,
 ) -> tuple:
     try:
         _apply_candidate_strategy(
@@ -904,6 +1058,9 @@ def _finalize_candidate_hits(
             n_results,
             max_distance=max_distance,
             source_file=source_file,
+            wings=wings,
+            source_kinds=source_kinds,
+            include_cold=include_cold,
         )
     except UnsupportedCapabilityError:
         return [], {
@@ -946,6 +1103,9 @@ def _vector_disabled_search(
     n_results: int,
     collection_name: str,
     source_file: str = None,
+    wings: List[str] = None,
+    source_kinds: List[str] = None,
+    include_cold: bool = False,
 ) -> dict:
     try:
         backend_name = resolve_backend_name(palace_path)
@@ -968,6 +1128,9 @@ def _vector_disabled_search(
         source_file=source_file,
         n_results=n_results,
         collection_name=collection_name,
+        wings=wings,
+        source_kinds=source_kinds,
+        include_cold=include_cold,
     )
 
 
@@ -1000,7 +1163,16 @@ def _open_search_collection(palace_path: str, collection_name: str):
 
 
 def _query_drawers_with_filter_fallback(
-    drawers_col, dkwargs, query, n_results, wing, room, source_file=None
+    drawers_col,
+    dkwargs,
+    query,
+    n_results,
+    wing,
+    room,
+    source_file=None,
+    wings=None,
+    source_kinds=None,
+    include_cold=False,
 ):
     """Run the filtered drawer query, falling back to an unfiltered query plus a
     Python-side post-filter when ChromaDB raises on the filtered query.
@@ -1027,6 +1199,8 @@ def _query_drawers_with_filter_fallback(
             n_results=min(n_results * 15, 500),
             include=["documents", "metadatas", "distances"],
         )
+        scoped_wings = _validate_scope(wing, wings)
+        kinds = _validate_source_kinds(source_kinds)
         fdocs, fmetas, fdists = [], [], []
         for doc, meta, dist in zip(
             _first_or_empty(raw, "documents"),
@@ -1034,16 +1208,45 @@ def _query_drawers_with_filter_fallback(
             _first_or_empty(raw, "distances"),
         ):
             meta = meta or {}
-            if wing and meta.get("wing") != wing:
-                continue
-            if room and meta.get("room") != room:
-                continue
-            if source_file and meta.get("source_file") != source_file:
+            if not _metadata_visible(
+                meta,
+                scoped_wings=scoped_wings,
+                room=room,
+                source_file=source_file,
+                source_kinds=kinds,
+                include_cold=include_cold,
+            ):
                 continue
             fdocs.append(doc)
             fmetas.append(meta)
             fdists.append(dist)
         return {"documents": [fdocs], "metadatas": [fmetas], "distances": [fdists]}
+
+
+def _visible_query_rows(
+    drawer_results,
+    *,
+    scoped_wings,
+    room,
+    source_file,
+    source_kinds,
+    include_cold,
+):
+    for doc, meta, dist in zip(
+        _first_or_empty(drawer_results, "documents"),
+        _first_or_empty(drawer_results, "metadatas"),
+        _first_or_empty(drawer_results, "distances"),
+    ):
+        meta = meta or {}
+        if _metadata_visible(
+            meta,
+            scoped_wings=scoped_wings,
+            room=room,
+            source_file=source_file,
+            source_kinds=source_kinds,
+            include_cold=include_cold,
+        ):
+            yield doc, meta, dist
 
 
 def search_memories(
@@ -1057,6 +1260,9 @@ def search_memories(
     vector_disabled: bool = False,
     candidate_strategy: str = "vector",
     collection_name: str = None,
+    wings: List[str] = None,
+    source_kinds: List[str] = None,
+    include_cold: bool = False,
 ) -> dict:
     """Programmatic search — returns a dict instead of printing.
 
@@ -1099,6 +1305,8 @@ def search_memories(
     # regardless of whether the call routes through the vector path or
     # the BM25-only fallback below.
     _validate_candidate_strategy(candidate_strategy)
+    scoped_wings = _validate_scope(wing, wings)
+    kinds = _validate_source_kinds(source_kinds)
 
     if vector_disabled:
         return _vector_disabled_search(
@@ -1109,6 +1317,9 @@ def search_memories(
             n_results=n_results,
             collection_name=collection_name,
             source_file=source_file,
+            wings=wings,
+            source_kinds=kinds,
+            include_cold=include_cold,
         )
 
     drawers_col, open_error = _open_search_collection(palace_path, collection_name)
@@ -1116,7 +1327,14 @@ def search_memories(
         return open_error
 
     metric = _metric_for_collection(drawers_col)
-    where = build_where_filter(wing, room, source_file)
+    where = build_where_filter(
+        wing,
+        room,
+        source_file,
+        wings=wings,
+        source_kinds=kinds,
+        include_cold=include_cold,
+    )
 
     # Hybrid retrieval: always query drawers directly (the floor), then use
     # closet hits to boost rankings. Closets are a ranking SIGNAL, never a
@@ -1128,13 +1346,24 @@ def search_memories(
     try:
         dkwargs = {
             "query_texts": [query],
-            "n_results": n_results * 3,  # over-fetch for re-ranking
+            # Cold-tier filtering is post-query for legacy missing-as-hot
+            # semantics, so fetch a wider pool before trimming.
+            "n_results": _vector_candidate_limit(n_results, include_cold),
             "include": ["documents", "metadatas", "distances"],
         }
         if where:
             dkwargs["where"] = where
         drawer_results = _query_drawers_with_filter_fallback(
-            drawers_col, dkwargs, query, n_results, wing, room, source_file
+            drawers_col,
+            dkwargs,
+            query,
+            n_results,
+            wing,
+            room,
+            source_file,
+            wings=wings,
+            source_kinds=kinds,
+            include_cold=include_cold,
         )
     except Exception as e:
         return {"error": f"Search error: {e}"}
@@ -1173,12 +1402,14 @@ def search_memories(
     CLOSET_DISTANCE_CAP = 1.5  # cosine dist > 1.5 = too weak to use as signal
 
     scored: list = []
-    for doc, meta, dist in zip(
-        _first_or_empty(drawer_results, "documents"),
-        _first_or_empty(drawer_results, "metadatas"),
-        _first_or_empty(drawer_results, "distances"),
+    for doc, meta, dist in _visible_query_rows(
+        drawer_results,
+        scoped_wings=scoped_wings,
+        room=room,
+        source_file=source_file,
+        source_kinds=kinds,
+        include_cold=include_cold,
     ):
-        meta = meta or {}
         doc = doc or ""
         # Filter on raw distance before rounding to avoid precision loss.
         if max_distance > 0.0 and dist > max_distance:
@@ -1309,13 +1540,23 @@ def search_memories(
         n_results=n_results,
         max_distance=max_distance,
         source_file=source_file,
+        wings=wings,
+        source_kinds=kinds,
+        include_cold=include_cold,
     )
     if strategy_error:
         return strategy_error
 
     return {
         "query": query,
-        "filters": {"wing": wing, "room": room, "source_file": source_file},
+        "filters": _filter_envelope(
+            wing=wing,
+            wings=wings,
+            room=room,
+            source_file=source_file,
+            source_kinds=kinds,
+            include_cold=include_cold,
+        ),
         "total_before_filter": len(_first_or_empty(drawer_results, "documents")),
         "results": hits,
     }

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -296,8 +296,12 @@ def _filter_envelope(
 
 
 def _vector_candidate_limit(n_results: int, include_cold: bool) -> int:
-    multiplier = 3 if include_cold else 15
-    return min(n_results * multiplier, 500)
+    # Visibility is enforced by Chroma's metadata filter, so the query only
+    # needs modest over-fetching for later distance/closet ranking.  The old
+    # hot-tier path fetched up to 500 rows and filtered cold rows afterwards,
+    # which was both slower and incomplete when the first hot hit ranked 501.
+    _ = include_cold
+    return n_results * 3
 
 
 def build_where_filter(
@@ -313,8 +317,9 @@ def build_where_filter(
 
     ChromaDB needs a ``$and`` only when ≥2 clauses are present; a single
     clause is returned bare and zero clauses yield an empty filter (#1815).
-    Tier visibility is post-filtered because Chroma cannot express
-    ``memory_tier is missing OR memory_tier != cold`` portably.
+    Chroma's ``$ne`` comparison includes records where the metadata key is
+    absent, preserving the legacy missing-as-hot behavior while excluding
+    cold records before nearest-neighbour ranking.
     """
     scoped_wings = _validate_scope(wing, wings)
     kinds = _validate_source_kinds(source_kinds)
@@ -329,7 +334,8 @@ def build_where_filter(
         clauses.append({"source_file": source_file})
     if kinds:
         clauses.append({"source_kind": {"$in": kinds}})
-    _ = include_cold
+    if not include_cold:
+        clauses.append({"memory_tier": {"$ne": "cold"}})
     if not clauses:
         return {}
     if len(clauses) == 1:
@@ -1346,8 +1352,8 @@ def search_memories(
     try:
         dkwargs = {
             "query_texts": [query],
-            # Cold-tier filtering is post-query for legacy missing-as-hot
-            # semantics, so fetch a wider pool before trimming.
+            # Metadata filtering removes cold rows inside Chroma before ANN
+            # ranking; over-fetch only for later distance/closet ranking.
             "n_results": _vector_candidate_limit(n_results, include_cold),
             "include": ["documents", "metadatas", "distances"],
         }

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -212,6 +212,7 @@ def run_mine(payload: dict[str, Any], progress_callback=None) -> dict[str, Any]:
                 include_ignored=include_ignored,
                 max_chunks_per_file=payload.get("max_chunks_per_file"),
                 progress_callback=progress_callback,
+                source_canonicality=payload.get("source_canonicality") or "canonical",
             )
         else:
             return {"success": False, "error": f"invalid mine mode: {mode}", "exit_code": 2}

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -104,6 +104,46 @@ def _capture(fn):
     return result, stdout.getvalue(), stderr.getvalue()
 
 
+def _verify_chroma_readiness(palace_path: str, collection_name: str) -> dict[str, Any]:
+    """Prove persisted vector state can be reopened and queried after mining."""
+    from .backends.chroma import hnsw_capacity_status
+
+    status = hnsw_capacity_status(palace_path, collection_name)
+    status["ready"] = False
+    if status.get("diverged"):
+        return status
+
+    try:
+        from .palace import get_backend_for_palace, get_collection
+
+        backend = get_backend_for_palace(palace_path, explicit="chroma")
+        backend.close_palace(palace_path)
+        collection = get_collection(
+            palace_path,
+            collection_name=collection_name,
+            create=False,
+            backend="chroma",
+        )
+        count = collection.count()
+        if count:
+            collection.query(
+                query_texts=["mempalace post-mine readiness probe"],
+                n_results=1,
+                include=["distances"],
+            )
+    except Exception as exc:
+        status.update(
+            status="unready",
+            message=f"persisted HNSW reopen/query failed after mine: {exc}",
+            readiness_error_class=type(exc).__name__,
+        )
+        return status
+
+    status["ready"] = True
+    status["query_ready"] = True
+    return status
+
+
 def execute_job(
     kind: str,
     payload: dict[str, Any],
@@ -170,6 +210,7 @@ def run_mine(payload: dict[str, Any], progress_callback=None) -> dict[str, Any]:
         _run_pass_zero(project_dir=source, palace_dir=palace_path, llm_provider=None)
 
     from .palace import MineAlreadyRunning, MineValidationError
+    from .source_metadata import LinkedWorktreeRejected
 
     try:
         if mode == "convos":
@@ -223,6 +264,15 @@ def run_mine(payload: dict[str, Any], progress_callback=None) -> dict[str, Any]:
             "error_class": "LockHeldByOtherProcess",
             "exit_code": 1,
         }
+    except LinkedWorktreeRejected as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_class": "LinkedWorktreeRejected",
+            "source": exc.source,
+            "canonical_root": exc.canonical_root,
+            "exit_code": 1,
+        }
     except MineValidationError as exc:
         return {
             "success": False,
@@ -241,7 +291,30 @@ def run_mine(payload: dict[str, Any], progress_callback=None) -> dict[str, Any]:
     except Exception as exc:
         return {"success": False, "error": f"mine failed: {exc}", "exit_code": 1}
 
-    return {"success": True, "kind": "mine", "mode": mode, "dry_run": dry_run, "exit_code": 0}
+    result = {"success": True, "kind": "mine", "mode": mode, "dry_run": dry_run, "exit_code": 0}
+    if dry_run:
+        return result
+
+    # A committed SQLite transaction is not sufficient proof that vector
+    # retrieval is production-ready.  Validate Chroma's persisted HNSW state
+    # before the durable job becomes terminal so automation cannot mistake a
+    # capacity-diverged palace for a successful mine.
+    from .palace import resolve_backend_name
+
+    if resolve_backend_name(palace_path) == "chroma":
+        vector_status = _verify_chroma_readiness(
+            palace_path,
+            MempalaceConfig().collection_name,
+        )
+        result["vector_status"] = vector_status
+        if not vector_status.get("ready"):
+            result.update(
+                success=False,
+                error=vector_status.get("message") or "HNSW capacity diverged after mine",
+                error_class="VectorReadinessError",
+                exit_code=1,
+            )
+    return result
 
 
 def run_sync(payload: dict[str, Any]) -> dict[str, Any]:
@@ -361,6 +434,7 @@ def run_diary_write(payload: dict[str, Any]) -> dict[str, Any]:
         entry=payload.get("entry") or "",
         topic=payload.get("topic") or "general",
         wing=payload.get("wing") or "",
+        _operation_id=payload.get("operation_id"),
     )
     result.setdefault("exit_code", 0 if result.get("success") else 1)
     return result
@@ -392,7 +466,11 @@ def run_mcp_tool(payload: dict[str, Any]) -> dict[str, Any]:
 
     if name not in TOOLS:
         return {"success": False, "error": f"unknown MCP tool: {name}", "exit_code": 2}
-    result = TOOLS[name]["handler"](**arguments)
+    handler_arguments = dict(arguments)
+    if name in {"mempalace_diary_write", "mempalace_checkpoint"}:
+        handler_arguments.pop("_operation_id", None)
+        handler_arguments["_operation_id"] = payload.get("operation_id")
+    result = TOOLS[name]["handler"](**handler_arguments)
     if isinstance(result, dict):
         # Several write tools signal failure with a bare {"error": ...} and no
         # explicit success flag (e.g. tool_create_tunnel / tool_delete_tunnel

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -101,12 +101,18 @@ def _capture(fn):
     return result, stdout.getvalue(), stderr.getvalue()
 
 
-def execute_job(kind: str, payload: dict[str, Any]) -> dict[str, Any]:
+def execute_job(
+    kind: str,
+    payload: dict[str, Any],
+    progress_callback=None,
+) -> dict[str, Any]:
     """Execute one daemon job and return a JSON-serializable result."""
 
     def _run():
         if kind == "mine":
-            return run_mine(payload)
+            if progress_callback is None:
+                return run_mine(payload)
+            return run_mine(payload, progress_callback=progress_callback)
         if kind == "sync":
             return run_sync(payload)
         if kind == "diary_write":
@@ -140,7 +146,7 @@ def execute_job(kind: str, payload: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
-def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
+def run_mine(payload: dict[str, Any], progress_callback=None) -> dict[str, Any]:
     """Run the same mine operation as the CLI, without daemon transport concerns."""
     palace_path = os.path.abspath(
         os.path.expanduser(payload.get("palace_path") or MempalaceConfig().palace_path)
@@ -174,6 +180,7 @@ def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
                 limit=limit,
                 dry_run=dry_run,
                 extract_mode=payload.get("extract") or "exchange",
+                progress_callback=progress_callback,
             )
         elif mode == "extract":
             from .format_miner import mine_formats
@@ -185,6 +192,7 @@ def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
                 agent=agent,
                 limit=limit,
                 dry_run=dry_run,
+                progress_callback=progress_callback,
             )
         elif mode == "projects":
             include_ignored = payload.get("include_ignored") or []
@@ -200,6 +208,7 @@ def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
                 respect_gitignore=not bool(payload.get("no_gitignore")),
                 include_ignored=include_ignored,
                 max_chunks_per_file=payload.get("max_chunks_per_file"),
+                progress_callback=progress_callback,
             )
         else:
             return {"success": False, "error": f"invalid mine mode: {mode}", "exit_code": 2}

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -29,6 +29,8 @@ _PER_JOB_ENV = (_PALACE_PATH_ENV, _BACKEND_ENV, _EXPLICIT_BACKEND_ENV)
 READ_TOOLS = frozenset(
     {
         "mempalace_status",
+        "mempalace_job_status",
+        "mempalace_list_jobs",
         "mempalace_list_wings",
         "mempalace_list_rooms",
         "mempalace_get_taxonomy",
@@ -61,6 +63,7 @@ WRITE_TOOLS = frozenset(
         "mempalace_diary_write",
         "mempalace_kg_add",
         "mempalace_kg_invalidate",
+        "mempalace_kg_supersede",
         "mempalace_create_tunnel",
         "mempalace_delete_tunnel",
         "mempalace_delete_hallway",

--- a/mempalace/source_metadata.py
+++ b/mempalace/source_metadata.py
@@ -60,6 +60,23 @@ def _validate_context(context: SourceContext) -> None:
         raise ValueError(f"invalid source_canonicality: {context.source_canonicality!r}")
 
 
+def source_kind_for_room(config: dict, room_name: str) -> str:
+    """Resolve a validated per-room source kind with a project default."""
+    default = config.get("source_kind", "code")
+    room = next(
+        (
+            item
+            for item in config.get("rooms", [])
+            if isinstance(item, dict) and item.get("name") == room_name
+        ),
+        {},
+    )
+    value = room.get("source_kind", default)
+    if value not in SOURCE_KINDS:
+        raise ValueError(f"invalid source_kind: {value!r}")
+    return value
+
+
 def build_source_metadata(
     context: SourceContext,
     content: str,

--- a/mempalace/source_metadata.py
+++ b/mempalace/source_metadata.py
@@ -6,10 +6,23 @@ import hashlib
 import os
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 
 SOURCE_KINDS = frozenset({"curated", "code", "documentation", "session", "worktree-artifact"})
 MEMORY_TIERS = frozenset({"hot", "cold"})
 SOURCE_CANONICALITIES = frozenset({"canonical", "linked-worktree"})
+
+
+class LinkedWorktreeRejected(ValueError):
+    """Raised when project mining targets a non-canonical Git worktree."""
+
+    def __init__(self, source: str, canonical_root: str | None):
+        self.source = source
+        self.canonical_root = canonical_root
+        message = "linked Git worktree mining is disabled; mine the canonical checkout"
+        if canonical_root:
+            message += f" at {canonical_root}"
+        super().__init__(message)
 
 
 @dataclass(frozen=True)
@@ -49,6 +62,68 @@ def git_revision(root: str) -> str | None:
         return None
     revision = result.stdout.strip()
     return revision if result.returncode == 0 and revision else None
+
+
+def _git_output(source: str, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", source, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _primary_worktree(source: str) -> str | None:
+    listing = _git_output(source, "worktree", "list", "--porcelain")
+    if not listing:
+        return None
+    for line in listing.splitlines():
+        if line.startswith("worktree "):
+            return os.path.realpath(line.removeprefix("worktree ").strip())
+    return None
+
+
+def detect_linked_worktree(source: str) -> tuple[bool, str | None]:
+    """Return whether ``source`` is a linked checkout and its primary root."""
+    source = os.path.realpath(os.path.expanduser(source))
+    roots = _git_output(
+        source,
+        "rev-parse",
+        "--absolute-git-dir",
+        "--path-format=absolute",
+        "--git-common-dir",
+    )
+    lines = roots.splitlines() if roots else []
+    if len(lines) != 2:
+        return False, None
+
+    git_dir = Path(lines[0]).resolve()
+    common_dir = Path(lines[1]).resolve()
+    try:
+        linked = git_dir.is_relative_to(common_dir / "worktrees")
+    except ValueError:
+        linked = False
+    return linked, _primary_worktree(source)
+
+
+def enforce_worktree_policy(
+    source: str,
+    config: dict,
+    requested_canonicality: str,
+) -> str:
+    """Apply project config and return canonical provenance for this source."""
+    linked, canonical_root = detect_linked_worktree(source)
+    explicitly_allowed = requested_canonicality == "linked-worktree"
+    if linked and config.get("reject_linked_worktrees", True) and not explicitly_allowed:
+        raise LinkedWorktreeRejected(source, canonical_root)
+    return "linked-worktree" if linked else "canonical"
 
 
 def _validate_context(context: SourceContext) -> None:

--- a/mempalace/source_metadata.py
+++ b/mempalace/source_metadata.py
@@ -1,0 +1,92 @@
+"""Deterministic, Chroma-safe source identity metadata for mined drawers."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from dataclasses import dataclass
+
+SOURCE_KINDS = frozenset({"curated", "code", "documentation", "session", "worktree-artifact"})
+MEMORY_TIERS = frozenset({"hot", "cold"})
+SOURCE_CANONICALITIES = frozenset({"canonical", "linked-worktree"})
+
+
+@dataclass(frozen=True)
+class SourceContext:
+    root: str
+    source_file: str
+    source_kind: str
+    memory_tier: str = "hot"
+    source_revision: str | None = None
+    source_canonicality: str = "canonical"
+    source_sha256: str | None = None
+
+
+def sha256_file(path: str) -> str | None:
+    """Hash source bytes without loading a potentially large file into memory."""
+    digest = hashlib.sha256()
+    try:
+        with open(path, "rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def git_revision(root: str) -> str | None:
+    """Return the repository HEAD for provenance, or None outside Git."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", root, "rev-parse", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    revision = result.stdout.strip()
+    return revision if result.returncode == 0 and revision else None
+
+
+def _validate_context(context: SourceContext) -> None:
+    if context.source_kind not in SOURCE_KINDS:
+        raise ValueError(f"invalid source_kind: {context.source_kind!r}")
+    if context.memory_tier not in MEMORY_TIERS:
+        raise ValueError(f"invalid memory_tier: {context.memory_tier!r}")
+    if context.source_canonicality not in SOURCE_CANONICALITIES:
+        raise ValueError(f"invalid source_canonicality: {context.source_canonicality!r}")
+
+
+def build_source_metadata(
+    context: SourceContext,
+    content: str,
+    chunk_index: int,
+) -> dict[str, str]:
+    """Build stable scalar metadata while leaving drawer content untouched."""
+    _validate_context(context)
+    root = os.path.realpath(os.path.expanduser(context.root))
+    source_file = os.path.realpath(os.path.expanduser(context.source_file))
+    relative = os.path.relpath(source_file, root).replace(os.sep, "/")
+    source_sha = context.source_sha256 or sha256_file(source_file)
+    content_bytes = content.encode("utf-8", errors="surrogatepass")
+
+    metadata = {
+        "source_kind": context.source_kind,
+        "memory_tier": context.memory_tier,
+        "source_root": root,
+        "source_identity": f"{context.source_kind}:{relative}",
+        "content_sha256": hashlib.sha256(content_bytes).hexdigest(),
+        "source_canonicality": context.source_canonicality,
+    }
+    if context.source_revision:
+        metadata["source_revision"] = context.source_revision
+    if source_sha:
+        metadata["source_sha256"] = source_sha
+
+    # Kept in the public signature because callers build metadata per chunk;
+    # the existing scalar chunk_index remains the chunk coordinate.
+    _ = chunk_index
+    return metadata

--- a/tests/benchmarks/test_async_mcp_bench.py
+++ b/tests/benchmarks/test_async_mcp_bench.py
@@ -1,0 +1,370 @@
+"""Production latency budgets for async MCP mining and migration search paths."""
+
+from __future__ import annotations
+
+import math
+import statistics
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from mempalace import daemon, mcp_jobs, service
+from mempalace.backends import ChromaBackend
+from mempalace.migration_bundle import rebuild_drawers_vector_index
+from mempalace.reorganize import MigrationAction, exact_hash, inventory_palace
+from mempalace.repair import _close_chroma_handles
+from mempalace.searcher import search_memories
+from tests.benchmarks.data_generator import PalaceDataGenerator
+from tests.benchmarks.report import record_metric
+
+
+MINE_SUBMISSION_P95_BUDGET_MS = 500.0
+JOB_READ_P95_BUDGET_MS = 100.0
+MAINTENANCE_BM25_P95_BUDGET_MS = 1_000.0
+POST_MAINTENANCE_REGRESSION_BUDGET = 1.10
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    """Return a nearest-rank percentile without a NumPy dependency."""
+    if not values:
+        raise ValueError("at least one latency is required")
+    ordered = sorted(values)
+    rank = max(0, math.ceil(len(ordered) * percentile) - 1)
+    return ordered[rank]
+
+
+def _record_latencies(category: str, values: list[float]) -> tuple[float, float]:
+    p50_ms = _percentile(values, 0.50)
+    p95_ms = _percentile(values, 0.95)
+    record_metric(category, "p50_ms", round(p50_ms, 3))
+    record_metric(category, "p95_ms", round(p95_ms, 3))
+    return p50_ms, p95_ms
+
+
+def _capture_http_server(monkeypatch) -> list:
+    """Capture the actual daemon HTTP server so teardown cannot leak a socket."""
+    servers: list = []
+    base = daemon.ThreadingHTTPServer
+
+    class CapturingServer(base):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            servers.append(self)
+
+    monkeypatch.setattr(daemon, "ThreadingHTTPServer", CapturingServer)
+    return servers
+
+
+def _start_daemon(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    execute_fn=None,
+    palace: Path | None = None,
+):
+    """Start the real loopback daemon with a controlled worker."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "daemon-state"))
+    palace = palace or (tmp_path / "daemon-palace")
+    palace.mkdir(exist_ok=True)
+    monkeypatch.setattr(
+        service,
+        "execute_job",
+        execute_fn
+        or (lambda _kind, _payload, *_args, **_kwargs: {"success": True, "exit_code": 0}),
+    )
+    servers = _capture_http_server(monkeypatch)
+    errors: list[BaseException] = []
+
+    def serve() -> None:
+        try:
+            daemon.run_server(str(palace), port=0)
+        except BaseException as exc:  # noqa: BLE001 - re-raised in the test thread
+            errors.append(exc)
+
+    thread = threading.Thread(target=serve, name="benchmark-daemon", daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 15.0
+    client = None
+    while time.monotonic() < deadline:
+        if errors:
+            raise AssertionError(f"benchmark daemon failed to start: {errors[0]!r}")
+        client = daemon.get_client_if_running(str(palace), health_timeout=0.2)
+        if client is not None:
+            return client, thread, palace, servers
+        time.sleep(0.02)
+    raise AssertionError("benchmark daemon did not become ready within 15 seconds")
+
+
+def _stop_daemon(client, thread: threading.Thread, servers: list) -> None:
+    try:
+        client.shutdown()
+    except Exception:  # noqa: BLE001 - forced shutdown below is the fallback
+        pass
+    thread.join(timeout=5.0)
+    if thread.is_alive() and servers:
+        servers[-1].shutdown()
+        servers[-1].server_close()
+        thread.join(timeout=5.0)
+    assert not thread.is_alive(), "benchmark daemon thread leaked"
+
+
+def _measure_search_rounds(
+    palace_path: str,
+    queries: list[str],
+    *,
+    vector_disabled: bool,
+    rounds: int = 3,
+) -> tuple[list[float], float]:
+    all_latencies: list[float] = []
+    round_p95: list[float] = []
+    for _ in range(rounds):
+        current: list[float] = []
+        for query in queries:
+            started = time.perf_counter()
+            result = search_memories(
+                query,
+                palace_path=palace_path,
+                n_results=5,
+                vector_disabled=vector_disabled,
+            )
+            current.append((time.perf_counter() - started) * 1_000)
+            assert "error" not in result
+        all_latencies.extend(current)
+        round_p95.append(_percentile(current, 0.95))
+    return all_latencies, statistics.median(round_p95)
+
+
+@pytest.mark.benchmark
+def test_async_mcp_submission_and_job_reads_meet_latency_budgets(tmp_path, monkeypatch):
+    """Exercise validation, loopback HTTP, durable SQLite enqueue, and MCP job reads."""
+    job_started = threading.Event()
+    release_job = threading.Event()
+
+    def execute_job(_kind, payload, *_args, **_kwargs):
+        if payload.get("wing") == "blocked-maintenance":
+            job_started.set()
+            assert release_job.wait(timeout=30.0), "benchmark blocked job was never released"
+        return {"success": True, "exit_code": 0}
+
+    client, thread, palace, servers = _start_daemon(
+        tmp_path,
+        monkeypatch,
+        execute_fn=execute_job,
+    )
+    try:
+        sources = tmp_path / "sources"
+        sources.mkdir()
+        for index in range(41):
+            (sources / f"project-{index:03d}").mkdir()
+
+        # Warm token/endpoint/HTTP connection paths before measuring steady-state p95.
+        warm = mcp_jobs.submit_mine(
+            str(palace),
+            {"source": str(sources / "project-000"), "mode": "projects", "wing": "warm"},
+        )
+        assert warm.get("accepted") is True
+        deadline = time.monotonic() + 5.0
+        while client.get_job(warm["job_id"])["state"] not in {"succeeded", "failed"}:
+            assert time.monotonic() < deadline, "warm benchmark job did not finish"
+            time.sleep(0.01)
+
+        blocked = mcp_jobs.submit_mine(
+            str(palace),
+            {
+                "source": str(sources / "project-000"),
+                "mode": "projects",
+                "wing": "blocked-maintenance",
+            },
+        )
+        assert blocked.get("accepted") is True
+        assert job_started.wait(timeout=5.0), "blocked maintenance job did not start"
+        assert client.get_job(blocked["job_id"])["state"] == "running"
+
+        submission_latencies: list[float] = []
+        job_ids: list[str] = []
+        for index in range(1, 41):
+            started = time.perf_counter()
+            result = mcp_jobs.submit_mine(
+                str(palace),
+                {
+                    "source": str(sources / f"project-{index:03d}"),
+                    "mode": "projects",
+                    "wing": f"bench-{index:03d}",
+                },
+            )
+            submission_latencies.append((time.perf_counter() - started) * 1_000)
+            assert result.get("accepted") is True
+            job_ids.append(result["job_id"])
+            # A successful response means the row is already durable and readable.
+            assert client.get_job(result["job_id"])["id"] == result["job_id"]
+
+        _, submission_p95 = _record_latencies("async_mcp_mine_submission", submission_latencies)
+        assert submission_p95 < MINE_SUBMISSION_P95_BUDGET_MS
+
+        # Warm the health + read paths independently from submission.
+        assert mcp_jobs.tool_job_status(job_ids[-1], palace_path=str(palace))["success"] is True
+        assert mcp_jobs.tool_list_jobs(limit=20, palace_path=str(palace))["success"] is True
+
+        status_latencies: list[float] = []
+        list_latencies: list[float] = []
+        for index in range(40):
+            started = time.perf_counter()
+            status = mcp_jobs.tool_job_status(
+                job_ids[index % len(job_ids)], palace_path=str(palace)
+            )
+            status_latencies.append((time.perf_counter() - started) * 1_000)
+            assert status["success"] is True
+
+            started = time.perf_counter()
+            page = mcp_jobs.tool_list_jobs(limit=20, palace_path=str(palace))
+            list_latencies.append((time.perf_counter() - started) * 1_000)
+            assert page["success"] is True
+
+        _, status_p95 = _record_latencies("async_mcp_job_status", status_latencies)
+        _, list_p95 = _record_latencies("async_mcp_job_list", list_latencies)
+        assert status_p95 < JOB_READ_P95_BUDGET_MS
+        assert list_p95 < JOB_READ_P95_BUDGET_MS
+        assert client.get_job(blocked["job_id"])["state"] == "running"
+    finally:
+        release_job.set()
+        _stop_daemon(client, thread, servers)
+
+
+@pytest.mark.benchmark
+def test_maintenance_search_and_post_rebuild_hybrid_meet_budgets(tmp_path, monkeypatch):
+    """Bound BM25 fallback latency and hybrid regression after vector maintenance."""
+    palace_path = str(tmp_path / "search-palace")
+    generator = PalaceDataGenerator(seed=42, scale="small")
+    generator.populate_palace_directly(
+        palace_path,
+        n_drawers=1_000,
+        include_needles=False,
+    )
+    _close_chroma_handles(palace_path)
+
+    queries = [
+        "authentication middleware",
+        "database migration",
+        "deployment pipeline",
+        "error handling",
+        "caching strategy",
+        "message queue",
+        "monitoring health check",
+        "query optimization",
+        "token refresh",
+        "batch processing",
+        "rate limiting",
+        "connection pooling",
+    ]
+    workload = queries * 4
+
+    # Warm both routes, then use the median of three round-level p95 values to
+    # avoid treating one scheduler pause as a search regression.
+    for query in queries:
+        search_memories(query, palace_path=palace_path, n_results=5)
+        search_memories(query, palace_path=palace_path, n_results=5, vector_disabled=True)
+
+    job_started = threading.Event()
+    release_job = threading.Event()
+
+    def execute_blocked_mine(_kind, _payload, *_args, **_kwargs):
+        job_started.set()
+        assert release_job.wait(timeout=30.0), "benchmark blocked job was never released"
+        return {"success": True, "exit_code": 0}
+
+    client, thread, _palace, servers = _start_daemon(
+        tmp_path / "maintenance-daemon",
+        monkeypatch,
+        execute_fn=execute_blocked_mine,
+        palace=Path(palace_path),
+    )
+    source = tmp_path / "maintenance-source"
+    source.mkdir()
+    blocked = mcp_jobs.submit_mine(
+        palace_path,
+        {"source": str(source), "mode": "projects", "wing": "blocked-maintenance"},
+    )
+    assert blocked.get("accepted") is True
+    assert job_started.wait(timeout=5.0), "blocked maintenance job did not start"
+    try:
+        bm25_latencies, bm25_p95 = _measure_search_rounds(
+            palace_path,
+            workload,
+            vector_disabled=True,
+        )
+        assert client.get_job(blocked["job_id"])["state"] == "running"
+    finally:
+        release_job.set()
+        _stop_daemon(client, thread, servers)
+    _record_latencies("maintenance_bm25_search", bm25_latencies)
+    record_metric("maintenance_bm25_search", "median_round_p95_ms", round(bm25_p95, 3))
+    assert bm25_p95 < MAINTENANCE_BM25_P95_BUDGET_MS
+
+    baseline_latencies, baseline_p95 = _measure_search_rounds(
+        palace_path,
+        workload,
+        vector_disabled=False,
+    )
+    _record_latencies("pre_maintenance_hybrid_search", baseline_latencies)
+    record_metric(
+        "pre_maintenance_hybrid_search",
+        "median_round_p95_ms",
+        round(baseline_p95, 3),
+    )
+
+    _close_chroma_handles(palace_path)
+    inventory = inventory_palace(
+        palace_path,
+        canonical_root=palace_path,
+        worktree_roots=(),
+        session_roots=(),
+    )
+    actions = [
+        MigrationAction(
+            drawer_id=record.drawer_id,
+            action="retain_benchmark",
+            destination_wing=str(record.metadata.get("wing") or "benchmark"),
+            reason="benchmark vector maintenance",
+            content_sha256=exact_hash(record.content),
+            metadata=dict(record.metadata),
+        )
+        for record in inventory
+    ]
+    backend = ChromaBackend()
+    maintenance_started = time.perf_counter()
+    rebuilt, reembedded = rebuild_drawers_vector_index(
+        backend=backend,
+        palace_path=palace_path,
+        inventory=inventory,
+        actions=actions,
+        evidence=(),
+        batch_size=250,
+    )
+    maintenance_ms = (time.perf_counter() - maintenance_started) * 1_000
+    assert rebuilt.count() == 1_000
+    assert reembedded == 0
+    record_metric("vector_maintenance", "elapsed_ms", round(maintenance_ms, 3))
+    record_metric("vector_maintenance", "vectors_reused", 1_000)
+    record_metric("vector_maintenance", "vectors_reembedded", reembedded)
+    backend.close_palace(palace_path)
+    del rebuilt
+    _close_chroma_handles(palace_path)
+
+    for query in queries:
+        search_memories(query, palace_path=palace_path, n_results=5)
+    post_latencies, post_p95 = _measure_search_rounds(
+        palace_path,
+        workload,
+        vector_disabled=False,
+    )
+    _record_latencies("post_maintenance_hybrid_search", post_latencies)
+    record_metric(
+        "post_maintenance_hybrid_search",
+        "median_round_p95_ms",
+        round(post_p95, 3),
+    )
+    ratio = post_p95 / max(baseline_p95, 0.001)
+    record_metric("post_maintenance_hybrid_search", "p95_ratio", round(ratio, 4))
+    assert ratio <= POST_MAINTENANCE_REGRESSION_BUDGET

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -313,6 +313,43 @@ def test_chroma_lexical_search_ids_roundtrip_through_get(tmp_path):
     backend.close()
 
 
+def test_chroma_get_source_chunks_scopes_parent_group(tmp_path):
+    backend = ChromaBackend()
+    palace = tmp_path / "palace"
+    col = backend.get_collection(str(palace), "mempalace_drawers", create=True)
+    col.add(
+        ids=["a-0", "a-1", "b-0"],
+        documents=["group a zero", "group a one", "group b zero"],
+        metadatas=[
+            {
+                "source_file": "/repo/shared.log",
+                "parent_drawer_id": "group-a",
+                "chunk_index": 0,
+            },
+            {
+                "source_file": "/repo/shared.log",
+                "parent_drawer_id": "group-a",
+                "chunk_index": 1,
+            },
+            {
+                "source_file": "/repo/shared.log",
+                "parent_drawer_id": "group-b",
+                "chunk_index": 0,
+            },
+        ],
+    )
+
+    chunks = col.get_source_chunks(
+        "/repo/shared.log",
+        parent_drawer_id="group-a",
+    )
+
+    assert chunks.ids == ["a-0", "a-1"]
+    assert chunks.documents == ["group a zero", "group a one"]
+    assert [metadata["chunk_index"] for metadata in chunks.metadatas] == [0, 1]
+    backend.close()
+
+
 def test_query_rejects_missing_input():
     fake = _FakeCollection()
     collection = ChromaCollection(fake)
@@ -453,6 +490,34 @@ def test_chroma_cache_picks_up_db_created_after_first_open(tmp_path):
     refreshed = backend._client(str(palace_path))
     assert refreshed is not sentinel
     assert backend._freshness[str(palace_path)] != (0, 0.0)
+
+
+def test_get_collection_does_not_invalidate_cache_after_its_own_thread_pin(tmp_path, monkeypatch):
+    """The hnsw thread-pin modify must not look like an external DB write."""
+    palace_path = str(tmp_path / "palace")
+    from mempalace.backends import chroma as chroma_module
+
+    real_pin = chroma_module._pin_hnsw_threads
+    pin_calls = []
+
+    def pin_once(collection):
+        pin_calls.append(collection.name)
+        return real_pin(collection)
+
+    monkeypatch.setattr(chroma_module, "_pin_hnsw_threads", pin_once)
+    backend = ChromaBackend()
+    try:
+        backend.get_collection(palace_path, "mempalace_drawers", create=True)
+        first_client = backend._clients[palace_path]
+        assert backend._freshness[palace_path] == backend._db_stat(palace_path)
+
+        backend.get_collection(palace_path, "mempalace_drawers", create=False)
+
+        assert backend._clients[palace_path] is first_client
+        assert backend._freshness[palace_path] == backend._db_stat(palace_path)
+        assert pin_calls == ["mempalace_drawers"]
+    finally:
+        backend.close()
 
 
 def test_base_collection_update_default_rejects_mismatched_lengths():
@@ -1426,7 +1491,32 @@ def test_pin_hnsw_threads_swallows_all_errors():
         def modify(self, *args, **kwargs):
             raise RuntimeError("boom")
 
-    _pin_hnsw_threads(_ExplodingCollection())  # must not raise
+    assert _pin_hnsw_threads(_ExplodingCollection()) is False
+
+
+def test_get_collection_retries_thread_pin_after_transient_failure(tmp_path, monkeypatch):
+    palace_path = str(tmp_path / "palace")
+    from mempalace.backends import chroma as chroma_module
+
+    outcomes = iter([False, True])
+    pin_calls = []
+
+    def flaky_pin(collection):
+        pin_calls.append(collection.name)
+        return next(outcomes)
+
+    monkeypatch.setattr(chroma_module, "_pin_hnsw_threads", flaky_pin)
+    backend = ChromaBackend()
+    try:
+        backend.get_collection(palace_path, "mempalace_drawers", create=True)
+        assert (palace_path, "mempalace_drawers") not in backend._pinned_collections
+
+        backend.get_collection(palace_path, "mempalace_drawers", create=False)
+
+        assert pin_calls == ["mempalace_drawers", "mempalace_drawers"]
+        assert (palace_path, "mempalace_drawers") in backend._pinned_collections
+    finally:
+        backend.close()
 
 
 def test_get_collection_applies_retrofit_on_existing_palace(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -861,6 +861,135 @@ def test_reorganize_has_no_apply_option():
     assert exc_info.value.code == 2
 
 
+def test_reorganize_prepare_and_apply_dispatch_reviewed_bundle(tmp_path, capsys):
+    common = [
+        "--palace",
+        str(tmp_path / "palace"),
+        "--canonical-root",
+        str(tmp_path / "repo"),
+        "--worktree-root",
+        str(tmp_path / "worktree"),
+        "--session-root",
+        str(tmp_path / "sessions"),
+        "--manifest",
+        str(tmp_path / "manifest.json"),
+        "--rollback-root",
+        str(tmp_path / "rollback"),
+        "--migrated-root",
+        str(tmp_path / "migrated"),
+    ]
+    with (
+        patch(
+            "mempalace.migration_bundle.prepare_migration_copies",
+            return_value={"inventory_total": 10, "duplicate_candidates": 2},
+        ) as prepare,
+        patch("sys.argv", ["mempalace", "reorganize", "prepare", *common]),
+    ):
+        main()
+
+    prepare.assert_called_once()
+    assert prepare.call_args.kwargs["hot_days"] == 90
+    assert "Rollback copy ready" in capsys.readouterr().out
+
+    with (
+        patch(
+            "mempalace.migration_bundle.apply_reviewed_migration",
+            return_value={
+                "status": "complete",
+                "records_before": 10,
+                "records_expected_after": 8,
+                "records_deleted_as_verified_duplicates": 2,
+            },
+        ) as apply_migration,
+        patch(
+            "sys.argv",
+            ["mempalace", "reorganize", "apply", *common, "--batch-size", "25"],
+        ),
+    ):
+        main()
+
+    apply_migration.assert_called_once()
+    assert apply_migration.call_args.kwargs["batch_size"] == 25
+    assert "Migrated copy verified" in capsys.readouterr().out
+
+
+def test_reorganize_activation_requires_explicit_yes(tmp_path):
+    argv = [
+        "mempalace",
+        "reorganize",
+        "activate",
+        "--palace",
+        str(tmp_path / "palace"),
+        "--manifest",
+        str(tmp_path / "manifest.json"),
+        "--migrated-root",
+        str(tmp_path / "migrated"),
+        "--previous-root",
+        str(tmp_path / "previous"),
+    ]
+    with (
+        patch("sys.argv", argv),
+        patch("mempalace.migration_bundle.activate_migrated_palace") as activate,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        main()
+
+    assert exc_info.value.code == 2
+    activate.assert_not_called()
+
+
+def test_reorganize_activate_and_rollback_dispatch_with_yes(tmp_path, capsys):
+    common = [
+        "--palace",
+        str(tmp_path / "palace"),
+        "--migrated-root",
+        str(tmp_path / "migrated"),
+        "--previous-root",
+        str(tmp_path / "previous"),
+        "--yes",
+    ]
+    with (
+        patch(
+            "mempalace.migration_bundle.activate_migrated_palace",
+            return_value={
+                "status": "active",
+                "active_palace": str(tmp_path / "palace"),
+                "previous_root": str(tmp_path / "previous"),
+            },
+        ) as activate,
+        patch(
+            "sys.argv",
+            [
+                "mempalace",
+                "reorganize",
+                "activate",
+                *common[:-1],
+                "--manifest",
+                str(tmp_path / "manifest.json"),
+                "--yes",
+            ],
+        ),
+    ):
+        main()
+    activate.assert_called_once()
+    assert "Migration activated" in capsys.readouterr().out
+
+    with (
+        patch(
+            "mempalace.migration_bundle.rollback_activated_palace",
+            return_value={
+                "status": "rolled_back",
+                "active_palace": str(tmp_path / "palace"),
+                "migrated_root": str(tmp_path / "migrated"),
+            },
+        ) as rollback,
+        patch("sys.argv", ["mempalace", "reorganize", "rollback", *common]),
+    ):
+        main()
+    rollback.assert_called_once()
+    assert "Migration rolled back" in capsys.readouterr().out
+
+
 def test_main_no_args_prints_help(capsys):
     with patch("sys.argv", ["mempalace"]):
         main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for mempalace.cli — the main CLI dispatcher."""
 
 import argparse
+import hashlib
 import os
 import shlex
 import sqlite3
@@ -762,6 +763,102 @@ def test_cmd_split_all_options():
 
 
 # ── main() argparse dispatch ──────────────────────────────────────────
+
+
+def test_reorganize_plan_writes_manifest_without_changing_sqlite(tmp_path, capsys):
+    palace = tmp_path / "palace"
+    canonical = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    sessions = tmp_path / "sessions"
+    for path in (palace, canonical, worktree, sessions):
+        path.mkdir()
+    db_path = palace / "chroma.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE collections (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+            CREATE TABLE segments (id INTEGER PRIMARY KEY, collection INTEGER NOT NULL);
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY,
+                segment_id INTEGER NOT NULL,
+                embedding_id TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE embedding_metadata (
+                id INTEGER,
+                key TEXT,
+                string_value TEXT,
+                int_value INTEGER,
+                float_value REAL,
+                bool_value INTEGER
+            );
+            INSERT INTO collections(id, name) VALUES (1, 'mempalace_drawers');
+            INSERT INTO segments(id, collection) VALUES (1, 1);
+            INSERT INTO embeddings(id, segment_id, embedding_id, created_at)
+                VALUES (1, 1, 'canonical', '2026-07-14T00:00:00Z');
+            """
+        )
+        conn.execute(
+            "INSERT INTO embedding_metadata(id, key, string_value) VALUES (1, ?, ?)",
+            ("chroma:document", "canonical text"),
+        )
+        conn.execute(
+            "INSERT INTO embedding_metadata(id, key, string_value) VALUES (1, ?, ?)",
+            ("source_file", str(canonical / "src/app.ts")),
+        )
+        conn.execute(
+            "INSERT INTO embedding_metadata(id, key, int_value) VALUES (1, ?, ?)",
+            ("chunk_index", 0),
+        )
+
+    before = hashlib.sha256(db_path.read_bytes()).hexdigest()
+    manifest = tmp_path / "private" / "manifest.json"
+    argv = [
+        "mempalace",
+        "reorganize",
+        "plan",
+        "--palace",
+        str(palace),
+        "--canonical-root",
+        str(canonical),
+        "--worktree-root",
+        str(worktree),
+        "--session-root",
+        str(sessions),
+        "--manifest",
+        str(manifest),
+    ]
+
+    with patch("sys.argv", argv):
+        main()
+
+    assert manifest.is_file()
+    assert hashlib.sha256(db_path.read_bytes()).hexdigest() == before
+    output = capsys.readouterr().out
+    assert "Dry run only" in output
+    assert "SQLite SHA-256" in output
+
+
+def test_reorganize_has_no_apply_option():
+    with (
+        patch(
+            "sys.argv",
+            [
+                "mempalace",
+                "reorganize",
+                "plan",
+                "--canonical-root",
+                "/repo",
+                "--manifest",
+                "/tmp/manifest.json",
+                "--apply",
+            ],
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        main()
+
+    assert exc_info.value.code == 2
 
 
 def test_main_no_args_prints_help(capsys):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -109,6 +109,70 @@ def test_queue_dedupes_and_recovers_running_jobs(tmp_path, monkeypatch):
     assert store.get(first.id).state == "queued"
 
 
+def test_queue_adds_progress_columns_and_updates_existing_database(tmp_path, monkeypatch):
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    queue = tmp_path / "queue.sqlite3"
+    store = daemon.QueueStore(queue)
+    job = store.enqueue("mine", {"source": "/repo"})
+
+    updated = store.update_progress(
+        job.id,
+        {"phase": "scanning", "files_processed": 2},
+    )
+
+    assert updated.progress == {"phase": "scanning", "files_processed": 2}
+    assert updated.updated_at is not None
+    assert updated.heartbeat_at is not None
+
+
+def test_queue_filters_jobs_and_reports_active(tmp_path, monkeypatch):
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    store = daemon.QueueStore(tmp_path / "queue.sqlite3")
+    mine = store.enqueue("mine", {"source": "/repo"})
+    write = store.enqueue("mcp_tool", {"name": "mempalace_checkpoint"})
+    store.claim_next()
+
+    assert [job.id for job in store.list(state="running", kind="mine")] == [mine.id]
+    assert [job.id for job in store.active(kind="mine")] == [mine.id]
+    assert [job.id for job in store.list(state="queued", kind="mcp_tool")] == [write.id]
+
+
+def test_enqueue_with_status_marks_active_deduplication(tmp_path, monkeypatch):
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    store = daemon.QueueStore(tmp_path / "queue.sqlite3")
+
+    first, first_deduplicated = store.enqueue_with_status(
+        "mine", {"source": "/repo"}, dedupe_key="same"
+    )
+    second, second_deduplicated = store.enqueue_with_status(
+        "mine", {"source": "/repo"}, dedupe_key="same"
+    )
+
+    assert first_deduplicated is False
+    assert second_deduplicated is True
+    assert second.id == first.id
+
+
+def test_job_to_dict_redacts_verbatim_write_payload(tmp_path, monkeypatch):
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    store = daemon.QueueStore(tmp_path / "queue.sqlite3")
+    job = store.enqueue(
+        "mcp_tool",
+        {
+            "name": "mempalace_add_drawer",
+            "arguments": {"content": "secret", "wing": "se", "room": "decisions"},
+        },
+    )
+
+    payload = daemon.job_to_dict(job, include_payload=True, redact_payload=True)
+
+    assert payload["payload"] == {
+        "name": "mempalace_add_drawer",
+        "arguments": "<redacted>",
+    }
+    assert "secret" not in str(payload)
+
+
 def test_daemon_http_lifecycle_executes_job(tmp_path, monkeypatch):
     calls = []
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -230,6 +230,10 @@ def test_daemon_http_lifecycle_executes_job(tmp_path, monkeypatch):
     assert finished["state"] == "succeeded"
     assert finished["result"]["stdout"] == "done\n"
     assert calls == [("mine", {"source": "src", "palace_path": str(palace.resolve())})]
+    summaries = client.list_jobs(limit=5, state="succeeded", kind="mine")
+    assert [summary["id"] for summary in summaries] == [job["id"]]
+    assert "payload" not in summaries[0]
+    assert "result" not in summaries[0]
 
     _stop_server(client, thread, holders)
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -173,6 +173,44 @@ def test_job_to_dict_redacts_verbatim_write_payload(tmp_path, monkeypatch):
     assert "secret" not in str(payload)
 
 
+def test_runtime_heartbeats_and_persists_job_progress(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(daemon, "DAEMON_HEARTBEAT_SECONDS", 0.02)
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    started = threading.Event()
+    release = threading.Event()
+
+    def fake_execute(kind, payload, progress_callback=None):
+        assert kind == "mine"
+        progress_callback({"phase": "mining", "files_processed": 1})
+        started.set()
+        release.wait(2)
+        return {"success": True, "exit_code": 0}
+
+    monkeypatch.setattr(service, "execute_job", fake_execute)
+    runtime = daemon.DaemonRuntime(str(palace))
+    job = runtime.store.enqueue("mine", {"source": str(tmp_path)})
+    worker = runtime.start_worker()
+
+    try:
+        assert started.wait(1)
+        first = runtime.store.get(job.id)
+        assert first.progress == {"phase": "mining", "files_processed": 1}
+        first_heartbeat = first.heartbeat_at
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            if runtime.store.get(job.id).heartbeat_at != first_heartbeat:
+                break
+            time.sleep(0.01)
+        assert runtime.store.get(job.id).heartbeat_at != first_heartbeat
+    finally:
+        release.set()
+        runtime.shutdown_event.set()
+        runtime.worker_wake.set()
+        worker.join(timeout=2)
+
+
 def test_daemon_http_lifecycle_executes_job(tmp_path, monkeypatch):
     calls = []
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -229,7 +229,16 @@ def test_daemon_http_lifecycle_executes_job(tmp_path, monkeypatch):
 
     assert finished["state"] == "succeeded"
     assert finished["result"]["stdout"] == "done\n"
-    assert calls == [("mine", {"source": "src", "palace_path": str(palace.resolve())})]
+    assert calls == [
+        (
+            "mine",
+            {
+                "source": "src",
+                "palace_path": str(palace.resolve()),
+                "operation_id": job["id"],
+            },
+        )
+    ]
     summaries = client.list_jobs(limit=5, state="succeeded", kind="mine")
     assert [summary["id"] for summary in summaries] == [job["id"]]
     assert "payload" not in summaries[0]
@@ -269,7 +278,7 @@ def test_submit_job_uses_client_and_waits(monkeypatch, tmp_path):
         def __init__(self):
             self.submitted = None
 
-        def submit(self, kind, payload, dedupe_key=None, priority=0):
+        def submit(self, kind, payload, dedupe_key=None, priority=0, timeout=5.0):
             self.submitted = (kind, payload, dedupe_key, priority)
             return {"id": "job-1", "state": "queued"}
 
@@ -570,6 +579,7 @@ def test_worker_overrides_client_palace_path(tmp_path, monkeypatch):
 
     def fake_execute(kind, payload):
         seen["palace_path"] = payload.get("palace_path")
+        seen["operation_id"] = payload.get("operation_id")
         return {"success": True, "exit_code": 0}
 
     client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
@@ -582,6 +592,7 @@ def test_worker_overrides_client_palace_path(tmp_path, monkeypatch):
         _stop_server(client, thread, holders)
     assert seen["palace_path"] == daemon.canonical_palace_path(str(palace))
     assert seen["palace_path"] != "/tmp/other-palace"
+    assert seen["operation_id"] == job["id"]
 
 
 def test_mcp_tool_allowlist_rejects_non_write_tools(tmp_path, monkeypatch):
@@ -803,17 +814,35 @@ def test_run_diary_write_forwards_args_and_sets_exit_code(monkeypatch):
 
     captured = {}
 
-    def fake_diary(agent_name, entry, topic, wing):
-        captured.update(agent_name=agent_name, entry=entry, topic=topic, wing=wing)
+    def fake_diary(agent_name, entry, topic, wing, _operation_id=None):
+        captured.update(
+            agent_name=agent_name,
+            entry=entry,
+            topic=topic,
+            wing=wing,
+            operation_id=_operation_id,
+        )
         return {"success": True}
 
     monkeypatch.setattr(mcp, "tool_diary_write", fake_diary)
     out = service.run_diary_write(
-        {"agent_name": "alice", "entry": "hello", "topic": "t", "wing": "w"}
+        {
+            "agent_name": "alice",
+            "entry": "hello",
+            "topic": "t",
+            "wing": "w",
+            "operation_id": "job-1",
+        }
     )
     assert out["success"] is True
     assert out["exit_code"] == 0
-    assert captured == {"agent_name": "alice", "entry": "hello", "topic": "t", "wing": "w"}
+    assert captured == {
+        "agent_name": "alice",
+        "entry": "hello",
+        "topic": "t",
+        "wing": "w",
+        "operation_id": "job-1",
+    }
 
 
 def test_run_mine_applies_backend_before_mode_validation(tmp_path):
@@ -826,6 +855,64 @@ def test_run_mine_applies_backend_before_mode_validation(tmp_path):
     out = service.run_mine({"palace_path": str(palace), "mode": "bogus", "backend": "chroma"})
     assert out["success"] is False
     assert out["exit_code"] == 2
+
+
+def test_run_mine_fails_terminal_job_when_hnsw_is_diverged(tmp_path, monkeypatch):
+    from mempalace import miner, service
+    from mempalace import palace as palace_module
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    source = tmp_path / "source"
+    source.mkdir()
+    monkeypatch.setattr(miner, "mine", lambda **kwargs: None)
+    monkeypatch.setattr(palace_module, "resolve_backend_name", lambda _path: "chroma")
+    monkeypatch.setattr(
+        service,
+        "_verify_chroma_readiness",
+        lambda *_args, **_kwargs: {
+            "status": "diverged",
+            "diverged": True,
+            "ready": False,
+            "message": "HNSW is behind SQLite",
+        },
+    )
+
+    out = service.run_mine({"palace_path": str(palace), "source": str(source), "mode": "projects"})
+
+    assert out["success"] is False
+    assert out["error_class"] == "VectorReadinessError"
+    assert out["vector_status"]["status"] == "diverged"
+    assert out["exit_code"] == 1
+
+
+def test_run_mine_accepts_inconclusive_capacity_only_after_query_probe(tmp_path, monkeypatch):
+    from mempalace import miner, service
+    from mempalace import palace as palace_module
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    source = tmp_path / "source"
+    source.mkdir()
+    monkeypatch.setattr(miner, "mine", lambda **kwargs: None)
+    monkeypatch.setattr(palace_module, "resolve_backend_name", lambda _path: "chroma")
+    monkeypatch.setattr(
+        service,
+        "_verify_chroma_readiness",
+        lambda *_args, **_kwargs: {
+            "status": "unknown",
+            "diverged": False,
+            "ready": True,
+            "query_ready": True,
+            "message": "metadata not flushed",
+        },
+    )
+
+    out = service.run_mine({"palace_path": str(palace), "source": str(source), "mode": "projects"})
+
+    assert out["success"] is True
+    assert out["vector_status"]["status"] == "unknown"
+    assert out["vector_status"]["query_ready"] is True
 
 
 def test_execute_job_dispatches_diary_write_mcp_tool_and_unknown(monkeypatch):
@@ -980,7 +1067,7 @@ def test_get_client_if_running_uses_short_probe_timeout(monkeypatch):
 
         def health(self, *, timeout):
             captured["timeout"] = timeout
-            return {"ok": True}
+            return {"ok": True, "worker_alive": True}
 
     monkeypatch.setattr(daemon, "DaemonClient", _FakeClient)
 
@@ -988,6 +1075,19 @@ def test_get_client_if_running_uses_short_probe_timeout(monkeypatch):
     client = daemon.get_client_if_running("/p", health_timeout=daemon.HOOK_PROBE_TIMEOUT)
     assert client is not None
     assert captured["timeout"] == daemon.HOOK_PROBE_TIMEOUT
+
+
+def test_get_client_if_running_rejects_dead_worker(monkeypatch):
+    class _FakeClient:
+        def __init__(self, palace_path):
+            pass
+
+        def health(self, *, timeout):
+            return {"ok": False, "worker_alive": False}
+
+    monkeypatch.setattr(daemon, "DaemonClient", _FakeClient)
+
+    assert daemon.get_client_if_running("/p", health_timeout=0.1) is None
 
 
 # --- _detached_kwargs ---

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -234,6 +234,29 @@ def test_daemon_http_lifecycle_executes_job(tmp_path, monkeypatch):
     _stop_server(client, thread, holders)
 
 
+def test_daemon_http_submit_reports_active_deduplication(tmp_path, monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def fake_execute(kind, payload):
+        started.set()
+        release.wait(2)
+        return {"success": True, "exit_code": 0}
+
+    client, thread, _palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
+    try:
+        first = client.submit("mine", {"source": "src"}, dedupe_key="same")
+        assert started.wait(1)
+        second = client.submit("mine", {"source": "src"}, dedupe_key="same")
+
+        assert first["deduplicated"] is False
+        assert second["deduplicated"] is True
+        assert second["id"] == first["id"]
+    finally:
+        release.set()
+        _stop_server(client, thread, holders)
+
+
 def test_submit_job_uses_client_and_waits(monkeypatch, tmp_path):
     palace = tmp_path / "palace"
     palace.mkdir()

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -309,9 +309,10 @@ def test_layer2_retrieve_no_filter():
         layer = Layer2(palace_path="/fake")
         layer.retrieve()
 
-    # No where filter should be passed
+    # Default retrieval excludes cold history while retaining legacy records
+    # whose memory_tier metadata is absent.
     call_kwargs = mock_col.get.call_args[1]
-    assert "where" not in call_kwargs
+    assert call_kwargs["where"] == {"memory_tier": {"$ne": "cold"}}
 
 
 def test_layer2_retrieve_error():
@@ -422,7 +423,12 @@ def test_layer3_search_with_wing_filter():
         layer.search("q", wing="proj")
 
     call_kwargs = mock_col.query.call_args[1]
-    assert call_kwargs["where"] == {"wing": "proj"}
+    assert call_kwargs["where"] == {
+        "$and": [
+            {"wing": "proj"},
+            {"memory_tier": {"$ne": "cold"}},
+        ]
+    }
 
 
 def test_layer3_search_with_room_filter():
@@ -441,7 +447,12 @@ def test_layer3_search_with_room_filter():
         layer.search("q", room="backend")
 
     call_kwargs = mock_col.query.call_args[1]
-    assert call_kwargs["where"] == {"room": "backend"}
+    assert call_kwargs["where"] == {
+        "$and": [
+            {"room": "backend"},
+            {"memory_tier": {"$ne": "cold"}},
+        ]
+    }
 
 
 def test_layer3_search_with_wing_and_room():

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -20,6 +20,7 @@ Design constraints
 import http.client
 import json
 import threading
+import time
 
 import pytest
 
@@ -230,6 +231,100 @@ def test_read_only_off_exposes_mutating_tools(http_server):
     status, body = _post(port, "/mcp", {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
     names = {t["name"] for t in json.loads(body)["result"]["tools"]}
     assert "mempalace_add_drawer" in names
+
+
+def test_job_status_and_bm25_search_respond_while_palace_operation_is_blocked(
+    http_server, monkeypatch
+):
+    from mempalace import mcp_jobs
+
+    port, _ = http_server
+    started = threading.Event()
+    release = threading.Event()
+    blocked_response = {}
+
+    def blocked_sync(**kwargs):
+        started.set()
+        release.wait(3)
+        return {"success": True}
+
+    def run_blocked_request():
+        blocked_response["value"] = _post(
+            port,
+            "/mcp",
+            {
+                "jsonrpc": "2.0",
+                "id": 20,
+                "method": "tools/call",
+                "params": {"name": "mempalace_sync", "arguments": {}},
+            },
+        )
+
+    monkeypatch.delenv(mcp_jobs.DAEMON_WRITES_ENV, raising=False)
+    monkeypatch.setattr(mcp, "_mcp_tool_preflight_refusal", lambda *args: None)
+    monkeypatch.setitem(mcp.TOOLS["mempalace_sync"], "handler", blocked_sync)
+    monkeypatch.setattr(
+        mcp_jobs,
+        "tool_job_status",
+        lambda job_id, palace_path=None: {
+            "success": True,
+            "job": {"id": job_id, "state": "running"},
+        },
+    )
+    monkeypatch.setattr(
+        mcp_jobs,
+        "active_maintenance_job",
+        lambda **kwargs: {"id": "mine-1", "kind": "mine", "state": "running"},
+    )
+    monkeypatch.setattr(mcp, "search_memories", lambda *args, **kwargs: {"results": []})
+
+    blocked = threading.Thread(target=run_blocked_request, daemon=True)
+    blocked.start()
+    assert started.wait(1)
+    safety_release = threading.Timer(1.0, release.set)
+    safety_release.start()
+    try:
+        before = time.monotonic()
+        status, status_body = _post(
+            port,
+            "/mcp",
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "method": "tools/call",
+                "params": {
+                    "name": "mempalace_job_status",
+                    "arguments": {"job_id": "mine-1"},
+                },
+            },
+        )
+        status_elapsed = time.monotonic() - before
+
+        before = time.monotonic()
+        search_status, search_body = _post(
+            port,
+            "/mcp",
+            {
+                "jsonrpc": "2.0",
+                "id": 22,
+                "method": "tools/call",
+                "params": {"name": "mempalace_search", "arguments": {"query": "ocr"}},
+            },
+        )
+        search_elapsed = time.monotonic() - before
+    finally:
+        release.set()
+        safety_release.cancel()
+        blocked.join(timeout=3)
+
+    assert status == 200
+    assert json.loads(status_body)["result"]
+    assert search_status == 200
+    search_result = json.loads(json.loads(search_body)["result"]["content"][0]["text"])
+    assert search_result["retrieval_mode"] == "bm25_sqlite"
+    assert status_elapsed < 0.5
+    assert search_elapsed < 0.5
+    assert blocked_response["value"][0] == 200
 
 
 def _make_self_signed_cert(tmp_path):

--- a/tests/test_mcp_jobs.py
+++ b/tests/test_mcp_jobs.py
@@ -4,6 +4,28 @@ import subprocess
 from mempalace import mcp_jobs
 
 
+class FakeClient:
+    def __init__(self, submitted=None, jobs=None, listed=None):
+        self.submitted = submitted or {"id": "job-1", "state": "queued"}
+        self.jobs = list(jobs or [])
+        self.listed = listed or []
+        self.submit_calls = []
+        self.list_calls = []
+
+    def submit(self, kind, payload, dedupe_key=None, priority=0):
+        self.submit_calls.append((kind, payload, dedupe_key, priority))
+        return dict(self.submitted)
+
+    def get_job(self, job_id):
+        if self.jobs:
+            return dict(self.jobs.pop(0))
+        return {**self.submitted, "id": job_id}
+
+    def list_jobs(self, limit=20, state=None, kind=None):
+        self.list_calls.append((limit, state, kind))
+        return list(self.listed)
+
+
 def _init_repo(path):
     subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
     subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True)
@@ -130,3 +152,104 @@ def test_submit_mine_fails_fast_when_daemon_is_unavailable(monkeypatch, tmp_path
     assert result["success"] is False
     assert result["error_class"] == "DaemonUnavailable"
     assert "daemon start" in result["hint"]
+
+
+def test_daemon_write_returns_completed_result_on_fast_path(monkeypatch):
+    client = FakeClient(
+        submitted={"id": "j1", "state": "queued"},
+        jobs=[
+            {
+                "id": "j1",
+                "state": "succeeded",
+                "result": {"success": True, "drawer_id": "d1", "exit_code": 0},
+            }
+        ],
+    )
+    monkeypatch.setattr(mcp_jobs, "get_client_if_running", lambda *a, **k: client)
+
+    result = mcp_jobs.dispatch_daemon_write(
+        "mempalace_add_drawer",
+        {"wing": "se", "room": "decisions", "content": "verbatim"},
+        palace_path="/palace",
+        fast_wait_ms=250,
+    )
+
+    assert result == {
+        "success": True,
+        "drawer_id": "d1",
+        "exit_code": 0,
+        "job_id": "j1",
+        "delivery": "completed",
+    }
+    assert client.submit_calls == [
+        (
+            "mcp_tool",
+            {
+                "name": "mempalace_add_drawer",
+                "arguments": {"wing": "se", "room": "decisions", "content": "verbatim"},
+            },
+            None,
+            0,
+        )
+    ]
+
+
+def test_daemon_write_returns_accepted_when_not_done(monkeypatch):
+    client = FakeClient(
+        submitted={"id": "j1", "state": "queued"},
+        jobs=[{"id": "j1", "state": "running"}],
+    )
+    monkeypatch.setattr(mcp_jobs, "get_client_if_running", lambda *a, **k: client)
+    monkeypatch.setattr(mcp_jobs.time, "sleep", lambda _seconds: None)
+    ticks = iter((0.0, 0.0, 1.0))
+    monkeypatch.setattr(mcp_jobs.time, "monotonic", lambda: next(ticks, 1.0))
+
+    result = mcp_jobs.dispatch_daemon_write(
+        "mempalace_checkpoint",
+        {"items": []},
+        palace_path="/palace",
+        fast_wait_ms=1,
+    )
+
+    assert result == {
+        "success": True,
+        "accepted": True,
+        "job_id": "j1",
+        "state": "running",
+        "delivery": "durable_queue",
+    }
+
+
+def test_job_status_and_list_use_daemon_without_exposing_payload(monkeypatch):
+    client = FakeClient(
+        jobs=[{"id": "j1", "state": "running", "progress": {"phase": "mining"}}],
+        listed=[{"id": "j1", "kind": "mine", "state": "running"}],
+    )
+    monkeypatch.setattr(mcp_jobs, "get_client_if_running", lambda *a, **k: client)
+
+    status = mcp_jobs.tool_job_status("j1", palace_path="/palace")
+    listed = mcp_jobs.tool_list_jobs(
+        limit=5,
+        state="running",
+        kind="mine",
+        palace_path="/palace",
+    )
+
+    assert status == {
+        "success": True,
+        "job": {"id": "j1", "state": "running", "progress": {"phase": "mining"}},
+    }
+    assert listed == {
+        "success": True,
+        "jobs": [{"id": "j1", "kind": "mine", "state": "running"}],
+    }
+    assert client.list_calls == [(5, "running", "mine")]
+
+
+def test_job_tools_fail_closed_when_daemon_is_unavailable(monkeypatch):
+    monkeypatch.setattr(mcp_jobs, "get_client_if_running", lambda *a, **k: None)
+
+    result = mcp_jobs.tool_job_status("j1", palace_path="/palace")
+
+    assert result["success"] is False
+    assert result["error_class"] == "DaemonUnavailable"

--- a/tests/test_mcp_jobs.py
+++ b/tests/test_mcp_jobs.py
@@ -1,0 +1,132 @@
+import os
+import subprocess
+
+from mempalace import mcp_jobs
+
+
+def _init_repo(path):
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], check=True)
+    (path / "README.md").write_text("fixture\n")
+    subprocess.run(["git", "-C", str(path), "add", "README.md"], check=True)
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "fixture"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_mine_dedupe_key_is_stable_for_symlinked_source(tmp_path):
+    source = tmp_path / "repo"
+    source.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(source)
+
+    direct = mcp_jobs.mine_dedupe_key(
+        "/palace", {"source": str(source), "mode": "projects", "wing": "se-code"}
+    )
+    symlinked = mcp_jobs.mine_dedupe_key(
+        "/palace", {"source": str(alias), "mode": "projects", "wing": "se-code"}
+    )
+
+    assert direct == symlinked
+
+
+def test_mine_dedupe_key_changes_with_project_config(tmp_path):
+    source = tmp_path / "repo"
+    source.mkdir()
+    config = source / "mempalace.yaml"
+    config.write_text("wing: first\n")
+    first = mcp_jobs.mine_dedupe_key("/palace", {"source": str(source), "mode": "projects"})
+    config.write_text("wing: second\n")
+    second = mcp_jobs.mine_dedupe_key("/palace", {"source": str(source), "mode": "projects"})
+    assert first != second
+
+
+def test_detect_linked_worktree_returns_primary_checkout(tmp_path):
+    primary = tmp_path / "primary"
+    linked = tmp_path / "linked"
+    primary.mkdir()
+    _init_repo(primary)
+    subprocess.run(
+        ["git", "-C", str(primary), "worktree", "add", str(linked)],
+        check=True,
+        capture_output=True,
+    )
+
+    is_linked, canonical = mcp_jobs.detect_linked_worktree(str(linked))
+
+    assert is_linked is True
+    assert canonical == str(primary.resolve())
+    assert mcp_jobs.detect_linked_worktree(str(primary)) == (False, str(primary.resolve()))
+
+
+def test_submit_mine_returns_accepted_job_and_deduplication(monkeypatch, tmp_path):
+    source = tmp_path / "repo"
+    source.mkdir()
+
+    def fake_submit(kind, payload, **kwargs):
+        assert kind == "mine"
+        assert kwargs["wait"] is False
+        assert kwargs["auto_start"] is False
+        assert kwargs["dedupe_key"] == mcp_jobs.mine_dedupe_key("/palace", payload)
+        return {
+            "id": "job-1",
+            "state": "queued",
+            "created_at": "2026-07-14T00:00:00+00:00",
+            "deduplicated": True,
+        }
+
+    monkeypatch.setattr(mcp_jobs, "submit_job", fake_submit)
+    result = mcp_jobs.submit_mine(
+        "/palace",
+        {"source": str(source), "mode": "projects", "wing": "se-code", "priority": 0},
+    )
+
+    assert result == {
+        "success": True,
+        "accepted": True,
+        "job_id": "job-1",
+        "state": "queued",
+        "deduplicated": True,
+        "source": os.path.realpath(source),
+        "mode": "projects",
+        "wing": "se-code",
+        "submitted_at": "2026-07-14T00:00:00+00:00",
+    }
+
+
+def test_submit_mine_rejects_linked_worktree_by_default(monkeypatch, tmp_path):
+    source = tmp_path / "repo"
+    source.mkdir()
+    monkeypatch.setattr(
+        mcp_jobs, "detect_linked_worktree", lambda _source: (True, "/canonical/repo")
+    )
+
+    result = mcp_jobs.submit_mine(
+        "/palace",
+        {"source": str(source), "mode": "projects", "allow_linked_worktree": False},
+    )
+
+    assert result["success"] is False
+    assert result["error_class"] == "LinkedWorktreeRejected"
+    assert result["canonical_root"] == "/canonical/repo"
+
+
+def test_submit_mine_fails_fast_when_daemon_is_unavailable(monkeypatch, tmp_path):
+    source = tmp_path / "repo"
+    source.mkdir()
+
+    def unavailable(*args, **kwargs):
+        raise mcp_jobs.DaemonError("offline")
+
+    monkeypatch.setattr(mcp_jobs, "submit_job", unavailable)
+    result = mcp_jobs.submit_mine(
+        "/palace",
+        {"source": str(source), "mode": "projects"},
+    )
+
+    assert result["success"] is False
+    assert result["error_class"] == "DaemonUnavailable"
+    assert "daemon start" in result["hint"]

--- a/tests/test_mcp_jobs.py
+++ b/tests/test_mcp_jobs.py
@@ -12,18 +12,22 @@ class FakeClient:
         self.submit_calls = []
         self.list_calls = []
 
-    def submit(self, kind, payload, dedupe_key=None, priority=0):
-        self.submit_calls.append((kind, payload, dedupe_key, priority))
+    def submit(self, kind, payload, dedupe_key=None, priority=0, timeout=5.0):
+        self.submit_calls.append((kind, payload, dedupe_key, priority, timeout))
         return dict(self.submitted)
 
-    def get_job(self, job_id):
+    def get_job(self, job_id, timeout=5.0):
         if self.jobs:
             return dict(self.jobs.pop(0))
         return {**self.submitted, "id": job_id}
 
-    def list_jobs(self, limit=20, state=None, kind=None):
-        self.list_calls.append((limit, state, kind))
+    def list_jobs(self, limit=20, state=None, kind=None, timeout=5.0):
+        self.list_calls.append((limit, state, kind, timeout))
         return list(self.listed)
+
+    def list_jobs_summary(self, limit=20, state=None, kind=None, timeout=5.0):
+        self.list_calls.append((limit, state, kind, timeout))
+        return {"jobs": list(self.listed), "counts": {"running": len(self.listed)}}
 
 
 def _init_repo(path):
@@ -92,6 +96,8 @@ def test_submit_mine_returns_accepted_job_and_deduplication(monkeypatch, tmp_pat
         assert kind == "mine"
         assert kwargs["wait"] is False
         assert kwargs["auto_start"] is False
+        assert kwargs["health_timeout"] == mcp_jobs.DAEMON_PROBE_TIMEOUT_SECONDS
+        assert kwargs["request_timeout"] == mcp_jobs.DAEMON_PROBE_TIMEOUT_SECONDS
         assert kwargs["dedupe_key"] == mcp_jobs.mine_dedupe_key("/palace", payload)
         return {
             "id": "job-1",
@@ -190,6 +196,7 @@ def test_daemon_write_returns_completed_result_on_fast_path(monkeypatch):
             },
             None,
             0,
+            mcp_jobs.DAEMON_PROBE_TIMEOUT_SECONDS,
         )
     ]
 
@@ -242,8 +249,9 @@ def test_job_status_and_list_use_daemon_without_exposing_payload(monkeypatch):
     assert listed == {
         "success": True,
         "jobs": [{"id": "j1", "kind": "mine", "state": "running"}],
+        "counts": {"running": 1},
     }
-    assert client.list_calls == [(5, "running", "mine")]
+    assert client.list_calls == [(5, "running", "mine", mcp_jobs.DAEMON_PROBE_TIMEOUT_SECONDS)]
 
 
 def test_job_tools_fail_closed_when_daemon_is_unavailable(monkeypatch):
@@ -268,4 +276,4 @@ def test_active_maintenance_job_returns_running_mine(monkeypatch):
     active = mcp_jobs.active_maintenance_job(palace_path="/palace")
 
     assert active == {"id": "mine-1", "kind": "mine", "state": "running"}
-    assert client.list_calls == [(10, "running", None)]
+    assert client.list_calls == [(10, "running", None, mcp_jobs.DAEMON_PROBE_TIMEOUT_SECONDS)]

--- a/tests/test_mcp_jobs.py
+++ b/tests/test_mcp_jobs.py
@@ -253,3 +253,19 @@ def test_job_tools_fail_closed_when_daemon_is_unavailable(monkeypatch):
 
     assert result["success"] is False
     assert result["error_class"] == "DaemonUnavailable"
+
+
+def test_active_maintenance_job_returns_running_mine(monkeypatch):
+    client = FakeClient(
+        listed=[
+            {"id": "write-1", "kind": "mcp_tool", "state": "running"},
+            {"id": "mine-1", "kind": "mine", "state": "running"},
+        ]
+    )
+    monkeypatch.setenv(mcp_jobs.DAEMON_WRITES_ENV, "1")
+    monkeypatch.setattr(mcp_jobs, "get_client_if_running", lambda *a, **k: client)
+
+    active = mcp_jobs.active_maintenance_job(palace_path="/palace")
+
+    assert active == {"id": "mine-1", "kind": "mine", "state": "running"}
+    assert client.list_calls == [(10, "running", None)]

--- a/tests/test_mcp_mine.py
+++ b/tests/test_mcp_mine.py
@@ -260,3 +260,28 @@ def test_generic_exception_carries_error_class(monkeypatch, config, tmp_dir):
     assert result["success"] is False
     assert "mine failed" in result["error"]
     assert result.get("error_class") == "RuntimeError"
+
+
+def test_daemon_mode_returns_async_accepted_job(monkeypatch, config, tmp_dir):
+    from mempalace import mcp_jobs, mcp_server
+
+    _patch(monkeypatch, config)
+    monkeypatch.setenv(mcp_jobs.DAEMON_WRITES_ENV, "1")
+    src = os.path.join(tmp_dir, "proj")
+    os.makedirs(src)
+    monkeypatch.setattr(
+        mcp_jobs,
+        "submit_mine",
+        lambda palace_path, payload: {
+            "success": True,
+            "accepted": True,
+            "job_id": "job-1",
+            "state": "queued",
+            "deduplicated": False,
+        },
+    )
+
+    result = mcp_server.tool_mine(source=src, wing="se-code")
+
+    assert result["accepted"] is True
+    assert result["job_id"] == "job-1"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1369,6 +1369,49 @@ class TestSearchTool:
         result = tool_search(query="database", room="backend")
         assert all(r["room"] == "backend" for r in result["results"])
 
+    def test_search_forwards_multiwing_hot_scope(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_jobs, mcp_server
+
+        seen = {}
+        monkeypatch.setattr(mcp_jobs, "active_maintenance_job", lambda **kwargs: None)
+        monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", lambda: None)
+        monkeypatch.setattr(mcp_server, "_vector_disabled", False)
+        monkeypatch.setattr(
+            mcp_server,
+            "search_memories",
+            lambda *args, **kwargs: seen.update(kwargs) or {"results": []},
+        )
+
+        result = mcp_server.tool_search(
+            "why OCR",
+            wings=["se", "se-code"],
+            source_kinds=["curated", "code"],
+        )
+
+        assert result == {"results": []}
+        assert seen["wings"] == ["se", "se-code"]
+        assert seen["source_kinds"] == ["curated", "code"]
+        assert seen["include_cold"] is False
+
+    def test_search_rejects_singular_and_plural_wings(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "search_memories", lambda *a, **k: pytest.fail())
+
+        result = mcp_server.tool_search("ocr", wing="se", wings=["se-code"])
+
+        assert "mutually exclusive" in result["error"]
+
+    def test_search_rejects_unknown_source_kind(self, monkeypatch, config, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        result = mcp_server.tool_search("ocr", source_kinds=["mystery"])
+
+        assert "source_kind" in result["error"]
+
     def test_search_with_source_file_filter(
         self, monkeypatch, config, palace_path, seeded_collection, kg
     ):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4883,6 +4883,49 @@ def test_job_read_tools_bypass_peer_writer_and_daemon_write_dispatch(monkeypatch
     assert result["job"] == {"id": "j1", "state": "running"}
 
 
+def test_search_uses_sqlite_bm25_while_maintenance_is_active(monkeypatch):
+    from mempalace import mcp_jobs, mcp_server
+
+    captured = {}
+
+    def search(query, **kwargs):
+        captured.update(query=query, kwargs=kwargs)
+        return {"results": []}
+
+    monkeypatch.setenv(mcp_jobs.DAEMON_WRITES_ENV, "1")
+    monkeypatch.setattr(
+        mcp_jobs,
+        "active_maintenance_job",
+        lambda **kwargs: {"id": "mine-1", "kind": "mine", "state": "running"},
+    )
+    monkeypatch.setattr(mcp_server, "search_memories", search)
+
+    result = mcp_server.tool_search("pdf ocr")
+
+    assert captured["kwargs"]["vector_disabled"] is True
+    assert result["index_state"] == "updating"
+    assert result["active_job_id"] == "mine-1"
+    assert result["retrieval_mode"] == "bm25_sqlite"
+
+
+def test_search_resets_chroma_cache_after_maintenance_finishes(monkeypatch):
+    from mempalace import mcp_jobs, mcp_server
+
+    resets = []
+    monkeypatch.setattr(mcp_jobs, "active_maintenance_job", lambda **kwargs: None)
+    monkeypatch.setattr(mcp_server, "_last_active_maintenance_job_id", "mine-1")
+    monkeypatch.setattr(mcp_server, "_force_chroma_cache_reset", lambda: resets.append(True))
+    monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", lambda: None)
+    monkeypatch.setattr(mcp_server, "_vector_disabled", False)
+    monkeypatch.setattr(mcp_server, "search_memories", lambda *a, **k: {"results": []})
+
+    result = mcp_server.tool_search("pdf ocr")
+
+    assert result == {"results": []}
+    assert resets == [True]
+    assert mcp_server._last_active_maintenance_job_id is None
+
+
 def test_peer_writer_guard_does_not_gate_read_tool(monkeypatch):
     from mempalace import mcp_server
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3286,6 +3286,34 @@ class TestDiaryTools:
         assert r["entries"][0]["topic"] == "architecture"
         assert "authentication" in r["entries"][0]["content"]
 
+    def test_diary_retry_with_same_operation_id_is_idempotent(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_diary_write
+
+        first = tool_diary_write(
+            agent_name="TestAgent",
+            entry="Committed before the daemon process crashed.",
+            topic="recovery",
+            _operation_id="job-stable-123",
+        )
+        count_after_commit = col.count()
+        retry = tool_diary_write(
+            agent_name="TestAgent",
+            entry="Committed before the daemon process crashed.",
+            topic="recovery",
+            _operation_id="job-stable-123",
+        )
+
+        assert first["success"] is True
+        assert retry["success"] is True
+        assert retry["reason"] == "already_exists"
+        assert retry["entry_id"] == first["entry_id"]
+        assert col.count() == count_after_commit == 1
+
     def test_diary_read_empty(self, monkeypatch, config, palace_path, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         _client, _col = _get_collection(palace_path, create=True)
@@ -4951,6 +4979,33 @@ def test_search_uses_sqlite_bm25_while_maintenance_is_active(monkeypatch):
     assert result["retrieval_mode"] == "bm25_sqlite"
 
 
+def test_search_uses_sqlite_when_writer_wins_status_transition_race(monkeypatch):
+    from contextlib import contextmanager
+
+    from mempalace import mcp_jobs, mcp_server, palace
+
+    captured = {}
+
+    @contextmanager
+    def busy_writer_gate(_palace_path):
+        yield False
+
+    def search(query, **kwargs):
+        captured.update(query=query, kwargs=kwargs)
+        return {"results": []}
+
+    monkeypatch.setattr(mcp_jobs, "active_maintenance_job", lambda **kwargs: None)
+    monkeypatch.setattr(palace, "palace_read_lock", busy_writer_gate)
+    monkeypatch.setattr(mcp_server, "search_memories", search)
+
+    result = mcp_server.tool_search("pdf ocr")
+
+    assert captured["kwargs"]["vector_disabled"] is True
+    assert result["index_state"] == "updating"
+    assert result["active_job_id"] is None
+    assert result["retrieval_mode"] == "bm25_sqlite"
+
+
 def test_search_resets_chroma_cache_after_maintenance_finishes(monkeypatch):
     from mempalace import mcp_jobs, mcp_server
 
@@ -4967,6 +5022,27 @@ def test_search_resets_chroma_cache_after_maintenance_finishes(monkeypatch):
     assert result == {"results": []}
     assert resets == [True]
     assert mcp_server._last_active_maintenance_job_id is None
+
+
+def test_non_search_chroma_read_refuses_while_maintenance_is_active(monkeypatch):
+    from mempalace import mcp_jobs, mcp_server
+
+    monkeypatch.setenv(mcp_jobs.DAEMON_WRITES_ENV, "1")
+    monkeypatch.setattr(
+        mcp_jobs,
+        "active_maintenance_job",
+        lambda **kwargs: {"id": "mine-1", "kind": "mine", "state": "running"},
+    )
+
+    def forbidden():
+        raise AssertionError("Chroma handler must not run during maintenance")
+
+    monkeypatch.setitem(mcp_server.TOOLS["mempalace_status"], "handler", forbidden)
+    result = mcp_server._invoke_direct_tool("mempalace_status", {})
+
+    assert result["success"] is False
+    assert result["error_class"] == "IndexUpdating"
+    assert result["active_job_id"] == "mine-1"
 
 
 def test_peer_writer_guard_does_not_gate_read_tool(monkeypatch):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4803,6 +4803,86 @@ def test_peer_writer_guard_refuses_mutating_tool_before_handler(monkeypatch):
     assert response["error"]["data"]["tool"] == "mempalace_add_drawer"
 
 
+def test_daemon_mode_routes_write_without_peer_writer_lock_or_direct_handler(monkeypatch):
+    from mempalace import mcp_jobs, mcp_server
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("daemon-backed writes must not use the direct writer lane")
+
+    captured = {}
+
+    def dispatch(tool_name, arguments, **kwargs):
+        captured.update(tool_name=tool_name, arguments=arguments, kwargs=kwargs)
+        return {
+            "success": True,
+            "accepted": True,
+            "job_id": "j1",
+            "state": "queued",
+            "delivery": "durable_queue",
+        }
+
+    monkeypatch.setenv(mcp_jobs.DAEMON_WRITES_ENV, "1")
+    monkeypatch.setattr(mcp_server, "_acquire_mcp_writer_lock", forbidden)
+    monkeypatch.setattr(mcp_server, "_mcp_sqlite_integrity_refusal", lambda *a: None)
+    monkeypatch.setitem(mcp_server.TOOLS["mempalace_add_drawer"], "handler", forbidden)
+    monkeypatch.setattr(mcp_jobs, "dispatch_daemon_write", dispatch)
+
+    response = mcp_server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {
+                "name": "mempalace_add_drawer",
+                "arguments": {
+                    "wing": "se",
+                    "room": "decisions",
+                    "content": "verbatim",
+                },
+            },
+        }
+    )
+
+    result = json.loads(response["result"]["content"][0]["text"])
+    assert result["job_id"] == "j1"
+    assert captured == {
+        "tool_name": "mempalace_add_drawer",
+        "arguments": {"wing": "se", "room": "decisions", "content": "verbatim"},
+        "kwargs": {"palace_path": mcp_server._config.palace_path},
+    }
+
+
+def test_job_read_tools_bypass_peer_writer_and_daemon_write_dispatch(monkeypatch):
+    from mempalace import mcp_jobs, mcp_server
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("job reads must bypass both writer lanes")
+
+    monkeypatch.setenv(mcp_jobs.DAEMON_WRITES_ENV, "1")
+    monkeypatch.setattr(mcp_server, "_acquire_mcp_writer_lock", forbidden)
+    monkeypatch.setattr(mcp_jobs, "dispatch_daemon_write", forbidden)
+    monkeypatch.setattr(
+        mcp_jobs,
+        "tool_job_status",
+        lambda job_id, palace_path=None: {
+            "success": True,
+            "job": {"id": job_id, "state": "running"},
+        },
+    )
+
+    response = mcp_server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "tools/call",
+            "params": {"name": "mempalace_job_status", "arguments": {"job_id": "j1"}},
+        }
+    )
+
+    result = json.loads(response["result"]["content"][0]["text"])
+    assert result["job"] == {"id": "j1", "state": "running"}
+
+
 def test_peer_writer_guard_does_not_gate_read_tool(monkeypatch):
     from mempalace import mcp_server
 

--- a/tests/test_migration_activation.py
+++ b/tests/test_migration_activation.py
@@ -1,0 +1,613 @@
+"""Synthetic activation and rollback tests for reviewed migration bundles."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import os
+import sqlite3
+import stat
+from contextlib import contextmanager
+
+import pytest
+
+from mempalace.migration_bundle import (
+    _require_daemons_stopped,
+    _validate_sidecars,
+    activate_migrated_palace,
+    bundle_permissions,
+    drawer_logical_snapshot,
+    rollback_activated_palace,
+)
+from mempalace.reorganize import exact_hash, palace_semantic_snapshot, palace_snapshot
+
+
+def _seed_palace(path, marker):
+    path.mkdir(parents=True)
+    with sqlite3.connect(path / "chroma.sqlite3") as connection:
+        connection.executescript(
+            """
+            CREATE TABLE marker(value TEXT NOT NULL);
+            CREATE TABLE collections (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                config_json_str TEXT,
+                schema_str TEXT
+            );
+            CREATE TABLE segments (id INTEGER PRIMARY KEY, collection INTEGER NOT NULL);
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY,
+                segment_id INTEGER NOT NULL,
+                embedding_id TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE embedding_metadata (
+                id INTEGER,
+                key TEXT,
+                string_value TEXT,
+                int_value INTEGER,
+                float_value REAL,
+                bool_value INTEGER
+            );
+            INSERT INTO collections(id, name, config_json_str, schema_str)
+                VALUES (
+                    1,
+                    'mempalace_drawers',
+                    '{"a":1,"b":2}',
+                    '{"defaults":{"ef":10,"threads":4},"version":1}'
+                );
+            INSERT INTO collections(id, name, config_json_str, schema_str)
+                VALUES (
+                    2,
+                    'mempalace_closets',
+                    '{"a":1,"b":2}',
+                    '{"defaults":{"ef":10,"threads":4},"version":1}'
+                );
+            INSERT INTO segments(id, collection) VALUES (1, 1), (2, 2);
+            INSERT INTO embeddings(id, segment_id, embedding_id, created_at)
+                VALUES (1, 1, 'drawer', '2026-07-14T00:00:00Z');
+            INSERT INTO embeddings(id, segment_id, embedding_id, created_at)
+                VALUES (2, 2, 'closet', '2026-07-14T00:00:00Z');
+            """
+        )
+        connection.execute("INSERT INTO marker(value) VALUES (?)", (marker,))
+        connection.execute(
+            "INSERT INTO embedding_metadata(id, key, string_value) VALUES (1, ?, ?)",
+            ("chroma:document", marker),
+        )
+        connection.execute(
+            "INSERT INTO embedding_metadata(id, key, string_value) VALUES (1, 'wing', 'se')"
+        )
+        connection.execute(
+            "INSERT INTO embedding_metadata(id, key, string_value) VALUES (2, ?, ?)",
+            ("chroma:document", f"closet {marker}"),
+        )
+        connection.execute(
+            "INSERT INTO embedding_metadata(id, key, string_value) VALUES (2, 'wing', 'se')"
+        )
+
+
+def _marker(path):
+    with sqlite3.connect(path / "chroma.sqlite3") as connection:
+        return connection.execute("SELECT value FROM marker").fetchone()[0]
+
+
+def _file_snapshot(path):
+    payload = path.read_bytes()
+    return {"size": len(payload), "sha256": hashlib.sha256(payload).hexdigest()}
+
+
+def _activation_fixture(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    active = tmp_path / "active" / "palace"
+    migrated = tmp_path / "bundle" / "migrated"
+    previous = tmp_path / "bundle" / "previous"
+    _seed_palace(active, "original")
+    _seed_palace(migrated / "palace", "migrated")
+    active.parent.mkdir(exist_ok=True)
+    (active.parent / "config.json").write_text(
+        json.dumps({"palace_path": str(active), "backend": "chroma"}) + "\n"
+    )
+    (active.parent / "hallways.json").write_text('[{"version":"old"}]\n')
+    (active.parent / "tunnels.json").write_text('[{"version":"old"}]\n')
+    (migrated / "config.json").write_text(
+        json.dumps({"palace_path": str(migrated / "palace"), "backend": "chroma"}) + "\n"
+    )
+    (migrated / "hallways.json").write_text('[{"version":"new"}]\n')
+    (migrated / "tunnels.json").write_text('[{"version":"new"}]\n')
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "palace_path_sha256": exact_hash(str(active.absolute())),
+                "sqlite_snapshot": palace_snapshot(active),
+                "source_semantic_snapshot": palace_semantic_snapshot(active),
+                "counts": {
+                    "inventory_total": 3,
+                    "verified_duplicate_candidates": 1,
+                },
+            }
+        )
+        + "\n"
+    )
+    os.chmod(manifest, 0o600)
+    apply_report = {
+        "version": 1,
+        "status": "complete",
+        "source_palace_sha256": exact_hash(str(active.absolute())),
+        "reviewed_manifest_sha256": hashlib.sha256(manifest.read_bytes()).hexdigest(),
+        "records_before": 3,
+        "records_expected_after": 2,
+        "records_deleted_as_verified_duplicates": 1,
+        "retained_records_verified": 2,
+        "verified_duplicates_absent": 1,
+        "sqlite_integrity": "ok",
+        "drawer_vector_readiness": {"ready": True},
+        "closet_vector_readiness": {"ready": True},
+        "derived_sidecars": {
+            "hallways.json": _file_snapshot(migrated / "hallways.json"),
+            "tunnels.json": _file_snapshot(migrated / "tunnels.json"),
+        },
+        "migrated_logical_snapshot": drawer_logical_snapshot(migrated / "palace"),
+        "migrated_semantic_snapshot": palace_semantic_snapshot(migrated / "palace"),
+        "migrated_snapshot": palace_snapshot(migrated / "palace"),
+    }
+    (migrated / "apply-report.json").write_text(json.dumps(apply_report) + "\n")
+    os.chmod(migrated / "apply-report.json", 0o600)
+    monkeypatch.setattr(
+        "mempalace.migration_bundle._verify_staging_readiness",
+        lambda _palace: None,
+    )
+    return active, migrated, previous, manifest
+
+
+def test_activation_and_rollback_preserve_both_palaces_and_sidecars(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+
+    activated = activate_migrated_palace(
+        active_palace=active,
+        reviewed_manifest=manifest,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+
+    assert activated["status"] == "active"
+    assert _marker(active) == "migrated"
+    assert _marker(previous / "palace") == "original"
+    assert (active.parent / "hallways.json").read_text() == '[{"version":"new"}]\n'
+    assert (previous / "hallways.json").read_text() == '[{"version":"old"}]\n'
+    assert (migrated / "palace").exists() is False
+    assert json.loads((previous / "activation-report.json").read_text())["status"] == "active"
+    assert bundle_permissions(previous) == []
+
+    rolled_back = rollback_activated_palace(
+        active_palace=active,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+
+    assert rolled_back["status"] == "rolled_back"
+    assert _marker(active) == "original"
+    assert _marker(migrated / "palace") == "migrated"
+    assert (active.parent / "hallways.json").read_text() == '[{"version":"old"}]\n'
+    assert (migrated / "hallways.json").read_text() == '[{"version":"new"}]\n'
+    assert (previous / "palace").exists() is False
+    assert json.loads((previous / "activation-report.json").read_text())["status"] == "rolled_back"
+    assert bundle_permissions(previous) == []
+    assert bundle_permissions(migrated) == []
+
+
+def test_activation_refuses_changed_active_snapshot(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    with sqlite3.connect(active / "chroma.sqlite3") as connection:
+        connection.execute("UPDATE marker SET value='changed'")
+
+    with pytest.raises(ValueError, match="active palace no longer matches"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+    assert _marker(active) == "changed"
+    assert _marker(migrated / "palace") == "migrated"
+    assert previous.exists() is False
+
+
+def test_activation_allows_semantically_equal_active_chroma_json_reserialization(
+    tmp_path, monkeypatch
+):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    reviewed = json.loads(manifest.read_text())
+    with sqlite3.connect(active / "chroma.sqlite3") as connection:
+        connection.execute(
+            "UPDATE collections SET schema_str = ? WHERE name = 'mempalace_drawers'",
+            ('{ "version": 1, "defaults": { "threads": 4, "ef": 10 } }',),
+        )
+
+    assert palace_snapshot(active) != reviewed["sqlite_snapshot"]
+    assert palace_semantic_snapshot(active) == reviewed["source_semantic_snapshot"]
+
+    activated = activate_migrated_palace(
+        active_palace=active,
+        reviewed_manifest=manifest,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+
+    assert activated["status"] == "active"
+    assert _marker(active) == "migrated"
+    assert _marker(previous / "palace") == "original"
+
+
+def test_activation_refuses_running_daemon(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    from mempalace import daemon
+
+    monkeypatch.setattr(daemon, "get_client_if_running", lambda *args, **kwargs: object())
+
+    with pytest.raises(RuntimeError, match="daemon must be stopped"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+    assert _marker(active) == "original"
+    assert _marker(migrated / "palace") == "migrated"
+    assert previous.exists() is False
+
+
+def test_activation_refuses_daemon_targeting_staged_palace(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    from mempalace import daemon
+
+    staged = str(migrated / "palace")
+    monkeypatch.setattr(
+        daemon,
+        "get_client_if_running",
+        lambda palace_path, **kwargs: object() if palace_path == staged else None,
+    )
+
+    with pytest.raises(RuntimeError, match="daemon must be stopped"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+    assert _marker(active) == "original"
+    assert _marker(migrated / "palace") == "migrated"
+
+
+def test_activation_binds_completed_report_and_sidecars(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    report_path = migrated / "apply-report.json"
+    report = json.loads(report_path.read_text())
+    report["reviewed_manifest_sha256"] = "wrong"
+    report_path.write_text(json.dumps(report) + "\n")
+
+    with pytest.raises(ValueError, match="different reviewed manifest"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+    report["reviewed_manifest_sha256"] = hashlib.sha256(manifest.read_bytes()).hexdigest()
+    report_path.write_text(json.dumps(report) + "\n")
+    (migrated / "hallways.json").write_text('[{"version":"tampered"}]\n')
+    with pytest.raises(ValueError, match="sidecars no longer match"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+
+def test_activation_allows_chroma_json_reserialization_when_semantics_match(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    report = json.loads((migrated / "apply-report.json").read_text())
+    with sqlite3.connect(migrated / "palace" / "chroma.sqlite3") as connection:
+        connection.execute(
+            "UPDATE collections SET schema_str = ? WHERE name = 'mempalace_drawers'",
+            ('{ "version": 1, "defaults": { "threads": 4, "ef": 10 } }',),
+        )
+    assert palace_snapshot(migrated / "palace") != report["migrated_snapshot"]
+    assert drawer_logical_snapshot(migrated / "palace") == report["migrated_logical_snapshot"]
+    assert palace_semantic_snapshot(migrated / "palace") == report["migrated_semantic_snapshot"]
+
+    activated = activate_migrated_palace(
+        active_palace=active,
+        reviewed_manifest=manifest,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+
+    assert activated["status"] == "active"
+    assert _marker(active) == "migrated"
+
+
+def test_activation_rejects_closet_content_drift(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    report = json.loads((migrated / "apply-report.json").read_text())
+    with sqlite3.connect(migrated / "palace" / "chroma.sqlite3") as connection:
+        connection.execute(
+            "UPDATE embedding_metadata SET string_value = 'tampered closet' "
+            "WHERE id = 2 AND key = 'chroma:document'"
+        )
+
+    assert drawer_logical_snapshot(migrated / "palace") == report["migrated_logical_snapshot"]
+    assert palace_semantic_snapshot(migrated / "palace") != report["migrated_semantic_snapshot"]
+
+    with pytest.raises(ValueError, match="semantic snapshot"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+
+def test_daemon_stop_check_uses_platform_safe_pid_probe(tmp_path, monkeypatch):
+    from mempalace import daemon
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "daemon-state"))
+    marker = daemon.pid_path(str(palace))
+    marker.parent.mkdir(parents=True)
+    marker.write_text("4242")
+    monkeypatch.setattr(daemon, "get_client_if_running", lambda *_args, **_kwargs: None)
+    probed = []
+
+    def safe_probe(pid):
+        probed.append(pid)
+        return True
+
+    monkeypatch.setattr(daemon, "_pid_alive", safe_probe)
+
+    with pytest.raises(RuntimeError, match="PID 4242 is still alive"):
+        _require_daemons_stopped([palace])
+
+    assert probed == [4242]
+
+
+def test_sidecar_revalidation_rejects_new_supported_sidecar(tmp_path):
+    root = tmp_path / "bundle"
+    root.mkdir()
+    expected = _validate_sidecars(root, ("hallways.json", "tunnels.json"))
+    (root / "hallways.json").write_text("[]\n")
+
+    with pytest.raises(ValueError, match="sidecars changed"):
+        _validate_sidecars(
+            root,
+            ("hallways.json", "tunnels.json"),
+            expected=expected,
+        )
+
+
+def test_activation_and_rollback_lock_every_palace_path(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    locked = []
+
+    @contextmanager
+    def recording_lock(path, *, blocking=False):
+        locked.append(os.path.abspath(path))
+        yield
+
+    monkeypatch.setattr("mempalace.migration_bundle.mine_palace_lock", recording_lock)
+
+    activate_migrated_palace(
+        active_palace=active,
+        reviewed_manifest=manifest,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+    assert set(locked) == {str(active.absolute()), str((migrated / "palace").absolute())}
+
+    locked.clear()
+    rollback_activated_palace(
+        active_palace=active,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+    assert set(locked) == {
+        str(active.absolute()),
+        str((migrated / "palace").absolute()),
+        str((previous / "palace").absolute()),
+    }
+
+
+def test_rollback_refuses_tampered_sidecar_symlink(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    activate_migrated_palace(
+        active_palace=active,
+        reviewed_manifest=manifest,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+    target = tmp_path / "unrelated.json"
+    target.write_text("do not chmod or promote\n")
+    (previous / "hallways.json").unlink()
+    (previous / "hallways.json").symlink_to(target)
+
+    with pytest.raises(ValueError, match="symlink"):
+        rollback_activated_palace(
+            active_palace=active,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+    assert _marker(active) == "migrated"
+    assert _marker(previous / "palace") == "original"
+
+
+def test_activation_compensates_when_staging_promotion_fails(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    real_replace = os.replace
+
+    def fail_staging_promotion(source, destination):
+        if os.fspath(source) == os.fspath(migrated / "palace") and os.fspath(
+            destination
+        ) == os.fspath(active):
+            raise OSError("synthetic promotion failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", fail_staging_promotion)
+
+    with pytest.raises(OSError, match="synthetic promotion failure"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+    assert _marker(active) == "original"
+    assert _marker(migrated / "palace") == "migrated"
+    assert (active.parent / "hallways.json").read_text() == '[{"version":"old"}]\n'
+    assert (migrated / "hallways.json").read_text() == '[{"version":"new"}]\n'
+    assert previous.exists() is False
+
+
+def test_activation_recovers_after_uncatchable_mid_swap_exit(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    real_replace = os.replace
+    failed = False
+
+    def crash_during_staging_promotion(source, destination):
+        nonlocal failed
+        if (
+            not failed
+            and os.fspath(source) == os.fspath(migrated / "palace")
+            and os.fspath(destination) == os.fspath(active)
+        ):
+            failed = True
+            raise SystemExit("synthetic process death")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", crash_during_staging_promotion)
+    with pytest.raises(SystemExit, match="synthetic process death"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+    journal = previous.parent / f".{previous.name}.activation-journal.json"
+    assert journal.is_file()
+    monkeypatch.setattr(os, "replace", real_replace)
+
+    recovered = activate_migrated_palace(
+        active_palace=active,
+        reviewed_manifest=manifest,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+
+    assert recovered["status"] == "active"
+    assert _marker(active) == "migrated"
+    assert _marker(previous / "palace") == "original"
+    assert journal.exists() is False
+
+
+def test_rollback_recovers_after_uncatchable_mid_swap_exit(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    activate_migrated_palace(
+        active_palace=active,
+        reviewed_manifest=manifest,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+    real_replace = os.replace
+    failed = False
+
+    def crash_during_previous_promotion(source, destination):
+        nonlocal failed
+        if (
+            not failed
+            and os.fspath(source) == os.fspath(previous / "palace")
+            and os.fspath(destination) == os.fspath(active)
+        ):
+            failed = True
+            raise SystemExit("synthetic process death")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", crash_during_previous_promotion)
+    with pytest.raises(SystemExit, match="synthetic process death"):
+        rollback_activated_palace(
+            active_palace=active,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+    journal = previous.parent / f".{previous.name}.activation-journal.json"
+    assert journal.is_file()
+    monkeypatch.setattr(os, "replace", real_replace)
+
+    recovered = rollback_activated_palace(
+        active_palace=active,
+        migrated_root=migrated,
+        previous_root=previous,
+    )
+
+    assert recovered["status"] == "rolled_back"
+    assert _marker(active) == "original"
+    assert _marker(migrated / "palace") == "migrated"
+    assert journal.exists() is False
+
+
+def test_activation_refuses_existing_previous_or_symlinked_staging(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    previous.mkdir()
+    with pytest.raises(ValueError, match="previous activation slot already exists"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+    previous.rmdir()
+    staged_palace = migrated / "palace"
+    real_palace = migrated / "real-palace"
+    staged_palace.rename(real_palace)
+    staged_palace.symlink_to(real_palace, target_is_directory=True)
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+
+def test_activation_preflight_failure_cleans_temp_without_chmodding_parent(tmp_path, monkeypatch):
+    active, migrated, previous, manifest = _activation_fixture(tmp_path, monkeypatch)
+    os.chmod(previous.parent, 0o755)
+    monkeypatch.setattr(
+        "mempalace.migration_bundle.shutil.copy2",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("synthetic copy failure")),
+    )
+
+    with pytest.raises(OSError, match="synthetic copy failure"):
+        activate_migrated_palace(
+            active_palace=active,
+            reviewed_manifest=manifest,
+            migrated_root=migrated,
+            previous_root=previous,
+        )
+
+    assert stat.S_IMODE(previous.parent.stat().st_mode) == 0o755
+    assert list(previous.parent.glob(f".{previous.name}.*.tmp")) == []
+    assert _marker(active) == "original"
+    assert _marker(migrated / "palace") == "migrated"

--- a/tests/test_migration_bundle.py
+++ b/tests/test_migration_bundle.py
@@ -1,0 +1,582 @@
+"""Tests for copy-only, reviewed MemPalace migration bundles."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import stat
+
+import pytest
+
+from mempalace.migration_bundle import (
+    _publish_directory_no_replace,
+    _read_available_embeddings,
+    apply_reviewed_migration,
+    apply_actions_to_collection,
+    bundle_permissions,
+    prepare_migration_copies,
+    verify_retained_records,
+)
+from mempalace.reorganize import (
+    InventoryRecord,
+    collect_duplicate_evidence,
+    inventory_palace,
+    palace_snapshot,
+    plan_actions,
+    write_manifest,
+)
+
+
+class _MemoryCollection:
+    def __init__(self, records):
+        self.rows = {
+            record.drawer_id: {
+                "document": record.content,
+                "metadata": dict(record.metadata),
+            }
+            for record in records
+        }
+
+    def update(self, *, ids, metadatas):
+        for drawer_id, metadata in zip(ids, metadatas):
+            if drawer_id in self.rows:
+                self.rows[drawer_id]["metadata"] = dict(metadata)
+
+    def delete(self, *, ids):
+        for drawer_id in ids:
+            self.rows.pop(drawer_id, None)
+
+    def count(self):
+        return len(self.rows)
+
+    def get(self, *, ids, include):
+        found = [drawer_id for drawer_id in ids if drawer_id in self.rows]
+        result = {"ids": found}
+        if "documents" in include:
+            result["documents"] = [self.rows[drawer_id]["document"] for drawer_id in found]
+        if "metadatas" in include:
+            result["metadatas"] = [self.rows[drawer_id]["metadata"] for drawer_id in found]
+        return result
+
+
+def test_embedding_reuse_isolates_only_unreadable_vector_ids():
+    class PartiallyUnreadable:
+        def get(self, *, ids, include):
+            assert include == ["embeddings"]
+            if "bad" in ids:
+                raise RuntimeError("Error finding id")
+            return {
+                "ids": list(ids),
+                "embeddings": [[float(index), 1.0] for index, _ in enumerate(ids)],
+            }
+
+    available = _read_available_embeddings(PartiallyUnreadable(), ["good-a", "bad", "good-b"])
+
+    assert set(available) == {"good-a", "good-b"}
+
+
+def _seed_palace(palace, rows):
+    palace.mkdir(parents=True)
+    db_path = palace / "chroma.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE collections (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                config_json_str TEXT,
+                schema_str TEXT
+            );
+            CREATE TABLE segments (id INTEGER PRIMARY KEY, collection INTEGER NOT NULL);
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY,
+                segment_id INTEGER NOT NULL,
+                embedding_id TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE embedding_metadata (
+                id INTEGER,
+                key TEXT,
+                string_value TEXT,
+                int_value INTEGER,
+                float_value REAL,
+                bool_value INTEGER
+            );
+            INSERT INTO collections(id, name, config_json_str, schema_str)
+                VALUES (
+                    1,
+                    'mempalace_drawers',
+                    '{"a":1,"b":2}',
+                    '{"defaults":{"ef":10,"threads":4},"version":1}'
+                );
+            INSERT INTO segments(id, collection) VALUES (1, 1);
+            """
+        )
+        for row_id, (drawer_id, content, metadata) in enumerate(rows, start=1):
+            conn.execute(
+                "INSERT INTO embeddings(id, segment_id, embedding_id, created_at) "
+                "VALUES (?, 1, ?, '2026-07-14T00:00:00Z')",
+                (row_id, drawer_id),
+            )
+            conn.execute(
+                "INSERT INTO embedding_metadata(id, key, string_value) VALUES (?, ?, ?)",
+                (row_id, "chroma:document", content),
+            )
+            for key, value in metadata.items():
+                column = "int_value" if isinstance(value, int) else "string_value"
+                conn.execute(
+                    f"INSERT INTO embedding_metadata(id, key, {column}) VALUES (?, ?, ?)",
+                    (row_id, key, value),
+                )
+    return db_path
+
+
+def _reviewed_fixture(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    active_root = tmp_path / "active"
+    palace = active_root / "palace"
+    canonical = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    sessions = tmp_path / "sessions"
+    for path in (canonical, worktree, sessions):
+        path.mkdir()
+    _seed_palace(
+        palace,
+        [
+            (
+                "canonical",
+                "same content",
+                {"wing": "se", "source_file": str(canonical / "src/a.ts"), "chunk_index": 0},
+            ),
+            (
+                "worktree",
+                "same content",
+                {"wing": "se", "source_file": str(worktree / "src/a.ts"), "chunk_index": 0},
+            ),
+        ],
+    )
+    (active_root / "config.json").write_text('{"backend": "chroma"}\n')
+    (active_root / "hallways.json").write_text("[]\n")
+    inventory = inventory_palace(
+        palace,
+        canonical_root=canonical,
+        worktree_roots=[worktree],
+        session_roots=[sessions],
+    )
+    actions = plan_actions(inventory)
+    evidence = collect_duplicate_evidence(inventory, actions)
+    manifest = tmp_path / "manifest.json"
+    write_manifest(
+        manifest,
+        inventory,
+        actions,
+        evidence,
+        palace_path=palace,
+        sqlite_snapshot=palace_snapshot(palace),
+    )
+    return palace, canonical, worktree, sessions, manifest
+
+
+def test_prepare_migration_copies_publishes_private_matching_bundles(tmp_path, monkeypatch):
+    palace, canonical, worktree, sessions, manifest = _reviewed_fixture(tmp_path, monkeypatch)
+    rollback = tmp_path / "out" / "rollback"
+    migrated = tmp_path / "out" / "migrated"
+
+    report = prepare_migration_copies(
+        source_palace=palace,
+        reviewed_manifest=manifest,
+        rollback_root=rollback,
+        migrated_root=migrated,
+        canonical_root=canonical,
+        worktree_roots=[worktree],
+        session_roots=[sessions],
+    )
+
+    assert report["success"] is True
+    assert report["inventory_total"] == 2
+    assert report["duplicate_candidates"] == 1
+    assert palace_snapshot(rollback / "palace") == palace_snapshot(palace)
+    assert palace_snapshot(migrated / "palace") == palace_snapshot(palace)
+    assert (rollback / "config.json").is_file()
+    assert (rollback / "hallways.json").is_file()
+    assert bundle_permissions(rollback) == []
+    assert bundle_permissions(migrated) == []
+    assert stat.S_IMODE((rollback / "palace").stat().st_mode) == 0o700
+
+
+def test_prepare_allows_semantically_equal_chroma_json_reserialization(tmp_path, monkeypatch):
+    palace, canonical, worktree, sessions, manifest = _reviewed_fixture(tmp_path, monkeypatch)
+    with sqlite3.connect(palace / "chroma.sqlite3") as conn:
+        conn.execute(
+            "UPDATE collections SET schema_str = ? WHERE name = 'mempalace_drawers'",
+            ('{ "version": 1, "defaults": { "threads": 4, "ef": 10 } }',),
+        )
+    rollback = tmp_path / "out" / "rollback"
+    migrated = tmp_path / "out" / "migrated"
+
+    report = prepare_migration_copies(
+        source_palace=palace,
+        reviewed_manifest=manifest,
+        rollback_root=rollback,
+        migrated_root=migrated,
+        canonical_root=canonical,
+        worktree_roots=[worktree],
+        session_roots=[sessions],
+    )
+
+    assert report["success"] is True
+    assert palace_snapshot(rollback / "palace") == palace_snapshot(palace)
+
+
+def test_prepare_version1_manifest_requires_exact_physical_snapshot(tmp_path, monkeypatch):
+    palace, canonical, worktree, sessions, manifest = _reviewed_fixture(tmp_path, monkeypatch)
+    reviewed = json.loads(manifest.read_text())
+    reviewed["version"] = 1
+    reviewed.pop("source_semantic_snapshot")
+    manifest.write_text(json.dumps(reviewed) + "\n")
+
+    prepare_migration_copies(
+        source_palace=palace,
+        reviewed_manifest=manifest,
+        rollback_root=tmp_path / "exact" / "rollback",
+        migrated_root=tmp_path / "exact" / "migrated",
+        canonical_root=canonical,
+        worktree_roots=[worktree],
+        session_roots=[sessions],
+    )
+
+    with sqlite3.connect(palace / "chroma.sqlite3") as conn:
+        conn.execute(
+            "UPDATE collections SET schema_str = ? WHERE name = 'mempalace_drawers'",
+            ('{ "version": 1, "defaults": { "threads": 4, "ef": 10 } }',),
+        )
+    with pytest.raises(ValueError, match="manifest snapshot"):
+        prepare_migration_copies(
+            source_palace=palace,
+            reviewed_manifest=manifest,
+            rollback_root=tmp_path / "drift" / "rollback",
+            migrated_root=tmp_path / "drift" / "migrated",
+            canonical_root=canonical,
+            worktree_roots=[worktree],
+            session_roots=[sessions],
+        )
+
+
+def test_prepare_migration_copies_rejects_snapshot_drift_and_cleans_outputs(tmp_path, monkeypatch):
+    palace, canonical, worktree, sessions, manifest = _reviewed_fixture(tmp_path, monkeypatch)
+    with sqlite3.connect(palace / "chroma.sqlite3") as conn:
+        conn.execute("CREATE TABLE changed_after_review(value TEXT)")
+    rollback = tmp_path / "out" / "rollback"
+    migrated = tmp_path / "out" / "migrated"
+
+    with pytest.raises(ValueError, match="semantic state no longer matches"):
+        prepare_migration_copies(
+            source_palace=palace,
+            reviewed_manifest=manifest,
+            rollback_root=rollback,
+            migrated_root=migrated,
+            canonical_root=canonical,
+            worktree_roots=[worktree],
+            session_roots=[sessions],
+        )
+
+    assert rollback.exists() is False
+    assert migrated.exists() is False
+
+
+def test_prepare_migration_copies_rejects_existing_or_symlink_destination(tmp_path, monkeypatch):
+    palace, canonical, worktree, sessions, manifest = _reviewed_fixture(tmp_path, monkeypatch)
+    rollback = tmp_path / "rollback"
+    rollback.mkdir()
+
+    with pytest.raises(ValueError, match="already exists"):
+        prepare_migration_copies(
+            source_palace=palace,
+            reviewed_manifest=manifest,
+            rollback_root=rollback,
+            migrated_root=tmp_path / "migrated",
+            canonical_root=canonical,
+            worktree_roots=[worktree],
+            session_roots=[sessions],
+        )
+
+
+def test_prepare_failure_never_deletes_competing_destination(tmp_path, monkeypatch):
+    palace, canonical, worktree, sessions, manifest = _reviewed_fixture(tmp_path, monkeypatch)
+    rollback = tmp_path / "out" / "rollback"
+    migrated = tmp_path / "out" / "migrated"
+    real_publish = _publish_directory_no_replace
+    competing_identity = None
+
+    def race_first_publish(source, destination):
+        nonlocal competing_identity
+        if destination == rollback:
+            rollback.mkdir()
+            competing_identity = rollback.stat().st_ino
+        return real_publish(source, destination)
+
+    monkeypatch.setattr(
+        "mempalace.migration_bundle._publish_directory_no_replace",
+        race_first_publish,
+    )
+
+    with pytest.raises(FileExistsError):
+        prepare_migration_copies(
+            source_palace=palace,
+            reviewed_manifest=manifest,
+            rollback_root=rollback,
+            migrated_root=migrated,
+            canonical_root=canonical,
+            worktree_roots=[worktree],
+            session_roots=[sessions],
+        )
+
+    assert rollback.stat().st_ino == competing_identity
+    assert list(rollback.iterdir()) == []
+    assert migrated.exists() is False
+
+
+def test_prepare_second_publish_failure_retains_completed_rollback(tmp_path, monkeypatch):
+    palace, canonical, worktree, sessions, manifest = _reviewed_fixture(tmp_path, monkeypatch)
+    rollback = tmp_path / "out" / "rollback"
+    migrated = tmp_path / "out" / "migrated"
+    real_publish = _publish_directory_no_replace
+    competing_identity = None
+
+    def race_second_publish(source, destination):
+        nonlocal competing_identity
+        if destination == migrated:
+            migrated.mkdir()
+            competing_identity = migrated.stat().st_ino
+        return real_publish(source, destination)
+
+    monkeypatch.setattr(
+        "mempalace.migration_bundle._publish_directory_no_replace",
+        race_second_publish,
+    )
+
+    with pytest.raises(FileExistsError):
+        prepare_migration_copies(
+            source_palace=palace,
+            reviewed_manifest=manifest,
+            rollback_root=rollback,
+            migrated_root=migrated,
+            canonical_root=canonical,
+            worktree_roots=[worktree],
+            session_roots=[sessions],
+        )
+
+    assert palace_snapshot(rollback / "palace") == palace_snapshot(palace)
+    assert migrated.stat().st_ino == competing_identity
+    assert list(migrated.iterdir()) == []
+
+
+def test_atomic_publish_refuses_existing_empty_directory(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    destination.mkdir()
+    (source / "complete").write_text("published content")
+    competing_identity = destination.stat().st_ino
+
+    with pytest.raises(FileExistsError):
+        _publish_directory_no_replace(source, destination)
+
+    assert source.is_dir()
+    assert destination.stat().st_ino == competing_identity
+    assert list(destination.iterdir()) == []
+
+
+def test_prepare_preserves_existing_parent_permissions(tmp_path, monkeypatch):
+    palace, canonical, worktree, sessions, manifest = _reviewed_fixture(tmp_path, monkeypatch)
+    output = tmp_path / "shared-output"
+    output.mkdir(mode=0o755)
+    output.chmod(0o755)
+
+    prepare_migration_copies(
+        source_palace=palace,
+        reviewed_manifest=manifest,
+        rollback_root=output / "rollback",
+        migrated_root=output / "migrated",
+        canonical_root=canonical,
+        worktree_roots=[worktree],
+        session_roots=[sessions],
+    )
+
+    assert stat.S_IMODE(output.stat().st_mode) == 0o755
+
+
+def test_apply_actions_deletes_only_evidenced_duplicate_and_is_idempotent():
+    canonical = InventoryRecord(
+        drawer_id="canonical",
+        content="same",
+        metadata={"wing": "se", "room": "code", "chunk_index": 0},
+        origin="canonical",
+        relative_identity="src/a.ts",
+        source_path="/repo/src/a.ts",
+    )
+    duplicate = InventoryRecord(
+        drawer_id="duplicate",
+        content="same",
+        metadata={"wing": "se", "room": "code", "chunk_index": 0},
+        origin="worktree",
+        relative_identity="src/a.ts",
+        source_path="/worktree/src/a.ts",
+    )
+    unique = InventoryRecord(
+        drawer_id="unique",
+        content="unique verbatim",
+        metadata={"wing": "se", "room": "notes", "chunk_index": 0},
+        origin="worktree",
+        relative_identity="notes/unique.md",
+        source_path="/worktree/notes/unique.md",
+    )
+    inventory = [canonical, duplicate, unique]
+    actions = plan_actions(inventory)
+    evidence = collect_duplicate_evidence(inventory, actions)
+    collection = _MemoryCollection(inventory)
+
+    report = apply_actions_to_collection(collection, inventory, actions, evidence, batch_size=1)
+    second = apply_actions_to_collection(collection, inventory, actions, evidence, batch_size=2)
+    verified = verify_retained_records(collection, inventory, actions, evidence)
+
+    assert report["records_deleted_as_verified_duplicates"] == 1
+    assert second == report
+    assert set(collection.rows) == {"canonical", "unique"}
+    assert collection.rows["canonical"]["metadata"]["wing"] == "se-code"
+    assert collection.rows["unique"]["metadata"]["wing"] == "se-sessions"
+    assert collection.rows["unique"]["document"] == "unique verbatim"
+    assert verified == {
+        "retained_records_verified": 2,
+        "verified_duplicates_absent": 1,
+    }
+
+
+def test_apply_actions_refuses_candidate_without_matching_evidence():
+    record = InventoryRecord(
+        drawer_id="worktree",
+        content="content",
+        metadata={"wing": "se", "chunk_index": 0},
+        origin="worktree",
+        relative_identity="src/a.ts",
+        source_path="/worktree/src/a.ts",
+    )
+    actions = plan_actions([record])
+    # Force an unsafe candidate action without producing proof.
+    unsafe = [actions[0].__class__(**{**actions[0].__dict__, "action": "duplicate_candidate"})]
+
+    with pytest.raises(ValueError, match="do not reconcile"):
+        apply_actions_to_collection(_MemoryCollection([record]), [record], unsafe, [])
+
+
+def test_apply_reviewed_migration_updates_copy_and_preserves_verbatim(tmp_path, monkeypatch):
+    from mempalace.palace import get_backend_for_palace, get_collection
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    active_root = tmp_path / "active"
+    palace = active_root / "palace"
+    canonical = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    sessions = tmp_path / "sessions"
+    for path in (canonical, worktree, sessions):
+        path.mkdir(parents=True)
+    collection = get_collection(str(palace), create=True, backend="chroma")
+    collection.upsert(
+        ids=["canonical", "duplicate", "unique"],
+        documents=["same content", "same content", "unique verbatim artifact"],
+        metadatas=[
+            {
+                "wing": "se",
+                "room": "code",
+                "source_file": str(canonical / "src/a.ts"),
+                "chunk_index": 0,
+            },
+            {
+                "wing": "se",
+                "room": "code",
+                "source_file": str(worktree / "src/a.ts"),
+                "chunk_index": 0,
+            },
+            {
+                "wing": "se",
+                "room": "notes",
+                "source_file": str(worktree / "notes/unique.md"),
+                "chunk_index": 0,
+            },
+        ],
+    )
+    get_backend_for_palace(str(palace), explicit="chroma").close_palace(str(palace))
+    active_root.mkdir(exist_ok=True)
+    (active_root / "config.json").write_text('{"backend": "chroma"}\n')
+
+    inventory = inventory_palace(
+        palace,
+        canonical_root=canonical,
+        worktree_roots=[worktree],
+        session_roots=[sessions],
+    )
+    actions = plan_actions(inventory)
+    evidence = collect_duplicate_evidence(inventory, actions)
+    manifest = tmp_path / "manifest.json"
+    write_manifest(
+        manifest,
+        inventory,
+        actions,
+        evidence,
+        palace_path=palace,
+        sqlite_snapshot=palace_snapshot(palace),
+    )
+    rollback = tmp_path / "bundle" / "rollback"
+    migrated = tmp_path / "bundle" / "migrated"
+    prepare_migration_copies(
+        source_palace=palace,
+        reviewed_manifest=manifest,
+        rollback_root=rollback,
+        migrated_root=migrated,
+        canonical_root=canonical,
+        worktree_roots=[worktree],
+        session_roots=[sessions],
+    )
+
+    report = apply_reviewed_migration(
+        source_palace=palace,
+        reviewed_manifest=manifest,
+        rollback_root=rollback,
+        migrated_root=migrated,
+        canonical_root=canonical,
+        worktree_roots=[worktree],
+        session_roots=[sessions],
+        batch_size=1,
+    )
+
+    assert report["status"] == "complete"
+    assert report["records_before"] == 3
+    assert report["records_expected_after"] == 2
+    assert report["records_deleted_as_verified_duplicates"] == 1
+    assert report["retained_records_verified"] == 2
+    assert report["orphan_hnsw_directories_removed"] >= 1
+    migrated_collection = get_collection(str(migrated / "palace"), create=False, backend="chroma")
+    rows = migrated_collection.get(
+        ids=["canonical", "duplicate", "unique"],
+        include=["documents", "metadatas"],
+    )
+    assert set(rows["ids"]) == {"canonical", "unique"}
+    by_id = {
+        drawer_id: (document, metadata)
+        for drawer_id, document, metadata in zip(rows["ids"], rows["documents"], rows["metadatas"])
+    }
+    assert by_id["canonical"][1]["wing"] == "se-code"
+    assert by_id["unique"][0] == "unique verbatim artifact"
+    assert by_id["unique"][1]["wing"] == "se-sessions"
+    filtered = migrated_collection.query(
+        query_texts=["same content"],
+        where={"wing": "se-code"},
+        n_results=1,
+        include=["documents", "metadatas", "distances"],
+    )
+    assert filtered.ids == [["canonical"]]
+    assert (migrated / "apply-report.json").is_file()
+    assert bundle_permissions(migrated) == []
+    get_backend_for_palace(str(migrated / "palace"), explicit="chroma").close_palace(
+        str(migrated / "palace")
+    )

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -312,6 +312,31 @@ def test_load_config_no_yaml_normalizes_hyphenated_wing():
         shutil.rmtree(parent)
 
 
+def test_load_config_rejects_unknown_source_kind(tmp_path):
+    (tmp_path / "mempalace.yaml").write_text("wing: x\nsource_kind: mystery\nrooms: []\n")
+
+    with pytest.raises(ValueError, match="source_kind"):
+        load_config(str(tmp_path))
+
+
+def test_load_config_rejects_unknown_room_source_kind(tmp_path):
+    (tmp_path / "mempalace.yaml").write_text(
+        "wing: x\nsource_kind: code\nrooms:\n  - name: docs\n    source_kind: mystery\n"
+    )
+
+    with pytest.raises(ValueError, match="source_kind"):
+        load_config(str(tmp_path))
+
+
+def test_load_config_rejects_non_boolean_worktree_policy(tmp_path):
+    (tmp_path / "mempalace.yaml").write_text(
+        "wing: x\nreject_linked_worktrees: sometimes\nrooms: []\n"
+    )
+
+    with pytest.raises(ValueError, match="reject_linked_worktrees"):
+        load_config(str(tmp_path))
+
+
 def test_scan_project_skips_mempalace_generated_files():
     with tempfile.TemporaryDirectory() as tmpdir:
         project_root = Path(tmpdir).resolve()

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -337,6 +337,47 @@ def test_load_config_rejects_non_boolean_worktree_policy(tmp_path):
         load_config(str(tmp_path))
 
 
+def test_direct_mine_rejects_linked_worktree_by_default(tmp_path, monkeypatch):
+    from mempalace import source_metadata
+    from mempalace.source_metadata import LinkedWorktreeRejected
+
+    project = tmp_path / "linked"
+    project.mkdir()
+    (project / "mempalace.yaml").write_text("wing: linked\nrooms: []\n")
+    monkeypatch.setattr(
+        source_metadata,
+        "detect_linked_worktree",
+        lambda _source: (True, "/canonical/repository"),
+    )
+
+    with pytest.raises(LinkedWorktreeRejected, match="canonical/repository"):
+        mine(str(project), str(tmp_path / "palace"), dry_run=True)
+
+
+def test_explicit_linked_worktree_override_reaches_miner(tmp_path, monkeypatch):
+    from mempalace import embedding, source_metadata
+
+    project = tmp_path / "linked"
+    project.mkdir()
+    (project / "mempalace.yaml").write_text("wing: linked\nrooms: []\n")
+    monkeypatch.setattr(
+        source_metadata,
+        "detect_linked_worktree",
+        lambda _source: (True, "/canonical/repository"),
+    )
+    monkeypatch.setattr(embedding, "describe_device", lambda: "test")
+
+    # An explicit override is how the daemon carries
+    # allow_linked_worktree=true across the durable queue.
+    mine(
+        str(project),
+        str(tmp_path / "palace"),
+        dry_run=True,
+        files=[],
+        source_canonicality="linked-worktree",
+    )
+
+
 def test_scan_project_skips_mempalace_generated_files():
     with tempfile.TemporaryDirectory() as tmpdir:
         project_root = Path(tmpdir).resolve()

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -973,6 +973,25 @@ def test_mine_dry_run_with_tiny_file_no_crash():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def test_mine_reports_progress_phases_and_file_counts(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    write_file(project / "app.py", "def useful():\n    return 'memory'\n" * 10)
+    events = []
+
+    mine(
+        str(project),
+        str(tmp_path / "palace"),
+        dry_run=True,
+        progress_callback=events.append,
+    )
+
+    assert events[0]["phase"] == "scanning"
+    assert any(event.get("files_total") == 1 for event in events)
+    assert events[-1]["phase"] == "verifying"
+    assert events[-1]["files_processed"] == 1
+
+
 def test_status_missing_palace_does_not_create_empty_collection(tmp_path, capsys):
     palace_path = tmp_path / "missing-palace"
 

--- a/tests/test_palace_locks.py
+++ b/tests/test_palace_locks.py
@@ -22,6 +22,7 @@ from mempalace.palace import (
     MineAlreadyRunning,
     mine_global_lock,
     mine_palace_lock,
+    palace_read_lock,
 )
 
 
@@ -119,6 +120,54 @@ def test_lock_reusable_after_release(tmp_path, monkeypatch):
     palace = str(tmp_path / "palace")
     with mine_palace_lock(palace):
         pass
+
+
+def test_shared_read_gate_prevents_writer_transition(tmp_path, monkeypatch):
+    """A vector reader already inside the gate must keep a writer out."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    palace = str(tmp_path / "palace")
+
+    with palace_read_lock(palace) as acquired:
+        assert acquired is True
+        with pytest.raises(MineAlreadyRunning):
+            with mine_palace_lock(palace):
+                pytest.fail("writer must not overlap an active vector reader")
+
+
+def test_process_holding_legacy_writer_lease_can_read(tmp_path, monkeypatch):
+    """A direct-mode MCP lease must not permanently disable its own vectors."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    palace = str(tmp_path / "palace")
+
+    with mine_palace_lock(palace):
+        with palace_read_lock(palace) as acquired:
+            assert acquired is True
+
+
+def test_blocking_writer_waits_for_shared_read_gate(tmp_path, monkeypatch):
+    """The durable writer waits for a reader and then acquires the gate."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    palace = str(tmp_path / "palace")
+    writer_entered = threading.Event()
+    writer_finished = threading.Event()
+
+    with palace_read_lock(palace) as acquired:
+        assert acquired is True
+
+        def writer():
+            with mine_palace_lock(palace, blocking=True):
+                writer_entered.set()
+            writer_finished.set()
+
+        thread = threading.Thread(target=writer)
+        thread.start()
+        time.sleep(0.05)
+        assert writer_entered.is_set() is False
+
+    thread.join(timeout=5)
+    assert thread.is_alive() is False
+    assert writer_entered.is_set() is True
+    assert writer_finished.is_set() is True
     # Re-acquire must succeed now that the previous holder released
     with mine_palace_lock(palace):
         pass

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -26,3 +26,20 @@ def test_progress_reporter_merges_state_and_throttles(monkeypatch):
 def test_progress_reporter_never_breaks_mining_when_callback_fails():
     reporter = ProgressReporter(lambda _event: (_ for _ in ()).throw(RuntimeError("boom")))
     reporter.emit(force=True, phase="scanning")
+
+
+def test_progress_callback_failure_is_still_throttled(monkeypatch):
+    attempts = []
+    ticks = iter([1.0, 1.1, 2.1])
+    monkeypatch.setattr("mempalace.progress.time.monotonic", lambda: next(ticks))
+
+    def broken(event):
+        attempts.append(event)
+        raise RuntimeError("queue unavailable")
+
+    reporter = ProgressReporter(broken, min_interval=1.0)
+    reporter.emit(files_processed=1)
+    reporter.emit(files_processed=2)
+    reporter.emit(files_processed=3)
+
+    assert [item["files_processed"] for item in attempts] == [1, 3]

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,28 @@
+from mempalace.progress import ProgressReporter
+
+
+def test_progress_reporter_merges_state_and_throttles(monkeypatch):
+    now = {"value": 10.0}
+    monkeypatch.setattr("mempalace.progress.time.monotonic", lambda: now["value"])
+    events = []
+    reporter = ProgressReporter(events.append, min_interval=1.0)
+
+    reporter.emit(force=True, phase="scanning", files_total=2)
+    reporter.emit(files_processed=1)
+    now["value"] = 11.1
+    reporter.emit(files_processed=2, files_changed=1)
+
+    assert events == [
+        {"phase": "scanning", "files_total": 2},
+        {
+            "phase": "scanning",
+            "files_total": 2,
+            "files_processed": 2,
+            "files_changed": 1,
+        },
+    ]
+
+
+def test_progress_reporter_never_breaks_mining_when_callback_fails():
+    reporter = ProgressReporter(lambda _event: (_ for _ in ()).throw(RuntimeError("boom")))
+    reporter.emit(force=True, phase="scanning")

--- a/tests/test_reorganize.py
+++ b/tests/test_reorganize.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
+import stat
 from datetime import date
 
 from mempalace.reorganize import (
     InventoryRecord,
+    collect_duplicate_evidence,
     exact_hash,
     inventory_palace,
     plan_actions,
+    prove_worktree_duplicate,
+    write_manifest,
 )
 
 
@@ -22,8 +27,14 @@ def _record(
     relative_identity: str | None = None,
     authored_at: str | None = None,
     pinned: bool = False,
+    chunk_index: int | None = 0,
+    source_sha256: str | None = None,
 ) -> InventoryRecord:
-    metadata = {"wing": "se", "chunk_index": 0}
+    metadata = {"wing": "se"}
+    if chunk_index is not None:
+        metadata["chunk_index"] = chunk_index
+    if source_sha256 is not None:
+        metadata["source_sha256"] = source_sha256
     if authored_at is not None:
         metadata["authored_at"] = authored_at
     if pinned:
@@ -209,3 +220,161 @@ def test_inventory_reads_chroma_sqlite_without_changing_it(tmp_path):
     }
     assert records[0].relative_identity == "src/a.ts"
     assert hashlib.sha256(db_path.read_bytes()).hexdigest() == before
+
+
+def test_duplicate_requires_same_relative_identity_chunk_and_content_hash():
+    canonical = _record(
+        "canonical",
+        "canonical",
+        content="A",
+        relative_identity="src/a.ts",
+        source_sha256="source-hash",
+    )
+
+    assert (
+        prove_worktree_duplicate(
+            _record(
+                "different-content",
+                "worktree",
+                content="B",
+                relative_identity="src/a.ts",
+                source_sha256="source-hash",
+            ),
+            canonical,
+        )
+        is None
+    )
+    assert (
+        prove_worktree_duplicate(
+            _record(
+                "different-chunk",
+                "worktree",
+                content="A",
+                relative_identity="src/a.ts",
+                chunk_index=1,
+                source_sha256="source-hash",
+            ),
+            canonical,
+        )
+        is None
+    )
+    assert (
+        prove_worktree_duplicate(
+            _record(
+                "different-source",
+                "worktree",
+                content="A",
+                relative_identity="src/a.ts",
+                source_sha256="other-source-hash",
+            ),
+            canonical,
+        )
+        is None
+    )
+    assert (
+        prove_worktree_duplicate(
+            _record(
+                "missing-identity",
+                "worktree",
+                content="A",
+                relative_identity=None,
+                source_sha256="source-hash",
+            ),
+            canonical,
+        )
+        is None
+    )
+
+
+def test_duplicate_proof_allows_legacy_pair_with_no_source_hash():
+    canonical = _record(
+        "canonical",
+        "canonical",
+        content="A",
+        relative_identity="src/a.ts",
+    )
+    worktree = _record(
+        "worktree",
+        "worktree",
+        content="A",
+        relative_identity="src/a.ts",
+    )
+
+    evidence = prove_worktree_duplicate(worktree, canonical)
+
+    assert evidence is not None
+    assert evidence.worktree_drawer_id == "worktree"
+    assert evidence.canonical_drawer_id == "canonical"
+    assert evidence.content_sha256 == exact_hash("A")
+
+
+def test_duplicate_with_only_one_source_hash_is_preserved_as_uncertain():
+    records = [
+        _record(
+            "canonical",
+            "canonical",
+            content="A",
+            relative_identity="src/a.ts",
+            source_sha256="known",
+        ),
+        _record(
+            "worktree",
+            "worktree",
+            content="A",
+            relative_identity="src/a.ts",
+        ),
+    ]
+
+    actions = plan_actions(records)
+
+    assert {action.drawer_id: action.action for action in actions}["worktree"] == (
+        "preserve_uncertain"
+    )
+    assert collect_duplicate_evidence(records, actions) == []
+
+
+def test_manifest_is_owner_only_deterministic_and_excludes_content(tmp_path):
+    records = [
+        _record(
+            "canonical",
+            "canonical",
+            content="SECRET DRAWER TEXT",
+            relative_identity="src/a.ts",
+        ),
+        _record(
+            "worktree",
+            "worktree",
+            content="SECRET DRAWER TEXT",
+            relative_identity="src/a.ts",
+        ),
+    ]
+    actions = plan_actions(records)
+    evidence = collect_duplicate_evidence(records, actions)
+    path = tmp_path / "manifest.json"
+
+    write_manifest(
+        path,
+        records,
+        actions,
+        evidence,
+        palace_path=tmp_path / "palace",
+        sqlite_snapshot={"size": 10, "mtime_ns": 20, "sha256": "db-hash"},
+    )
+    first = path.read_bytes()
+    write_manifest(
+        path,
+        list(reversed(records)),
+        list(reversed(actions)),
+        list(reversed(evidence)),
+        palace_path=tmp_path / "palace",
+        sqlite_snapshot={"size": 10, "mtime_ns": 20, "sha256": "db-hash"},
+    )
+
+    assert path.read_bytes() == first
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert b"SECRET DRAWER TEXT" not in first
+    payload = json.loads(first)
+    assert payload["version"] == 1
+    assert payload["counts"]["inventory_total"] == 2
+    assert payload["counts"]["verified_duplicate_candidates"] == 1
+    assert payload["sqlite_snapshot"]["sha256"] == "db-hash"

--- a/tests/test_reorganize.py
+++ b/tests/test_reorganize.py
@@ -13,6 +13,7 @@ from mempalace.reorganize import (
     collect_duplicate_evidence,
     exact_hash,
     inventory_palace,
+    palace_snapshot,
     plan_actions,
     prove_worktree_duplicate,
     write_manifest,
@@ -222,6 +223,41 @@ def test_inventory_reads_chroma_sqlite_without_changing_it(tmp_path):
     assert hashlib.sha256(db_path.read_bytes()).hexdigest() == before
 
 
+def test_unknown_provenance_in_se_wing_stays_unclassified(tmp_path):
+    palace = tmp_path / "palace"
+    canonical = tmp_path / "repo"
+    elsewhere = tmp_path / "elsewhere"
+    for path in (palace, canonical, elsewhere):
+        path.mkdir()
+    _seed_palace(
+        palace,
+        [
+            ("curated", "decision", {"wing": "se", "room": "decisions"}),
+            (
+                "unknown",
+                "mystery",
+                {
+                    "wing": "se",
+                    "room": "general",
+                    "source_file": str(elsewhere / "unknown.txt"),
+                },
+            ),
+        ],
+    )
+
+    records = inventory_palace(
+        palace,
+        canonical_root=canonical,
+        worktree_roots=[],
+        session_roots=[],
+    )
+
+    assert {record.drawer_id: record.origin for record in records} == {
+        "curated": "curated",
+        "unknown": "unclassified",
+    }
+
+
 def test_duplicate_requires_same_relative_identity_chunk_and_content_hash():
     canonical = _record(
         "canonical",
@@ -244,6 +280,22 @@ def test_duplicate_requires_same_relative_identity_chunk_and_content_hash():
         )
         is None
     )
+
+    traversal_canonical = _record(
+        "traversal-canonical",
+        "canonical",
+        content="A",
+        relative_identity="../outside.ts",
+        source_sha256="source-hash",
+    )
+    traversal_worktree = _record(
+        "traversal-worktree",
+        "worktree",
+        content="A",
+        relative_identity="../outside.ts",
+        source_sha256="source-hash",
+    )
+    assert prove_worktree_duplicate(traversal_worktree, traversal_canonical) is None
     assert (
         prove_worktree_duplicate(
             _record(
@@ -378,3 +430,84 @@ def test_manifest_is_owner_only_deterministic_and_excludes_content(tmp_path):
     assert payload["counts"]["inventory_total"] == 2
     assert payload["counts"]["verified_duplicate_candidates"] == 1
     assert payload["sqlite_snapshot"]["sha256"] == "db-hash"
+
+
+def test_inventory_preserves_dotfile_relative_identity(tmp_path):
+    palace = tmp_path / "palace"
+    canonical = tmp_path / "repo"
+    palace.mkdir()
+    canonical.mkdir()
+    _seed_palace(
+        palace,
+        [
+            (
+                "dotfile",
+                "workflow",
+                {
+                    "wing": "se-code",
+                    "source_kind": "code",
+                    "source_canonicality": "canonical",
+                    "source_identity": "code:.github/workflows/ci.yml",
+                    "chunk_index": 0,
+                },
+            )
+        ],
+    )
+
+    records = inventory_palace(
+        palace,
+        canonical_root=canonical,
+        worktree_roots=[],
+        session_roots=[],
+    )
+
+    assert records[0].relative_identity == ".github/workflows/ci.yml"
+
+
+def test_windows_drive_identity_is_not_treated_as_relative(tmp_path):
+    palace = tmp_path / "palace"
+    canonical = tmp_path / "repo"
+    palace.mkdir()
+    canonical.mkdir()
+    _seed_palace(
+        palace,
+        [
+            (
+                "windows-absolute",
+                "content",
+                {
+                    "wing": "se-code",
+                    "source_kind": "code",
+                    "source_canonicality": "canonical",
+                    "source_identity": "code:C:/repo/src/app.ts",
+                    "chunk_index": 0,
+                },
+            )
+        ],
+    )
+
+    records = inventory_palace(
+        palace,
+        canonical_root=canonical,
+        worktree_roots=[],
+        session_roots=[],
+    )
+
+    assert records[0].relative_identity is None
+
+
+def test_palace_snapshot_tracks_wal_changes(tmp_path):
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    db_path = palace / "chroma.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE example(value TEXT)")
+
+    without_wal = palace_snapshot(palace)
+    (palace / "chroma.sqlite3-wal").write_bytes(b"pending write")
+    with_wal = palace_snapshot(palace)
+
+    assert without_wal["wal_present"] is False
+    assert with_wal["wal_present"] is True
+    assert with_wal["wal_sha256"] == hashlib.sha256(b"pending write").hexdigest()
+    assert with_wal != without_wal

--- a/tests/test_reorganize.py
+++ b/tests/test_reorganize.py
@@ -8,14 +8,20 @@ import sqlite3
 import stat
 from datetime import date
 
+import pytest
+
 from mempalace.reorganize import (
     InventoryRecord,
+    build_manifest_payload,
     collect_duplicate_evidence,
     exact_hash,
     inventory_palace,
+    palace_semantic_snapshot,
     palace_snapshot,
     plan_actions,
     prove_worktree_duplicate,
+    read_manifest,
+    validate_reviewed_manifest,
     write_manifest,
 )
 
@@ -403,6 +409,7 @@ def test_manifest_is_owner_only_deterministic_and_excludes_content(tmp_path):
     actions = plan_actions(records)
     evidence = collect_duplicate_evidence(records, actions)
     path = tmp_path / "manifest.json"
+    semantic_snapshot = {"table_count": 1, "row_count": 2, "sha256": "semantic-hash"}
 
     write_manifest(
         path,
@@ -411,6 +418,7 @@ def test_manifest_is_owner_only_deterministic_and_excludes_content(tmp_path):
         evidence,
         palace_path=tmp_path / "palace",
         sqlite_snapshot={"size": 10, "mtime_ns": 20, "sha256": "db-hash"},
+        source_semantic_snapshot=semantic_snapshot,
     )
     first = path.read_bytes()
     write_manifest(
@@ -420,16 +428,87 @@ def test_manifest_is_owner_only_deterministic_and_excludes_content(tmp_path):
         list(reversed(evidence)),
         palace_path=tmp_path / "palace",
         sqlite_snapshot={"size": 10, "mtime_ns": 20, "sha256": "db-hash"},
+        source_semantic_snapshot=semantic_snapshot,
     )
 
     assert path.read_bytes() == first
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
     assert b"SECRET DRAWER TEXT" not in first
     payload = json.loads(first)
-    assert payload["version"] == 1
+    assert payload["version"] == 2
     assert payload["counts"]["inventory_total"] == 2
     assert payload["counts"]["verified_duplicate_candidates"] == 1
     assert payload["sqlite_snapshot"]["sha256"] == "db-hash"
+    assert payload["source_semantic_snapshot"] == semantic_snapshot
+
+
+def test_reviewed_manifest_requires_exact_current_plan(tmp_path):
+    records = [
+        _record("canonical", "canonical", content="A", relative_identity="src/a.ts"),
+        _record("worktree", "worktree", content="A", relative_identity="src/a.ts"),
+    ]
+    actions = plan_actions(records)
+    evidence = collect_duplicate_evidence(records, actions)
+    snapshot = {"size": 10, "mtime_ns": 20, "sha256": "db-hash"}
+    semantic_snapshot = {"table_count": 1, "row_count": 2, "sha256": "semantic-hash"}
+    reviewed = build_manifest_payload(
+        records,
+        actions,
+        evidence,
+        palace_path=tmp_path / "palace",
+        sqlite_snapshot=snapshot,
+        source_semantic_snapshot=semantic_snapshot,
+    )
+
+    validate_reviewed_manifest(
+        reviewed,
+        records,
+        actions,
+        evidence,
+        palace_path=tmp_path / "palace",
+        sqlite_snapshot=snapshot,
+        source_semantic_snapshot=semantic_snapshot,
+    )
+
+    drifted = json.loads(json.dumps(reviewed))
+    drifted["actions"][0]["content_sha256"] = "changed"
+    with pytest.raises(ValueError, match="does not match"):
+        validate_reviewed_manifest(
+            drifted,
+            records,
+            actions,
+            evidence,
+            palace_path=tmp_path / "palace",
+            sqlite_snapshot=snapshot,
+            source_semantic_snapshot=semantic_snapshot,
+        )
+
+    legacy = json.loads(json.dumps(reviewed))
+    legacy["version"] = 1
+    legacy.pop("source_semantic_snapshot")
+    validate_reviewed_manifest(
+        legacy,
+        records,
+        actions,
+        evidence,
+        palace_path=tmp_path / "palace",
+        sqlite_snapshot=snapshot,
+        source_semantic_snapshot=semantic_snapshot,
+    )
+
+
+def test_read_manifest_rejects_symlink_and_wrong_version(tmp_path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text('{"version": 3}')
+    with pytest.raises(ValueError, match="unsupported"):
+        read_manifest(manifest)
+
+    target = tmp_path / "target.json"
+    target.write_text('{"version": 1}')
+    alias = tmp_path / "alias.json"
+    alias.symlink_to(target)
+    with pytest.raises(ValueError, match="symlink"):
+        read_manifest(alias)
 
 
 def test_inventory_preserves_dotfile_relative_identity(tmp_path):
@@ -511,3 +590,49 @@ def test_palace_snapshot_tracks_wal_changes(tmp_path):
     assert with_wal["wal_present"] is True
     assert with_wal["wal_sha256"] == hashlib.sha256(b"pending write").hexdigest()
     assert with_wal != without_wal
+
+
+def test_palace_semantic_snapshot_includes_indexes_triggers_and_views(tmp_path):
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    with sqlite3.connect(palace / "chroma.sqlite3") as connection:
+        connection.execute("CREATE TABLE records(id INTEGER PRIMARY KEY, value TEXT)")
+        connection.execute("INSERT INTO records(value) VALUES ('stable')")
+    initial = palace_semantic_snapshot(palace)
+
+    with sqlite3.connect(palace / "chroma.sqlite3") as connection:
+        connection.execute("CREATE INDEX records_value_idx ON records(value)")
+    indexed = palace_semantic_snapshot(palace)
+    assert indexed != initial
+
+    with sqlite3.connect(palace / "chroma.sqlite3") as connection:
+        connection.execute("CREATE VIEW record_values AS SELECT value FROM records")
+    viewed = palace_semantic_snapshot(palace)
+    assert viewed != indexed
+
+    with sqlite3.connect(palace / "chroma.sqlite3") as connection:
+        connection.execute(
+            "CREATE TRIGGER records_noop AFTER UPDATE ON records BEGIN SELECT 1; END"
+        )
+    assert palace_semantic_snapshot(palace) != viewed
+
+
+def test_palace_semantic_snapshot_ignores_chroma_acquire_write_history_only(tmp_path):
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    with sqlite3.connect(palace / "chroma.sqlite3") as connection:
+        connection.execute(
+            "CREATE TABLE acquire_write(id INTEGER PRIMARY KEY, lock_status INTEGER)"
+        )
+        connection.execute("CREATE TABLE records(id INTEGER PRIMARY KEY, value TEXT)")
+        connection.execute("INSERT INTO acquire_write(lock_status) VALUES (1)")
+        connection.execute("INSERT INTO records(value) VALUES ('stable')")
+    initial = palace_semantic_snapshot(palace)
+
+    with sqlite3.connect(palace / "chroma.sqlite3") as connection:
+        connection.execute("INSERT INTO acquire_write(lock_status) VALUES (1)")
+    assert palace_semantic_snapshot(palace) == initial
+
+    with sqlite3.connect(palace / "chroma.sqlite3") as connection:
+        connection.execute("INSERT INTO records(value) VALUES ('real change')")
+    assert palace_semantic_snapshot(palace) != initial

--- a/tests/test_reorganize.py
+++ b/tests/test_reorganize.py
@@ -1,0 +1,211 @@
+"""Tests for read-only palace reorganization planning."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from datetime import date
+
+from mempalace.reorganize import (
+    InventoryRecord,
+    exact_hash,
+    inventory_palace,
+    plan_actions,
+)
+
+
+def _record(
+    drawer_id: str,
+    origin: str,
+    *,
+    content: str,
+    relative_identity: str | None = None,
+    authored_at: str | None = None,
+    pinned: bool = False,
+) -> InventoryRecord:
+    metadata = {"wing": "se", "chunk_index": 0}
+    if authored_at is not None:
+        metadata["authored_at"] = authored_at
+    if pinned:
+        metadata["pinned"] = True
+    return InventoryRecord(
+        drawer_id=drawer_id,
+        content=content,
+        metadata=metadata,
+        origin=origin,
+        relative_identity=relative_identity,
+        source_path=None,
+    )
+
+
+def _seed_palace(palace, rows):
+    db_path = palace / "chroma.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE collections (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+            CREATE TABLE segments (id INTEGER PRIMARY KEY, collection INTEGER NOT NULL);
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY,
+                segment_id INTEGER NOT NULL,
+                embedding_id TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE embedding_metadata (
+                id INTEGER,
+                key TEXT,
+                string_value TEXT,
+                int_value INTEGER,
+                float_value REAL,
+                bool_value INTEGER
+            );
+            INSERT INTO collections(id, name) VALUES (1, 'mempalace_drawers');
+            INSERT INTO segments(id, collection) VALUES (1, 1);
+            """
+        )
+        for row_id, (drawer_id, content, metadata) in enumerate(rows, start=1):
+            conn.execute(
+                "INSERT INTO embeddings(id, segment_id, embedding_id, created_at) "
+                "VALUES (?, 1, ?, '2026-07-14T00:00:00Z')",
+                (row_id, drawer_id),
+            )
+            conn.execute(
+                "INSERT INTO embedding_metadata(id, key, string_value) VALUES (?, ?, ?)",
+                (row_id, "chroma:document", content),
+            )
+            for key, value in metadata.items():
+                if isinstance(value, bool):
+                    column = "bool_value"
+                    stored = int(value)
+                elif isinstance(value, int):
+                    column = "int_value"
+                    stored = value
+                elif isinstance(value, float):
+                    column = "float_value"
+                    stored = value
+                else:
+                    column = "string_value"
+                    stored = str(value)
+                conn.execute(
+                    f"INSERT INTO embedding_metadata(id, key, {column}) VALUES (?, ?, ?)",
+                    (row_id, key, stored),
+                )
+    return db_path
+
+
+def test_exact_hash_hashes_verbatim_utf8_content():
+    content = "decision\nwith trailing space "
+    assert exact_hash(content) == hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def test_plan_classifies_canonical_sessions_and_worktree_candidates():
+    actions = plan_actions(
+        [
+            _record(
+                "canonical",
+                "canonical",
+                content="A",
+                relative_identity="src/a.ts",
+            ),
+            _record(
+                "worktree",
+                "worktree",
+                content="A",
+                relative_identity="src/a.ts",
+            ),
+            _record(
+                "session",
+                "session",
+                content="talk",
+                authored_at="2026-01-01",
+            ),
+        ],
+        hot_days=90,
+        now=date(2026, 7, 14),
+    )
+
+    by_id = {action.drawer_id: action for action in actions}
+    assert by_id["canonical"].destination_wing == "se-code"
+    assert by_id["worktree"].action == "duplicate_candidate"
+    assert by_id["session"].metadata["memory_tier"] == "cold"
+
+
+def test_pinned_old_session_stays_hot():
+    actions = plan_actions(
+        [
+            _record(
+                "session",
+                "session",
+                content="talk",
+                authored_at="2020-01-01",
+                pinned=True,
+            )
+        ],
+        hot_days=90,
+        now=date(2026, 7, 14),
+    )
+
+    assert actions[0].metadata["memory_tier"] == "hot"
+
+
+def test_inventory_reads_chroma_sqlite_without_changing_it(tmp_path):
+    palace = tmp_path / "palace"
+    canonical = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    sessions = tmp_path / "sessions"
+    for path in (palace, canonical, worktree, sessions):
+        path.mkdir()
+
+    db_path = _seed_palace(
+        palace,
+        [
+            (
+                "z-worktree",
+                "same",
+                {
+                    "wing": "se",
+                    "source_file": str(worktree / "src/a.ts"),
+                    "chunk_index": 0,
+                },
+            ),
+            (
+                "a-canonical",
+                "same",
+                {
+                    "wing": "se",
+                    "source_file": str(canonical / "src/a.ts"),
+                    "chunk_index": 0,
+                },
+            ),
+            (
+                "m-session",
+                "talk",
+                {
+                    "wing": "se",
+                    "source_file": str(sessions / "one.jsonl"),
+                    "authored_at": "2026-01-01",
+                },
+            ),
+        ],
+    )
+    before = hashlib.sha256(db_path.read_bytes()).hexdigest()
+
+    records = inventory_palace(
+        palace,
+        canonical_root=canonical,
+        worktree_roots=[worktree],
+        session_roots=[sessions],
+    )
+
+    assert [record.drawer_id for record in records] == [
+        "a-canonical",
+        "m-session",
+        "z-worktree",
+    ]
+    assert {record.drawer_id: record.origin for record in records} == {
+        "a-canonical": "canonical",
+        "m-session": "session",
+        "z-worktree": "worktree",
+    }
+    assert records[0].relative_identity == "src/a.ts"
+    assert hashlib.sha256(db_path.read_bytes()).hexdigest() == before

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -2048,9 +2048,11 @@ def _make_fts5_palace(tmp_path, *, corrupt: bool) -> str:
 
 def test_errors_are_isolated_fts5_classification():
     fts = "malformed inverted index for FTS5 table main.embedding_fulltext_search"
+    macos_fts = "fts5: corruption found reading blob 9 from table embedding_fulltext_search"
     page = "Page 4 of B-tree 12345: database disk image is malformed"
     assert repair._errors_are_isolated_fts5([fts])
     assert repair._errors_are_isolated_fts5([fts, fts])
+    assert repair._errors_are_isolated_fts5([macos_fts])
     assert not repair._errors_are_isolated_fts5([])
     assert not repair._errors_are_isolated_fts5([page])
     # Any non-FTS5 error in the set means the data itself may be damaged.

--- a/tests/test_room_detector_local.py
+++ b/tests/test_room_detector_local.py
@@ -238,6 +238,23 @@ def test_save_config_valid_yaml(tmp_path):
     assert data["rooms"][0]["name"] == "general"
 
 
+def test_save_config_marks_documentation_source_kind(tmp_path):
+    rooms = [
+        {"name": "documentation", "description": "Docs", "keywords": ["docs"]},
+        {"name": "backend", "description": "Code", "keywords": ["api"]},
+    ]
+
+    save_config(str(tmp_path), "test_proj", rooms)
+
+    import yaml
+
+    data = yaml.safe_load((tmp_path / "mempalace.yaml").read_text())
+    docs = next(room for room in data["rooms"] if room["name"] == "documentation")
+    assert data["source_kind"] == "code"
+    assert data["reject_linked_worktrees"] is True
+    assert docs["source_kind"] == "documentation"
+
+
 # ── print_proposed_structure ──────────────────────────────────────────
 
 

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -21,39 +21,74 @@ class TestBuildWhereFilter:
     """build_where_filter composes a ChromaDB where clause from optional
     wing / room / source_file constraints (#1815). ChromaDB needs a ``$and``
     only when ≥2 clauses are present; a single clause is returned bare and
-    zero clauses yield an empty filter."""
+    zero explicit scopes still yield the default hot-tier filter."""
 
     def test_no_filters_returns_empty(self):
-        assert build_where_filter() == {}
+        assert build_where_filter() == {"memory_tier": {"$ne": "cold"}}
 
     def test_wing_only(self):
-        assert build_where_filter(wing="backend") == {"wing": "backend"}
+        assert build_where_filter(wing="backend") == {
+            "$and": [
+                {"wing": "backend"},
+                {"memory_tier": {"$ne": "cold"}},
+            ]
+        }
 
     def test_room_only(self):
-        assert build_where_filter(room="auth") == {"room": "auth"}
+        assert build_where_filter(room="auth") == {
+            "$and": [
+                {"room": "auth"},
+                {"memory_tier": {"$ne": "cold"}},
+            ]
+        }
 
     def test_wing_and_room(self):
         assert build_where_filter(wing="backend", room="auth") == {
-            "$and": [{"wing": "backend"}, {"room": "auth"}]
+            "$and": [
+                {"wing": "backend"},
+                {"room": "auth"},
+                {"memory_tier": {"$ne": "cold"}},
+            ]
         }
 
     def test_source_file_only(self):
-        assert build_where_filter(source_file="auth.py") == {"source_file": "auth.py"}
+        assert build_where_filter(source_file="auth.py") == {
+            "$and": [
+                {"source_file": "auth.py"},
+                {"memory_tier": {"$ne": "cold"}},
+            ]
+        }
 
     def test_wing_and_source_file(self):
         assert build_where_filter(wing="backend", source_file="auth.py") == {
-            "$and": [{"wing": "backend"}, {"source_file": "auth.py"}]
+            "$and": [
+                {"wing": "backend"},
+                {"source_file": "auth.py"},
+                {"memory_tier": {"$ne": "cold"}},
+            ]
         }
 
     def test_room_and_source_file(self):
         assert build_where_filter(room="auth", source_file="auth.py") == {
-            "$and": [{"room": "auth"}, {"source_file": "auth.py"}]
+            "$and": [
+                {"room": "auth"},
+                {"source_file": "auth.py"},
+                {"memory_tier": {"$ne": "cold"}},
+            ]
         }
 
     def test_wing_room_and_source_file(self):
         assert build_where_filter(wing="backend", room="auth", source_file="auth.py") == {
-            "$and": [{"wing": "backend"}, {"room": "auth"}, {"source_file": "auth.py"}]
+            "$and": [
+                {"wing": "backend"},
+                {"room": "auth"},
+                {"source_file": "auth.py"},
+                {"memory_tier": {"$ne": "cold"}},
+            ]
         }
+
+    def test_include_cold_omits_tier_filter(self):
+        assert build_where_filter(include_cold=True) == {}
 
     def test_multiwing_source_kind_filter(self):
         where = build_where_filter(

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -55,6 +55,18 @@ class TestBuildWhereFilter:
             "$and": [{"wing": "backend"}, {"room": "auth"}, {"source_file": "auth.py"}]
         }
 
+    def test_multiwing_source_kind_filter(self):
+        where = build_where_filter(
+            wings=["se", "se-code"],
+            source_kinds=["curated", "code"],
+        )
+        assert {"wing": {"$in": ["se", "se-code"]}} in where["$and"]
+        assert {"source_kind": {"$in": ["curated", "code"]}} in where["$and"]
+
+    def test_singular_and_plural_wings_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            build_where_filter(wing="se", wings=["se-code"])
+
 
 # ── search_memories (API) ──────────────────────────────────────────────
 
@@ -139,6 +151,93 @@ class TestSearchMemories:
         assert "error" not in result
         assert result["results"], "BM25 fallback should still find the auth drawer"
         assert all(r["source_file"] == "auth.py" for r in result["results"])
+
+    def test_multiwing_source_kind_and_hot_default_match_vector_and_bm25(self, palace_path):
+        from mempalace.palace import get_collection
+
+        col = get_collection(palace_path, create=True)
+        col.upsert(
+            ids=["curated-hot", "code-cold", "legacy-hot", "other-wing"],
+            documents=[
+                "shared scope needle curated hot",
+                "shared scope needle code cold",
+                "shared scope needle legacy tier",
+                "shared scope needle outside",
+            ],
+            metadatas=[
+                {
+                    "wing": "se",
+                    "room": "decisions",
+                    "source_file": "curated.md",
+                    "source_kind": "curated",
+                    "memory_tier": "hot",
+                },
+                {
+                    "wing": "se-code",
+                    "room": "workers",
+                    "source_file": "worker.py",
+                    "source_kind": "code",
+                    "memory_tier": "cold",
+                },
+                {
+                    "wing": "se-code",
+                    "room": "workers",
+                    "source_file": "legacy.py",
+                    "source_kind": "code",
+                },
+                {
+                    "wing": "other",
+                    "room": "workers",
+                    "source_file": "other.py",
+                    "source_kind": "code",
+                    "memory_tier": "hot",
+                },
+            ],
+        )
+
+        kwargs = {
+            "wings": ["se", "se-code"],
+            "source_kinds": ["curated", "code"],
+            "n_results": 10,
+            "collection_name": "mempalace_drawers",
+        }
+        vector = search_memories("shared scope needle", palace_path, **kwargs)
+        bm25 = search_memories("shared scope needle", palace_path, vector_disabled=True, **kwargs)
+
+        assert {hit["source_file"] for hit in vector["results"]} == {
+            "curated.md",
+            "legacy.py",
+        }
+        assert {hit["source_file"] for hit in bm25["results"]} == {
+            "curated.md",
+            "legacy.py",
+        }
+
+    def test_include_cold_opt_in_returns_cold_results(self, palace_path):
+        from mempalace.palace import get_collection
+
+        col = get_collection(palace_path, create=True)
+        col.upsert(
+            ids=["cold"],
+            documents=["archived session needle"],
+            metadatas=[
+                {
+                    "wing": "se-sessions",
+                    "room": "history",
+                    "source_file": "session.jsonl",
+                    "source_kind": "session",
+                    "memory_tier": "cold",
+                }
+            ],
+        )
+
+        hidden = search_memories("archived session needle", palace_path, n_results=5)
+        visible = search_memories(
+            "archived session needle", palace_path, n_results=5, include_cold=True
+        )
+
+        assert hidden["results"] == []
+        assert [hit["source_file"] for hit in visible["results"]] == ["session.jsonl"]
 
     def test_n_results_limit(self, palace_path, seeded_collection):
         result = search_memories("code", palace_path, n_results=2)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -274,6 +274,240 @@ class TestSearchMemories:
         assert hidden["results"] == []
         assert [hit["source_file"] for hit in visible["results"]] == ["session.jsonl"]
 
+    def test_sparse_cold_default_overfetches_without_large_hnsw_filter(self):
+        mock_col = MagicMock()
+        mock_col.get.return_value = {"ids": ["cold-1", "cold-2"]}
+        mock_col.count.return_value = 100
+        mock_col.query.return_value = {
+            "ids": [["cold-1", "hot-1"]],
+            "documents": [["cold result", "hot result"]],
+            "metadatas": [
+                [
+                    {
+                        "wing": "se-sessions",
+                        "room": "history",
+                        "source_file": "cold.jsonl",
+                        "memory_tier": "cold",
+                    },
+                    {
+                        "wing": "se-code",
+                        "room": "workers",
+                        "source_file": "hot.ts",
+                        "memory_tier": "hot",
+                    },
+                ]
+            ],
+            "distances": [[0.1, 0.2]],
+        }
+
+        with (
+            patch("mempalace.searcher.get_collection", return_value=mock_col),
+            patch(
+                "mempalace.searcher.get_closets_collection",
+                side_effect=RuntimeError("no closets"),
+            ),
+        ):
+            result = search_memories("needle", "/fake/path", n_results=5)
+
+        query_kwargs = mock_col.query.call_args.kwargs
+        assert "where" not in query_kwargs
+        assert query_kwargs["n_results"] == 17
+        assert [hit["source_file"] for hit in result["results"]] == ["hot.ts"]
+
+    def test_sparse_cold_retries_for_complete_hot_drawer_candidate_pool(self):
+        mock_col = MagicMock()
+        mock_col.get.return_value = {"ids": [f"cold-{index}" for index in range(20)]}
+        mock_col.count.return_value = 100
+        first_metadatas = [
+            {
+                "wing": "se-sessions",
+                "room": "history",
+                "source_file": f"cold-{index}.jsonl",
+                "memory_tier": "cold",
+            }
+            for index in range(20)
+        ] + [
+            {
+                "wing": "se-code",
+                "room": "workers",
+                "source_file": f"hot-{index}.ts",
+                "memory_tier": "hot",
+            }
+            for index in range(5)
+        ]
+        second_metadatas = [
+            {
+                "wing": "se-code",
+                "room": "workers",
+                "source_file": f"hot-{index}.ts",
+                "memory_tier": "hot",
+            }
+            for index in range(15)
+        ]
+        mock_col.query.side_effect = [
+            {
+                "ids": [[f"result-{index}" for index in range(25)]],
+                "documents": [[f"result {index}" for index in range(25)]],
+                "metadatas": [first_metadatas],
+                "distances": [[index / 100 for index in range(25)]],
+            },
+            {
+                "ids": [[f"hot-{index}" for index in range(15)]],
+                "documents": [[f"hot result {index}" for index in range(15)]],
+                "metadatas": [second_metadatas],
+                "distances": [[index / 100 for index in range(15)]],
+            },
+        ]
+
+        with (
+            patch("mempalace.searcher.get_collection", return_value=mock_col),
+            patch(
+                "mempalace.searcher.get_closets_collection",
+                side_effect=RuntimeError("no closets"),
+            ),
+        ):
+            result = search_memories("needle", "/fake/path", n_results=5)
+
+        assert mock_col.query.call_count == 2
+        assert mock_col.query.call_args_list[0].kwargs["n_results"] == 30
+        assert mock_col.query.call_args_list[1].kwargs["n_results"] == 35
+        assert len(result["results"]) == 5
+
+    def test_sparse_cold_retries_for_complete_hot_closet_candidate_pool(self):
+        drawers_col = MagicMock()
+        drawers_col.get.return_value = {"ids": []}
+        drawers_col.count.return_value = 20
+        drawers_col.query.return_value = {
+            "ids": [[f"drawer-{index}" for index in range(15)]],
+            "documents": [[f"drawer {index}" for index in range(15)]],
+            "metadatas": [
+                [
+                    {
+                        "wing": "se-code",
+                        "room": "workers",
+                        "source_file": f"hot-{index}.ts",
+                        "memory_tier": "hot",
+                    }
+                    for index in range(15)
+                ]
+            ],
+            "distances": [[index / 100 for index in range(15)]],
+        }
+
+        closets_col = MagicMock()
+        closets_col.get.return_value = {"ids": [f"cold-{index}" for index in range(20)]}
+        closets_col.count.return_value = 100
+        first_metadatas = [
+            {"source_file": f"cold-{index}.jsonl", "memory_tier": "cold"} for index in range(15)
+        ] + [{"source_file": f"hot-{index}.ts", "memory_tier": "hot"} for index in range(5)]
+        second_metadatas = [
+            {"source_file": f"hot-{index}.ts", "memory_tier": "hot"} for index in range(10)
+        ]
+        closets_col.query.side_effect = [
+            {
+                "ids": [[f"closet-{index}" for index in range(20)]],
+                "documents": [[f"closet {index}" for index in range(20)]],
+                "metadatas": [first_metadatas],
+                "distances": [[index / 100 for index in range(20)]],
+            },
+            {
+                "ids": [[f"hot-closet-{index}" for index in range(10)]],
+                "documents": [[f"hot closet {index}" for index in range(10)]],
+                "metadatas": [second_metadatas],
+                "distances": [[index / 100 for index in range(10)]],
+            },
+        ]
+
+        with (
+            patch("mempalace.searcher.get_collection", return_value=drawers_col),
+            patch("mempalace.searcher.get_closets_collection", return_value=closets_col),
+        ):
+            search_memories("needle", "/fake/path", n_results=5)
+
+        assert closets_col.query.call_count == 2
+        assert closets_col.query.call_args_list[0].kwargs["n_results"] == 20
+        assert closets_col.query.call_args_list[1].kwargs["n_results"] == 30
+
+    def test_dense_cold_default_keeps_hnsw_filter(self):
+        mock_col = MagicMock()
+        mock_col.get.return_value = {"ids": [f"cold-{index}" for index in range(257)]}
+        mock_col.query.return_value = {
+            "ids": [[]],
+            "documents": [[]],
+            "metadatas": [[]],
+            "distances": [[]],
+        }
+
+        with (
+            patch("mempalace.searcher.get_collection", return_value=mock_col),
+            patch(
+                "mempalace.searcher.get_closets_collection",
+                side_effect=RuntimeError("no closets"),
+            ),
+        ):
+            search_memories("needle", "/fake/path", n_results=5)
+
+        query_kwargs = mock_col.query.call_args.kwargs
+        assert query_kwargs["where"] == {"memory_tier": {"$ne": "cold"}}
+        assert query_kwargs["n_results"] == 15
+
+    def test_repeated_boosted_source_is_hydrated_once(self):
+        source = "/repo/large-session.jsonl"
+        drawers_col = MagicMock()
+        drawers_col.count.return_value = 5
+        drawers_col.query.return_value = {
+            "ids": [[f"drawer-{index}" for index in range(5)]],
+            "documents": [[f"matched chunk {index}" for index in range(5)]],
+            "metadatas": [
+                [
+                    {
+                        "wing": "se-sessions",
+                        "room": "history",
+                        "source_file": source,
+                        "chunk_index": index,
+                        "memory_tier": "hot",
+                    }
+                    for index in range(5)
+                ]
+            ],
+            "distances": [[0.1 + index / 100 for index in range(5)]],
+        }
+        source_drawers = MagicMock()
+        source_drawers.ids = [f"drawer-{index}" for index in range(5)]
+        source_drawers.documents = [f"source chunk {index}" for index in range(5)]
+        source_drawers.metadatas = [{"chunk_index": index} for index in range(5)]
+        drawers_col.get_source_chunks.return_value = source_drawers
+
+        def drawer_get(**kwargs):
+            if kwargs.get("where") == {"memory_tier": "cold"}:
+                return {"ids": []}
+            raise AssertionError("unexpected generic get")
+
+        drawers_col.get.side_effect = drawer_get
+
+        closets_col = MagicMock()
+        closets_col.count.return_value = 1
+        closets_col.get.return_value = {"ids": []}
+        closets_col.query.return_value = {
+            "ids": [["closet-1"]],
+            "documents": [["large session closet"]],
+            "metadatas": [[{"source_file": source, "memory_tier": "hot"}]],
+            "distances": [[0.2]],
+        }
+
+        with (
+            patch("mempalace.searcher.get_collection", return_value=drawers_col),
+            patch("mempalace.searcher.get_closets_collection", return_value=closets_col),
+        ):
+            result = search_memories("session", "/fake/path", n_results=5)
+
+        drawers_col.get_source_chunks.assert_called_once_with(
+            source,
+            parent_drawer_id=None,
+        )
+        assert len(result["results"]) == 5
+        assert all(hit["total_drawers"] == 5 for hit in result["results"])
+
     def test_n_results_limit(self, palace_path, seeded_collection):
         result = search_memories("code", palace_path, n_results=2)
         assert len(result["results"]) <= 2

--- a/tests/test_source_metadata.py
+++ b/tests/test_source_metadata.py
@@ -2,7 +2,11 @@ import hashlib
 
 import pytest
 
-from mempalace.source_metadata import SourceContext, build_source_metadata
+from mempalace.source_metadata import (
+    SourceContext,
+    build_source_metadata,
+    source_kind_for_room,
+)
 
 
 def test_build_source_metadata_is_scalar_and_deterministic(tmp_path):
@@ -61,3 +65,13 @@ def test_source_metadata_rejects_unknown_enums(tmp_path, field, value):
 
     with pytest.raises(ValueError, match=field):
         build_source_metadata(SourceContext(**values), "note", 0)
+
+
+def test_room_source_kind_overrides_project_default():
+    config = {
+        "source_kind": "code",
+        "rooms": [{"name": "docs", "source_kind": "documentation"}],
+    }
+
+    assert source_kind_for_room(config, "docs") == "documentation"
+    assert source_kind_for_room(config, "backend") == "code"

--- a/tests/test_source_metadata.py
+++ b/tests/test_source_metadata.py
@@ -1,0 +1,63 @@
+import hashlib
+
+import pytest
+
+from mempalace.source_metadata import SourceContext, build_source_metadata
+
+
+def test_build_source_metadata_is_scalar_and_deterministic(tmp_path):
+    source = tmp_path / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text("print('x')\n")
+    context = SourceContext(
+        root=str(tmp_path),
+        source_file=str(source),
+        source_kind="code",
+        memory_tier="hot",
+        source_revision="abc123",
+    )
+
+    first = build_source_metadata(context, "print('x')\n", 0)
+    second = build_source_metadata(context, "print('x')\n", 0)
+
+    assert first == second
+    assert first["source_identity"] == "code:src/app.py"
+    assert first["content_sha256"] == hashlib.sha256(b"print('x')\n").hexdigest()
+    assert first["source_sha256"] == hashlib.sha256(source.read_bytes()).hexdigest()
+    assert first["source_revision"] == "abc123"
+    assert all(isinstance(value, (str, int, float, bool)) for value in first.values())
+
+
+def test_source_identity_uses_canonical_root_for_symlink(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    source = root / "README.md"
+    source.write_text("docs")
+    alias = tmp_path / "alias"
+    alias.symlink_to(root)
+
+    direct = build_source_metadata(
+        SourceContext(str(root), str(source), "documentation"), "docs", 0
+    )
+    linked = build_source_metadata(
+        SourceContext(str(alias), str(alias / "README.md"), "documentation"), "docs", 0
+    )
+
+    assert direct["source_root"] == linked["source_root"]
+    assert direct["source_identity"] == linked["source_identity"]
+
+
+@pytest.mark.parametrize("field,value", [("source_kind", "mystery"), ("memory_tier", "archive")])
+def test_source_metadata_rejects_unknown_enums(tmp_path, field, value):
+    source = tmp_path / "note.txt"
+    source.write_text("note")
+    values = {
+        "root": str(tmp_path),
+        "source_file": str(source),
+        "source_kind": "curated",
+        "memory_tier": "hot",
+    }
+    values[field] = value
+
+    with pytest.raises(ValueError, match=field):
+        build_source_metadata(SourceContext(**values), "note", 0)

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Detailed parameter schemas for all 35 MCP tools.
+Detailed parameter schemas for all 37 MCP tools.
 
 ## Palace — Read Tools
 
@@ -55,7 +55,10 @@ Semantic search. Returns verbatim drawer content with similarity scores.
 | `query` | string | **Yes** | What to search for |
 | `limit` | integer | No | Max results (default: 5) |
 | `wing` | string | No | Filter by wing |
+| `wings` | array of strings | No | Filter across multiple wings; mutually exclusive with `wing` |
 | `room` | string | No | Filter by room |
+| `source_kinds` | array of strings | No | Filter by `curated`, `code`, `documentation`, `session`, or `worktree-artifact` |
+| `include_cold` | boolean | No | Include cold historical memories (default: false; legacy records without a tier remain visible) |
 
 **Returns:** `{ query, filters, results: [{ text, wing, room, source_file, similarity }] }`
 
@@ -81,6 +84,34 @@ Returns the AAAK dialect specification.
 **Parameters:** None
 
 **Returns:** `{ aaak_spec: "..." }`
+
+---
+
+### `mempalace_job_status`
+
+Read one durable daemon job without opening the palace index. Use this after an
+asynchronous `mempalace_mine` or a queued write returns a `job_id`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `job_id` | string | **Yes** | Job ID returned by a daemon-backed MCP call |
+
+**Returns:** `{ success, job: { id, kind, state, attempts, created_at, started_at?, finished_at?, heartbeat_at?, progress?, result?, error? } }`. Results are present only for terminal jobs.
+
+---
+
+### `mempalace_list_jobs`
+
+List recent durable daemon jobs and safe operational summaries. Verbatim write
+payloads are never returned.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `limit` | integer | No | Recent jobs to return (default 20, max 100) |
+| `state` | string | No | Filter by job state |
+| `kind` | string | No | Filter by job kind, such as `mine` or `mcp_tool` |
+
+**Returns:** `{ success, jobs: [...], counts: { queued, running, succeeded, failed, cancelled } }`, with payload/result details redacted from list entries.
 
 ---
 
@@ -130,7 +161,12 @@ Delete a drawer by ID. Irreversible.
 
 ### `mempalace_mine`
 
-Mine a directory into the palace — the MCP equivalent of `mempalace mine`. Wraps the same in-process miners the CLI uses; runs synchronously and returns the miner's summary as `output`. The palace write lock is automatic — a concurrent mine returns a structured already-running error. Orphan cleanup is separate (see `mempalace_sync`).
+Mine a directory into the palace — the MCP equivalent of `mempalace mine`.
+With `MEMPALACE_MCP_DAEMON_WRITES=1`, validation durably submits the mine and
+returns immediately; poll `mempalace_job_status` for progress and the terminal
+result. The daemon must already be running, and enabled mode never falls back
+to direct writes. Without that opt-in flag, legacy synchronous behavior remains
+available. Orphan cleanup is separate (see `mempalace_sync`).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -141,8 +177,12 @@ Mine a directory into the palace — the MCP equivalent of `mempalace mine`. Wra
 | `limit` | integer | No | Max files to process (0 = all; default 0) |
 | `dry_run` | boolean | No | Report what would be filed without writing (default false) |
 | `extract` | string | No | Convos extraction strategy: `exchange` (default) or `general`; ignored by other modes |
+| `allow_linked_worktree` | boolean | No | Allow `projects` mode to mine a linked Git worktree (default false) |
+| `priority` | integer | No | Daemon queue priority (default 0) |
 
-**Returns:** `{ success, mode, dry_run, output }` on success (`output` is the miner's human-readable summary; `output_truncated: true` is added when a very large summary is tail-trimmed), or `{ success: false, error, error_class? }` on failure.
+**Returns in daemon-backed mode:** `{ success, accepted, job_id, state, deduplicated, source, mode, wing, submitted_at }`.
+
+**Returns in legacy mode:** `{ success, mode, dry_run, output }` on success (`output` is the miner's human-readable summary; `output_truncated: true` is added when a very large summary is tail-trimmed), or `{ success: false, error, error_class? }` on failure.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

- Moves MCP mining and write-classified tools onto the existing durable daemon queue, with asynchronous submission, deduplication, progress/heartbeat reporting, responsive job reads, and SQLite/BM25 search during maintenance.
- Adds canonical source metadata plus scoped `se`, `se-code`, and `se-sessions` retrieval, hot/cold filtering, sparse-cold over-fetch safeguards, cached per-client HNSW thread pinning, and vector reuse during maintenance.
- Adds a reviewed, copy-only migration workflow with versioned physical/semantic manifests, exact-evidence deletion, owner-only rollback/staging bundles, atomic no-clobber publication, whole-palace/sidecar activation attestation, crash recovery, and explicit rollback.
- Documents and verifies the sales-enablement migration from 13,653 to 10,138 drawers. The live palace is intentionally not activated by this PR.

## How to test

```bash
.venv/bin/ruff check .
.venv/bin/ruff format --check .
.venv/bin/pytest -q tests/ --ignore=tests/benchmarks
.venv/bin/pytest -q -m benchmark tests/benchmarks/test_async_mcp_bench.py
```

Final evidence:

- 3,383 passed, 31 skipped in the complete non-benchmark suite.
- 2 enforced benchmark tests passed with an actively blocked maintenance job.
- Async mine submission p95: 42.4 ms; job status p95: 7.3 ms; job listing p95: 19.6 ms; maintenance BM25 p95: 14.8 ms.
- The 240-query copied-palace comparison measured a 0.9419 migrated/baseline hybrid median-p95 ratio, within the 1.10 budget.
- Independent review reports no remaining merge blocker.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
