### PR TITLE
feat(repair): add `reconcile` mode — re-index only the HNSW-missing drawers

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -643,16 +643,16 @@ class _SafePersistentDataUnpickler:
             return _Restricted(f).load()
 
 
-def _hnsw_element_count(palace_path: str, segment_id: str) -> Optional[int]:
-    """Return the element count chromadb thinks the HNSW segment holds.
+def _hnsw_id_to_label_keys(palace_path: str, segment_id: str) -> Optional[set[str]]:
+    """Return the set of embedding IDs the HNSW segment's pickle knows about.
 
     Reads ``index_metadata.pickle`` via a tight-allowlist unpickler and
-    counts ``id_to_label`` entries. This is the count chromadb consults
-    when sizing/loading the HNSW index on next open — distinct from
-    hnswlib's internal ``cur_element_count`` in the binary files. For
-    #1222's divergence check this is the number that matters, because it
-    is what gets compared against ``count() * resize_factor`` when
-    chromadb decides whether to resize HNSW on load.
+    returns the KEYS of its ``id_to_label`` map — the chroma embedding IDs
+    (string UUIDs) currently present in the flushed HNSW index. This is the
+    authoritative "what is indexed" set: :func:`_hnsw_element_count` counts
+    it for #1222's divergence check, and :mod:`mempalace.repair`'s reconcile
+    mode diffs it against the sqlite embedding IDs to find exactly which
+    drawers are missing from the index.
 
     Uses :class:`_SafePersistentDataUnpickler` rather than chromadb's own
     ``PersistentData.load_from_file`` so the probe works even when
@@ -680,11 +680,29 @@ def _hnsw_element_count(palace_path: str, segment_id: str) -> Optional[int]:
         else:
             id_to_label = getattr(pd, "id_to_label", None)
         if isinstance(id_to_label, dict):
-            return len(id_to_label)
+            return set(id_to_label.keys())
         return None
     except Exception:
-        logger.debug("_hnsw_element_count failed for %s", pickle_path, exc_info=True)
+        logger.debug("_hnsw_id_to_label_keys failed for %s", pickle_path, exc_info=True)
         return None
+
+
+def _hnsw_element_count(palace_path: str, segment_id: str) -> Optional[int]:
+    """Return the element count chromadb thinks the HNSW segment holds.
+
+    Thin wrapper over :func:`_hnsw_id_to_label_keys` — counts the
+    ``id_to_label`` entries in ``index_metadata.pickle``. This is the count
+    chromadb consults when sizing/loading the HNSW index on next open —
+    distinct from hnswlib's internal ``cur_element_count`` in the binary
+    files. For #1222's divergence check this is the number that matters,
+    because it is what gets compared against ``count() * resize_factor``
+    when chromadb decides whether to resize HNSW on load.
+
+    Returns ``None`` when the pickle is absent (fresh / never-flushed
+    segment) or unreadable. Callers treat ``None`` as "unknown".
+    """
+    keys = _hnsw_id_to_label_keys(palace_path, segment_id)
+    return len(keys) if keys is not None else None
 
 
 # Divergence threshold: chromadb's HNSW flushes asynchronously, so HNSW

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -2202,6 +2202,26 @@ def cmd_repair_status(args):
     repair_status(palace_path=palace_path)
 
 
+def _run_reconcile_mode(palace_path: str, collection_name: str, dry_run: bool) -> None:
+    """Dispatch ``repair --mode reconcile``: surgical HNSW re-index of only the
+    drawers missing from the index, with clean non-zero exits for the
+    too-large-gap and mine-in-progress cases."""
+    from .palace import MineAlreadyRunning
+    from .repair import ReconcileNotSafe, reconcile_index
+
+    try:
+        reconcile_index(palace_path, collection_name, dry_run=dry_run)
+    except ReconcileNotSafe as exc:
+        print(f"\n  {exc}")
+        sys.exit(1)
+    except MineAlreadyRunning as exc:
+        print(
+            f"\n  {exc}\n  A mine is holding the palace; "
+            "retry reconcile once it finishes."
+        )
+        sys.exit(1)
+
+
 def cmd_repair(args):
     """Rebuild palace vector index from SQLite metadata.
 
@@ -2253,6 +2273,10 @@ def cmd_repair(args):
             dry_run=getattr(args, "dry_run", False),
             assume_yes=getattr(args, "yes", False),
         )
+        return
+
+    if getattr(args, "mode", "legacy") == "reconcile":
+        _run_reconcile_mode(palace_path, collection_name, getattr(args, "dry_run", False))
         return
 
     if getattr(args, "mode", "legacy") == "from-sqlite":
@@ -3255,14 +3279,17 @@ def main():
     )
     p_repair.add_argument(
         "--mode",
-        choices=["legacy", "max-seq-id", "from-sqlite"],
+        choices=["legacy", "max-seq-id", "from-sqlite", "reconcile"],
         default="legacy",
         help=(
             "legacy: full-palace rebuild via the chromadb client (default). "
             "max-seq-id: un-poison max_seq_id rows corrupted by the legacy 0.6.x shim. "
             "from-sqlite: rebuild by reading rows directly from chroma.sqlite3, "
             "bypassing the chromadb client. Use when legacy mode bails because the "
-            "chromadb client cannot open the collection."
+            "chromadb client cannot open the collection. "
+            "reconcile: re-index ONLY the drawers missing from the HNSW index "
+            "(re-embeds just the gap, not the whole palace) — the fast fix for a "
+            "small flush-lag divergence. Refuses a large gap; use from-sqlite then."
         ),
     )
     p_repair.add_argument(

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -2215,10 +2215,7 @@ def _run_reconcile_mode(palace_path: str, collection_name: str, dry_run: bool) -
         print(f"\n  {exc}")
         sys.exit(1)
     except MineAlreadyRunning as exc:
-        print(
-            f"\n  {exc}\n  A mine is holding the palace; "
-            "retry reconcile once it finishes."
-        )
+        print(f"\n  {exc}\n  A mine is holding the palace; retry reconcile once it finishes.")
         sys.exit(1)
 
 

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -45,12 +45,27 @@ from typing import Callable, Iterator, Optional
 
 from chromadb.errors import NotFoundError as ChromaNotFoundError
 
-from .backends.chroma import ChromaBackend, hnsw_capacity_status
+from .backends.chroma import ChromaBackend, _hnsw_id_to_label_keys, hnsw_capacity_status
 from .config import sqlite_read_uri
 
 
 COLLECTION_NAME = "mempalace_drawers"
 REPAIR_TEMP_COLLECTION = f"{COLLECTION_NAME}__repair_tmp"
+
+# Reconcile mode caps — refuse the surgical reconcile path when the HNSW gap
+# is too large and fall back to a full ``--mode from-sqlite`` rebuild. Both an
+# absolute and a relative ceiling: reconcile opens the LIVE vector segment
+# (unlike from-sqlite, which only reads chroma.sqlite3), so a #1222-scale gap
+# could trigger an uncatchable native resize on open. The relative cap stops a
+# small palace being reconciled through a gap that is tiny in absolute terms
+# but a large fraction of its contents.
+RECONCILE_MAX_MISSING = 5000
+RECONCILE_MAX_MISSING_FRACTION = 0.02
+
+# Chunk size for the ``embedding_id IN (...)`` filter in extract_via_sqlite's
+# only_ids path — keeps each SQL statement's parameter count well under
+# SQLite's default 999 host-parameter limit.
+_EXTRACT_ID_CHUNK = 500
 
 # The closets collection (AAAK index layer) is intentionally fixed —
 # closets reference drawer IDs by string and live alongside drawers in the
@@ -335,6 +350,22 @@ class RebuildCollectionError(RuntimeError):
     def __init__(self, message: str, *, live_replaced: bool):
         super().__init__(message)
         self.live_replaced = live_replaced
+
+
+class ReconcileNotSafe(RuntimeError):
+    """Raised when the HNSW gap is too large for the surgical reconcile path.
+
+    Reconcile opens the LIVE vector segment (unlike ``from-sqlite``, which
+    reads only ``chroma.sqlite3``), so a catastrophic gap (#1222: max_elements
+    frozen far below the true count) can trigger an uncatchable native resize
+    on open. The caps refuse *before* ``get_collection`` is ever called and
+    point the operator at ``--mode from-sqlite --archive-existing`` instead.
+    """
+
+    def __init__(self, message: str, *, n_missing: int, sqlite_count: "int | None"):
+        super().__init__(message)
+        self.n_missing = n_missing
+        self.sqlite_count = sqlite_count
 
 
 def _rebuild_collection_via_temp(
@@ -1744,7 +1775,63 @@ def _rebuild_one_collection(
     return upserted
 
 
-def extract_via_sqlite(palace_path: str, collection_name: str) -> Iterator[tuple[str, str, dict]]:
+def _emit_extracted_rows(
+    conn: sqlite3.Connection,
+    segment_id: str,
+    id_chunk: "Optional[list[str]]",
+) -> Iterator[tuple[str, str, dict]]:
+    """Run one metadata-segment scan and yield ``(embedding_id, document,
+    metadata)``, optionally filtered to the ``embedding_id`` values in
+    ``id_chunk``.
+
+    Shared by :func:`extract_via_sqlite`'s full-scan and only_ids paths so the
+    typed-column resolution lives in exactly one place. Grouping is per call:
+    every ``embedding_metadata`` row for a given ``embedding_id`` is fetched in
+    the same scan (the filter, when present, matches by ``embedding_id``), so a
+    drawer's metadata never straddles two chunks.
+    """
+    params: list = [segment_id]
+    id_filter = ""
+    if id_chunk is not None:
+        placeholders = ",".join("?" for _ in id_chunk)
+        id_filter = f" AND e.embedding_id IN ({placeholders})"
+        params.extend(id_chunk)
+
+    per_id: dict[str, dict] = defaultdict(dict)
+    order: list[str] = []
+    for emb_id, key, sv, iv, fv, bv in conn.execute(
+        f"""
+        SELECT e.embedding_id, em.key, em.string_value, em.int_value,
+               em.float_value, em.bool_value
+        FROM embedding_metadata em
+        JOIN embeddings e ON em.id = e.id
+        WHERE e.segment_id = ?{id_filter}
+        ORDER BY em.id
+        """,
+        params,
+    ):
+        if emb_id not in per_id:
+            order.append(emb_id)
+        if sv is not None:
+            per_id[emb_id][key] = sv
+        elif iv is not None:
+            per_id[emb_id][key] = iv
+        elif fv is not None:
+            per_id[emb_id][key] = fv
+        elif bv is not None:
+            per_id[emb_id][key] = bool(bv)
+
+    for emb_id in order:
+        kv = per_id[emb_id]
+        doc = kv.pop("chroma:document", "")
+        yield emb_id, doc, kv
+
+
+def extract_via_sqlite(
+    palace_path: str,
+    collection_name: str,
+    only_ids: "Optional[set[str]]" = None,
+) -> Iterator[tuple[str, str, dict]]:
     """Yield ``(embedding_id, document, metadata)`` for every row in
     ``collection_name``'s metadata segment by reading ``chroma.sqlite3``
     directly.
