### PR TITLE
feat(routing): add shared daemon write-routing policy

### DIFF
--- a/docs/write-routing-policy.md
+++ b/docs/write-routing-policy.md
@@ -1,0 +1,119 @@
+# Write routing policy
+
+This document defines the shared policy used by the staged Tier 3 daemon
+rollout tracked in #1963.
+
+This foundation PR does not change existing hook or CLI routing. It provides
+one tested policy model that later hook and CLI PRs can consume without
+inventing different fallback rules.
+
+## Policies
+
+`direct`
+
+    Always execute through the existing direct local path.
+
+`prefer`
+
+    Use an available daemon. A caller that is allowed to start the daemon may
+    do so. Otherwise, fall back to the direct path.
+
+`require`
+
+    Use an available daemon. A caller that is allowed to start the daemon may
+    do so. If neither is possible, block the operation. Never fall back to a
+    direct ChromaDB writer.
+
+## Concrete routing outcomes
+
+The shared decision function returns one of:
+
+- `direct`
+- `daemon`
+- `blocked`
+
+It also reports whether the caller should auto-start the daemon and why the
+route was selected.
+
+Hooks generally pass `daemon_can_start=False` because hook execution has a
+tight latency budget.
+
+Interactive CLI commands can pass `daemon_can_start=True`.
+
+## Configuration
+
+Global environment policy:
+
+    MEMPALACE_WRITE_ROUTING=direct|prefer|require
+
+Hook-specific environment policy:
+
+    MEMPALACE_HOOK_WRITE_ROUTING=direct|prefer|require
+
+CLI-specific environment policy:
+
+    MEMPALACE_CLI_WRITE_ROUTING=direct|prefer|require
+
+Configuration-file shape:
+
+    {
+      "write_routing": {
+        "default": "direct",
+        "hooks": "prefer",
+        "cli": "require"
+      }
+    }
+
+## Precedence
+
+For hooks:
+
+1. `MEMPALACE_HOOK_WRITE_ROUTING`
+2. `MEMPALACE_WRITE_ROUTING`
+3. legacy `MEMPALACE_HOOKS_DAEMON`
+4. `write_routing.hooks`
+5. `write_routing.default`
+6. legacy `hooks.daemon`
+7. `direct`
+
+For CLI writes:
+
+1. `MEMPALACE_CLI_WRITE_ROUTING`
+2. `MEMPALACE_WRITE_ROUTING`
+3. `write_routing.cli`
+4. `write_routing.default`
+5. `direct`
+
+## Backward compatibility
+
+The existing `MEMPALACE_HOOKS_DAEMON` environment variable and
+`hooks.daemon` config value remain supported.
+
+Legacy true values map to `prefer`.
+
+Legacy false values map to `direct`.
+
+The existing `MempalaceConfig.hook_use_daemon` property is intentionally
+unchanged in this PR. Hook and CLI behavior remains unchanged until their
+policy-aware rollout PRs land.
+
+## Invalid policy values
+
+New policy settings accept only:
+
+- `direct`
+- `prefer`
+- `require`
+
+Invalid values fail with a source-specific error rather than silently falling
+back. This is important because silently turning a misspelled `require` into a
+direct write would violate the safety purpose of the policy.
+
+## Follow-up PRs
+
+PR 2 will apply the policy to hook-triggered writes.
+
+PR 3 will apply the policy to routine CLI writes.
+
+Maintenance operations such as repair, migration, and index rebuild are not
+ordinary routed writes. They require a separate exclusive-maintenance policy.

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -11,6 +11,14 @@ from datetime import date, datetime
 from functools import lru_cache
 from pathlib import Path
 
+from .write_routing import (
+    ResolvedWriteRoutingPolicy,
+    RoutingPolicyCandidate,
+    WriteRoutingError,
+    WriteRoutingPolicy,
+    resolve_write_routing_policy,
+)
+
 # ── Input validation ──────────────────────────────────────────────────────────
 # Shared sanitizers for wing/room/entity names. Prevents path traversal,
 # excessively long strings, and special characters that could cause issues
@@ -886,6 +894,102 @@ class MempalaceConfig:
     def hook_desktop_toast(self):
         """Whether the stop hook shows a desktop notification via notify-send."""
         return self._file_config.get("hooks", {}).get("desktop_toast", False)
