### PR TITLE
fix(repair): wait out transient SQLite contention

### DIFF
--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -573,6 +573,9 @@ def sqlite_drawer_count(palace_path: str, collection_name: Optional[str] = None)
         return None
 
 
+_SQLITE_INTEGRITY_BUSY_TIMEOUT_SECONDS = 15.0
+
+
 def sqlite_integrity_errors(palace_path: str) -> list[str]:
     """Return SQLite quick_check errors for chroma.sqlite3.
 
@@ -591,7 +594,16 @@ def sqlite_integrity_errors(palace_path: str) -> list[str]:
         return []
 
     try:
-        with sqlite3.connect(sqlite_read_uri(sqlite_path), uri=True) as conn:
+        # A writer holding SQLite's lock is contention, not corruption. The
+        # sqlite3 module defaults to five seconds, which is shorter than
+        # routine batch mines and curator writes on rollback-journal palaces.
+        # Give those writers a bounded grace period before surfacing BUSY to
+        # callers; genuine corruption still comes from PRAGMA quick_check.
+        with sqlite3.connect(
+            sqlite_read_uri(sqlite_path),
+            uri=True,
+            timeout=_SQLITE_INTEGRITY_BUSY_TIMEOUT_SECONDS,
+        ) as conn:
             rows = conn.execute("PRAGMA quick_check").fetchall()
     except sqlite3.Error as e:
         return [f"PRAGMA quick_check failed: {e}"]

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1358,6 +1358,57 @@ def test_sqlite_integrity_errors_returns_empty_for_healthy_db(tmp_path):
     assert repair.sqlite_integrity_errors(str(palace)) == []
 
 
+def test_sqlite_integrity_errors_uses_bounded_contention_timeout(tmp_path, monkeypatch):
+    """Integrity checks wait out routine writers without a real-time sleep.
+
+    Assert the sqlite connection contract directly so this regression test is
+    deterministic and does not add the seven-second delay from the original
+    proposal to every test run.
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    db_path = palace / "chroma.sqlite3"
+    db_path.touch()
+
+    calls = []
+
+    class _Result:
+        @staticmethod
+        def fetchall():
+            return [("ok",)]
+
+    class _Connection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, statement):
+            calls.append(("execute", statement))
+            return _Result()
+
+    def _connect(database, **kwargs):
+        calls.append(("connect", database, kwargs))
+        return _Connection()
+
+    monkeypatch.setattr(repair.sqlite3, "connect", _connect)
+
+    assert repair.sqlite_integrity_errors(str(palace)) == []
+    assert calls == [
+        (
+            "connect",
+            repair.sqlite_read_uri(str(db_path)),
+            {
+                "uri": True,
+                "timeout": repair._SQLITE_INTEGRITY_BUSY_TIMEOUT_SECONDS,
+            },
+        ),
+        ("execute", "PRAGMA quick_check"),
+    ]
+    assert repair._SQLITE_INTEGRITY_BUSY_TIMEOUT_SECONDS == 15.0
+
+
 def test_sqlite_integrity_errors_reports_unreadable_sqlite_file(tmp_path):
     palace = tmp_path / "palace"
     palace.mkdir()


### PR DESCRIPTION
## What changed

- Give `sqlite_integrity_errors()` an explicit 15-second SQLite busy timeout.
- Add a deterministic regression test that verifies the connection contract without a multi-second sleep.

## Why

`PRAGMA quick_check` previously inherited Python's five-second default timeout. A healthy palace with a longer-running batch writer could therefore return `database is locked`, which callers interpreted as SQLite corruption. Contention should get a bounded grace period; actual `quick_check` findings still fail exactly as before.

This is the clean replacement for the core fix in #1932. It deliberately excludes that branch's unrelated L1 and CLI commits and its seven-second test.

## Local validation

- `uv run pytest tests/test_repair.py -q` — 92 passed
- `uv run ruff check mempalace/repair.py tests/test_repair.py`
- `uv run ruff format --check mempalace/repair.py tests/test_repair.py`
- Real SQLite smoke on this Mac: held `BEGIN EXCLUSIVE` from a peer connection for ~0.35s; `sqlite_integrity_errors()` waited and returned clean after the writer released.

Supersedes the intended repair-only portion of #1932.