@@ -1767,18 +1854,26 @@ def extract_via_sqlite(palace_path: str, collection_name: str) -> Iterator[tuple
     returned as the document; this matches how chromadb itself stores
     ``add(documents=...)``.
 
-    Driven from ``embeddings`` (LEFT JOIN ``embedding_metadata``), not
-    the other way around: an embedding with zero ``embedding_metadata``
-    rows — a sparse historical write with no ``chroma:document`` and no
-    other key, the same condition ``_extract_drawers`` already sanitizes
+    Driven from `embeddings` (LEFT JOIN `embedding_metadata`), not
+    the other way around: an embedding with zero `embedding_metadata`
+    rows — a sparse historical write with no `chroma:document` and no
+    other key, the same condition `_extract_drawers` already sanitizes
     for the collection-layer path, see #1458 — must still be yielded
     with an empty metadata dict, not silently excluded by the join.
+
+    When `only_ids` is provided, only rows whose `embedding_id` is in the
+    set are yielded, fetched in chunks of `_EXTRACT_ID_CHUNK` via
+    `IN (...)` so the reconcile path can pull just the drawers missing from
+    the HNSW index without scanning the whole metadata segment. An empty
+    `only_ids` set yields nothing.
 
     Silent on missing palace, missing ``chroma.sqlite3``, or unknown
     collection name — yields nothing. Callers that need to distinguish
     "empty collection" from "collection not present" should query
     :func:`sqlite_drawer_count` first.
     """
+    if only_ids is not None and not only_ids:
+        return
     sqlite_path = os.path.join(palace_path, "chroma.sqlite3")
     if not os.path.isfile(sqlite_path):
         return
@@ -1797,40 +1892,14 @@ def extract_via_sqlite(palace_path: str, collection_name: str) -> Iterator[tuple
             return
         segment_id = seg_row[0]
 
-        per_id: dict[str, dict] = defaultdict(dict)
-        order: list[str] = []
-        for emb_id, key, sv, iv, fv, bv in conn.execute(
-            """
-            SELECT e.embedding_id, em.key, em.string_value, em.int_value,
-                   em.float_value, em.bool_value
-            FROM embeddings e
-            LEFT JOIN embedding_metadata em ON em.id = e.id
-            WHERE e.segment_id = ?
-            ORDER BY e.id
-            """,
-            (segment_id,),
-        ):
-            if emb_id not in per_id:
-                order.append(emb_id)
-            if key is None:
-                # LEFT JOIN unmatched row: this embedding has zero
-                # embedding_metadata rows. `order`/`per_id` already
-                # account for it via the defaultdict below; nothing to
-                # merge for this row.
-                continue
-            if sv is not None:
-                per_id[emb_id][key] = sv
-            elif iv is not None:
-                per_id[emb_id][key] = iv
-            elif fv is not None:
-                per_id[emb_id][key] = fv
-            elif bv is not None:
-                per_id[emb_id][key] = bool(bv)
-
-        for emb_id in order:
-            kv = per_id[emb_id]
-            doc = kv.pop("chroma:document", "")
-            yield emb_id, doc, kv
+        if only_ids is None:
+            yield from _emit_extracted_rows(conn, segment_id, None)
+        else:
+            id_list = list(only_ids)
+            for i in range(0, len(id_list), _EXTRACT_ID_CHUNK):
+                yield from _emit_extracted_rows(
+                    conn, segment_id, id_list[i : i + _EXTRACT_ID_CHUNK]
+                )
     finally:
         conn.close()
 
@@ -2404,6 +2473,263 @@ def status(palace_path=None, collection_name: Optional[str] = None) -> dict:
         )
     print()
     return {"drawers": drawers, "closets": closets}
+
+
+# ---------------------------------------------------------------------------
+# reconcile mode: re-index only the drawers missing from the HNSW index
+# ---------------------------------------------------------------------------
+
+
+def _sqlite_embedding_ids(palace_path: str, collection_name: str) -> "Optional[set[str]]":
+    """Return the set of embedding IDs stored in ``chroma.sqlite3`` for the
+    collection — every drawer that *should* be present in the HNSW index.
+
+    Mirrors :func:`mempalace.backends.chroma._sqlite_embedding_count` (same
+    collection-scoped join) but returns the IDs instead of a count, so
+    :func:`compute_missing_ids` can diff them against the HNSW ``id_to_label``
+    keys. Deliberately does NOT join ``embedding_metadata``: a drawer with zero
+    metadata rows still has an ``embeddings`` row and must not be dropped from
+    the "should be indexed" set.
+
+    Returns ``None`` when the ids cannot be read (missing DB, or a sqlite error
+    such as a sustained writer lock) so the caller never mistakes an unreadable
+    palace for an empty one — returning an empty set there would let reconcile
+    silently report "nothing missing" while a mine simply held the lock. A
+    ``busy_timeout`` (same grace period as :func:`sqlite_integrity_errors`) lets
+    a transient writer lock resolve before we give up. Returns a (possibly
+    empty) set only on a successful read.
+    """
+    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+    try:
+        conn = sqlite3.connect(
+            sqlite_read_uri(db_path),
+            uri=True,
+            timeout=_SQLITE_INTEGRITY_BUSY_TIMEOUT_SECONDS,
+        )
+    except sqlite3.Error:
+        return None
+    try:
+        ids: set[str] = set()
+        for (emb_id,) in conn.execute(
+            """
+            SELECT e.embedding_id
+            FROM embeddings e
+            JOIN segments s ON e.segment_id = s.id
+            JOIN collections c ON s.collection = c.id
+            WHERE c.name = ?
+            """,
+            (collection_name,),
+        ):
+            ids.add(emb_id)
+        return ids
+    except sqlite3.Error:
+        return None
+    finally:
+        conn.close()
+
+
+def compute_missing_ids(
+    palace_path: str, collection_name: str = COLLECTION_NAME
+) -> "tuple[Optional[set[str]], dict]":
+    """Return ``(missing_ids, status)`` — the embedding IDs present in sqlite
+    but absent from the flushed HNSW index, plus the raw
+    :func:`hnsw_capacity_status` dict.
+
+    ``missing_ids`` is ``None`` when the diff cannot be computed reliably (no
+    vector segment, or the HNSW metadata pickle is absent/unreadable) — the
+    caller must NOT treat that as "nothing missing". A negative divergence
+    (HNSW holds more than sqlite) yields an empty set: reconcile is a no-op,
+    never a delete.
+    """
+    status = hnsw_capacity_status(palace_path, collection_name)
+    seg_id = status.get("segment_id")
+    if seg_id is None:
+        return None, status
+    hnsw_keys = _hnsw_id_to_label_keys(palace_path, seg_id)
+    if hnsw_keys is None:
+        return None, status
+    sqlite_ids = _sqlite_embedding_ids(palace_path, collection_name)
+    if sqlite_ids is None:
+        return None, status
+    # Override with the authoritative count from the SAME read that produced
+    # ``missing``, so the cap's fraction denominator and ``missing`` can never
+    # disagree — and so ``sqlite_count`` is always an int for callers that
+    # format it (hnsw_capacity_status's own count read can be None under a
+    # transient lock, which would otherwise crash an f"{sqlite_count:,}").
+    status["sqlite_count"] = len(sqlite_ids)
+    missing = sqlite_ids - hnsw_keys
+    return missing, status
+
+
+def reconcile_index(
+    palace_path: str,
+    collection_name: str = COLLECTION_NAME,
+    *,
+    dry_run: bool = False,
+    batch_size: int = 500,
+) -> dict:
+    """Re-index only the drawers missing from the HNSW index.
+
+    The surgical alternative to a full ``--mode from-sqlite`` rebuild for the
+    common small-divergence case (a flush-lag or crash-truncated pickle that
+    left a few hundred drawers out of the index while chroma.sqlite3 stayed
+    intact). Diffs the sqlite embedding IDs against the HNSW ``id_to_label``
+    keys and re-upserts just the missing drawers through the same
+    ``ChromaCollection.upsert`` primitive the live MCP write path uses —
+    re-embedding those documents and letting chromadb fold them into the
+    existing index, with no delete-and-recreate.
+
+    Returns a result dict::
+
+        {"missing", "reconciled", "fetched",
+         "divergence_before", "divergence_after", "flushed"}
+
+    Raises :class:`ReconcileNotSafe` when the gap exceeds the caps (opening the
+    live segment on a #1222-scale gap can crash natively). Propagates
+    :class:`~mempalace.palace.MineAlreadyRunning` when a mine holds the palace
+    — the caller should retry once the mine finishes.
+    """
+    palace_path = os.path.abspath(os.path.expanduser(palace_path))
+
+    print(f"\n{'=' * 55}")
+    print("  MemPalace Repair — Reconcile HNSW index")
+    print(f"{'=' * 55}\n")
+    print(f"  Palace: {palace_path}")
+
+    # Preflight: the same sqlite integrity gate the rebuild paths use. A
+    # malformed DB must never be the source of a re-embed.
+    sqlite_errors = sqlite_integrity_errors(palace_path)
+    if sqlite_errors:
+        print_sqlite_integrity_abort(palace_path, sqlite_errors)
+        return {"missing": 0, "reconciled": 0, "aborted": "sqlite_integrity"}
+
+    missing, status = compute_missing_ids(palace_path, collection_name)
+    divergence_before = status.get("divergence")
+    if missing is None:
+        print(
+            "\n  Cannot compute the missing-drawer set: "
+            f"{status.get('message', 'no vector segment / HNSW metadata')}.\n"
+            "  Nothing reconciled. If vectors are disabled by a corrupt index, "
+            "use --mode from-sqlite --archive-existing."
+        )
+        return {
+            "missing": 0,
+            "reconciled": 0,
+            "divergence_before": divergence_before,
+        }
+
+    sqlite_count = status.get("sqlite_count")
+    n_missing = len(missing)
+
+    if n_missing == 0:
+        print("\n  HNSW index already covers every sqlite drawer — nothing to reconcile.")
+        return {
+            "missing": 0,
+            "reconciled": 0,
+            "divergence_before": divergence_before,
+            "divergence_after": divergence_before,
+            "flushed": True,
+        }
+
+    # Caps — refuse a large gap BEFORE opening the live segment (see
+    # ReconcileNotSafe). Absolute AND relative.
+    frac = n_missing / max(sqlite_count or 0, 1)
+    if n_missing > RECONCILE_MAX_MISSING or frac > RECONCILE_MAX_MISSING_FRACTION:
+        raise ReconcileNotSafe(
+            f"HNSW gap too large for reconcile: {n_missing:,} drawers missing "
+            f"({frac * 100:.1f}% of {sqlite_count:,}). Caps: "
+            f"{RECONCILE_MAX_MISSING:,} absolute / "
+            f"{RECONCILE_MAX_MISSING_FRACTION * 100:.0f}% relative. "
+            "Use --mode from-sqlite --archive-existing for a full rebuild.",
+            n_missing=n_missing,
+            sqlite_count=sqlite_count,
+        )
+
+    print(
+        f"\n  {n_missing:,} drawers missing from the HNSW index "
+        f"(sqlite {sqlite_count:,} / divergence {divergence_before})."
+    )
+
+    if dry_run:
+        print("  --dry-run: no changes made.")
+        return {
+            "missing": n_missing,
+            "reconciled": 0,
+            "divergence_before": divergence_before,
+            "dry_run": True,
+        }
+
+    # Fetch documents + metadata for exactly the missing IDs (chunked IN()).
+    ids: list[str] = []
+    docs: list[str] = []
+    metas: list[dict] = []
+    for emb_id, doc, meta in extract_via_sqlite(palace_path, collection_name, only_ids=missing):
+        ids.append(emb_id)
+        docs.append(doc)
+        metas.append(meta)
+    fetched = len(ids)
+    if fetched < n_missing:
+        # extract_via_sqlite drops rows whose every typed metadata column is
+        # NULL (chromadb never writes that shape); surface it, don't hide it.
+        print(
+            f"  Note: fetched {fetched:,} of {n_missing:,} missing drawers from "
+            "sqlite; the rest have no metadata rows and are skipped."
+        )
+    if fetched == 0:
+        print("  Nothing to upsert after fetch — no reconcilable rows.")
+        return {
+            "missing": n_missing,
+            "reconciled": 0,
+            "fetched": 0,
+            "divergence_before": divergence_before,
+        }
+
+    # Open the LIVE collection and re-upsert the missing drawers through the
+    # same locked primitive the MCP write path uses. Re-embeds at upsert time
+    # (the stored vectors are not reused — same rationale as
+    # rebuild_from_sqlite; the embedding model is deterministic). A running
+    # mine makes ``upsert`` raise MineAlreadyRunning, which propagates.
+    backend = ChromaBackend()
+    col = backend.get_collection(palace_path, collection_name)
+    reconciled = 0
+    for i in range(0, fetched, batch_size):
+        batch_ids = ids[i : i + batch_size]
+        col.upsert(
+            ids=batch_ids,
+            documents=docs[i : i + batch_size],
+            metadatas=metas[i : i + batch_size],
+        )
+        reconciled += len(batch_ids)
+    print(f"  Upserted {reconciled:,} drawers.")
+
+    # Post-verify from the pickle. On a legacy palace with a large
+    # ``hnsw:sync_threshold`` the pickle may not have re-flushed yet (the index
+    # binary has the vectors, but the metadata pickle MCP reads for its
+    # divergence check lags) — never claim the divergence is closed on a stale
+    # pickle, and do NOT lower the threshold to force a flush (scope creep).
+    post = hnsw_capacity_status(palace_path, collection_name)
+    divergence_after = post.get("divergence")
+    flushed = divergence_after is not None and divergence_after <= 0
+    if flushed:
+        print("  HNSW index reconciled — divergence closed, vector search re-enabled.")
+    else:
+        print(
+            f"  Upserts applied, but the HNSW metadata pickle still reports "
+            f"divergence {divergence_after} (collection sync_threshold not yet "
+            "reached). The index binary holds the new vectors; the pickle will "
+            "reflect them on the next persist. Vector search may stay disabled "
+            "until then."
+        )
+    return {
+        "missing": n_missing,
+        "reconciled": reconciled,
+        "fetched": fetched,
+        "divergence_before": divergence_before,
+        "divergence_after": divergence_after,
+        "flushed": flushed,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -2596,10 +2596,18 @@ def reconcile_index(
         {"missing", "reconciled", "fetched",
          "divergence_before", "divergence_after", "flushed"}
 
+    Concurrency: the complete transaction — integrity preflight, missing-ID
+    diff, sqlite extraction, every upsert batch, and the final verification —
+    runs under ONE per-palace writer lease (``mine_palace_lock``), so no
+    concurrent writer can move sqlite or the HNSW segment between phases and
+    the reconcile set always describes the generation being modified. Nested
+    ``ChromaCollection.upsert`` lock acquisitions pass through via the lock's
+    process-wide re-entrancy.
+
     Raises :class:`ReconcileNotSafe` when the gap exceeds the caps (opening the
-    live segment on a #1222-scale gap can crash natively). Propagates
-    :class:`~mempalace.palace.MineAlreadyRunning` when a mine holds the palace
-    — the caller should retry once the mine finishes.
+    live segment on a #1222-scale gap can crash natively). Raises
+    :class:`~mempalace.palace.MineAlreadyRunning` at entry when another writer
+    holds the palace — the caller should retry once it finishes.
     """
     palace_path = os.path.abspath(os.path.expanduser(palace_path))
 
@@ -2608,6 +2616,32 @@ def reconcile_index(
     print(f"{'=' * 55}\n")
     print(f"  Palace: {palace_path}")
 
+    # ONE palace writer lease for the COMPLETE transaction. Any phase running
+    # outside it lets a concurrent writer move sqlite/HNSW between phases: the
+    # missing-ID snapshot then describes an older generation than the state
+    # being modified — the safety cap no longer applies to the current state,
+    # already-repaired IDs get processed again, and stale extracted rows can
+    # overwrite a newer concurrent update. Nested ChromaCollection.upsert
+    # acquisitions pass through via the lock's process-wide re-entrancy; a
+    # foreign holder raises MineAlreadyRunning here, before any read. Lazy
+    # import for the same reason as maybe_autoheal_fts5_index's: keep
+    # repair.py's import graph light for callers that never hit this path.
+    from .palace import mine_palace_lock
+
+    with mine_palace_lock(palace_path):
+        return _reconcile_under_lease(
+            palace_path, collection_name, dry_run=dry_run, batch_size=batch_size
+        )
+
+
+def _reconcile_under_lease(
+    palace_path: str,
+    collection_name: str,
+    *,
+    dry_run: bool,
+    batch_size: int,
+) -> dict:
+    """Body of :func:`reconcile_index`; the caller holds the palace writer lease."""
     # Preflight: the same sqlite integrity gate the rebuild paths use. A
     # malformed DB must never be the source of a re-embed.
     sqlite_errors = sqlite_integrity_errors(palace_path)

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -2581,6 +2581,16 @@ def reconcile_index(
     re-embedding those documents and letting chromadb fold them into the
     existing index, with no delete-and-recreate.
 
+    Scope: reconcile is for a *flush-lag* gap — the HNSW binary is sound and
+    only the metadata pickle lags (or a crash truncated it). It opens the live
+    segment, so a genuinely corrupt / undersized HNSW (the #1222 / #1308 class,
+    where ``count`` / ``upsert`` fault natively) can still crash on open even at
+    a small divergence that clears the caps — a native access violation the
+    caps cannot predict and Python cannot catch. That is a
+    ``--mode from-sqlite --archive-existing`` rebuild case (from-sqlite reads
+    chroma.sqlite3 directly and never opens the failing segment), not a
+    reconcile case.
+
     Returns a result dict::
 
         {"missing", "reconciled", "fetched",

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -1803,15 +1803,17 @@ def _emit_extracted_rows(
         f"""
         SELECT e.embedding_id, em.key, em.string_value, em.int_value,
                em.float_value, em.bool_value
-        FROM embedding_metadata em
-        JOIN embeddings e ON em.id = e.id
+        FROM embeddings e
+        LEFT JOIN embedding_metadata em ON em.id = e.id
         WHERE e.segment_id = ?{id_filter}
-        ORDER BY em.id
+        ORDER BY e.id
         """,
         params,
     ):
         if emb_id not in per_id:
             order.append(emb_id)
+        if key is None:
+            continue
         if sv is not None:
             per_id[emb_id][key] = sv
         elif iv is not None:

--- a/tests/test_repair_reconcile.py
+++ b/tests/test_repair_reconcile.py
@@ -1,0 +1,386 @@
+"""Tests for ``mempalace repair --mode reconcile``.
+
+Reconcile re-indexes ONLY the drawers missing from the HNSW index by diffing
+the sqlite embedding IDs against the HNSW ``id_to_label`` keys and re-upserting
+just the gap — the fast fix for a small flush-lag divergence, versus a full
+``--mode from-sqlite`` re-embed of the whole palace.
+
+Two layers here:
+
+* Unit tests synthesize the on-disk shape directly (a ``chroma.sqlite3`` plus an
+  ``index_metadata.pickle`` matching chromadb 1.5.x's ``{"id_to_label": {...}}``)
+  and never open a chromadb client — the diff/extract functions read sqlite and
+  the pickle only.
+* Orchestration tests patch ``mempalace.repair.ChromaBackend`` so the live
+  ``upsert`` path is a mock (same approach ``test_repair.py`` uses for the
+  rebuild path) while the diff, cap, and fetch logic run for real against the
+  synthetic palace. The real end-to-end "divergence closes" proof runs against
+  a live palace, not CI.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mempalace import repair
+from mempalace.backends.chroma import _hnsw_element_count, _hnsw_id_to_label_keys
+from mempalace.palace import MineAlreadyRunning
+from mempalace.repair import (
+    ReconcileNotSafe,
+    _sqlite_embedding_ids,
+    compute_missing_ids,
+    extract_via_sqlite,
+    reconcile_index,
+)
+
+COLLECTION = "mempalace_drawers"
+VECTOR_SEG = "seg-vec"
+META_SEG = "seg-meta"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+def _seed(
+    palace: str,
+    sqlite_ids: list[str],
+    hnsw_ids: "list[str] | None",
+    *,
+    sync_threshold: "int | None" = 2,
+    docs: "dict[str, str] | None" = None,
+) -> None:
+    """Seed a synthetic palace.
+
+    ``sqlite_ids`` become ``embeddings`` rows under the METADATA segment (each
+    with a ``chroma:document`` + wing/room, so ``extract_via_sqlite`` returns
+    them). ``hnsw_ids`` — when not None — become the ``id_to_label`` keys of a
+    chromadb-1.5.x-shaped ``index_metadata.pickle`` in the VECTOR segment dir;
+    None models a never-flushed segment (no pickle).
+    """
+    db_path = os.path.join(palace, "chroma.sqlite3")
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE collections (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+            CREATE TABLE collection_metadata (
+                collection_id TEXT REFERENCES collections(id) ON DELETE CASCADE,
+                key TEXT NOT NULL, str_value TEXT, int_value INTEGER,
+                float_value REAL, bool_value INTEGER,
+                PRIMARY KEY (collection_id, key)
+            );
+            CREATE TABLE segments (
+                id TEXT PRIMARY KEY, collection TEXT NOT NULL, scope TEXT NOT NULL
+            );
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY, segment_id TEXT NOT NULL,
+                embedding_id TEXT NOT NULL, seq_id BLOB NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE embedding_metadata (
+                id INTEGER REFERENCES embeddings(id), key TEXT NOT NULL,
+                string_value TEXT, int_value INTEGER, float_value REAL,
+                bool_value INTEGER, PRIMARY KEY (id, key)
+            );
+            """
+        )
+        col_id = "col-test"
+        conn.execute("INSERT INTO collections (id, name) VALUES (?, ?)", (col_id, COLLECTION))
+        if sync_threshold is not None:
+            conn.execute(
+                """INSERT INTO collection_metadata (collection_id, key, int_value)
+                   VALUES (?, 'hnsw:sync_threshold', ?)""",
+                (col_id, sync_threshold),
+            )
+        conn.execute(
+            "INSERT INTO segments (id, collection, scope) VALUES (?, ?, 'VECTOR')",
+            (VECTOR_SEG, col_id),
+        )
+        conn.execute(
+            "INSERT INTO segments (id, collection, scope) VALUES (?, ?, 'METADATA')",
+            (META_SEG, col_id),
+        )
+        for i, eid in enumerate(sqlite_ids, start=1):
+            conn.execute(
+                """INSERT INTO embeddings (id, segment_id, embedding_id, seq_id)
+                   VALUES (?, ?, ?, ?)""",
+                (i, META_SEG, eid, b"\x00" * 8),
+            )
+            doc = (docs or {}).get(eid, f"doc for {eid}")
+            conn.execute(
+                """INSERT INTO embedding_metadata (id, key, string_value)
+                   VALUES (?, 'chroma:document', ?)""",
+                (i, doc),
+            )
+            conn.execute(
+                """INSERT INTO embedding_metadata (id, key, string_value)
+                   VALUES (?, 'wing', 'w')""",
+                (i,),
+            )
+            conn.execute(
+                """INSERT INTO embedding_metadata (id, key, string_value)
+                   VALUES (?, 'room', 'r')""",
+                (i,),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    if hnsw_ids is not None:
+        seg_dir = os.path.join(palace, VECTOR_SEG)
+        os.makedirs(seg_dir, exist_ok=True)
+        state = {
+            "dimensionality": 384,
+            "total_elements_added": len(hnsw_ids),
+            "max_seq_id": None,
+            "id_to_label": {eid: i for i, eid in enumerate(hnsw_ids)},
+            "label_to_id": {i: eid for i, eid in enumerate(hnsw_ids)},
+            "id_to_seq_id": {},
+        }
+        with open(os.path.join(seg_dir, "index_metadata.pickle"), "wb") as f:
+            pickle.dump(state, f, pickle.HIGHEST_PROTOCOL)
+
+
+def _ids(n: int, start: int = 0) -> list[str]:
+    return [f"d-{i}" for i in range(start, start + n)]
+
+
+def _install_mock_backend(mock_backend_cls, collection):
+    mock_backend = MagicMock()
+    mock_backend.get_collection.return_value = collection
+    mock_backend_cls.return_value = mock_backend
+    return mock_backend
+
+
+# ── _hnsw_id_to_label_keys / _hnsw_element_count ──────────────────────
+
+
+def test_hnsw_id_to_label_keys_returns_keys(tmp_path):
+    _seed(str(tmp_path), _ids(5), hnsw_ids=_ids(3))
+    keys = _hnsw_id_to_label_keys(str(tmp_path), VECTOR_SEG)
+    assert keys == {"d-0", "d-1", "d-2"}
+
+
+def test_hnsw_id_to_label_keys_missing_pickle_is_none(tmp_path):
+    _seed(str(tmp_path), _ids(5), hnsw_ids=None)
+    assert _hnsw_id_to_label_keys(str(tmp_path), VECTOR_SEG) is None
+
+
+def test_hnsw_id_to_label_keys_rejects_tampered_pickle(tmp_path):
+    """The allowlist unpickler must reject a GLOBAL opcode → returns None."""
+    seg_dir = tmp_path / VECTOR_SEG
+    seg_dir.mkdir()
+    (seg_dir / "index_metadata.pickle").write_bytes(b"c" + b"os\nsystem\n" + pickle.STOP)
+    assert _hnsw_id_to_label_keys(str(tmp_path), VECTOR_SEG) is None
+
+
+def test_hnsw_element_count_wraps_keys(tmp_path):
+    """Regression: the refactored count is still len(id_to_label)."""
+    _seed(str(tmp_path), _ids(10), hnsw_ids=_ids(7))
+    assert _hnsw_element_count(str(tmp_path), VECTOR_SEG) == 7
+
+
+def test_hnsw_element_count_none_without_pickle(tmp_path):
+    _seed(str(tmp_path), _ids(10), hnsw_ids=None)
+    assert _hnsw_element_count(str(tmp_path), VECTOR_SEG) is None
+
+
+# ── _sqlite_embedding_ids ─────────────────────────────────────────────
+
+
+def test_sqlite_embedding_ids_returns_all(tmp_path):
+    _seed(str(tmp_path), _ids(6), hnsw_ids=_ids(2))
+    assert _sqlite_embedding_ids(str(tmp_path), COLLECTION) == set(_ids(6))
+
+
+def test_sqlite_embedding_ids_none_without_db(tmp_path):
+    # None (not empty set) so an unreadable palace is never mistaken for one
+    # with zero drawers — the difference between "can't read" and "nothing".
+    assert _sqlite_embedding_ids(str(tmp_path), COLLECTION) is None
+
+
+# ── compute_missing_ids ───────────────────────────────────────────────
+
+
+def test_compute_missing_ids_finds_the_gap(tmp_path):
+    _seed(str(tmp_path), _ids(10), hnsw_ids=_ids(7))
+    missing, status = compute_missing_ids(str(tmp_path), COLLECTION)
+    assert missing == {"d-7", "d-8", "d-9"}
+    assert status["sqlite_count"] == 10
+    assert status["hnsw_count"] == 7
+
+
+def test_compute_missing_ids_empty_when_indexed(tmp_path):
+    _seed(str(tmp_path), _ids(5), hnsw_ids=_ids(5))
+    missing, _ = compute_missing_ids(str(tmp_path), COLLECTION)
+    assert missing == set()
+
+
+def test_compute_missing_ids_none_when_pickle_absent(tmp_path):
+    """A never-flushed pickle is "unknown", never "nothing missing"."""
+    _seed(str(tmp_path), _ids(5), hnsw_ids=None)
+    missing, _ = compute_missing_ids(str(tmp_path), COLLECTION)
+    assert missing is None
+
+
+def test_compute_missing_ids_none_when_sqlite_unreadable(tmp_path, monkeypatch):
+    """A sqlite read failure (e.g. sustained lock) must surface as "unknown",
+    never as an empty gap that reconcile would treat as a clean no-op."""
+    _seed(str(tmp_path), _ids(5), hnsw_ids=_ids(3))
+    monkeypatch.setattr(repair, "_sqlite_embedding_ids", lambda *a, **k: None)
+    missing, _ = compute_missing_ids(str(tmp_path), COLLECTION)
+    assert missing is None
+
+
+def test_compute_missing_ids_negative_divergence_is_noop(tmp_path):
+    """HNSW holding more than sqlite yields an empty set — never a delete."""
+    _seed(str(tmp_path), _ids(5), hnsw_ids=_ids(10))
+    missing, status = compute_missing_ids(str(tmp_path), COLLECTION)
+    assert missing == set()
+    assert status["divergence"] == -5
+
+
+# ── extract_via_sqlite(only_ids=...) ──────────────────────────────────
+
+
+def test_extract_only_ids_filters(tmp_path):
+    _seed(str(tmp_path), _ids(6), hnsw_ids=_ids(2))
+    got = dict((eid, (doc, meta)) for eid, doc, meta in extract_via_sqlite(
+        str(tmp_path), COLLECTION, only_ids={"d-2", "d-4"}
+    ))
+    assert set(got) == {"d-2", "d-4"}
+    assert got["d-2"][0] == "doc for d-2"
+    assert got["d-2"][1] == {"wing": "w", "room": "r"}
+
+
+def test_extract_only_ids_empty_yields_nothing(tmp_path):
+    _seed(str(tmp_path), _ids(6), hnsw_ids=_ids(2))
+    assert list(extract_via_sqlite(str(tmp_path), COLLECTION, only_ids=set())) == []
+
+
+def test_extract_only_ids_chunks_over_sqlite_param_limit(tmp_path):
+    """More than _EXTRACT_ID_CHUNK ids must be fetched across chunks, not one
+    oversized IN() that would blow SQLite's host-parameter limit."""
+    n = repair._EXTRACT_ID_CHUNK * 2 + 7  # spans three chunks
+    _seed(str(tmp_path), _ids(n), hnsw_ids=[])
+    want = set(_ids(n))
+    got = {eid for eid, _, _ in extract_via_sqlite(str(tmp_path), COLLECTION, only_ids=want)}
+    assert got == want
+
+
+def test_extract_full_scan_unchanged(tmp_path):
+    """only_ids=None keeps the original whole-segment behavior."""
+    _seed(str(tmp_path), _ids(4), hnsw_ids=_ids(1))
+    got = {eid for eid, _, _ in extract_via_sqlite(str(tmp_path), COLLECTION)}
+    assert got == set(_ids(4))
+
+
+# ── reconcile_index orchestration (mocked backend) ────────────────────
+
+
+# The 2% fraction cap is tuned for large palaces (the real case is 472/292_052
+# = 0.16%). On a tiny test palace any gap is a large fraction, so the happy-path
+# tests lift the fraction cap to isolate the diff→fetch→upsert mechanic; the cap
+# itself has dedicated tests below.
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_closes_gap_upserts_only_missing(mock_backend_cls, tmp_path):
+    _seed(str(tmp_path), _ids(10), hnsw_ids=_ids(7))
+    mock_col = MagicMock()
+    mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
+
+    with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0):
+        result = reconcile_index(str(tmp_path), COLLECTION)
+
+    assert result["missing"] == 3
+    assert result["reconciled"] == 3
+    assert result["fetched"] == 3
+    mock_backend.get_collection.assert_called_once()
+    # Exactly the missing ids were upserted (batched here into one call).
+    upserted = set()
+    for call in mock_col.upsert.call_args_list:
+        upserted.update(call.kwargs["ids"])
+    assert upserted == {"d-7", "d-8", "d-9"}
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_batches_large_gap(mock_backend_cls, tmp_path):
+    _seed(str(tmp_path), _ids(12), hnsw_ids=[])
+    # 12 missing, batch_size 5 → 3 upsert calls (5 + 5 + 2).
+    mock_col = MagicMock()
+    _install_mock_backend(mock_backend_cls, mock_col)
+
+    with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0):
+        result = reconcile_index(str(tmp_path), COLLECTION, batch_size=5)
+
+    assert result["reconciled"] == 12
+    assert mock_col.upsert.call_count == 3
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_no_gap_is_noop(mock_backend_cls, tmp_path):
+    _seed(str(tmp_path), _ids(5), hnsw_ids=_ids(5))
+    result = reconcile_index(str(tmp_path), COLLECTION)
+    assert result["missing"] == 0
+    assert result["reconciled"] == 0
+    mock_backend_cls.assert_not_called()  # never opened the live segment
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_bails_when_pickle_absent(mock_backend_cls, tmp_path):
+    _seed(str(tmp_path), _ids(5), hnsw_ids=None)
+    result = reconcile_index(str(tmp_path), COLLECTION)
+    assert result["reconciled"] == 0
+    mock_backend_cls.assert_not_called()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_cap_trips_on_fraction(mock_backend_cls, tmp_path):
+    # 10 missing of 100 = 10% > 2% fraction cap → refuse before opening.
+    _seed(str(tmp_path), _ids(100), hnsw_ids=_ids(90))
+    with pytest.raises(ReconcileNotSafe) as exc:
+        reconcile_index(str(tmp_path), COLLECTION)
+    assert exc.value.n_missing == 10
+    assert exc.value.sqlite_count == 100
+    mock_backend_cls.assert_not_called()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_cap_trips_on_absolute(mock_backend_cls, tmp_path):
+    _seed(str(tmp_path), _ids(100), hnsw_ids=_ids(90))
+    # Isolate the absolute cap: fraction lifted, absolute lowered to 3 < 10.
+    with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0), patch.object(
+        repair, "RECONCILE_MAX_MISSING", 3
+    ):
+        with pytest.raises(ReconcileNotSafe):
+            reconcile_index(str(tmp_path), COLLECTION)
+    mock_backend_cls.assert_not_called()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_dry_run_makes_no_changes(mock_backend_cls, tmp_path):
+    _seed(str(tmp_path), _ids(10), hnsw_ids=_ids(7))
+    with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0):
+        result = reconcile_index(str(tmp_path), COLLECTION, dry_run=True)
+    assert result["dry_run"] is True
+    assert result["missing"] == 3
+    assert result["reconciled"] == 0
+    mock_backend_cls.assert_not_called()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_propagates_mine_already_running(mock_backend_cls, tmp_path):
+    _seed(str(tmp_path), _ids(10), hnsw_ids=_ids(7))
+    mock_col = MagicMock()
+    mock_col.upsert.side_effect = MineAlreadyRunning(str(tmp_path))
+    _install_mock_backend(mock_backend_cls, mock_col)
+
+    with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0):
+        with pytest.raises(MineAlreadyRunning):
+            reconcile_index(str(tmp_path), COLLECTION)