+
+    def resolve_write_routing(self, scope: str) -> ResolvedWriteRoutingPolicy:
+        """Resolve the configured write policy for ``hooks`` or ``cli``.
+
+        Precedence is:
+
+        1. scope-specific environment variable;
+        2. global environment variable;
+        3. legacy hook environment variable;
+        4. scope-specific config value;
+        5. global config value;
+        6. legacy hook config value;
+        7. ``direct``.
+
+        This foundation does not change current hook or CLI behavior. The
+        policy-aware consumers are introduced by follow-up PRs.
+        """
+
+        normalized_scope = str(scope).strip().lower()
+        env_names = {
+            "hooks": "MEMPALACE_HOOK_WRITE_ROUTING",
+            "cli": "MEMPALACE_CLI_WRITE_ROUTING",
+        }
+
+        if normalized_scope not in env_names:
+            raise WriteRoutingError("write routing scope must be 'hooks' or 'cli'")
+
+        routing_config = self._file_config.get("write_routing", {})
+        if routing_config is None:
+            routing_config = {}
+
+        if not isinstance(routing_config, dict):
+            raise WriteRoutingError("config write_routing must be an object")
+
+        candidates = [
+            RoutingPolicyCandidate(
+                env_names[normalized_scope],
+                os.environ.get(env_names[normalized_scope]),
+            ),
+            RoutingPolicyCandidate(
+                "MEMPALACE_WRITE_ROUTING",
+                os.environ.get("MEMPALACE_WRITE_ROUTING"),
+            ),
+        ]
+
+        if normalized_scope == "hooks":
+            candidates.append(
+                RoutingPolicyCandidate(
+                    "MEMPALACE_HOOKS_DAEMON (legacy)",
+                    os.environ.get("MEMPALACE_HOOKS_DAEMON"),
+                    legacy_boolean=True,
+                )
+            )
+
+        candidates.extend(
+            [
+                RoutingPolicyCandidate(
+                    f"config write_routing.{normalized_scope}",
+                    routing_config.get(normalized_scope),
+                ),
+                RoutingPolicyCandidate(
+                    "config write_routing.default",
+                    routing_config.get("default"),
+                ),
+            ]
+        )
+
+        if normalized_scope == "hooks":
+            hooks_config = self._file_config.get("hooks", {})
+            if hooks_config is None:
+                hooks_config = {}
+
+            if not isinstance(hooks_config, dict):
+                raise WriteRoutingError("config hooks must be an object")
+
+            candidates.append(
+                RoutingPolicyCandidate(
+                    "config hooks.daemon (legacy)",
+                    hooks_config.get("daemon"),
+                    legacy_boolean=True,
+                )
+            )
+
+        return resolve_write_routing_policy(candidates)
+
+    @property
+    def hook_write_routing(self) -> WriteRoutingPolicy:
+        """Resolved future routing policy for hook-triggered writes."""
+
+        return self.resolve_write_routing("hooks").policy
+
+    @property
+    def cli_write_routing(self) -> WriteRoutingPolicy:
+        """Resolved future routing policy for routine CLI writes."""
+
+        return self.resolve_write_routing("cli").policy
 
     @property
     def hook_use_daemon(self):

