### PR TITLE
fix(daemon): defer jobs refused the palace lock, don't fail them (#2014)

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -810,6 +810,12 @@ def _submit_daemon_cli_job(kind: str, payload: dict, args, *, background: bool) 
             backend=backend,
             wait=not background,
             auto_start=True,
+            # A job refused the palace lock is deferred, not failed (#2014), so
+            # it never becomes terminal while the holder lives. Waiting it out
+            # would strand this terminal behind a peer that can outlive the
+            # default hour; report the parked job instead. A job that is really
+            # running (a long mine) is still waited out.
+            stop_on_lock_deferral=not background,
         )
     except DaemonError as exc:
         print(f"mempalace: daemon submission failed: {exc}", file=sys.stderr)
@@ -818,6 +824,26 @@ def _submit_daemon_cli_job(kind: str, payload: dict, args, *, background: bool) 
     if background:
         print(f"Submitted daemon job {job['id']} ({kind})")
         return
+
+    from .daemon import job_deferred_by_lock
+
+    if job_deferred_by_lock(job):
+        reason = (job.get("error") or {}).get("message") or "the palace write lock is held"
+        # --palace is global, so it has to be echoed back ahead of the
+        # subcommand: without it the suggestion silently lists the DEFAULT
+        # palace's queue (or nothing at all) instead of the one this job is
+        # parked in -- a wrong answer that looks authoritative.
+        # `daemon jobs` and not `daemon wait`: we just declined to wait out the
+        # holder, so pointing the operator at a command that blocks on the very
+        # state we could not wait for would undo the point of this branch.
+        palace_flag = f"--palace {shlex.quote(args.palace)} " if args.palace else ""
+        print(f"mempalace: {reason}", file=sys.stderr)
+        print(
+            f"mempalace: job {job['id']} is queued and runs when the holder exits "
+            f"(check it with: mempalace {palace_flag}daemon jobs)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     result = job.get("result") or {}
     from .service import print_job_result

--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import math
 import os
 import secrets
 import sqlite3
@@ -39,6 +40,39 @@ DEFAULT_WAIT_TIMEOUT = 60.0 * 60.0
 HOOK_PROBE_TIMEOUT = 0.5
 TERMINAL_STATES = {"succeeded", "failed", "cancelled"}
 MAX_ATTEMPTS = 3
+# ``error_class`` marking a job refused the per-palace write lock. The lock
+# wraps the palace write itself, so a refusal means no drawer was filed and
+# re-running cannot duplicate palace content. Distinct from a crash
+# mid-execution, whose outcome is unknown -- see ``QueueStore.defer``.
+LOCK_REFUSAL_ERROR_CLASS = "LockHeldByOtherProcess"
+_DEFAULT_LOCK_BACKOFF_SECONDS = 60.0
+
+
+def _lock_defer_backoff_seconds() -> float:
+    """Seconds a job refused the lock cools off before the worker re-claims it.
+
+    The holder keeps the lock for as long as its write runs, which can be a long
+    mine, so re-claiming at once would spin without progress. Anything that is
+    not a positive, finite number yields the default: a typo must not crash the
+    daemon at import; ``0`` or a negative value would make the cooldown expire
+    instantly and spin the worker against a lock it cannot take; and ``inf``
+    would park the job until the daemon restarts, which is the dropped work
+    #2014 is about.
+    """
+    try:
+        value = float(
+            os.environ.get("MEMPALACE_DAEMON_LOCK_BACKOFF_SECONDS", "")
+            or _DEFAULT_LOCK_BACKOFF_SECONDS
+        )
+    except ValueError:
+        return _DEFAULT_LOCK_BACKOFF_SECONDS
+    if not math.isfinite(value) or value <= 0:
+        return _DEFAULT_LOCK_BACKOFF_SECONDS
+    return value
+
+
+# Override via env for operators; tests patch the module attribute directly.
+LOCK_DEFER_BACKOFF_SECONDS = _lock_defer_backoff_seconds()
 MAX_BODY_BYTES = 1 << 20  # 1 MiB cap on request bodies (auth-gated DoS guard)
 SHUTDOWN_DRAIN_SECONDS = 10.0
 # Terminal jobs are kept for diagnostics then pruned so the queue DB (which
@@ -411,36 +445,67 @@ class QueueStore:
             row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
             return self._row_to_job(row)
 
-    def claim_next(self) -> Job | None:
+    def claim_next(self, *, exclude: set[str] | None = None) -> Job | None:
         # Atomic across processes: the UPDATE only fires if the row is still
         # 'queued'. If two daemon processes SELECT the same row, the first to
         # UPDATE it flips state to 'running' (rowcount=1); the second's UPDATE
         # matches 0 rows (WHERE state='queued' is now false) and we re-loop
         # instead of double-executing the job. The in-process RLock does not
         # protect against a second OS process — this guard does.
+        #
+        # ``exclude`` skips jobs still cooling off after a lock refusal, so the
+        # ordering below cannot hand back the same refused job forever while
+        # newer work waits behind it. The cooldown is the worker's, held in
+        # memory rather than the schema (which has no migrations): a restart
+        # just retries such a job at once, costing one refusal, never the work.
+        #
+        # The filter runs in Python rather than as ``id NOT IN (?, ?, ...)``:
+        # that binds one host parameter per cooling job, and
+        # SQLITE_MAX_VARIABLE_NUMBER defaults to 999 below SQLite 3.32 (we
+        # support Python 3.9, whose bundled SQLite can predate it). Over the cap
+        # the query raises into the worker's catch-all, which retries a second
+        # later against a set that only ages out on the cooldown, so the queue
+        # would stall in cooldown-long fits rather than drain. Fetching
+        # ``len(exclude) + 1`` rows costs one parameter and is enough by
+        # pigeonhole: at most ``len(exclude)`` of those rows can be excluded, so
+        # the first one that survives the filter is the row a plain LIMIT 1 would
+        # have returned.
+        #
+        # ``error_json`` is cleared because it describes the claim that just
+        # ended: ``defer`` parks the refusal reason on a queued job, and a stale
+        # one would outlive its cause -- reporting a lock refusal for a job that
+        # later crashed, and leaking into recover_running's dead-letter (which
+        # COALESCEs it) in place of ``MaxAttemptsExceeded``.
+        exclude = exclude or set()
         with self._lock, self._connect() as conn:
-            row = conn.execute(
+            # Only the ids: the rows being skipped are here to be discarded, and
+            # jobs carry verbatim payloads, so selecting * would materialise a
+            # cooling job's user content just to read its id past it.
+            candidates = conn.execute(
                 """
-                SELECT * FROM jobs
+                SELECT id FROM jobs
                 WHERE state = 'queued'
                 ORDER BY priority DESC, created_at ASC
-                LIMIT 1
-                """
-            ).fetchone()
-            if row is None:
+                LIMIT ?
+                """,
+                (len(exclude) + 1,),
+            ).fetchall()
+            job_id = next((r["id"] for r in candidates if r["id"] not in exclude), None)
+            if job_id is None:
                 return None
             cur = conn.execute(
                 """
                 UPDATE jobs
-                SET state = 'running', started_at = ?, attempts = attempts + 1
+                SET state = 'running', started_at = ?, attempts = attempts + 1,
+                    error_json = NULL
                 WHERE id = ? AND state = 'queued'
                 """,
-                (_now(), row["id"]),
+                (_now(), job_id),
             )
             if cur.rowcount != 1:
                 # Lost the race to another process — nothing to run this iteration.
                 return None
-            claimed = conn.execute("SELECT * FROM jobs WHERE id = ?", (row["id"],)).fetchone()
+            claimed = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
             return self._row_to_job(claimed)
 
     def finish(
@@ -472,6 +537,56 @@ class QueueStore:
                     json.dumps(result or {}, ensure_ascii=False),
                     json.dumps(error or {}, ensure_ascii=False) if error else None,
                     job_id,
+                ),
+            )
+            row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+            return self._row_to_job(row)
+
+    def defer(
+        self,
+        job_id: str,
+        *,
+        claimed_started_at: str | None = None,
+        error: dict[str, Any] | None = None,
+    ) -> Job:
+        """Return a job refused the palace write lock to ``queued``, unspent.
+
+        ``mine_palace_lock`` wraps the palace write itself, so a refusal means
+        no drawer was filed and re-running cannot duplicate palace content.
+        That is what separates it from the failure ``MAX_ATTEMPTS`` guards -- a
+        daemon that died mid-execution, whose outcome is unknown and whose blind
+        retry would re-file verbatim content. Undoing ``claim_next``'s increment
+        keeps a palace that stays locked from spending the retry budget of work
+        that never landed.
+
+        ``error`` records why the job went back to the queue, so a job parked
+        behind a lock is distinguishable from one merely awaiting its turn.
+        ``claim_next`` clears it on the next claim, so the reason never outlives
+        the claim it describes.
+
+        The ``state = 'running'`` guard mirrors ``finish(only_if_running=True)``:
+        if shutdown already cancelled this job, deferring must not resurrect it.
+        ``claimed_started_at`` narrows the update further, to the claim that was
+        actually refused: if the row was re-queued and re-claimed in the window
+        (recover_running on another daemon start), a late defer must not throw
+        away that newer claim by re-queuing -- and refunding -- work it does not
+        own. ``None`` skips the check.
+        """
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE jobs
+                SET state = 'queued', started_at = NULL,
+                    attempts = MAX(attempts - 1, 0),
+                    error_json = ?
+                WHERE id = ? AND state = 'running'
+                  AND (? IS NULL OR started_at = ?)
+                """,
+                (
+                    json.dumps(error or {}, ensure_ascii=False) if error else None,
+                    job_id,
+                    claimed_started_at,
+                    claimed_started_at,
                 ),
             )
             row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
@@ -523,6 +638,24 @@ class QueueStore:
         )
 
 