--- a/tests/test_repair_reconcile.py
+++ b/tests/test_repair_reconcile.py
@@ -275,6 +275,22 @@ def test_extract_only_ids_filters(tmp_path):
     assert got["d-2"][1] == {"wing": "w", "room": "r"}
 
 
+def test_extract_only_ids_preserves_sparse_metadata_rows(tmp_path):
+    _seed(str(tmp_path), ["d-0", "d-1"], hnsw_ids=["d-0"])
+    conn = sqlite3.connect(tmp_path / "chroma.sqlite3")
+    try:
+        row = conn.execute("SELECT id FROM embeddings WHERE embedding_id = ?", ("d-1",)).fetchone()
+        assert row is not None
+        conn.execute("DELETE FROM embedding_metadata WHERE id = ?", (row[0],))
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert list(extract_via_sqlite(str(tmp_path), COLLECTION, only_ids={"d-1"})) == [
+        ("d-1", "", {})
+    ]
+
+
 def test_extract_only_ids_empty_yields_nothing(tmp_path):
     _seed(str(tmp_path), _ids(6), hnsw_ids=_ids(2))
     assert list(extract_via_sqlite(str(tmp_path), COLLECTION, only_ids=set())) == []

--- a/tests/test_repair_reconcile.py
+++ b/tests/test_repair_reconcile.py
@@ -16,10 +16,17 @@ Two layers here:
   rebuild path) while the diff, cap, and fetch logic run for real against the
   synthetic palace. The real end-to-end "divergence closes" proof runs against
   a live palace, not CI.