--- a/mempalace/write_routing.py
+++ b/mempalace/write_routing.py
@@ -1,0 +1,210 @@
+"""Shared daemon-routing policy for MemPalace write callers.
+
+The policy is deliberately transport-agnostic. Hook and CLI consumers decide
+whether a daemon is already available and whether they are allowed to start
+one; this module turns those facts plus a policy into one explicit route.
+
+This module changes no caller defaults by itself. Hook and CLI adoption are
+separate follow-up PRs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Iterable
+
+
+class WriteRoutingError(ValueError):
+    """Raised when a write-routing policy is invalid or cannot be applied."""
+
+
+class WriteRoutingPolicy(str, Enum):
+    """User-selected policy for routine write operations."""
+
+    DIRECT = "direct"
+    PREFER = "prefer"
+    REQUIRE = "require"
+
+
+class WriteRoutingTarget(str, Enum):
+    """Concrete route selected for one write operation."""
+
+    DIRECT = "direct"
+    DAEMON = "daemon"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class RoutingPolicyCandidate:
+    """One precedence-ordered source for a routing policy."""
+
+    source: str
+    value: Any
+    legacy_boolean: bool = False
+
+
+@dataclass(frozen=True)
+class ResolvedWriteRoutingPolicy:
+    """A normalized policy plus the source that selected it."""
+
+    policy: WriteRoutingPolicy
+    source: str
+
+
+@dataclass(frozen=True)
+class WriteRoutingDecision:
+    """Concrete routing decision for a single operation."""
+
+    policy: WriteRoutingPolicy
+    target: WriteRoutingTarget
+    auto_start_daemon: bool
+    reason: str
+
+    @property
+    def use_daemon(self) -> bool:
+        """Whether this operation should use the daemon."""
+        return self.target is WriteRoutingTarget.DAEMON
+
+    @property
+    def blocked(self) -> bool:
+        """Whether the operation must stop instead of writing directly."""
+        return self.target is WriteRoutingTarget.BLOCKED
+
+
+_LEGACY_TRUE = {"1", "true", "yes", "on", "daemon"}
+_LEGACY_FALSE = {"0", "false", "no", "off"}
+
+
+def parse_write_routing_policy(
+    value: Any,
+    *,
+    legacy_boolean: bool = False,
+) -> WriteRoutingPolicy:
+    """Normalize one routing-policy value.
+
+    New policy settings accept only ``direct``, ``prefer``, and ``require``.
+
+    Legacy boolean settings additionally map truthy values to ``prefer`` and
+    falsy values to ``direct`` so existing ``hooks.daemon`` configurations
+    retain their historical behavior.
+    """
+
+    if isinstance(value, WriteRoutingPolicy):
+        return value
+
+    if legacy_boolean and isinstance(value, bool):
+        return WriteRoutingPolicy.PREFER if value else WriteRoutingPolicy.DIRECT
+
+    if legacy_boolean and isinstance(value, int) and not isinstance(value, bool):
+        if value == 1:
+            return WriteRoutingPolicy.PREFER
+        if value == 0:
+            return WriteRoutingPolicy.DIRECT
+
+    if not isinstance(value, str):
+        raise WriteRoutingError("write routing policy must be one of: direct, prefer, require")
+
+    normalized = value.strip().lower()
+
+    try:
+        return WriteRoutingPolicy(normalized)
+    except ValueError:
+        pass
+
+    if legacy_boolean:
+        if normalized in _LEGACY_TRUE:
+            return WriteRoutingPolicy.PREFER
+        if normalized in _LEGACY_FALSE:
+            return WriteRoutingPolicy.DIRECT
+
+    raise WriteRoutingError(
+        f"invalid write routing policy {value!r}; expected direct, prefer, or require"
+    )
+
+
+def resolve_write_routing_policy(
+    candidates: Iterable[RoutingPolicyCandidate],
+    *,
+    default: WriteRoutingPolicy = WriteRoutingPolicy.DIRECT,
+) -> ResolvedWriteRoutingPolicy:
+    """Return the first configured policy from ordered policy sources."""
+
+    for candidate in candidates:
+        if candidate.value is None:
+            continue
+
+        try:
+            policy = parse_write_routing_policy(
+                candidate.value,
+                legacy_boolean=candidate.legacy_boolean,
+            )
+        except WriteRoutingError as exc:
+            raise WriteRoutingError(f"{candidate.source}: {exc}") from exc
+
+        return ResolvedWriteRoutingPolicy(
+            policy=policy,
+            source=candidate.source,
+        )
+
+    return ResolvedWriteRoutingPolicy(
+        policy=default,
+        source="default",
+    )
+
+
+def choose_write_route(
+    policy: WriteRoutingPolicy,
+    *,
+    daemon_available: bool,
+    daemon_can_start: bool,
+) -> WriteRoutingDecision:
+    """Choose direct, daemon, or blocked for one routine write.
+
+    ``daemon_can_start`` is normally false for latency-sensitive hooks and
+    true for interactive CLI commands.
+
+    The key safety guarantee is that ``require`` never degrades to a direct
+    write when the daemon is unavailable.
+    """
+
+    policy = parse_write_routing_policy(policy)
+
+    if policy is WriteRoutingPolicy.DIRECT:
+        return WriteRoutingDecision(
+            policy=policy,
+            target=WriteRoutingTarget.DIRECT,
+            auto_start_daemon=False,
+            reason="policy-direct",
+        )
+
+    if daemon_available:
+        return WriteRoutingDecision(
+            policy=policy,
+            target=WriteRoutingTarget.DAEMON,
+            auto_start_daemon=False,
+            reason="daemon-available",
+        )
+
+    if daemon_can_start:
+        return WriteRoutingDecision(
+            policy=policy,
+            target=WriteRoutingTarget.DAEMON,
+            auto_start_daemon=True,
+            reason="daemon-auto-start",
+        )
+
+    if policy is WriteRoutingPolicy.PREFER:
+        return WriteRoutingDecision(
+            policy=policy,
+            target=WriteRoutingTarget.DIRECT,
+            auto_start_daemon=False,
+            reason="daemon-unavailable-fallback",
+        )
+
+    return WriteRoutingDecision(
+        policy=policy,
+        target=WriteRoutingTarget.BLOCKED,
+        auto_start_daemon=False,
+        reason="daemon-required-unavailable",
+    )

--- a/tests/test_write_routing.py
+++ b/tests/test_write_routing.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mempalace.config import MempalaceConfig
+from mempalace.write_routing import (
+    RoutingPolicyCandidate,
+    WriteRoutingError,
+    WriteRoutingPolicy,
+    WriteRoutingTarget,
+    choose_write_route,
+    parse_write_routing_policy,
+    resolve_write_routing_policy,
+)
+
+
+_ROUTING_ENV_KEYS = (
+    "MEMPALACE_WRITE_ROUTING",
+    "MEMPALACE_HOOK_WRITE_ROUTING",
+    "MEMPALACE_CLI_WRITE_ROUTING",
+    "MEMPALACE_HOOKS_DAEMON",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_routing_env(monkeypatch):
+    for key in _ROUTING_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _write_config(tmp_path, payload):
+    (tmp_path / "config.json").write_text(
+        json.dumps(payload),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["direct", " DIRECT ", WriteRoutingPolicy.DIRECT],
+)
+def test_parse_direct(value):
+    assert parse_write_routing_policy(value) is WriteRoutingPolicy.DIRECT
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["prefer", " PREFER ", WriteRoutingPolicy.PREFER],
+)
+def test_parse_prefer(value):
+    assert parse_write_routing_policy(value) is WriteRoutingPolicy.PREFER
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["require", " REQUIRE ", WriteRoutingPolicy.REQUIRE],
+)
+def test_parse_require(value):
+    assert parse_write_routing_policy(value) is WriteRoutingPolicy.REQUIRE
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, 1, "true", "yes", "on", "daemon"],
+)
+def test_legacy_truthy_maps_to_prefer(value):
+    assert (
+        parse_write_routing_policy(
+            value,
+            legacy_boolean=True,
+        )
+        is WriteRoutingPolicy.PREFER
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [False, 0, "false", "no", "off"],
+)
+def test_legacy_falsy_maps_to_direct(value):
+    assert (
+        parse_write_routing_policy(
+            value,
+            legacy_boolean=True,
+        )
+        is WriteRoutingPolicy.DIRECT
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, False, 1, 0, "maybe", ""],
+)
+def test_new_policy_rejects_legacy_or_invalid_values(value):
+    with pytest.raises(WriteRoutingError):
+        parse_write_routing_policy(value)
+
+
+def test_resolver_returns_first_configured_candidate():
+    resolved = resolve_write_routing_policy(
+        [
+            RoutingPolicyCandidate("first", None),
+            RoutingPolicyCandidate("second", "require"),
+            RoutingPolicyCandidate("third", "direct"),
+        ]
+    )
+
+    assert resolved.policy is WriteRoutingPolicy.REQUIRE
+    assert resolved.source == "second"
+
+
+def test_resolver_names_invalid_source():
+    with pytest.raises(
+        WriteRoutingError,
+        match="MEMPALACE_WRITE_ROUTING",
+    ):
+        resolve_write_routing_policy(
+            [
+                RoutingPolicyCandidate(
+                    "MEMPALACE_WRITE_ROUTING",
+                    "typo",
+                )
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        "policy",
+        "available",
+        "can_start",
+        "target",
+        "auto_start",
+    ),
+    [
+        (
+            WriteRoutingPolicy.DIRECT,
+            False,
+            False,
+            WriteRoutingTarget.DIRECT,
+            False,
+        ),
+        (
+            WriteRoutingPolicy.DIRECT,
+            True,
+            True,
+            WriteRoutingTarget.DIRECT,
+            False,
+        ),
+        (
+            WriteRoutingPolicy.PREFER,
+            True,
+            False,
+            WriteRoutingTarget.DAEMON,
+            False,
+        ),
+        (
+            WriteRoutingPolicy.PREFER,
+            False,
+            True,
+            WriteRoutingTarget.DAEMON,
+            True,
+        ),
+        (
+            WriteRoutingPolicy.PREFER,
+            False,
+            False,
+            WriteRoutingTarget.DIRECT,
+            False,
+        ),
+        (
+            WriteRoutingPolicy.REQUIRE,
+            True,
+            False,
+            WriteRoutingTarget.DAEMON,
+            False,
+        ),
+        (
+            WriteRoutingPolicy.REQUIRE,
+            False,
+            True,
+            WriteRoutingTarget.DAEMON,
+            True,
+        ),
+        (
+            WriteRoutingPolicy.REQUIRE,
+            False,
+            False,
+            WriteRoutingTarget.BLOCKED,
+            False,
+        ),
+    ],
+)
+def test_decision_matrix(
+    policy,
+    available,
+    can_start,
+    target,
+    auto_start,
+):
+    decision = choose_write_route(
+        policy,
+        daemon_available=available,
+        daemon_can_start=can_start,
+    )
+
+    assert decision.target is target
+    assert decision.auto_start_daemon is auto_start
+    assert decision.use_daemon is (target is WriteRoutingTarget.DAEMON)
+    assert decision.blocked is (target is WriteRoutingTarget.BLOCKED)
+
+
+def test_hook_policy_defaults_to_direct(tmp_path):
+    cfg = MempalaceConfig(config_dir=tmp_path)
+
+    resolved = cfg.resolve_write_routing("hooks")
+
+    assert resolved.policy is WriteRoutingPolicy.DIRECT
+    assert resolved.source == "default"
+
+
+def test_cli_policy_defaults_to_direct(tmp_path):
+    cfg = MempalaceConfig(config_dir=tmp_path)
+
+    assert cfg.cli_write_routing is WriteRoutingPolicy.DIRECT
+
+
+def test_scoped_env_beats_global_and_config(
+    tmp_path,
+    monkeypatch,
+):
+    _write_config(
+        tmp_path,
+        {
+            "write_routing": {
+                "default": "direct",
+                "hooks": "prefer",
+            }
+        },
+    )
+
+    monkeypatch.setenv(
+        "MEMPALACE_WRITE_ROUTING",
+        "prefer",
+    )
+    monkeypatch.setenv(
+        "MEMPALACE_HOOK_WRITE_ROUTING",
+        "require",
+    )
+
+    resolved = MempalaceConfig(config_dir=tmp_path).resolve_write_routing("hooks")
+
+    assert resolved.policy is WriteRoutingPolicy.REQUIRE
+    assert resolved.source == "MEMPALACE_HOOK_WRITE_ROUTING"
+
+
+def test_global_env_beats_legacy_hook_env_and_config(
+    tmp_path,
+    monkeypatch,
+):
+    _write_config(
+        tmp_path,
+        {
+            "write_routing": {
+                "hooks": "direct",
+            },
+            "hooks": {
+                "daemon": False,
+            },
+        },
+    )
+
+    monkeypatch.setenv(
+        "MEMPALACE_WRITE_ROUTING",
+        "require",
+    )
+    monkeypatch.setenv(
+        "MEMPALACE_HOOKS_DAEMON",
+        "true",
+    )
+
+    cfg = MempalaceConfig(config_dir=tmp_path)
+
+    assert cfg.hook_write_routing is WriteRoutingPolicy.REQUIRE
+
+
+def test_legacy_hook_env_beats_config(
+    tmp_path,
+    monkeypatch,
+):
+    _write_config(
+        tmp_path,
+        {
+            "write_routing": {
+                "hooks": "direct",
+            },
+            "hooks": {
+                "daemon": False,
+            },
+        },
+    )
+
+    monkeypatch.setenv(
+        "MEMPALACE_HOOKS_DAEMON",
+        "true",
+    )
+
+    resolved = MempalaceConfig(config_dir=tmp_path).resolve_write_routing("hooks")
+
+    assert resolved.policy is WriteRoutingPolicy.PREFER
+    assert resolved.source == "MEMPALACE_HOOKS_DAEMON (legacy)"
+
+
+def test_scoped_config_beats_global_config(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "write_routing": {
+                "default": "prefer",
+                "cli": "require",
+            }
+        },
+    )
+
+    resolved = MempalaceConfig(config_dir=tmp_path).resolve_write_routing("cli")
+
+    assert resolved.policy is WriteRoutingPolicy.REQUIRE
+    assert resolved.source == "config write_routing.cli"
+
+
+def test_global_config_applies_to_both_scopes(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "write_routing": {
+                "default": "prefer",
+            }
+        },
+    )
+
+    cfg = MempalaceConfig(config_dir=tmp_path)
+
+    assert cfg.hook_write_routing is WriteRoutingPolicy.PREFER
+    assert cfg.cli_write_routing is WriteRoutingPolicy.PREFER
+
+
+def test_legacy_hook_config_maps_true_to_prefer(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "hooks": {
+                "daemon": True,
+            }
+        },
+    )
+
+    resolved = MempalaceConfig(config_dir=tmp_path).resolve_write_routing("hooks")
+
+    assert resolved.policy is WriteRoutingPolicy.PREFER
+    assert resolved.source == "config hooks.daemon (legacy)"
+
+
+def test_existing_hook_use_daemon_behavior_is_unchanged(
+    tmp_path,
+    monkeypatch,
+):
+    _write_config(
+        tmp_path,
+        {
+            "hooks": {
+                "daemon": False,
+            }
+        },
+    )
+
+    monkeypatch.setenv(
+        "MEMPALACE_HOOKS_DAEMON",
+        "yes",
+    )
+
+    assert MempalaceConfig(config_dir=tmp_path).hook_use_daemon is True
+
+
+def test_invalid_scoped_policy_fails_loudly(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "write_routing": {
+                "hooks": "typo",
+            }
+        },
+    )
+
+    with pytest.raises(
+        WriteRoutingError,
+        match="config write_routing.hooks",
+    ):
+        MempalaceConfig(config_dir=tmp_path).resolve_write_routing("hooks")
+
+
+def test_invalid_routing_object_fails_loudly(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "write_routing": "require",
+        },
+    )
+
+    with pytest.raises(
+        WriteRoutingError,
+        match="must be an object",
+    ):
+        MempalaceConfig(config_dir=tmp_path).resolve_write_routing("cli")
+
+
+def test_unknown_scope_is_rejected(tmp_path):
+    with pytest.raises(
+        WriteRoutingError,
+        match="scope",
+    ):
+        MempalaceConfig(config_dir=tmp_path).resolve_write_routing("mcp")


### PR DESCRIPTION
## What does this PR do?

Contributes to #1963.

This PR adds a shared, transport-independent write-routing policy foundation for the staged Tier 3 daemon rollout.

It deliberately does **not** change the current hook or CLI execution paths. Instead, it gives the follow-up hook-routing and CLI-routing PRs one common, tested policy model so they do not implement different fallback rules.

## Policy model

### `direct`

Always use the existing direct local execution path.

### `prefer`

Use the daemon when it is already available.

A caller that is allowed to start the daemon may do so. If the daemon is unavailable and cannot be started, fall back to the direct path.

### `require`

Use the daemon when it is already available.

A caller that is allowed to start the daemon may do so. If the daemon is unavailable and cannot be started, block the operation.

`require` never silently falls back to a direct ChromaDB writer.

## Routing decisions

The shared decision function returns one explicit target:

- `direct`
- `daemon`
- `blocked`

It also records:

- whether the caller should auto-start the daemon;
- why the route was selected;
- the resolved policy and its configuration source.

This allows hooks and CLI commands to share the same policy while retaining different lifecycle constraints.

For example:

- hooks can evaluate the policy with daemon auto-start disabled because hook execution has a tight time budget;
- interactive CLI commands can allow daemon auto-start.

## Configuration

Global environment policy:

    MEMPALACE_WRITE_ROUTING=direct|prefer|require

Hook-specific environment policy:

    MEMPALACE_HOOK_WRITE_ROUTING=direct|prefer|require

CLI-specific environment policy:

    MEMPALACE_CLI_WRITE_ROUTING=direct|prefer|require

Configuration-file shape:

    {
      "write_routing": {
        "default": "direct",
        "hooks": "prefer",
        "cli": "require"
      }
    }

## Precedence

Hook routing is resolved in this order:

1. `MEMPALACE_HOOK_WRITE_ROUTING`
2. `MEMPALACE_WRITE_ROUTING`
3. legacy `MEMPALACE_HOOKS_DAEMON`
4. `write_routing.hooks`
5. `write_routing.default`
6. legacy `hooks.daemon`
7. `direct`

CLI routing is resolved in this order:

1. `MEMPALACE_CLI_WRITE_ROUTING`
2. `MEMPALACE_WRITE_ROUTING`
3. `write_routing.cli`
4. `write_routing.default`
5. `direct`

## Backward compatibility

The existing hook settings remain supported:

- `MEMPALACE_HOOKS_DAEMON`
- `hooks.daemon`

Legacy true values map to `prefer`.

Legacy false values map to `direct`.

The existing `MempalaceConfig.hook_use_daemon` property is intentionally unchanged, so this PR does not alter current hook behavior.

Current CLI behavior is also unchanged.

## Safety properties

- `require` never silently degrades to a direct writer.
- Invalid policy values fail with a source-specific error.
- Scope-specific settings override global settings.
- Environment settings override configuration-file settings.
- Hooks and CLI commands use the same deterministic decision matrix.
- No changes are made to `mine_palace_lock()` or the fail-fast direct-writer contract.
- No daemon is started by this foundation PR.
- No current routing default changes.

## Implementation

This PR adds:

- `mempalace/write_routing.py`
  - canonical policy and target enums;
  - policy parsing;
  - legacy boolean compatibility;
  - precedence-aware policy resolution;
  - deterministic route selection;
  - structured routing decisions.

- `MempalaceConfig` integration
  - global, hook-specific, and CLI-specific policy resolution;
  - source reporting;
  - legacy hook-setting compatibility.

- `docs/write-routing-policy.md`
  - policy semantics;
  - configuration and precedence;
  - compatibility guarantees;
  - staged rollout plan.

## Tests

Coverage includes:

- canonical `direct`, `prefer`, and `require` parsing;
- case and whitespace normalization;
- legacy boolean compatibility;
- invalid-value rejection;
- source-aware error messages;
- the complete routing decision matrix;
- daemon-available and daemon-auto-start behavior;
- hook and CLI defaults;
- environment and configuration precedence;
- global and scope-specific settings;
- legacy `hook_use_daemon` behavior remaining unchanged;
- malformed configuration handling;
- unknown-scope rejection.

Run:
````
    python3 -m ruff format --check .
    python3 -m ruff check .
    python3 -m pytest tests/test_write_routing.py tests/test_config.py -q
    python -m pytest tests/ -v
````
## Follow-up rollout

This is the first of three focused PRs:

1. Shared routing-policy foundation — this PR.
2. Hook routing — apply the policy to hook-triggered writes and prevent direct fallback in `require` mode.
3. CLI routing — apply the policy to routine CLI writes while keeping maintenance operations under a separate exclusive-maintenance policy.

## References

Contributes to the Tier 3 work tracked in #1963.

Prepares the hook and CLI rollout after the daemon gateway work in #1976.

Related to #1270, #1888, #2002, and #2026.

## Checklist

- [x] Focused tests pass
- [x] Ruff lint passes
- [x] Ruff format check passes
- [x] No current hook or CLI routing defaults changed
- [x] Legacy hook configuration remains supported
- [x] No palace-lock behavior changed