+def job_deferred_by_lock(job: dict[str, Any]) -> bool:
+    """True when a job's last claim was refused the palace lock.
+
+    Such a job is deferred, not failed (#2014): it went back to the queue and
+    runs once the lock frees. That makes it non-terminal, so a caller blocking
+    until ``TERMINAL_STATES`` would wait out the holder -- which can be a
+    long-lived session. Interactive callers use this to report the parked job
+    instead of stranding the terminal.
+
+    Keyed on the reason ``defer`` records, which ``claim_next`` clears on the
+    next claim: the answer is about the claim that just ended, not a live probe
+    of the lock (the holder may already have exited during the backoff).
+    """
+    if job.get("state") != "queued":
+        return False
+    return (job.get("error") or {}).get("error_class") == LOCK_REFUSAL_ERROR_CLASS
+
+
 def job_to_dict(job: Job, *, include_payload: bool = True) -> dict[str, Any]:
     out = {
         "id": job.id,
@@ -551,6 +684,9 @@ class DaemonRuntime:
         self.worker_wake = threading.Event()
         self.active_job_id: str | None = None
         self.worker_thread: threading.Thread | None = None
+        # job_id -> monotonic deadline before which a lock-refused job is not
+        # re-claimed (#2014). Worker-owned; only _worker_loop touches it.
+        self._deferred_until: dict[str, float] = {}
 
     def start_worker(self) -> threading.Thread:
         self.store.recover_running()
@@ -579,12 +715,37 @@ class DaemonRuntime:
         except Exception:  # noqa: BLE001 - a finish failure must not kill the worker
             pass
 
+    def _safe_defer(
+        self, job_id: str, *, claimed_started_at: str | None = None, error: dict | None = None
+    ) -> None:
+        try:
+            self.store.defer(job_id, claimed_started_at=claimed_started_at, error=error)
+        except Exception:  # noqa: BLE001 - a defer failure must not kill the worker
+            # The job stays 'running', so recover_running normally re-queues it
+            # on the next start and the work is still held -- mirroring
+            # _safe_finish's swallow. (recover_running does not refund the
+            # attempt, so repeated defer failures across MAX_ATTEMPTS restarts
+            # would eventually dead-letter it.)
+            pass
+
+    def _cooling_job_ids(self) -> set[str]:
+        """Ids of jobs still inside their post-refusal cooldown.
+
+        Pruned on every read, so the map tracks only jobs the worker is actually
+        holding back and cannot grow without bound.
+        """
+        now = time.monotonic()
+        self._deferred_until = {
+            job_id: until for job_id, until in self._deferred_until.items() if until > now
+        }
+        return set(self._deferred_until)
+
     def _worker_loop(self) -> None:
         from .service import execute_job
 
         while not self.shutdown_event.is_set():
             try:
-                job = self.store.claim_next()
+                job = self.store.claim_next(exclude=self._cooling_job_ids())
             except Exception:  # noqa: BLE001 - sqlite/disk errors must not kill the worker
                 self.shutdown_event.wait(1.0)
                 continue
@@ -602,6 +763,32 @@ class DaemonRuntime:
                     payload["backend"] = self.backend
                 result = execute_job(job.kind, payload)
                 ok = bool(result.get("success", True))
+                if not ok and result.get("error_class") == LOCK_REFUSAL_ERROR_CLASS:
+                    # Refused the palace write lock: no drawer was filed, so this
+                    # is a deferral, not a failure (#2014). Dead-lettering it
+                    # here would silently drop the work -- only hook-submitted
+                    # kinds get re-emitted, and the hook is not a retry
+                    # mechanism.
+                    self._safe_defer(
+                        job.id,
+                        claimed_started_at=job.started_at,
+                        error={
+                            "error_class": LOCK_REFUSAL_ERROR_CLASS,
+                            "message": result.get(
+                                "error", "palace write lock held by another process"
+                            ),
+                        },
+                    )
+                    # Cool the job off in the map instead of sleeping here. This
+                    # is the only worker, and the holder may outlive any wait we
+                    # could pick -- it keeps the lock until its write finishes,
+                    # and that write can be a long mine. Blocking would stall
+                    # every unrelated job behind a lock that has nothing to do
+                    # with them, and a job merely queued behind this one would
+                    # never be claimed, so it would never get the refusal marker
+                    # its caller waits on: the #2014 hang wearing a different hat.
+                    self._deferred_until[job.id] = time.monotonic() + LOCK_DEFER_BACKOFF_SECONDS
+                    continue
                 state = "succeeded" if ok else "failed"
                 error = None if ok else {"message": result.get("error", "job failed")}
                 self._safe_finish(job.id, state=state, result=result, error=error)
@@ -935,11 +1122,23 @@ class DaemonClient:
     def list_jobs(self, limit: int = 20) -> list[dict[str, Any]]:
         return self.request("GET", f"/jobs?limit={int(limit)}")["jobs"]
 
-    def wait(self, job_id: str, *, timeout: float = DEFAULT_WAIT_TIMEOUT) -> dict[str, Any]:
+    def wait(
+        self,
+        job_id: str,
+        *,
+        timeout: float = DEFAULT_WAIT_TIMEOUT,
+        stop_on_lock_deferral: bool = False,
+    ) -> dict[str, Any]:
         deadline = time.monotonic() + timeout
         while True:
             job = self.get_job(job_id)
             if job["state"] in TERMINAL_STATES:
+                return job
+            # A job parked behind the palace lock never becomes terminal on its
+            # own, so an interactive caller must be able to stop here instead of
+            # waiting out the holder (#2014). Background callers keep the old
+            # behaviour and simply wait.
+            if stop_on_lock_deferral and job_deferred_by_lock(job):
                 return job
             if time.monotonic() >= deadline:
                 raise DaemonError(f"timed out waiting for job {job_id}")
@@ -1120,6 +1319,7 @@ def submit_job(
     wait: bool = True,
     auto_start: bool = False,
     timeout: float = DEFAULT_WAIT_TIMEOUT,
+    stop_on_lock_deferral: bool = False,
 ) -> dict[str, Any]:
     # Strictly opt-in: callers that want the daemon auto-started must say so
     # explicitly (the CLI --daemon path passes auto_start=True). The default
@@ -1133,7 +1333,7 @@ def submit_job(
     job = client.submit(kind, payload, dedupe_key=dedupe_key, priority=priority)
     if not wait:
         return job
-    return client.wait(job["id"], timeout=timeout)
+    return client.wait(job["id"], timeout=timeout, stop_on_lock_deferral=stop_on_lock_deferral)
 
 
 def stop_daemon(palace_path: str) -> bool:

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -723,7 +723,31 @@ def _submit_daemon_job(
         wait=wait,
         auto_start=False,
         timeout=timeout,
+        # A job refused the palace lock is deferred, not failed (#2014), so it
+        # is never terminal while the holder lives. The waiting callers below
+        # wait on purpose, but a parked job cannot reach the state they wait
+        # for: they would burn the whole timeout and then report a failure that
+        # did not happen. Take the parked job back instead; the daemon still
+        # runs it once the lock frees.
+        stop_on_lock_deferral=True,
     )
+
+
+def _job_deferred_by_lock(job: dict) -> bool:
+    """True when the daemon parked this job behind the palace write lock.
+
+    Imported lazily like ``submit_job`` above: only callers that actually reach
+    the daemon pay for the module, and by this point it is already loaded.
+    """
+    from .daemon import job_deferred_by_lock
+
+    return job_deferred_by_lock(job)
+
+
+def _lock_deferral_reason(job: dict) -> str:
+    """Operator-facing reason a job is parked, for the hook log."""
+    reason = (job.get("error") or {}).get("message") or "the palace write lock is held"
+    return f"{reason} (job {job.get('id')} stays queued and runs when the holder exits)"
 
 
 def _maybe_auto_ingest():
@@ -802,7 +826,12 @@ def _mine_sync():
                         timeout=60,
                     )
                     result = job.get("result") or {}
-                    if job.get("state") != "succeeded" or not result.get("success", True):
+                    if _job_deferred_by_lock(job):
+                        # Parked behind the palace lock, not failed: the daemon
+                        # runs it once the holder exits. Saying "failed" here
+                        # would be the false report #2014 is about.
+                        _log(f"Daemon sync mine deferred: {_lock_deferral_reason(job)}")
+                    elif job.get("state") != "succeeded" or not result.get("success", True):
                         _log(f"Daemon sync mine failed: {result.get('error', job.get('error'))}")
                 except Exception as exc:
                     # Daemon accepted context — don't fall back (would double-mine).
@@ -935,6 +964,9 @@ def _save_diary_direct(
     the agent wrote to, so project-derived wings stay discoverable.
 
     Returns {"count": N, "themes": [...]} on success, {"count": 0} on failure.
+    A daemon lock deferral also returns {"count": 0}: nothing is filed yet, but
+    the entry is queued and the daemon files it once the holder exits, so the
+    checkpoint marker is deliberately not advanced.
     """
     messages = _extract_recent_messages(transcript_path)
     if not messages:
@@ -993,6 +1025,12 @@ def _save_diary_direct(
                 if toast:
                     _desktop_toast(f"Checkpoint saved - {len(messages)} messages archived")
                 return {"count": len(messages), "themes": themes}
+            if _job_deferred_by_lock(job):
+                # Queued behind the palace lock: the entry is held and the daemon
+                # files it once the holder exits. Not a failure, and not a reason
+                # to re-file it here -- that would duplicate verbatim content.
+                _log(f"Daemon diary checkpoint deferred: {_lock_deferral_reason(job)}")
+                return {"count": 0}
             _log(f"Daemon diary checkpoint failed: {result.get('error', job.get('error'))}")
             return {"count": 0}
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2800,6 +2800,7 @@ def tool_mine(
     mining — use ``mempalace_sync`` for that.
     """
     global _metadata_cache
+    from .daemon import LOCK_REFUSAL_ERROR_CLASS
     from .palace import MineAlreadyRunning, MineValidationError
 
     if not _config.palace_path:
@@ -2862,7 +2863,7 @@ def tool_mine(
             return {
                 "success": False,
                 "error": f"another mine is in progress: {exc}",
-                "error_class": "LockHeldByOtherProcess",
+                "error_class": LOCK_REFUSAL_ERROR_CLASS,
             }
         except MineValidationError as exc:
             return {
@@ -3072,6 +3073,7 @@ def tool_delete_by_source(source_file: str, dry_run: bool = True):
 def tool_sync(project_dir: str = None, wing: str = None, apply: bool = False):
     """Prune drawers whose source files are gitignored, missing, or moved (#1252)."""
     global _metadata_cache
+    from .daemon import LOCK_REFUSAL_ERROR_CLASS
     from .palace import MineAlreadyRunning
     from .sync import sync_palace
 
@@ -3096,7 +3098,7 @@ def tool_sync(project_dir: str = None, wing: str = None, apply: bool = False):
             return {
                 "success": False,
                 "error": f"another mine is in progress: {exc}",
-                "error_class": "LockHeldByOtherProcess",
+                "error_class": LOCK_REFUSAL_ERROR_CLASS,
             }
         except ValueError as exc:
             return {"success": False, "error": str(exc)}
@@ -3498,6 +3500,9 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
     that diary reads are case-insensitive (see #1243). "Claude",
     "claude", and "CLAUDE" all resolve to the same agent.
     """
+    from .daemon import LOCK_REFUSAL_ERROR_CLASS
+    from .palace import MineAlreadyRunning
+
     try:
         agent_name = sanitize_name(agent_name, "agent_name").lower()
         entry = sanitize_content(entry)
@@ -3605,6 +3610,21 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
             "timestamp": now.isoformat(),
             "chunks": len(chunk_ids),
             "chunk_ids": chunk_ids,
+        }
+    except MineAlreadyRunning as e:
+        # Order matters: this typed handler precedes the bare Exception below,
+        # mirroring tool_mine / tool_sync. The lock wraps ``col.add`` itself, so
+        # a peer holding it means no entry was filed -- a refusal, not a write
+        # failure -- and the daemon defers such a job rather than dead-lettering
+        # it (#2014). Swallowed into the generic branch the refusal loses
+        # ``error_class``, becomes indistinguishable from a genuine write error,
+        # and the queued diary entry is dropped. The daemon's constant, not a
+        # literal: the two sides are a wire contract, and drift on either end
+        # silently un-fixes #2014.
+        return {
+            "success": False,
+            "error": f"another mine is in progress: {e}",
+            "error_class": LOCK_REFUSAL_ERROR_CLASS,
         }
     except Exception as e:
         return {"success": False, "error": str(e)}

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -160,6 +160,7 @@ def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
 
         _run_pass_zero(project_dir=source, palace_dir=palace_path, llm_provider=None)
 
+    from .daemon import LOCK_REFUSAL_ERROR_CLASS
     from .palace import MineAlreadyRunning, MineValidationError
 
     try:
@@ -207,7 +208,7 @@ def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
         return {
             "success": False,
             "error": str(exc),
-            "error_class": "LockHeldByOtherProcess",
+            "error_class": LOCK_REFUSAL_ERROR_CLASS,
             "exit_code": 1,
         }
     except MineValidationError as exc:
@@ -240,6 +241,7 @@ def run_sync(payload: dict[str, Any]) -> dict[str, Any]:
     _apply_backend(payload.get("backend"))
 
     from .backends import detect_backend_for_path
+    from .daemon import LOCK_REFUSAL_ERROR_CLASS
     from .palace import MineAlreadyRunning, _backend_artifact_label, resolve_backend_name
 
     if not os.path.isdir(palace_path):
@@ -299,7 +301,7 @@ def run_sync(payload: dict[str, Any]) -> dict[str, Any]:
         return {
             "success": False,
             "error": str(exc),
-            "error_class": "LockHeldByOtherProcess",
+            "error_class": LOCK_REFUSAL_ERROR_CLASS,
             "exit_code": 1,
         }
     except ValueError as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -665,6 +665,54 @@ def test_cmd_mine_daemon_background_submits_job(mock_config_cls, capsys):
 
 
 @patch("mempalace.cli.MempalaceConfig")
+def test_cmd_mine_daemon_lock_deferral_reports_a_runnable_command(mock_config_cls, capsys):
+    """A foreground mine refused the palace lock must say so and hand back a
+    command that actually works. --palace is global, so it has to be echoed back
+    ahead of the subcommand: without it the suggestion silently lists the
+    default palace's queue instead of the one the job is parked in."""
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    parked = {
+        "id": "job-1",
+        "state": "queued",
+        "error": {
+            "error_class": "LockHeldByOtherProcess",
+            "message": "palace /my palace is held by PID 999",
+        },
+    }
+    args = argparse.Namespace(
+        dir="/src",
+        palace="/my palace",  # non-default, and with a space to pin the quoting
+        mode="projects",
+        wing=None,
+        agent="mempalace",
+        limit=0,
+        dry_run=False,
+        no_gitignore=False,
+        include_ignored=None,
+        extract="exchange",
+        daemon=True,
+        background=False,
+        backend=None,
+        global_backend=None,
+        max_chunks_per_file=None,
+        redetect_origin=False,
+    )
+    with patch("mempalace.daemon.submit_job", return_value=parked) as mock_submit:
+        with pytest.raises(SystemExit) as exc:
+            cmd_mine(args)
+
+    assert exc.value.code == 1
+    assert mock_submit.call_args.kwargs["stop_on_lock_deferral"] is True
+    err = capsys.readouterr().err
+    assert "is held by PID 999" in err  # the holder, not a generic failure
+    assert "daemon submission failed" not in err  # the submission did not fail
+    assert f"mempalace --palace {shlex.quote('/my palace')} daemon jobs" in err
+    # Not `daemon wait`: this branch exists because we would not wait out the
+    # holder, so it must not hand back a command that does exactly that.
+    assert "daemon wait" not in err
+
+
+@patch("mempalace.cli.MempalaceConfig")
 def test_cmd_mine_background_requires_daemon(mock_config_cls, capsys):
     mock_config_cls.return_value.palace_path = "/fake/palace"
     args = argparse.Namespace(

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,4 +1,5 @@
 import os
+import sqlite3
 import subprocess
 import threading
 import time
@@ -144,7 +145,7 @@ def test_submit_job_uses_client_and_waits(monkeypatch, tmp_path):
             self.submitted = (kind, payload, dedupe_key, priority)
             return {"id": "job-1", "state": "queued"}
 
-        def wait(self, job_id, timeout=daemon.DEFAULT_WAIT_TIMEOUT):
+        def wait(self, job_id, timeout=daemon.DEFAULT_WAIT_TIMEOUT, stop_on_lock_deferral=False):
             assert job_id == "job-1"
             return {
                 "id": "job-1",
@@ -365,6 +366,488 @@ def test_recover_running_dead_letters_exhausted_jobs(tmp_path, monkeypatch):
     final = store.get(job.id)
     assert final.state == "failed"
     assert final.attempts == daemon.MAX_ATTEMPTS
+
+
+# --- #2014: a lease refusal is a deferral, not a failure ---
+
+
+def test_lease_refusal_defers_job_and_runs_it_on_the_next_claim(tmp_path, monkeypatch):
+    """A LockHeldByOtherProcess refusal means the palace write never landed, so
+    re-running it cannot duplicate content. It must be deferred and picked up
+    again, not dead-lettered. Regression for #2014, where a lock conflict ended
+    terminal 'failed' and only ever ran again if some hook happened to re-submit
+    equivalent work."""
+    calls = {"n": 0}
+
+    def fake_execute(kind, payload):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return {
+                "success": False,
+                "error": "palace /p is held by PID 999 (mempalace-mcp)",
+                "error_class": daemon.LOCK_REFUSAL_ERROR_CLASS,
+                "exit_code": 1,
+            }
+        return {"success": True, "exit_code": 0}
+
+    monkeypatch.setattr(daemon, "LOCK_DEFER_BACKOFF_SECONDS", 0.05)
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
+    try:
+        job = client.submit("diary_write", {"entry": "verbatim"})
+        finished = client.wait(job["id"], timeout=10)
+        assert finished["state"] == "succeeded"
+        assert calls["n"] == 2  # refused once, then executed for real
+        # The refusal spent no attempt: only the successful claim counted.
+        assert finished["attempts"] == 1
+    finally:
+        _stop_server(client, thread, holders)
+
+
+def test_repeated_lease_refusal_never_exhausts_attempts(tmp_path, monkeypatch):
+    """#2014's actual promise: a palace locked across many claims must never
+    dead-letter the work. One refusal cannot show that -- MAX_ATTEMPTS is 3, so
+    the job has to survive more refusals than that and still run."""
+    calls = {"n": 0}
+    refusals = daemon.MAX_ATTEMPTS + 2
+
+    def fake_execute(kind, payload):
+        calls["n"] += 1
+        if calls["n"] <= refusals:
+            return {
+                "success": False,
+                "error": "palace /p is held by PID 999",
+                "error_class": daemon.LOCK_REFUSAL_ERROR_CLASS,
+                "exit_code": 1,
+            }
+        return {"success": True, "exit_code": 0}
+
+    monkeypatch.setattr(daemon, "LOCK_DEFER_BACKOFF_SECONDS", 0.02)
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
+    try:
+        job = client.submit("mine", {"source": "src"})
+        finished = client.wait(job["id"], timeout=20)
+        assert finished["state"] == "succeeded"
+        assert calls["n"] == refusals + 1
+        assert finished["attempts"] == 1  # every refusal refunded its claim
+    finally:
+        _stop_server(client, thread, holders)
+
+
+def test_wait_returns_a_lock_deferred_job_instead_of_waiting_out_the_holder(tmp_path, monkeypatch):
+    """An interactive caller must not block until a deferred job goes terminal --
+    it never will while the holder lives, so the default hour-long wait would
+    strand the terminal behind a peer session. Background waiters keep waiting."""
+
+    def fake_execute(kind, payload):
+        return {
+            "success": False,
+            "error": "palace /p is held by PID 999 (mempalace-mcp)",
+            "error_class": daemon.LOCK_REFUSAL_ERROR_CLASS,
+            "exit_code": 1,
+        }
+
+    monkeypatch.setattr(daemon, "LOCK_DEFER_BACKOFF_SECONDS", 5.0)
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
+    try:
+        job = client.submit("mine", {"source": "src"})
+        parked = client.wait(job["id"], timeout=10, stop_on_lock_deferral=True)
+        assert parked["state"] == "queued"  # returned early, not terminal
+        assert daemon.job_deferred_by_lock(parked)
+        assert "PID 999" in parked["error"]["message"]
+
+        # Without the flag the same job is not terminal, so the wait times out
+        # rather than returning -- the hang a naive deferral would introduce.
+        with pytest.raises(daemon.DaemonError):
+            client.wait(job["id"], timeout=0.5)
+    finally:
+        _stop_server(client, thread, holders)
+
+
+def test_job_deferred_by_lock_ignores_ordinary_queued_and_failed_jobs(tmp_path, monkeypatch):
+    """The predicate must not mistake a job merely awaiting its turn -- or a
+    genuinely failed one -- for a lock deferral, or the CLI would bail out of a
+    healthy queue."""
+    assert not daemon.job_deferred_by_lock({"state": "queued", "error": None})
+    assert not daemon.job_deferred_by_lock({"state": "queued", "error": {}})
+    assert not daemon.job_deferred_by_lock(
+        {"state": "failed", "error": {"error_class": daemon.LOCK_REFUSAL_ERROR_CLASS}}
+    )
+    assert not daemon.job_deferred_by_lock(
+        {"state": "queued", "error": {"error_class": "ValueError"}}
+    )
+    assert daemon.job_deferred_by_lock(
+        {"state": "queued", "error": {"error_class": daemon.LOCK_REFUSAL_ERROR_CLASS}}
+    )
+
+
+def test_claim_clears_a_stale_deferral_reason(tmp_path, monkeypatch):
+    """The reason defer parks on a queued job describes the claim that ended.
+    Leaving it would outlive its cause: the predicate would report a lock
+    refusal for a job that later crashed, and recover_running's dead-letter
+    (which COALESCEs error_json) would blame the lock instead of
+    MaxAttemptsExceeded."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    job = store.enqueue("diary_write", {"entry": "x"})
+
+    store.claim_next()
+    store.defer(job.id, error={"error_class": daemon.LOCK_REFUSAL_ERROR_CLASS, "message": "held"})
+    assert daemon.job_deferred_by_lock(daemon.job_to_dict(store.get(job.id)))
+
+    claimed = store.claim_next()
+    assert claimed.error is None  # the refusal belonged to the previous claim
+
+    # Now crash out at MAX_ATTEMPTS: the dead-letter must name the real cause.
+    with store._lock, store._connect() as conn:
+        conn.execute(
+            "UPDATE jobs SET state='running', attempts=? WHERE id=?",
+            (daemon.MAX_ATTEMPTS, job.id),
+        )
+    store.recover_running()
+    final = store.get(job.id)
+    assert final.state == "failed"
+    assert final.error["error_class"] == "MaxAttemptsExceeded"
+
+
+def test_defer_records_why_the_job_went_back_to_the_queue(tmp_path, monkeypatch):
+    """A job parked behind the palace lock must be distinguishable from one
+    merely awaiting its turn.
+
+    The reason is what job_deferred_by_lock keys on, and what the foreground CLI
+    and the hook log quote back at the operator; without it a parked job and a
+    job simply waiting its turn are the same row. (`daemon jobs` prints only
+    id/state/kind/created_at, so it does not show this -- surfacing it there is
+    a separate change.)"""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    job = store.enqueue("mine", {"source": "src"})
+    store.claim_next()
+
+    deferred = store.defer(
+        job.id,
+        error={"error_class": daemon.LOCK_REFUSAL_ERROR_CLASS, "message": "held by PID 999"},
+    )
+    assert deferred.state == "queued"
+    assert deferred.error["error_class"] == daemon.LOCK_REFUSAL_ERROR_CLASS
+    assert "PID 999" in deferred.error["message"]
+
+
+def test_invalid_lock_backoff_env_falls_back_to_the_default(monkeypatch):
+    """Anything that is not a positive, finite number yields the default.
+
+    A typo must not crash the daemon at import; 0 or a negative value would make
+    the cooldown expire instantly and spin the worker against a lock it cannot
+    take; and inf/nan are the sharp edges of float() -- inf parses fine and is
+    > 0, so a bare positivity check would park the job until the daemon
+    restarts, which is exactly the dropped work #2014 is about."""
+    for bad in ("not-a-float", "-5", "0", "", "inf", "-inf", "nan"):
+        monkeypatch.setenv("MEMPALACE_DAEMON_LOCK_BACKOFF_SECONDS", bad)
+        assert daemon._lock_defer_backoff_seconds() == daemon._DEFAULT_LOCK_BACKOFF_SECONDS, bad
+
+    monkeypatch.setenv("MEMPALACE_DAEMON_LOCK_BACKOFF_SECONDS", "0.5")
+    assert daemon._lock_defer_backoff_seconds() == 0.5
+
+    monkeypatch.delenv("MEMPALACE_DAEMON_LOCK_BACKOFF_SECONDS")
+    assert daemon._lock_defer_backoff_seconds() == daemon._DEFAULT_LOCK_BACKOFF_SECONDS
+
+
+def test_defer_returns_job_to_queued_without_spending_an_attempt(tmp_path, monkeypatch):
+    """defer must undo claim_next's increment, so a palace held across many
+    claims cannot walk a job to MAX_ATTEMPTS on work that never landed."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    job = store.enqueue("mine", {"source": "src"})
+
+    claimed = store.claim_next()
+    assert claimed.attempts == 1
+    assert claimed.state == "running"
+
+    deferred = store.defer(job.id)
+    assert deferred.state == "queued"
+    assert deferred.attempts == 0
+    assert deferred.started_at is None
+    # Still claimable -- the work is held, not lost.
+    assert store.claim_next().id == job.id
+
+
+def test_defer_scoped_to_a_stale_claim_is_a_no_op(tmp_path, monkeypatch):
+    """defer is scoped to the claim that was refused. If the row was meanwhile
+    re-queued and re-claimed (recover_running on another daemon start), a late
+    defer keyed to the old claim must not flip the newer claim back to 'queued'
+    -- that would refund its attempt and re-run work whose outcome the newer
+    claimant already owns."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    job = store.enqueue("mine", {"source": "s"})
+
+    # started_at is the claim token this test compares, and adjacent claims can
+    # land inside one clock tick on hosts with a coarse wall clock (Windows
+    # datetime.now() ticks at ~15.6ms before 3.13). Make every stamp unique so
+    # the assertions exercise the guard, not the clock.
+    real_now = daemon._now
+    stamps = iter(range(10_000))
+    monkeypatch.setattr(daemon, "_now", lambda: f"{real_now()}#{next(stamps):04d}")
+
+    stale = store.claim_next()  # the claim that got the refusal
+    deferred = store.defer(job.id, claimed_started_at=stale.started_at)
+    assert deferred.state == "queued"  # scoping to one's own claim still defers
+
+    fresh = store.claim_next()  # the row is claimed again behind the first claimant
+    assert fresh.state == "running"
+
+    late = store.defer(job.id, claimed_started_at=stale.started_at)
+    assert late.state == "running", "a defer scoped to a stale claim must not fire"
+    assert late.attempts == fresh.attempts
+
+
+def test_defer_preserves_attempts_spent_on_earlier_real_executions(tmp_path, monkeypatch):
+    """The refund undoes one claim, not the job's whole history. An execution
+    that crashed left an unknown outcome and must keep costing its attempt --
+    otherwise an alternating crash/refusal pattern would defeat MAX_ATTEMPTS and
+    re-file verbatim content forever."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    job = store.enqueue("diary_write", {"entry": "x"})
+
+    store.claim_next()  # attempt 1: crashes mid-execution (outcome unknown)
+    assert store.recover_running() == 1  # re-queued, attempt NOT refunded
+    assert store.get(job.id).attempts == 1
+
+    store.claim_next()  # attempt 2: refused the lock this time
+    deferred = store.defer(job.id)
+    assert deferred.attempts == 1  # only the refused claim was refunded, not the crash
+
+
+def test_shutdown_while_a_job_is_cooling_leaves_it_queued(tmp_path, monkeypatch):
+    """A job already deferred must survive shutdown as 'queued', not be swept
+    into a terminal state and dropped.
+
+    The worker does not hold a deferred job: it records the cooldown and moves
+    on, so `finally` clears active_job_id and the drain (which joins the worker
+    before reading it) finds nothing in flight to cancel. Pin that, because a
+    shutdown that cancelled a deferred job would be #2014 again."""
+    monkeypatch.setattr(daemon, "LOCK_DEFER_BACKOFF_SECONDS", 5.0)
+
+    def fake_execute(kind, payload):
+        return {
+            "success": False,
+            "error": "palace /p is held by PID 999",
+            "error_class": daemon.LOCK_REFUSAL_ERROR_CLASS,
+            "exit_code": 1,
+        }
+
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
+    try:
+        job = client.submit("diary_write", {"entry": "verbatim"})
+        # Wait for the REFUSAL, not merely for 'queued': a job is queued the moment
+        # it is submitted, so waiting on the state alone would pass this test before
+        # any deferral had happened. The marker only appears once defer ran.
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if daemon.job_deferred_by_lock(client.get_job(job["id"])):
+                break
+            time.sleep(0.02)
+        assert daemon.job_deferred_by_lock(client.get_job(job["id"])), "never reached a deferral"
+    finally:
+        _stop_server(client, thread, holders)
+
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    final = store.get(job["id"])
+    assert final.state == "queued", "a deferred job must not be cancelled by shutdown"
+    assert store.claim_next().id == job["id"]  # still runnable on the next start
+
+
+def test_defer_does_not_resurrect_a_cancelled_job(tmp_path, monkeypatch):
+    """defer mirrors finish(only_if_running=True): once shutdown cancelled an
+    in-flight job, a late deferral must not queue it for re-execution."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+    job = store.enqueue("diary_write", {"entry": "x"})
+    store.claim_next()
+    store.finish(job.id, state="cancelled", result={})
+
+    after = store.defer(job.id)
+    assert after.state == "cancelled"
+    assert store.claim_next() is None
+
+
+def test_claim_next_skips_excluded_jobs_without_binding_a_parameter_each(tmp_path, monkeypatch):
+    """The cooling set must not be spliced into the SQL as one host parameter per
+    job: SQLITE_MAX_VARIABLE_NUMBER defaults to 999 below SQLite 3.32 and this
+    project still supports Python 3.9. Over the cap the query raises into the
+    worker's catch-all, which retries against a set that only ages out on the
+    cooldown, so the queue stalls in cooldown-long fits. It also has to keep
+    picking the right row: the oldest queued job that is not excluded."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    store = daemon.QueueStore(daemon.queue_path(str(palace)))
+
+    first = store.enqueue("mine", {"source": "first"})
+    second = store.enqueue("mine", {"source": "second"})
+
+    # Excluding the oldest hands back the next one, not None.
+    claimed = store.claim_next(exclude={first.id})
+    assert claimed is not None
+    assert claimed.id == second.id
+
+    # Excluding every queued job yields nothing rather than the wrong job.
+    store.defer(second.id)
+    assert store.claim_next(exclude={first.id, second.id}) is None
+
+    if not hasattr(sqlite3.Connection, "setlimit"):  # setlimit is 3.11+
+        pytest.skip("sqlite3.Connection.setlimit needed to pin the parameter cap")
+
+    # Force the pre-3.32 cap of 999 rather than trusting whatever SQLite this
+    # interpreter bundles: on a build with a large cap the old
+    # `id NOT IN (?, ?, ...)` shape passes and this test would guard nothing.
+    real_connect = sqlite3.connect
+
+    def capped_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+        return conn
+
+    monkeypatch.setattr(sqlite3, "connect", capped_connect)
+
+    huge = {f"cooling-{i:07d}" for i in range(5_000)}  # 5x the cap
+    claimed = store.claim_next(exclude=huge)
+    assert claimed is not None
+    assert claimed.id == first.id  # priority DESC, created_at ASC still honoured
+
+    # And priority still wins over age, with an exclusion in play.
+    store.defer(first.id)
+    urgent = store.enqueue("diary_write", {"entry": "x"}, priority=10)
+    assert store.claim_next(exclude=huge).id == urgent.id
+
+
+def test_submit_job_forwards_stop_on_lock_deferral_to_wait(monkeypatch):
+    """submit_job is the only door the CLI and the hooks use, so if it drops the
+    flag on the floor every caller silently goes back to waiting out a holder
+    that may never let go. Nothing else in the suite covers the forwarding."""
+    seen = {}
+
+    class _Client:
+        def submit(self, kind, payload, dedupe_key=None, priority=0):
+            return {"id": "job-1", "state": "queued"}
+
+        def wait(self, job_id, *, timeout=None, stop_on_lock_deferral=False):
+            seen["stop_on_lock_deferral"] = stop_on_lock_deferral
+            return {"id": job_id, "state": "queued"}
+
+    monkeypatch.setattr(daemon, "ensure_client", lambda *a, **kw: _Client())
+
+    daemon.submit_job("mine", {"source": "s"}, palace_path="/p", stop_on_lock_deferral=True)
+    assert seen["stop_on_lock_deferral"] is True
+
+    daemon.submit_job("mine", {"source": "s"}, palace_path="/p")
+    assert seen["stop_on_lock_deferral"] is False  # default stays the old waiting behaviour
+
+
+def test_a_deferred_job_does_not_stall_unrelated_queued_work(tmp_path, monkeypatch):
+    """The worker is the only one, and claim_next hands back the oldest queued
+    job -- which, after a refusal, is the deferred job itself. If the worker
+    waited out the cooldown in line, that one job would hold the queue hostage
+    for as long as the holder lived (the flock is held while the write runs, and
+    a wedged write holds it indefinitely, #2024), and nothing else would run.
+    The cooldown must skip the job, not block the loop."""
+    monkeypatch.setattr(daemon, "LOCK_DEFER_BACKOFF_SECONDS", 30.0)
+    ran = []
+
+    def fake_execute(kind, payload):
+        ran.append(kind)
+        if kind == "mine":  # older, and refused for the whole test
+            return {
+                "success": False,
+                "error": "palace /p is held by PID 999",
+                "error_class": daemon.LOCK_REFUSAL_ERROR_CLASS,
+                "exit_code": 1,
+            }
+        return {"success": True, "exit_code": 0}
+
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
+    try:
+        blocked = client.submit("mine", {"source": "src"})
+        unrelated = client.submit("diary_write", {"entry": "verbatim"})
+
+        # The unrelated job must run despite a 30s cooldown on the older one.
+        done = client.wait(unrelated["id"], timeout=10)
+        assert done["state"] == "succeeded"
+        assert "diary_write" in ran
+
+        # And the blocked job is still held, not lost.
+        parked = client.get_job(blocked["id"])
+        assert parked["state"] == "queued"
+        assert daemon.job_deferred_by_lock(parked)
+    finally:
+        _stop_server(client, thread, holders)
+
+
+def test_a_job_queued_behind_a_deferred_one_gets_its_own_refusal_marker(tmp_path, monkeypatch):
+    """A caller waiting on a job that is merely queued behind a deferred job has
+    nothing to key on: the job was never claimed, so it carries no marker, and
+    stop_on_lock_deferral cannot fire. It would wait out its full timeout and
+    then report a failure that never happened -- #2014 through the back door.
+    Because the cooldown skips the deferred job instead of blocking the worker,
+    the second job is claimed, refused, and marked on its own."""
+    monkeypatch.setattr(daemon, "LOCK_DEFER_BACKOFF_SECONDS", 30.0)
+
+    def fake_execute(kind, payload):
+        return {
+            "success": False,
+            "error": "palace /p is held by PID 999 (mempalace-mcp)",
+            "error_class": daemon.LOCK_REFUSAL_ERROR_CLASS,
+            "exit_code": 1,
+        }
+
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
+    try:
+        first = client.submit("mine", {"source": "a"})
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if daemon.job_deferred_by_lock(client.get_job(first["id"])):
+                break
+            time.sleep(0.02)
+        assert daemon.job_deferred_by_lock(client.get_job(first["id"]))
+
+        # Submitted while the first job is cooling: it must still be claimed.
+        second = client.submit("mine", {"source": "b"})
+        parked = client.wait(second["id"], timeout=10, stop_on_lock_deferral=True)
+        assert parked["state"] == "queued"
+        assert daemon.job_deferred_by_lock(parked), "the CLI/hook short-circuit cannot fire"
+        assert "PID 999" in parked["error"]["message"]
+    finally:
+        _stop_server(client, thread, holders)
+
+
+def test_failure_that_is_not_a_lease_refusal_stays_terminal(tmp_path, monkeypatch):
+    """Only a lease refusal defers. A genuine failure has an unknown outcome --
+    the daemon may have written before dying -- which is exactly what MAX_ATTEMPTS
+    guards, so it must stay terminal and never be blindly re-run."""
+
+    def fake_execute(kind, payload):
+        return {"success": False, "error": "boom", "error_class": "ValueError", "exit_code": 1}
+
+    client, thread, palace, holders = _start_server(tmp_path, monkeypatch, fake_execute)
+    try:
+        job = client.submit("diary_write", {"entry": "x"})
+        finished = client.wait(job["id"], timeout=10)
+        assert finished["state"] == "failed"
+        assert finished["error"]["message"] == "boom"
+    finally:
+        _stop_server(client, thread, holders)
 
 
 def test_claim_next_does_not_reclaim_running_job(tmp_path, monkeypatch):
@@ -753,6 +1236,53 @@ def test_run_sync_structured_errors_on_sync_failures(tmp_path, monkeypatch):
     r = service.run_sync({"palace_path": str(palace), "dry_run": True})
     assert r["success"] is False
     assert "sync failed" in r["error"]
+
+
+def test_run_mine_lease_refusal_returns_the_lock_error_class(tmp_path, monkeypatch):
+    """run_mine is the sole source of the refusal marker for kind 'mine' -- the
+    primary #2014 vector, submitted by the hooks and the CLI. The worker's
+    defer-vs-dead-letter gate keys on this error_class, so if a refactor drops
+    it (say, a broad handler reordered above MineAlreadyRunning), the daemon
+    silently goes back to dead-lettering refused mines while every worker test
+    stays green: they all inject the marker by hand."""
+    import mempalace.miner as miner_module
+    from mempalace import service
+    from mempalace.palace import MineAlreadyRunning
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    def _locked(**kw):
+        raise MineAlreadyRunning("palace is held by PID 999")
+
+    monkeypatch.setattr(miner_module, "mine", _locked)
+    r = service.run_mine(
+        {"palace_path": str(palace), "source": str(tmp_path / "src"), "mode": "projects"}
+    )
+    assert r["success"] is False
+    assert r["error_class"] == daemon.LOCK_REFUSAL_ERROR_CLASS
+    assert r["exit_code"] == 1
+
+
+def test_safe_defer_swallows_store_errors_and_leaves_the_job_running(tmp_path, monkeypatch):
+    """_safe_defer mirrors _safe_finish: a queue-DB hiccup during defer must not
+    kill the worker. The job stays 'running' for recover_running to re-queue on
+    the next start. Dropping the swallow would let the error reach the worker's
+    outer except, which dead-letters the lock-refused job -- the #2014 outcome
+    this branch exists to remove."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    runtime = daemon.DaemonRuntime(str(palace))
+    job = runtime.store.enqueue("mine", {"source": "s"})
+    runtime.store.claim_next()
+
+    def _boom(*args, **kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(runtime.store, "defer", _boom)
+    runtime._safe_defer(job.id, error={"error_class": daemon.LOCK_REFUSAL_ERROR_CLASS})
+    assert runtime.store.get(job.id).state == "running"
 
 
 # --- post-merge review follow-ups (Copilot review on #1826) ---

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -505,6 +505,54 @@ def test_save_diary_direct_daemon_opt_in_submits_job(tmp_path):
     assert (tmp_path / "last_checkpoint").exists()
 
 
+def test_save_diary_daemon_lock_deferral_does_not_stall_the_hook(tmp_path):
+    """A refused job is deferred, not failed (#2014), so it is never terminal
+    while the holder lives.
+
+    This path waits on purpose -- a real diary write takes its time -- but it
+    waits for a state that a parked job cannot reach. Without
+    stop_on_lock_deferral it burns its whole 30s timeout on every session stop
+    and then reports a submission failure that never happened: the entry is
+    queued and the daemon files it once the lock frees."""
+    transcript = tmp_path / "t.jsonl"
+    palace_dir = tmp_path / "palace"
+    palace_dir.mkdir()
+    _write_transcript(
+        transcript,
+        [{"message": {"role": "user", "content": f"message {i}"}} for i in range(3)],
+    )
+    env = {"MEMPALACE_HOOKS_DAEMON": "yes", "MEMPALACE_PALACE_PATH": str(palace_dir)}
+    parked = {
+        "id": "job-parked",
+        "state": "queued",
+        "error": {
+            "error_class": "LockHeldByOtherProcess",
+            "message": "palace /p is held by PID 999 (mempalace-mcp)",
+        },
+        "result": None,
+    }
+
+    with patch.dict("os.environ", env):
+        with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
+            with patch("mempalace.hooks_cli._daemon_available", return_value=True):
+                with patch("mempalace.daemon.submit_job", return_value=parked) as mock_submit:
+                    with patch("mempalace.hooks_cli._log") as mock_log:
+                        result = _save_diary_direct(
+                            str(transcript), "sess1", wing="wing_project", agent_name="claude"
+                        )
+
+    # The hook must ask the daemon to hand a parked job straight back.
+    assert mock_submit.call_args.kwargs["stop_on_lock_deferral"] is True
+
+    assert result["count"] == 0  # nothing filed yet -- the daemon still owes the write
+    assert not (tmp_path / "last_checkpoint").exists()  # and it must not be acked
+
+    logged = " ".join(str(c.args[0]) for c in mock_log.call_args_list)
+    assert "deferred" in logged
+    assert "PID 999" in logged
+    assert "Daemon diary checkpoint failed" not in logged, "a parked job is not a failure"
+
+
 def test_hooks_daemon_enabled_requires_explicit_true():
     with patch("mempalace.hooks_cli.MempalaceConfig") as mock_cfg_cls:
         assert _hooks_daemon_enabled() is False
@@ -971,6 +1019,40 @@ def test_mine_sync_with_env_uses_projects_mode(tmp_path):
                 mock_run.assert_called_once()
                 cmd = mock_run.call_args[0][0]
                 assert cmd[cmd.index("--mode") + 1] == "projects"
+
+
+def test_mine_sync_daemon_lock_deferral_is_not_reported_as_a_failure(tmp_path):
+    """The precompact sync path waits (wait=True, timeout=60) but is documented as
+    living under the harness 30s ceiling, so a job it can never see go terminal is
+    doubly bad here: without stop_on_lock_deferral it burns past the ceiling and
+    then logs a failure for work the daemon still holds and will run."""
+    mempal_dir = tmp_path / "project"
+    mempal_dir.mkdir()
+    parked = {
+        "id": "job-parked",
+        "state": "queued",
+        "error": {
+            "error_class": "LockHeldByOtherProcess",
+            "message": "palace /p is held by PID 999 (mempalace-mcp)",
+        },
+        "result": None,
+    }
+    env = {"MEMPAL_DIR": str(mempal_dir), "MEMPALACE_HOOKS_DAEMON": "yes"}
+    with patch.dict("os.environ", env):
+        with patch("mempalace.hooks_cli.STATE_DIR", tmp_path):
+            with patch("mempalace.hooks_cli._daemon_available", return_value=True):
+                with patch("mempalace.daemon.submit_job", return_value=parked) as mock_submit:
+                    with patch("mempalace.hooks_cli._log") as mock_log:
+                        with patch("mempalace.hooks_cli.subprocess.run") as mock_run:
+                            _mine_sync()
+
+    assert mock_submit.call_args.kwargs["stop_on_lock_deferral"] is True
+    mock_run.assert_not_called()  # the daemon owns it; spawning a mine would double-write
+
+    logged = " ".join(str(c.args[0]) for c in mock_log.call_args_list)
+    assert "deferred" in logged
+    assert "PID 999" in logged
+    assert "Daemon sync mine failed" not in logged, "a parked job is not a failure"
 
 
 def test_mine_sync_uses_mempalace_python(tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4259,6 +4259,32 @@ class TestStructuredErrors:
         assert "another mine is in progress" in result["error"]
         assert result.get("error_class") == "LockHeldByOtherProcess"
 
+    def test_tool_diary_write_lease_refusal_returns_error_class(self, monkeypatch):
+        """tool_diary_write must mark a peer-held palace lease with error_class,
+        like tool_mine/tool_sync already do. The daemon keys its defer-vs-fail
+        decision on that marker (#2014); swallowed by the bare `except Exception`
+        the refusal was indistinguishable from a genuine write error, so a queued
+        diary entry was dead-lettered instead of retried."""
+        from mempalace import daemon, mcp_server
+        from mempalace.palace import MineAlreadyRunning
+
+        class _LeaseHeldCollection:
+            def add(self, **kwargs):
+                raise MineAlreadyRunning("palace /p is held by PID 999 (mempalace-mcp)")
+
+        monkeypatch.setattr(
+            mcp_server, "_get_collection", lambda create=False: _LeaseHeldCollection()
+        )
+        monkeypatch.setattr(mcp_server, "_wal_log", lambda *a, **kw: None)
+
+        result = mcp_server.tool_diary_write(agent_name="tester", entry="verbatim", topic="t")
+        assert result["success"] is False
+        assert "is held by PID 999" in result["error"]
+        # Assert against the daemon's constant, not a literal: the two are a
+        # wire contract, and drift silently un-fixes #2014 (the daemon would
+        # stop recognising the refusal and dead-letter the job again).
+        assert result.get("error_class") == daemon.LOCK_REFUSAL_ERROR_CLASS
+
     def test_mcp_idle_timeout_invalid_env_disables_watchdog(self, monkeypatch):
         """Invalid MEMPALACE_MCP_IDLE_HOURS disables idle auto-exit."""
         from mempalace import mcp_server


### PR DESCRIPTION
## What does this PR do?

A daemon job refused the palace write lock was marked terminal `failed` and never retried. `mine_palace_lock` guards the palace write itself, so a refusal means no drawer was filed, but the queue recorded it exactly like a crash mid-execution, whose outcome is unknown. The work was dropped: it only ran again if a hook happened to re-submit equivalent work, and a job kind no hook re-emits was lost outright.

On develop, with a peer process holding the lock (the lock is re-entrant within one process, so the holder has to be external):

```
state    : failed
attempts : 1
-- lock released, 3s later --
state    : failed      <- never reconsidered
```

Refusals now defer instead of failing:

- `QueueStore.defer()` puts the job back to `queued`, clears `started_at`, undoes the claim's attempt increment, and records why it was parked. A palace held across many claims can no longer walk work that never landed up to `MAX_ATTEMPTS`. The `state = 'running'` guard mirrors `finish(only_if_running=True)`, so a job already cancelled by shutdown isn't resurrected, and the update is scoped to the claim that was refused (`started_at` match), so a defer racing a recovery re-claim cannot re-queue work it does not own.
- The worker keys the deferral on `error_class == "LockHeldByOtherProcess"`, then **cools the job off in memory and moves on to the next one**. It does not sleep in line. This is the only worker, and the holder keeps the lock until its write finishes, which can be a long mine, so blocking here would stall every unrelated job behind a lock that has nothing to do with them. `claim_next(exclude=...)` skips a cooling job, so the oldest-first ordering cannot hand the same refused job back forever while newer work waits.
- The cooldown is the worker's, held in memory. A `not_before` column would survive a restart, but the queue schema is `CREATE TABLE IF NOT EXISTS` with no migration step, so persisting it means adding one, and the only thing a restart costs here is a single immediate refusal before the job cools off again. That did not seem worth a schema change in a bugfix; if persistence matters more than schema stability, a `not_before` column is the follow-up.
- `claim_next` clears the recorded reason, so it never outlives the claim it describes.
- Every other failure stays terminal. That boundary is the whole point: a crashed job's outcome is unknown, and blindly re-running a non-idempotent kind would re-file verbatim content, which is exactly what `MAX_ATTEMPTS` guards.

`MEMPALACE_DAEMON_LOCK_BACKOFF_SECONDS` (default 60) tunes the cooldown. Anything not positive and finite falls back to the default: `inf` parses fine and passes a bare positivity check, which would park the job until the daemon restarted.

### Why the retry is safe

`diary_write` is the awkward case, so it is worth being precise. `_wal_log` runs *before* the collection write, so a refusal happens after a WAL line was already appended. That line is an audit record: `entry` is in `_WAL_REDACT_KEYS`, the file has no readers anywhere in the tree, and nothing replays it. The palace write is what the lock guards and it did not happen, so re-running cannot duplicate verbatim content.

Each retry does append another such record, so a palace held for a long time leaves one audit line per cooldown period for the job. That is log noise, not duplicated content, and it is the price of not dropping the write.

### Callers that wait

Deferral makes a refused job non-terminal, and `DaemonClient.wait` only returns on a terminal state. Three callers wait on purpose, and all three would have waited for a state a parked job cannot reach:

- `mine --daemon` (foreground) would have blocked for the full one-hour default and then printed `daemon submission failed: timed out waiting for job ...`, which is wrong twice over: the submission succeeded, and the job is still queued to run.
- The hook paths in `hooks_cli` (the pre-compaction `mine` at `wait=True, timeout=60`, and the Stop-hook diary checkpoint at `wait=True, timeout=30`) would have burned their whole timeout on every fire and then logged a failure that never happened.

`wait(stop_on_lock_deferral=True)` hands the parked job back instead. The CLI reports the holder and a command that actually runs, and the hooks log the deferral rather than a failure:

```
mempalace: palace /tmp/fg2014_e6F0/palace is held by PID 45909 (/tmp/fg2014_e6F0/holder.py 40); wait for it to finish or stop the holder before retrying
mempalace: job 9187e327120c4650b4332d6f946bc466 is queued and runs when the holder exits (check it with: mempalace --palace /tmp/fg2014_e6F0/palace daemon jobs)
```

`--palace` is global, so it has to be echoed back ahead of the subcommand; without it the suggestion silently lists the default palace's queue instead of the one the job is parked in.

Because a cooling job no longer blocks the worker, a job submitted *behind* a deferred one is still claimed and refused on its own, so it gets its own marker and its caller short-circuits too. A job that is genuinely running (a long mine) is still waited out: the short-circuit only fires on `queued` plus the refusal marker. Background callers keep the old behaviour.

### The same bug class elsewhere

`tool_diary_write` had to be fixed for the gate to reach it. It swallowed `MineAlreadyRunning` in its bare `except Exception`, so the refusal arrived with no `error_class`, and `diary_write` (one of the two kinds in the queue dump on the issue) would still have been dead-lettered. It now uses a typed handler ahead of the bare `Exception`, the way `tool_mine` and `tool_sync` already do.

Of the four job kinds, `mine` and `sync` mark the refusal in `service.run_mine` / `run_sync`, and `diary_write` is fixed here. Two gaps are left deliberately, both pre-existing and both keeping exactly the behaviour they had before this change:

- `mcp_tool` dispatches the write tools, and four of them (`tool_add_drawer`, `tool_update_drawer`, `tool_delete_drawer`, `tool_delete_by_source`) reach a collection write but swallow `MineAlreadyRunning` in bare handlers, so their refusals would still be dead-lettered. `tool_checkpoint` is a fifth, one step quieter: it files through `tool_add_drawer` and buries the refusals in its `errors` list with no top-level `error`, so the job even reports `succeeded`. Nothing submits that kind internally right now.
- `mine_formats` swallows it per file and in its outer handler, so a `mine --mode extract --daemon` job reports success on a refusal rather than surfacing it at all. This one is reachable through the daemon today, and the refusal never leaves `mine_formats`, so the new gate cannot see it either way.

All of these are worth their own fix; folding them in would mean touching most of the write surface in a bugfix PR.

## How to test

```bash
python -m pytest tests/test_daemon.py -k "lease or defer or backoff or claim_clears or cooling or stall or behind or excluded or run_mine_lease" -v
python -m pytest tests/test_hooks_cli.py -k lock_deferral -v
python -m pytest tests/test_cli.py -k lock_deferral -v
python -m pytest tests/test_mcp_server.py -k diary_write_lease_refusal -v
```

End to end, with a peer process holding the lock:

```bash
export MEMPALACE_DAEMON_LOCK_BACKOFF_SECONDS=3
mkdir -p /tmp/p/palace /tmp/p/proj

python - <<'PY' &
import time
from mempalace.palace import mine_palace_lock
with mine_palace_lock("/tmp/p/palace"):
    time.sleep(40)
PY

mempalace --palace /tmp/p/palace mine /tmp/p/proj --daemon --background
mempalace --palace /tmp/p/palace daemon jobs   # not failed
# once the holder exits:
mempalace --palace /tmp/p/palace daemon jobs   # succeeded
```

Before the change the first `daemon jobs` shows `failed`, and the job stays failed after the holder exits.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

Fixes #2014