+* Writer-lease tests hold or probe the real ``mine_palace_lock`` file through
+  an independent file handle (byte-range locks on Windows and BSD ``flock``
+  are per-handle, so a second handle conflicts even from the same process) —
+  proving no concurrent writer can interleave at any phase boundary of the
+  reconcile transaction.
 """
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
 import os
 import pickle
 import sqlite3
@@ -44,6 +51,15 @@ META_SEG = "seg-meta"
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _lock_dir_in_tmp(tmp_path, monkeypatch):
+    """Keep ``mine_palace_lock``'s ``~/.mempalace/locks`` inside the test tmp
+    dir. ``os.path.expanduser("~")`` reads HOME on POSIX but USERPROFILE on
+    Windows — set both (same pattern as ``test_palace_locks.py``)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
 
 def _seed(
@@ -250,9 +266,10 @@ def test_compute_missing_ids_negative_divergence_is_noop(tmp_path):
 
 def test_extract_only_ids_filters(tmp_path):
     _seed(str(tmp_path), _ids(6), hnsw_ids=_ids(2))
-    got = dict((eid, (doc, meta)) for eid, doc, meta in extract_via_sqlite(
-        str(tmp_path), COLLECTION, only_ids={"d-2", "d-4"}
-    ))
+    got = dict(
+        (eid, (doc, meta))
+        for eid, doc, meta in extract_via_sqlite(str(tmp_path), COLLECTION, only_ids={"d-2", "d-4"})
+    )
     assert set(got) == {"d-2", "d-4"}
     assert got["d-2"][0] == "doc for d-2"
     assert got["d-2"][1] == {"wing": "w", "room": "r"}
@@ -355,8 +372,9 @@ def test_reconcile_cap_trips_on_fraction(mock_backend_cls, tmp_path):
 def test_reconcile_cap_trips_on_absolute(mock_backend_cls, tmp_path):
     _seed(str(tmp_path), _ids(100), hnsw_ids=_ids(90))
     # Isolate the absolute cap: fraction lifted, absolute lowered to 3 < 10.
-    with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0), patch.object(
-        repair, "RECONCILE_MAX_MISSING", 3
+    with (
+        patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0),
+        patch.object(repair, "RECONCILE_MAX_MISSING", 3),
     ):
         with pytest.raises(ReconcileNotSafe):
             reconcile_index(str(tmp_path), COLLECTION)
