### PR TITLE
fix(mcp_server): reset chromadb System cache on staleness reconnect (#2002)

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -998,6 +998,13 @@ def _get_client():
         _refresh_vector_disabled_flag()
         if inode_changed or mtime_changed:
             ChromaBackend._quarantined_paths.discard(_config.palace_path)
+            # #2002: a peer process changed chroma.sqlite3 on disk. chromadb
+            # caches its System (and the live HNSW segment) keyed by path, so
+            # make_client() below would hand back the STALE segment, which then
+            # persists its outdated index over the peer's writes, driving the
+            # persisted count backwards. Drop chromadb's shared cache first so
+            # make_client() rebuilds the segment from the on-disk state.
+            _force_chroma_cache_reset()
         _client_cache = ChromaBackend.make_client(_config.palace_path)
         _collection_cache = None
         _collection_cache_backend = None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4176,6 +4176,51 @@ class TestStructuredErrors:
             "_get_client should call _prepare_palace_for_open on reconnect"
         )
 
+    def test_get_client_resets_chroma_system_cache_on_reconnect(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        """``_get_client`` must clear chromadb's path-keyed System/HNSW cache
+        (via ``_force_chroma_cache_reset``) *before* calling ``make_client`` on an
+        inode/mtime reconnect. Otherwise chromadb hands back the stale in-memory
+        HNSW segment, which persists its outdated index over a peer writer's
+        on-disk changes, driving the persisted count backwards (#2002)."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+        from mempalace.backends.chroma import ChromaBackend
+
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+
+        # Prime the cache.
+        mcp_server._get_collection()
+
+        # Simulate a peer writer touching chroma.sqlite3 on disk.
+        old_mtime = mcp_server._palace_db_mtime
+        monkeypatch.setattr(mcp_server, "_palace_db_mtime", old_mtime - 10.0)
+
+        order: list[str] = []
+        real_reset = mcp_server._force_chroma_cache_reset
+        real_make = ChromaBackend.make_client
+
+        def spy_reset():
+            order.append("reset")
+            real_reset()
+
+        @staticmethod
+        def spy_make(path):
+            order.append("make_client")
+            return real_make(path)
+
+        monkeypatch.setattr(mcp_server, "_force_chroma_cache_reset", spy_reset)
+        monkeypatch.setattr(ChromaBackend, "make_client", spy_make)
+
+        mcp_server._get_client()
+
+        assert order == ["reset", "make_client"], (
+            "_get_client must reset chromadb's system cache BEFORE reopening the "
+            "client on a staleness reconnect (#2002)"
+        )
+
     def test_call_kg_retries_after_concurrent_close(self, monkeypatch):
         """A KG closed mid-handler must trigger a one-shot retry with a fresh
         instance — not surface a -32000 to the MCP client."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2707,12 +2707,16 @@ class TestDeleteBySource:
     def test_dry_run_reports_closet_match_count(self, monkeypatch, config, palace_path, kg):
         """Dry run surfaces the closet blast radius (#1722) without deleting."""
         self._seed(monkeypatch, config, palace_path, kg)
-        closets_col = self._seed_closets(palace_path)
+        self._seed_closets(palace_path)
         from mempalace.mcp_server import tool_delete_by_source
+        from mempalace.palace import get_closets_collection
 
         result = tool_delete_by_source("results_mempal_hybrid_v4_session_1.jsonl")
         assert result["dry_run"] is True
         assert result["closet_match_count"] == 2
+        # Re-acquire: the staleness reconnect drops chromadb's path-keyed System
+        # cache (#2002), so a handle taken before the call is dead by now.
+        closets_col = get_closets_collection(palace_path, create=False)
         # Nothing removed — all three closets still present.
         assert len(closets_col.get(include=[])["ids"]) == 3
 
@@ -2731,13 +2735,17 @@ class TestDeleteBySource:
         """Deleting by source purges the matching closets too, so the AAAK
         index keeps no stale pointers at the now-deleted drawers (#1722)."""
         self._seed(monkeypatch, config, palace_path, kg)
-        closets_col = self._seed_closets(palace_path)
+        self._seed_closets(palace_path)
         from mempalace.mcp_server import tool_delete_by_source
+        from mempalace.palace import get_closets_collection
 
         result = tool_delete_by_source("results_mempal_hybrid_v4_session_1.jsonl", dry_run=False)
         assert result["success"] is True
         assert result["deleted"] == 2
         assert result["closets_deleted"] == 2
+        # Re-acquire: the staleness reconnect drops chromadb's path-keyed System
+        # cache (#2002), so a handle taken before the call is dead by now.
+        closets_col = get_closets_collection(palace_path, create=False)
         # The two benchmark closets are gone; the real-client closet survives.
         remaining = closets_col.get(include=["metadatas"])
         sources = {m["source_file"] for m in remaining["metadatas"]}


### PR DESCRIPTION
Fixes #2002. Part of the #1963 concurrent-writer epic; independent of the #1976 daemon/bridge work.

Thanks @fatkobra for the go-ahead on a focused PR.

## Problem

`_get_client()` detects a peer writer's inode/mtime change on `chroma.sqlite3` and rebuilds the client via `ChromaBackend.make_client()`. But chromadb caches its `System`, and therefore the live in-memory `PersistentLocalHnswSegment`, keyed by path. So the rebuilt "fresh" client is handed back the same stale segment, which on its next `_persist()` writes its outdated index over the on-disk one, destroying records other writers had already indexed.

Observed on a live multi-writer palace: the persisted HNSW count went backwards (4 to 3). Over one day, sqlite grew by ~107 drawers while the index grew by ~40, so roughly 63% of new drawers never reached the index and vector search silently degraded to BM25.

## Fix

Call the existing `_force_chroma_cache_reset()` on the staleness path, before `make_client()`, so chromadb rebuilds the segment from the on-disk state. It is guarded by the existing `inode_changed or mtime_changed` check, so first-open is unaffected.

`_force_chroma_cache_reset()` already closes the client, drops the backend's per-palace cache, and calls `SharedSystemClient.clear_system_cache()`. It simply was not being called on this path (it is already used in the missing-DB and repair paths). `clear_system_cache()` is the accepted workaround for this class of path-keyed staleness in chromadb (cf. chroma-core/chroma#2536, chroma-core/chroma#5843).

## Test

`test_get_client_resets_chroma_system_cache_on_reconnect` asserts the reset runs before `make_client()` on an mtime reconnect. It fails on `develop` (order is `['make_client']`) and passes with the fix (`['reset', 'make_client']`). The existing `test_get_client_rearms_quarantine_on_reconnect` (#1573) and the inode/mtime invalidation tests still pass.

## Scope

This removes one concrete data-loss path on the staleness reconnect. It does not make multi-writer safe on its own; chromadb `PersistentClient` is single-process by design, which is what #1976 / #1270 address at the architecture level.

## Manual multi-process reproduction

With a long-lived writer plus a genuinely separate process:

1. long-lived writer indexes 3 records,
2. separate process indexes 2,
3. long-lived writer indexes 1.

Without the fix the persisted index count regresses; with the fix it ends at 6 (monotonic). Happy to add this as a `@pytest.mark.slow` integration test if you'd prefer it in-tree; I kept it out of the suite to keep CI deterministic.