@@ -384,3 +402,243 @@ def test_reconcile_propagates_mine_already_running(mock_backend_cls, tmp_path):
     with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0):
         with pytest.raises(MineAlreadyRunning):
             reconcile_index(str(tmp_path), COLLECTION)
+
+
+# ── writer lease across the reconcile transaction ─────────────────────
+#
+# Reconcile must hold ONE palace writer lease for the complete transaction —
+# integrity preflight, missing-ID diff, sqlite extraction, every upsert batch,
+# and the final verification. Any phase running outside the lease lets a
+# concurrent writer move sqlite/HNSW between phases, so the reconcile set can
+# describe an older generation than the state being modified.
+#
+# The foreign writer is simulated with an INDEPENDENT file handle on the lock
+# file: Windows byte-range locks and POSIX flock are per-handle / per-open-
+# file-description, so a second handle conflicts even from the same process —
+# no subprocess needed.
+
+
+def _palace_lock_path(palace: str) -> str:
+    """Mirror mine_palace_lock's lock-file derivation for the test's palace."""
+    resolved = os.path.realpath(os.path.expanduser(palace))
+    key = hashlib.sha256(os.path.normcase(resolved).encode()).hexdigest()[:16]
+    return os.path.join(os.path.expanduser("~"), ".mempalace", "locks", f"mine_palace_{key}.lock")
+
+
+def _lock_byte0(lf) -> bool:
+    """Try a non-blocking byte-0 lock on handle ``lf``; True when acquired."""
+    lf.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        try:
+            msvcrt.locking(lf.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError:
+            return False
+        return True
+    import fcntl
+
+    try:
+        fcntl.flock(lf, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return False
+    return True
+
+
+def _unlock_byte0(lf) -> None:
+    lf.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(lf.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(lf, fcntl.LOCK_UN)
+
+
+def _open_lock_handle(lock_path):
+    os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+    if not os.path.exists(lock_path):
+        fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
+        os.close(fd)
+    return open(lock_path, "r+b")
+
+
+@contextlib.contextmanager
+def _foreign_writer_holding(lock_path):
+    """Hold the palace lock the way another writer process would."""
+    lf = _open_lock_handle(lock_path)
+    try:
+        assert _lock_byte0(lf), "test setup: foreign writer could not acquire"
+        try:
+            yield
+        finally:
+            _unlock_byte0(lf)
+    finally:
+        lf.close()
+
+
+def _foreign_writer_refused(lock_path) -> bool:
+    """True when a simulated foreign writer CANNOT acquire the palace lock."""
+    if not os.path.exists(lock_path):
+        return False  # no lock file → nothing is holding the palace
+    lf = _open_lock_handle(lock_path)
+    try:
+        if _lock_byte0(lf):
+            _unlock_byte0(lf)
+            return False
+        return True
+    finally:
+        lf.close()
+
+
+def _spy_phases(monkeypatch, lock_path, seen):
+    """Wrap each reconcile phase with a pass-through spy recording — at the
+    moment the phase runs — whether a foreign writer is refused the lock."""
+    real_integrity = repair.sqlite_integrity_errors
+
+    def spy_integrity(*a, **k):
+        seen.append(("preflight", _foreign_writer_refused(lock_path)))
+        return real_integrity(*a, **k)
+
+    monkeypatch.setattr(repair, "sqlite_integrity_errors", spy_integrity)
+
+    real_diff = repair.compute_missing_ids
+
+    def spy_diff(*a, **k):
+        seen.append(("diff", _foreign_writer_refused(lock_path)))
+        return real_diff(*a, **k)
+
+    monkeypatch.setattr(repair, "compute_missing_ids", spy_diff)
+
+    real_extract = repair.extract_via_sqlite
+
+    def spy_extract(*a, **k):
+        seen.append(("extract", _foreign_writer_refused(lock_path)))
+        yield from real_extract(*a, **k)
+
+    monkeypatch.setattr(repair, "extract_via_sqlite", spy_extract)
+
+    real_verify = repair.hnsw_capacity_status
+
+    def spy_verify(*a, **k):
+        # Fires twice: once nested inside compute_missing_ids (which calls
+        # hnsw_capacity_status as part of the diff) and once as the real
+        # post-upsert verification. Both must run under the lease, so the
+        # extra checkpoint only adds proof-points.
+        seen.append(("verify", _foreign_writer_refused(lock_path)))
+        return real_verify(*a, **k)
+
+    monkeypatch.setattr(repair, "hnsw_capacity_status", spy_verify)
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_holds_one_writer_lease_across_all_phases(
+    mock_backend_cls, tmp_path, monkeypatch
+):
+    """Interleaving-writer regression: at EVERY phase boundary a concurrent
+    writer must be refused the palace lock, and the lease must be free again
+    once the transaction is over."""
+    _seed(str(tmp_path), _ids(10), hnsw_ids=_ids(7))
+    lock_path = _palace_lock_path(str(tmp_path))
+    seen: list = []
+    _spy_phases(monkeypatch, lock_path, seen)
+
+    mock_col = MagicMock()
+    mock_col.upsert.side_effect = lambda **kw: seen.append(
+        ("upsert", _foreign_writer_refused(lock_path))
+    )
+    _install_mock_backend(mock_backend_cls, mock_col)
+
+    with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0):
+        result = reconcile_index(str(tmp_path), COLLECTION)
+
+    assert result["reconciled"] == 3
+    assert {p for p, _ in seen} >= {"preflight", "diff", "extract", "upsert", "verify"}
+    assert all(refused for _, refused in seen), f"writer interleaved at: {seen}"
+    # Transaction over → the lease is released, a writer may acquire again.
+    assert not _foreign_writer_refused(lock_path)
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_nested_real_write_lock_reenters_under_the_lease(mock_backend_cls, tmp_path):
+    """Exercise the REAL ``ChromaCollection._write_lock`` → ``mine_palace_lock``
+    nesting under reconcile's outer lease: the nested acquisition must pass
+    through re-entrantly (no self-deadlock, no ``MineAlreadyRunning``) while a
+    foreign writer stays refused for the duration of the upsert. Only the
+    innermost chromadb collection is mocked — the adapter's locking runs."""
+    from mempalace.backends.chroma import ChromaCollection
+
+    _seed(str(tmp_path), _ids(10), hnsw_ids=_ids(7))
+    lock_path = _palace_lock_path(str(tmp_path))
+    seen: list = []
+
+    inner = MagicMock()  # the raw chromadb collection beneath the adapter
+    inner.upsert.side_effect = lambda **kw: seen.append(
+        ("nested-upsert", _foreign_writer_refused(lock_path))
+    )
+    real_col = ChromaCollection(inner, palace_path=str(tmp_path))
+    _install_mock_backend(mock_backend_cls, real_col)
+
+    with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0):
+        result = reconcile_index(str(tmp_path), COLLECTION)
+
+    assert result["reconciled"] == 3
+    assert seen == [("nested-upsert", True)]
+    assert not _foreign_writer_refused(lock_path)
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_dry_run_diff_runs_under_the_lease(mock_backend_cls, tmp_path, monkeypatch):
+    """The dry-run report must come from a lease-consistent snapshot too."""
+    _seed(str(tmp_path), _ids(10), hnsw_ids=_ids(7))
+    lock_path = _palace_lock_path(str(tmp_path))
+    seen: list = []
+    _spy_phases(monkeypatch, lock_path, seen)
+
+    with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0):
+        result = reconcile_index(str(tmp_path), COLLECTION, dry_run=True)
+
+    assert result["dry_run"] is True
+    assert ("diff", True) in seen
+    assert not _foreign_writer_refused(lock_path)
+    mock_backend_cls.assert_not_called()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_refuses_at_entry_when_a_writer_holds_the_palace(
+    mock_backend_cls, tmp_path, monkeypatch
+):
+    """With a foreign writer holding the palace, reconcile must refuse BEFORE
+    the preflight — no phase may read a palace another writer is moving."""
+    _seed(str(tmp_path), _ids(10), hnsw_ids=_ids(7))
+    called: list = []
+    monkeypatch.setattr(
+        repair, "sqlite_integrity_errors", lambda *a, **k: called.append("preflight") or []
+    )
+
+    with _foreign_writer_holding(_palace_lock_path(str(tmp_path))):
+        with pytest.raises(MineAlreadyRunning):
+            reconcile_index(str(tmp_path), COLLECTION)
+
+    assert called == []
+    mock_backend_cls.assert_not_called()
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_reconcile_releases_lease_when_a_phase_raises(mock_backend_cls, tmp_path):
+    """A failing phase must not strand the palace lease."""
+    _seed(str(tmp_path), _ids(10), hnsw_ids=_ids(7))
+    mock_col = MagicMock()
+    mock_col.upsert.side_effect = RuntimeError("upsert exploded")
+    _install_mock_backend(mock_backend_cls, mock_col)
+
+    with patch.object(repair, "RECONCILE_MAX_MISSING_FRACTION", 1.0):
+        with pytest.raises(RuntimeError):
+            reconcile_index(str(tmp_path), COLLECTION)
+
+    lock_path = _palace_lock_path(str(tmp_path))
+    # Non-vacuous: the lease WAS taken (lock file exists) and is free again.
+    assert os.path.exists(lock_path)
+    assert not _foreign_writer_refused(lock_path)


### PR DESCRIPTION
## What

Adds `mempalace repair --mode reconcile`: a surgical alternative to a full `--mode from-sqlite` rebuild for the common **small flush-lag divergence** — the case where the HNSW metadata pickle lags `chroma.sqlite3` by a few hundred drawers (a crash-truncated pickle, or the un-flushed tail after a killed mine), so `hnsw_capacity_status` disables vector search even though the index binary is otherwise sound.

Instead of re-embedding the whole palace (`from-sqlite` re-embeds all N drawers — minutes on a large palace), reconcile diffs the sqlite embedding IDs against the HNSW `id_to_label` keys and re-upserts **only** the missing drawers through the same locked `ChromaCollection.upsert` primitive the live MCP write path uses.

## How

- **`backends/chroma.py`** — new `_hnsw_id_to_label_keys(palace, seg_id) -> set[str]` exposes the indexed-ID set from `index_metadata.pickle` (via the existing allowlist unpickler); `_hnsw_element_count()` becomes a thin wrapper over it (behaviour + existing tests unchanged).
- **`repair.py`**
  - `_sqlite_embedding_ids()` — the IDs that *should* be indexed (collection-scoped, no `embedding_metadata` join so 0-metadata drawers aren't dropped). Returns `None` (not an empty set) on a missing DB or a sqlite lock/error, with a `busy_timeout`, so a held mine can never masquerade as "nothing missing".
  - `compute_missing_ids()` = `sqlite_ids − hnsw_id_to_label_keys`.
  - `reconcile_index()` — preflight `sqlite_integrity`, compute the gap, fetch just those rows (`extract_via_sqlite(only_ids=...)`, chunked `IN`), upsert in batches, re-probe, and report honestly whether the pickle re-flushed (never claims a closed divergence on a legacy palace whose large `hnsw:sync_threshold` hasn't triggered a persist).
  - `ReconcileNotSafe` + caps (**5000 absolute / 2% relative**): refuse a large gap **before** `get_collection` opens the live segment, and point at `from-sqlite`. Reconcile opens the live vector segment (unlike from-sqlite, which reads sqlite directly), so a #1222-scale gap must not be handed to a native resize on open.
  - `extract_via_sqlite()` gains an optional chunked `only_ids` path (the full-scan path is byte-for-byte unchanged).
- **`cli.py`** — `repair --mode reconcile [--dry-run]` dispatch.

## Safety / scope

- Non-destructive: additive upsert only, never delete-and-recreate; `chroma.sqlite3` is untouched as the source of truth. Propagates `MineAlreadyRunning` (clean retry) rather than racing a mine on the HNSW segment.
- **Reconcile is for a flush-lag gap.** A genuinely corrupt / undersized HNSW (the #1222 / #1308 class, where `count`/`upsert` fault natively) can still crash on open even at a *small* divergence that clears the caps — an uncatchable native access violation the size caps cannot predict. That is a `from-sqlite --archive-existing` case (reads sqlite, never opens the failing segment), and the docstring says so. Found empirically against a real ~292k palace whose 0.16% divergence hid exactly this: `--dry-run` detected the gap cleanly, but the live segment access-violated on `count()`.

## Tests

24 new tests in `tests/test_repair_reconcile.py`:

- **unit** (synthetic sqlite + pickle, no chromadb open): `_hnsw_id_to_label_keys` (keys / missing / tampered-pickle), `_sqlite_embedding_ids`, `compute_missing_ids` (gap / no-gap / None-on-absent-pickle / None-on-unreadable-sqlite / negative-divergence), `extract_via_sqlite` only_ids (filter / chunk-over-limit / empty / full-scan-unchanged).
- **orchestration** (mocked backend): gap → upserts exactly the missing ids; batching; no-op; bails when pickle absent; cap trips (absolute + fraction, before opening); dry-run; `MineAlreadyRunning` propagates.

`test_hnsw_capacity.py` + `test_repair.py` (126) still green after the `_hnsw_element_count` refactor; `test_cli.py -k repair` (19) green; ruff clean.

## Validation at scale

`repair --mode reconcile --dry-run` on a 292,052-drawer palace detected the exact **472-drawer gap (0.16%)**, and the fraction cap correctly did **not** trip.
