### PR TITLE
feat(cli): apply shared daemon write-routing policy

### DIFF
--- a/docs/cli-write-routing.md
+++ b/docs/cli-write-routing.md
@@ -1,0 +1,107 @@
+# CLI write routing
+
+Routine CLI writes consume the shared routing policy introduced for the Tier 3
+rollout tracked in #1963.
+
+## Routed commands
+
+The policy applies to:
+
+- `mempalace mine`;
+- `mempalace sweep`;
+- `mempalace sync`;
+- the optional post-setup mine run by `mempalace init`.
+
+## Policies
+
+### `direct`
+
+Use the existing direct in-process execution path.
+
+### `prefer`
+
+Submit through the local daemon. Interactive CLI commands are allowed to start
+the daemon when it is not already running.
+
+### `require`
+
+Submit through the local daemon. Interactive CLI commands are allowed to start
+the daemon when it is not already running.
+
+For CLI commands, `prefer` and `require` both select the daemon because daemon
+startup is permitted. Their difference remains meaningful to hook callers,
+which cannot cold-start the daemon.
+
+## Explicit flags
+
+Force daemon execution:
+
+    mempalace mine ./project --daemon
+
+Force direct execution:
+
+    mempalace mine ./project --direct
+
+The flags are mutually exclusive and override environment/config policy.
+
+Background execution:
+
+    mempalace mine ./project --background
+
+`--background` is valid when the selected route is the daemon. A direct route
+with `--background` exits with a configuration error.
+
+## Configuration
+
+Use the daemon for routine CLI writes:
+
+    MEMPALACE_CLI_WRITE_ROUTING=prefer
+
+Prohibit an accidental direct route:
+
+    MEMPALACE_CLI_WRITE_ROUTING=require
+
+Retain direct behavior:
+
+    MEMPALACE_CLI_WRITE_ROUTING=direct
+
+Config file:
+
+    {
+      "write_routing": {
+        "cli": "require"
+      }
+    }
+
+## Defaults and rollout
+
+The default remains `direct` in this PR.
+
+This means existing users receive no silent execution-topology change. A
+supervised Tier 3 deployment enables `prefer` or `require` explicitly. The
+production default can be changed later after the stacked rollout is reviewed.
+
+## Safety properties
+
+- Daemon submission errors never trigger direct fallback.
+- A failed or ambiguous submission may already have created a durable job;
+  retrying directly could duplicate content.
+- Post-init mining forwards the already-scanned file list into the daemon, so
+  the project is not scanned twice.
+- `sweep` is now a first-class daemon job.
+- `--direct` remains an explicit emergency/debug escape hatch.
+- No low-level lock behavior is changed.
+
+## Maintenance exclusions
+
+These remain outside ordinary routing:
+
+- repair;
+- migration and wing migration;
+- index rebuild;
+- closet compression;
+- embedder identity changes.
+
+They can replace indexes, rewrite broad metadata sets, or require all cached
+handles to close. They need an exclusive-maintenance protocol rather than an
+ordinary queued-write job.

--- a/docs/write-routing-policy.md
+++ b/docs/write-routing-policy.md
@@ -147,10 +147,11 @@ operations offline, with no writable service running.
 
 ## Follow-up PRs
 
-Hook-triggered writes now consume this policy; see
+Hook-triggered writes consume this policy; see
 `docs/hook-write-routing.md`.
 
-The remaining rollout PR will apply the policy to routine CLI writes.
+Routine CLI writes also consume this policy; see
+`docs/cli-write-routing.md`.
 
 Maintenance operations such as repair, migration, and index rebuild are not
 ordinary routed writes. They require a separate exclusive-maintenance policy.

--- a/mempalace/cli/__init__.py
+++ b/mempalace/cli/__init__.py
@@ -48,6 +48,11 @@ import warnings
 from pathlib import Path
 
 from ..config import MempalaceConfig
+from ..cli_write_routing import (
+    add_cli_write_routing_flags,
+    resolve_cli_write_routing,
+)
+from ..write_routing import WriteRoutingError
 from ..corpus_origin import detect_origin_heuristic, detect_origin_llm
 from ..llm_client import LLMError, get_provider
 from ..version import __version__

--- a/mempalace/cli/_common.py
+++ b/mempalace/cli/_common.py
@@ -41,6 +41,21 @@ def _maintenance_requires_chroma(palace_path: str, command_name: str) -> bool:
     return False
 
 
+def _resolve_cli_write_routing_or_exit(args, operation: str):
+    """Resolve routine CLI routing and render configuration errors."""
+    try:
+        return resolve_cli_write_routing(
+            args,
+            operation=operation,
+        )
+    except WriteRoutingError as exc:
+        print(
+            f"mempalace: invalid CLI write routing: {exc}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from exc
+
+
 def _gather_origin_samples(project_dir) -> list:
     """Collect Tier-1 samples for corpus-origin detection.
 

--- a/mempalace/cli/cmd_init.py
+++ b/mempalace/cli/cmd_init.py
@@ -278,6 +278,37 @@ def _maybe_run_mine_after_init(args, cfg) -> None:
             return
 
     palace_path = cfg.palace_path
+    routing = _resolve_cli_write_routing_or_exit(
+        args,
+        "init auto-mine",
+    )
+    if routing.use_daemon:
+        payload = {
+            "source": os.path.abspath(os.path.expanduser(project_dir)),
+            "mode": "projects",
+            "wing": None,
+            "agent": "mempalace",
+            "limit": 0,
+            "dry_run": False,
+            "extract": "exchange",
+            "no_gitignore": False,
+            "include_ignored": [],
+            "max_chunks_per_file": None,
+            "redetect_origin": False,
+            "files": (
+                [str(file_path) for file_path in scanned_files]
+                if scanned_files is not None
+                else None
+            ),
+        }
+        _submit_daemon_cli_job(
+            "mine",
+            payload,
+            args,
+            background=False,
+            auto_start=routing.decision.auto_start_daemon,
+        )
+        return
     try:
         mine(
             project_dir=project_dir,

--- a/mempalace/cli/cmd_mine.py
+++ b/mempalace/cli/cmd_mine.py
@@ -11,27 +11,42 @@ def cmd_mine(args):
     for raw in args.include_ignored or []:
         include_ignored.extend(part.strip() for part in raw.split(",") if part.strip())
 
-    if getattr(args, "background", False) and not getattr(args, "daemon", False):
-        print("mempalace: --background requires --daemon", file=sys.stderr)
-        sys.exit(2)
+    payload = {
+        "source": os.path.abspath(os.path.expanduser(args.dir)),
+        "mode": mode,
+        "wing": args.wing,
+        "agent": args.agent,
+        "limit": args.limit,
+        "dry_run": args.dry_run,
+        "extract": args.extract,
+        "no_gitignore": args.no_gitignore,
+        "include_ignored": include_ignored,
+        "max_chunks_per_file": getattr(
+            args,
+            "max_chunks_per_file",
+            None,
+        ),
+        "redetect_origin": getattr(
+            args,
+            "redetect_origin",
+            False,
+        ),
+    }
+    if source_adapter:
+        payload["source_adapter"] = source_adapter
 
-    if getattr(args, "daemon", False):
-        payload = {
-            "source": os.path.abspath(os.path.expanduser(args.dir)),
-            "mode": mode,
-            "wing": args.wing,
-            "agent": args.agent,
-            "limit": args.limit,
-            "dry_run": args.dry_run,
-            "extract": args.extract,
-            "no_gitignore": args.no_gitignore,
-            "include_ignored": include_ignored,
-            "max_chunks_per_file": getattr(args, "max_chunks_per_file", None),
-            "redetect_origin": getattr(args, "redetect_origin", False),
-        }
-        if source_adapter:
-            payload["source_adapter"] = source_adapter
-        _submit_daemon_cli_job("mine", payload, args, background=getattr(args, "background", False))
+    routing = _resolve_cli_write_routing_or_exit(
+        args,
+        "mine",
+    )
+    if routing.use_daemon:
+        _submit_daemon_cli_job(
+            "mine",
+            payload,
+            args,
+            background=bool(getattr(args, "background", False)),
+            auto_start=routing.decision.auto_start_daemon,
+        )
         return
 
     from ..palace import MineAlreadyRunning, MineValidationError
@@ -316,6 +331,19 @@ def cmd_sweep(args):
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     target = os.path.expanduser(args.target)
 
+    routing = _resolve_cli_write_routing_or_exit(
+        args,
+        "sweep",
+    )
+    if routing.use_daemon:
+        _submit_daemon_cli_job(
+            "sweep",
+            {"target": target},
+            args,
+            background=bool(getattr(args, "background", False)),
+            auto_start=routing.decision.auto_start_daemon,
+        )
+        return
     if os.path.isfile(target):
         result = sweep(target, palace_path)
         print(

--- a/mempalace/cli/cmd_sync.py
+++ b/mempalace/cli/cmd_sync.py
@@ -7,20 +7,25 @@ def cmd_sync(args):
     """Prune drawers whose source files are gitignored, deleted, or moved (#1252)."""
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
 
-    if getattr(args, "background", False) and not getattr(args, "daemon", False):
-        print("mempalace: --background requires --daemon", file=sys.stderr)
-        sys.exit(2)
-
-    if getattr(args, "daemon", False):
-        payload = {
-            "dir": args.dir,
-            "root": list(args.root or []),
-            "wing": args.wing,
-            "dry_run": args.dry_run,
-        }
-        _submit_daemon_cli_job("sync", payload, args, background=getattr(args, "background", False))
+    payload = {
+        "dir": args.dir,
+        "root": list(args.root or []),
+        "wing": args.wing,
+        "dry_run": args.dry_run,
+    }
+    routing = _resolve_cli_write_routing_or_exit(
+        args,
+        "sync",
+    )
+    if routing.use_daemon:
+        _submit_daemon_cli_job(
+            "sync",
+            payload,
+            args,
+            background=bool(getattr(args, "background", False)),
+            auto_start=routing.decision.auto_start_daemon,
+        )
         return
-
     from ..palace import MineAlreadyRunning
     from ..wal import _wal_log
     from ..backends import detect_backend_for_path
@@ -121,7 +126,14 @@ def cmd_sync(args):
     print(f"\n{'=' * 55}\n")
 
 
-def _submit_daemon_cli_job(kind: str, payload: dict, args, *, background: bool) -> None:
+def _submit_daemon_cli_job(
+    kind: str,
+    payload: dict,
+    args,
+    *,
+    background: bool,
+    auto_start: bool = True,
+) -> None:
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     backend = _backend_arg(args)
     from ..daemon import DaemonError, submit_job
@@ -133,7 +145,7 @@ def _submit_daemon_cli_job(kind: str, payload: dict, args, *, background: bool) 
             palace_path=palace_path,
             backend=backend,
             wait=not background,
-            auto_start=True,
+            auto_start=auto_start,
             # A job refused the palace lock is deferred, not failed (#2014), so
             # it never becomes terminal while the holder lives. Waiting it out
             # would strand this terminal behind a peer that can outlive the

--- a/mempalace/cli/parser.py
+++ b/mempalace/cli/parser.py
@@ -151,6 +151,11 @@ def main():
     )
 
     # mine
+    add_cli_write_routing_flags(
+        p_init,
+        allow_background=False,
+    )
+
     p_mine = sub.add_parser("mine", help="Mine files into the palace")
     p_mine.add_argument(
         "dir", help="Directory to mine, or one conversation file with --mode convos"
@@ -212,16 +217,7 @@ def main():
     p_mine.add_argument(
         "--dry-run", action="store_true", help="Show what would be filed without filing"
     )
-    p_mine.add_argument(
-        "--daemon",
-        action="store_true",
-        help="Submit this mine to the opt-in local daemon queue",
-    )
-    p_mine.add_argument(
-        "--background",
-        action="store_true",
-        help="With --daemon, return a job id immediately instead of waiting",
-    )
+    add_cli_write_routing_flags(p_mine)
     p_mine.add_argument(
         "--extract",
         choices=["exchange", "general"],
@@ -265,6 +261,7 @@ def main():
     )
 
     # sync
+    add_cli_write_routing_flags(p_sweep)
     p_sync = sub.add_parser(
         "sync",
         help="Prune drawers whose source files are gitignored, deleted, or moved (#1252)",
@@ -295,18 +292,9 @@ def main():
         action="store_false",
         help="Actually delete drawers (overrides --dry-run; requires --wing or a project root)",
     )
-    p_sync.add_argument(
-        "--daemon",
-        action="store_true",
-        help="Submit this sync to the opt-in local daemon queue",
-    )
-    p_sync.add_argument(
-        "--background",
-        action="store_true",
-        help="With --daemon, return a job id immediately instead of waiting",
-    )
 
     # search
+    add_cli_write_routing_flags(p_sync)
     p_search = sub.add_parser("search", help="Find anything, exact words")
     p_search.add_argument("query", help="What to search for")
     p_search.add_argument(

--- a/mempalace/cli_write_routing.py
+++ b/mempalace/cli_write_routing.py
@@ -1,0 +1,144 @@
+"""CLI adapter for the shared daemon write-routing policy.
+
+This module keeps parser flags, configuration precedence, and route selection
+out of the large CLI module. It applies only to routine CLI writes.
+
+Maintenance operations such as repair, migration, index rebuild, closet
+compression, and embedder-identity changes deliberately remain outside this
+policy until an exclusive-maintenance protocol exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+from .config import MempalaceConfig
+from .write_routing import (
+    ResolvedWriteRoutingPolicy,
+    WriteRoutingDecision,
+    WriteRoutingError,
+    WriteRoutingPolicy,
+    choose_write_route,
+)
+
+
+@dataclass(frozen=True)
+class CliWriteRouting:
+    """Resolved route for one routine CLI write."""
+
+    decision: WriteRoutingDecision
+    source: str
+    explicit: bool
+
+    @property
+    def use_daemon(self) -> bool:
+        return self.decision.use_daemon
+
+    @property
+    def use_direct(self) -> bool:
+        return not self.decision.use_daemon and not self.decision.blocked
+
+
+def add_cli_write_routing_flags(
+    parser: argparse.ArgumentParser,
+    *,
+    allow_background: bool = True,
+) -> None:
+    """Add consistent routing flags to a routine write command."""
+
+    routing = parser.add_mutually_exclusive_group()
+    routing.add_argument(
+        "--daemon",
+        action="store_true",
+        help=(
+            "Force this operation through the local daemon, overriding "
+            "the configured CLI write-routing policy"
+        ),
+    )
+    routing.add_argument(
+        "--direct",
+        action="store_true",
+        help=(
+            "Force the legacy direct execution path, overriding "
+            "the configured CLI write-routing policy"
+        ),
+    )
+
+    if allow_background:
+        parser.add_argument(
+            "--background",
+            action="store_true",
+            help=(
+                "Return a daemon job id immediately instead of waiting; "
+                "requires a daemon-selected route"
+            ),
+        )
+
+
+def resolve_cli_write_routing(
+    args,
+    *,
+    operation: str,
+) -> CliWriteRouting:
+    """Resolve an explicit flag or the configured CLI policy.
+
+    Interactive CLI commands are allowed to start the daemon. Therefore both
+    ``prefer`` and ``require`` select the daemon when no explicit ``--direct``
+    override is present.
+
+    The daemon submission function is responsible for starting or reusing the
+    daemon atomically. We intentionally do not perform a separate health probe,
+    which would introduce a check-then-submit race.
+    """
+
+    force_daemon = bool(getattr(args, "daemon", False))
+    force_direct = bool(getattr(args, "direct", False))
+    background = bool(getattr(args, "background", False))
+
+    if force_daemon and force_direct:
+        raise WriteRoutingError(f"{operation}: --daemon and --direct are mutually exclusive")
+
+    if force_daemon:
+        resolved = ResolvedWriteRoutingPolicy(
+            policy=WriteRoutingPolicy.REQUIRE,
+            source="--daemon",
+        )
+        explicit = True
+    elif force_direct:
+        resolved = ResolvedWriteRoutingPolicy(
+            policy=WriteRoutingPolicy.DIRECT,
+            source="--direct",
+        )
+        explicit = True
+    else:
+        resolved = MempalaceConfig().resolve_write_routing("cli")
+        explicit = False
+
+    decision = choose_write_route(
+        resolved.policy,
+        daemon_available=False,
+        daemon_can_start=True,
+    )
+
+    if background and not decision.use_daemon:
+        raise WriteRoutingError(
+            f"{operation}: --background requires --daemon under direct routing; "
+            "--background requires a daemon route selected by --daemon "
+            "or a prefer/require policy"
+        )
+
+    if decision.blocked:
+        # This should be unreachable for interactive CLI commands because they
+        # are allowed to auto-start the daemon. Keep the guard explicit so a
+        # future policy change can never degrade to direct execution.
+        raise WriteRoutingError(
+            f"{operation}: the configured policy requires the daemon, "
+            "but no daemon route is available"
+        )
+
+    return CliWriteRouting(
+        decision=decision,
+        source=resolved.source,
+        explicit=explicit,
+    )

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -140,6 +140,8 @@ def execute_job(kind: str, payload: dict[str, Any]) -> dict[str, Any]:
             return run_mine(payload)
         if kind == "sync":
             return run_sync(payload)
+        if kind == "sweep":
+            return run_sweep(payload)
         if kind == "diary_write":
             return run_diary_write(payload)
         if kind == "mcp_tool":
@@ -187,6 +189,73 @@ def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
     agent = payload.get("agent") or "mempalace"
     limit = int(payload.get("limit") or 0)
     dry_run = bool(payload.get("dry_run"))
+
+    raw_files = payload.get("files")
+    files = None
+
+    if raw_files is not None:
+        if source_adapter:
+            return {
+                "success": False,
+                "error": ("mine files payload cannot be combined with a source adapter"),
+                "exit_code": 2,
+            }
+
+        if mode != "projects":
+            return {
+                "success": False,
+                "error": "mine files payload is supported only in projects mode",
+                "exit_code": 2,
+            }
+
+        if not isinstance(raw_files, list):
+            return {
+                "success": False,
+                "error": "mine files payload must be a list",
+                "exit_code": 2,
+            }
+
+        if not isinstance(source, str) or not source.strip():
+            return {
+                "success": False,
+                "error": "mine source is required when files are provided",
+                "exit_code": 2,
+            }
+
+        from pathlib import Path
+
+        project_root = Path(source).expanduser().resolve(strict=False)
+        files = []
+
+        for index, raw_file in enumerate(raw_files):
+            if not isinstance(raw_file, str) or not raw_file.strip():
+                return {
+                    "success": False,
+                    "error": (
+                        "mine files payload entries must be non-empty strings; "
+                        f"invalid entry at index {index}"
+                    ),
+                    "exit_code": 2,
+                }
+
+            candidate = Path(raw_file).expanduser()
+            if not candidate.is_absolute():
+                candidate = project_root / candidate
+
+            resolved_file = candidate.resolve(strict=False)
+
+            try:
+                resolved_file.relative_to(project_root)
+            except ValueError:
+                return {
+                    "success": False,
+                    "error": (
+                        f"mine files payload contains a path outside the project root: {raw_file}"
+                    ),
+                    "exit_code": 2,
+                }
+
+            files.append(resolved_file)
 
     if payload.get("redetect_origin") and not source_adapter:
         from .cli import _run_pass_zero
@@ -243,6 +312,7 @@ def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
                 respect_gitignore=not bool(payload.get("no_gitignore")),
                 include_ignored=include_ignored,
                 max_chunks_per_file=payload.get("max_chunks_per_file"),
+                files=files,
             )
         else:
             return {"success": False, "error": f"invalid mine mode: {mode}", "exit_code": 2}
@@ -277,6 +347,91 @@ def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
         "kind": "mine",
         "mode": result_mode,
         "dry_run": dry_run,
+        "exit_code": 0,
+    }
+
+
+@_restores_palace_env
+def run_sweep(payload: dict[str, Any]) -> dict[str, Any]:
+    """Run transcript sweep through the daemon worker."""
+
+    palace_path = os.path.abspath(
+        os.path.expanduser(payload.get("palace_path") or MempalaceConfig().palace_path)
+    )
+    os.environ["MEMPALACE_PALACE_PATH"] = palace_path
+    _apply_backend(payload.get("backend"))
+
+    target_raw = payload.get("target")
+    if not isinstance(target_raw, str) or not target_raw.strip():
+        return {
+            "success": False,
+            "error": "sweep target must be a non-empty path",
+            "exit_code": 2,
+        }
+
+    target = os.path.abspath(os.path.expanduser(target_raw))
+
+    from .daemon import LOCK_REFUSAL_ERROR_CLASS
+    from .palace import MineAlreadyRunning
+    from .sweeper import sweep, sweep_directory
+
+    try:
+        if os.path.isfile(target):
+            result = sweep(target, palace_path)
+            print(
+                f" Swept {target}: +{result['drawers_added']} new, "
+                f"{result['drawers_already_present']} already present, "
+                f"{result['drawers_skipped']} skipped (< cursor)."
+            )
+        elif os.path.isdir(target):
+            result = sweep_directory(target, palace_path)
+            print(
+                f" Swept {result['files_succeeded']}/"
+                f"{result['files_attempted']} files from {target}: "
+                f"+{result['drawers_added']} new, "
+                f"{result['drawers_already_present']} already present, "
+                f"{result['drawers_skipped']} skipped (< cursor)."
+            )
+        else:
+            return {
+                "success": False,
+                "error": f"Not a file or directory: {target}",
+                "exit_code": 1,
+            }
+    except MineAlreadyRunning as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_class": LOCK_REFUSAL_ERROR_CLASS,
+            "exit_code": 1,
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": f"sweep failed: {exc}",
+            "exit_code": 1,
+        }
+
+    failures = result.get("failures") or []
+    if failures:
+        print(
+            f" WARNING: {len(failures)} file(s) failed to sweep - see stderr / logs for details.",
+            file=sys.stderr,
+        )
+        return {
+            "success": False,
+            "kind": "sweep",
+            "target": target,
+            "result": result,
+            "error": f"{len(failures)} file(s) failed to sweep",
+            "exit_code": 2,
+        }
+
+    return {
+        "success": True,
+        "kind": "sweep",
+        "target": target,
+        "result": result,
         "exit_code": 0,
     }
 

--- a/tests/test_cli_write_routing.py
+++ b/tests/test_cli_write_routing.py
@@ -1,0 +1,635 @@
+from __future__ import annotations
+
+import argparse
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from mempalace import cli, service
+from mempalace.cli_write_routing import (
+    CliWriteRouting,
+    add_cli_write_routing_flags,
+    resolve_cli_write_routing,
+)
+from mempalace.write_routing import (
+    ResolvedWriteRoutingPolicy,
+    WriteRoutingError,
+    WriteRoutingPolicy,
+    WriteRoutingTarget,
+    choose_write_route,
+)
+
+
+_SERVICE_ENV_KEYS = (
+    "MEMPALACE_PALACE_PATH",
+    "MEMPAL_PALACE_PATH",
+    "MEMPALACE_BACKEND",
+    "MEMPALACE_BACKEND_EXPLICIT",
+)
+
+# Capture the real pre-suite values once. Direct service helpers mutate these
+# process-global variables, whereas production daemon jobs normally run through
+# execute_job(), which snapshots and restores them.
+_SERVICE_ENV_SNAPSHOT = {key: os.environ.get(key) for key in _SERVICE_ENV_KEYS}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_service_environment():
+    """Restore service process globals before and after every focused test."""
+
+    for key, value in _SERVICE_ENV_SNAPSHOT.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+    yield
+
+    for key, value in _SERVICE_ENV_SNAPSHOT.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+class _RoutingConfig:
+    def __init__(
+        self,
+        policy: WriteRoutingPolicy,
+        *,
+        source: str = "test",
+        palace_path: str = "/tmp/palace",
+    ):
+        self._policy = policy
+        self._source = source
+        self.palace_path = palace_path
+
+    def resolve_write_routing(
+        self,
+        scope: str,
+    ) -> ResolvedWriteRoutingPolicy:
+        assert scope == "cli"
+        return ResolvedWriteRoutingPolicy(
+            policy=self._policy,
+            source=self._source,
+        )
+
+
+def _args(**overrides):
+    values = {
+        "palace": None,
+        "backend": None,
+        "global_backend": None,
+        "daemon": False,
+        "direct": False,
+        "background": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _route(
+    policy: WriteRoutingPolicy,
+    *,
+    source: str = "test",
+) -> CliWriteRouting:
+    decision = choose_write_route(
+        policy,
+        daemon_available=False,
+        daemon_can_start=True,
+    )
+    return CliWriteRouting(
+        decision=decision,
+        source=source,
+        explicit=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        WriteRoutingPolicy.PREFER,
+        WriteRoutingPolicy.REQUIRE,
+    ],
+)
+def test_cli_prefer_and_require_select_startable_daemon(
+    policy,
+):
+    with patch(
+        "mempalace.cli_write_routing.MempalaceConfig",
+        return_value=_RoutingConfig(policy),
+    ):
+        routing = resolve_cli_write_routing(
+            _args(),
+            operation="mine",
+        )
+
+    assert routing.use_daemon is True
+    assert routing.decision.target is WriteRoutingTarget.DAEMON
+    assert routing.decision.auto_start_daemon is True
+
+
+def test_cli_direct_policy_selects_direct():
+    with patch(
+        "mempalace.cli_write_routing.MempalaceConfig",
+        return_value=_RoutingConfig(WriteRoutingPolicy.DIRECT),
+    ):
+        routing = resolve_cli_write_routing(
+            _args(),
+            operation="mine",
+        )
+
+    assert routing.use_direct is True
+    assert routing.use_daemon is False
+
+
+def test_explicit_direct_overrides_require_policy():
+    with patch(
+        "mempalace.cli_write_routing.MempalaceConfig",
+    ) as config:
+        routing = resolve_cli_write_routing(
+            _args(direct=True),
+            operation="mine",
+        )
+
+    config.assert_not_called()
+    assert routing.use_direct is True
+    assert routing.source == "--direct"
+    assert routing.explicit is True
+
+
+def test_explicit_daemon_overrides_direct_policy():
+    with patch(
+        "mempalace.cli_write_routing.MempalaceConfig",
+    ) as config:
+        routing = resolve_cli_write_routing(
+            _args(daemon=True),
+            operation="mine",
+        )
+
+    config.assert_not_called()
+    assert routing.use_daemon is True
+    assert routing.source == "--daemon"
+    assert routing.explicit is True
+
+
+def test_background_is_rejected_for_direct_route():
+    with patch(
+        "mempalace.cli_write_routing.MempalaceConfig",
+        return_value=_RoutingConfig(WriteRoutingPolicy.DIRECT),
+    ):
+        with pytest.raises(
+            WriteRoutingError,
+            match="--background requires a daemon route",
+        ):
+            resolve_cli_write_routing(
+                _args(background=True),
+                operation="mine",
+            )
+
+
+def test_background_is_allowed_for_prefer_route():
+    with patch(
+        "mempalace.cli_write_routing.MempalaceConfig",
+        return_value=_RoutingConfig(WriteRoutingPolicy.PREFER),
+    ):
+        routing = resolve_cli_write_routing(
+            _args(background=True),
+            operation="mine",
+        )
+
+    assert routing.use_daemon is True
+
+
+def test_parser_flags_are_mutually_exclusive():
+    parser = argparse.ArgumentParser()
+    add_cli_write_routing_flags(parser)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--daemon", "--direct"])
+
+
+def _mine_args(tmp_path, **overrides):
+    values = {
+        "palace": str(tmp_path / "palace"),
+        "backend": None,
+        "global_backend": None,
+        "dir": str(tmp_path / "project"),
+        "mode": "projects",
+        "wing": None,
+        "agent": "mempalace",
+        "limit": 0,
+        "dry_run": False,
+        "extract": "exchange",
+        "no_gitignore": False,
+        "include_ignored": [],
+        "max_chunks_per_file": None,
+        "redetect_origin": False,
+        "daemon": False,
+        "direct": False,
+        "background": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_cmd_mine_prefer_submits_daemon_job(tmp_path):
+    args = _mine_args(tmp_path)
+
+    with (
+        patch(
+            "mempalace.cli._resolve_cli_write_routing_or_exit",
+            return_value=_route(WriteRoutingPolicy.PREFER),
+        ),
+        patch(
+            "mempalace.cli._submit_daemon_cli_job",
+        ) as submit,
+        patch(
+            "mempalace.miner.mine",
+        ) as direct_mine,
+    ):
+        cli.cmd_mine(args)
+
+    direct_mine.assert_not_called()
+    submit.assert_called_once()
+
+    kind, payload, submitted_args = submit.call_args.args
+    assert kind == "mine"
+    assert submitted_args is args
+    assert payload["source"] == args.dir
+    assert payload["mode"] == "projects"
+    assert submit.call_args.kwargs == {
+        "background": False,
+        "auto_start": True,
+    }
+
+
+def test_cmd_mine_direct_preserves_direct_path(tmp_path):
+    args = _mine_args(tmp_path)
+
+    with (
+        patch(
+            "mempalace.cli._resolve_cli_write_routing_or_exit",
+            return_value=_route(WriteRoutingPolicy.DIRECT),
+        ),
+        patch(
+            "mempalace.cli._submit_daemon_cli_job",
+        ) as submit,
+        patch(
+            "mempalace.miner.mine",
+        ) as direct_mine,
+    ):
+        cli.cmd_mine(args)
+
+    submit.assert_not_called()
+    direct_mine.assert_called_once()
+
+
+def test_daemon_submission_failure_never_falls_back_direct(
+    tmp_path,
+):
+    args = _mine_args(tmp_path)
+
+    with (
+        patch(
+            "mempalace.cli._resolve_cli_write_routing_or_exit",
+            return_value=_route(WriteRoutingPolicy.REQUIRE),
+        ),
+        patch(
+            "mempalace.cli._submit_daemon_cli_job",
+            side_effect=SystemExit(1),
+        ),
+        patch(
+            "mempalace.miner.mine",
+        ) as direct_mine,
+    ):
+        with pytest.raises(SystemExit):
+            cli.cmd_mine(args)
+
+    direct_mine.assert_not_called()
+
+
+def test_cmd_sync_prefer_submits_daemon_job(tmp_path):
+    args = _args(
+        palace=str(tmp_path / "palace"),
+        dir=str(tmp_path / "project"),
+        root=[],
+        wing=None,
+        dry_run=False,
+    )
+
+    with (
+        patch(
+            "mempalace.cli._resolve_cli_write_routing_or_exit",
+            return_value=_route(WriteRoutingPolicy.PREFER),
+        ),
+        patch(
+            "mempalace.cli._submit_daemon_cli_job",
+        ) as submit,
+        patch(
+            "mempalace.sync.sync_palace",
+        ) as direct_sync,
+    ):
+        cli.cmd_sync(args)
+
+    direct_sync.assert_not_called()
+    submit.assert_called_once()
+
+    assert submit.call_args.args[0] == "sync"
+    assert submit.call_args.args[1] == {
+        "dir": args.dir,
+        "root": [],
+        "wing": None,
+        "dry_run": False,
+    }
+
+
+def test_cmd_sweep_prefer_submits_daemon_job(tmp_path):
+    args = _args(
+        palace=str(tmp_path / "palace"),
+        target=str(tmp_path / "session.jsonl"),
+    )
+
+    with (
+        patch(
+            "mempalace.cli._resolve_cli_write_routing_or_exit",
+            return_value=_route(WriteRoutingPolicy.PREFER),
+        ),
+        patch(
+            "mempalace.cli._submit_daemon_cli_job",
+        ) as submit,
+        patch(
+            "mempalace.sweeper.sweep",
+        ) as direct_sweep,
+    ):
+        cli.cmd_sweep(args)
+
+    direct_sweep.assert_not_called()
+    submit.assert_called_once()
+
+    assert submit.call_args.args[0] == "sweep"
+    assert submit.call_args.args[1] == {
+        "target": str(tmp_path / "session.jsonl"),
+    }
+
+
+def test_init_auto_mine_daemon_preserves_prescan(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    palace = tmp_path / "palace"
+    project.mkdir()
+
+    first = project / "a.md"
+    second = project / "b.md"
+    first.write_text("a", encoding="utf-8")
+    second.write_text("b", encoding="utf-8")
+
+    args = _args(
+        palace=str(palace),
+        dir=str(project),
+        auto_mine=True,
+    )
+    config = SimpleNamespace(palace_path=str(palace))
+
+    with (
+        patch(
+            "mempalace.miner.scan_project",
+            return_value=[first, second],
+        ) as scan,
+        patch(
+            "mempalace.cli._resolve_cli_write_routing_or_exit",
+            return_value=_route(WriteRoutingPolicy.PREFER),
+        ),
+        patch(
+            "mempalace.cli._submit_daemon_cli_job",
+        ) as submit,
+        patch(
+            "mempalace.miner.mine",
+        ) as direct_mine,
+    ):
+        cli._maybe_run_mine_after_init(args, config)
+
+    scan.assert_called_once_with(str(project))
+    direct_mine.assert_not_called()
+    submit.assert_called_once()
+
+    payload = submit.call_args.args[1]
+    assert payload["source"] == str(project)
+    assert payload["files"] == [
+        str(first),
+        str(second),
+    ]
+
+
+def test_init_auto_mine_direct_reuses_prescan(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    palace = tmp_path / "palace"
+    project.mkdir()
+
+    source = project / "a.md"
+    source.write_text("a", encoding="utf-8")
+
+    args = _args(
+        palace=str(palace),
+        dir=str(project),
+        auto_mine=True,
+    )
+    config = SimpleNamespace(palace_path=str(palace))
+
+    with (
+        patch(
+            "mempalace.miner.scan_project",
+            return_value=[source],
+        ),
+        patch(
+            "mempalace.cli._resolve_cli_write_routing_or_exit",
+            return_value=_route(WriteRoutingPolicy.DIRECT),
+        ),
+        patch(
+            "mempalace.cli._submit_daemon_cli_job",
+        ) as submit,
+        patch(
+            "mempalace.miner.mine",
+        ) as direct_mine,
+    ):
+        cli._maybe_run_mine_after_init(args, config)
+
+    submit.assert_not_called()
+    direct_mine.assert_called_once_with(
+        project_dir=str(project),
+        palace_path=str(palace),
+        files=[source],
+    )
+
+
+def test_service_run_sweep_file(tmp_path):
+    palace = tmp_path / "palace"
+    target = tmp_path / "session.jsonl"
+    target.write_text("{}\n", encoding="utf-8")
+
+    sweep_result = {
+        "drawers_added": 2,
+        "drawers_already_present": 1,
+        "drawers_skipped": 3,
+    }
+
+    with patch(
+        "mempalace.sweeper.sweep",
+        return_value=sweep_result,
+    ) as sweep:
+        result = service.run_sweep(
+            {
+                "palace_path": str(palace),
+                "target": str(target),
+            }
+        )
+
+    sweep.assert_called_once_with(
+        str(target),
+        str(palace.resolve()),
+    )
+    assert result["success"] is True
+    assert result["exit_code"] == 0
+    assert result["result"] == sweep_result
+
+
+def test_service_run_sweep_directory_partial_failure(
+    tmp_path,
+):
+    palace = tmp_path / "palace"
+    target = tmp_path / "sessions"
+    target.mkdir()
+
+    sweep_result = {
+        "files_succeeded": 1,
+        "files_attempted": 2,
+        "drawers_added": 2,
+        "drawers_already_present": 0,
+        "drawers_skipped": 0,
+        "failures": [{"path": "bad.jsonl"}],
+    }
+
+    with patch(
+        "mempalace.sweeper.sweep_directory",
+        return_value=sweep_result,
+    ):
+        result = service.run_sweep(
+            {
+                "palace_path": str(palace),
+                "target": str(target),
+            }
+        )
+
+    assert result["success"] is False
+    assert result["exit_code"] == 2
+
+
+def test_execute_job_dispatches_sweep():
+    with patch(
+        "mempalace.service.run_sweep",
+        return_value={
+            "success": True,
+            "exit_code": 0,
+        },
+    ) as run_sweep:
+        result = service.execute_job(
+            "sweep",
+            {"target": "session.jsonl"},
+        )
+
+    run_sweep.assert_called_once_with({"target": "session.jsonl"})
+    assert result["success"] is True
+
+
+def test_service_run_mine_forwards_valid_prescanned_files(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    nested = project / "nested"
+    palace = tmp_path / "palace"
+
+    nested.mkdir(parents=True)
+
+    first = project / "a.md"
+    second = nested / "b.md"
+
+    first.write_text("a", encoding="utf-8")
+    second.write_text("b", encoding="utf-8")
+
+    with patch("mempalace.miner.mine") as mine:
+        result = service.run_mine(
+            {
+                "palace_path": str(palace),
+                "source": str(project),
+                "mode": "projects",
+                "files": [
+                    str(first),
+                    "nested/b.md",
+                ],
+                "dry_run": True,
+            }
+        )
+
+    assert result["success"] is True
+
+    mine.assert_called_once()
+    assert mine.call_args.kwargs["files"] == [
+        first.resolve(),
+        second.resolve(),
+    ]
+
+
+def test_service_run_mine_rejects_prescanned_path_outside_project(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    outside = tmp_path / "outside.md"
+
+    project.mkdir()
+    outside.write_text("outside", encoding="utf-8")
+
+    with patch("mempalace.miner.mine") as mine:
+        result = service.run_mine(
+            {
+                "palace_path": str(tmp_path / "palace"),
+                "source": str(project),
+                "mode": "projects",
+                "files": [str(outside)],
+                "dry_run": True,
+            }
+        )
+
+    mine.assert_not_called()
+    assert result["success"] is False
+    assert result["exit_code"] == 2
+    assert "outside the project root" in result["error"]
+
+
+def test_service_run_mine_rejects_non_list_files_payload(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with patch("mempalace.miner.mine") as mine:
+        result = service.run_mine(
+            {
+                "palace_path": str(tmp_path / "palace"),
+                "source": str(project),
+                "mode": "projects",
+                "files": "a.md",
+                "dry_run": True,
+            }
+        )
+
+    mine.assert_not_called()
+    assert result == {
+        "success": False,
+        "error": "mine files payload must be a list",
+        "exit_code": 2,
+    }


### PR DESCRIPTION
## What does this PR do?
## Dependency
## What does this PR do?

Builds on the shared routing-policy foundation merged in #2027 and the hook-routing implementation merged in #2030.

Contributes to #1963.


This is the third PR in the staged hook and CLI gateway rollout.

It applies the shared `direct` / `prefer` / `require` policy to routine CLI write operations:

- `mempalace mine`;
- `mempalace sweep`;
- `mempalace sync`;
- the optional post-setup mine run by `mempalace init`.

It also makes `sweep` a first-class daemon job and preserves the one-time project scan performed by `init` when that mine is submitted to the daemon.

## Policy behavior

### `direct`

Use the existing direct in-process execution path.

### `prefer`

Submit through the local daemon.

Interactive CLI commands are allowed to start the daemon if it is not already running.

### `require`

Submit through the local daemon.

Interactive CLI commands are allowed to start the daemon if it is not already running.

Because CLI commands can start the daemon, both `prefer` and `require` normally select it. The distinction remains important for hook callers, which cannot safely cold-start the daemon.

## Explicit overrides

Force daemon routing:

    mempalace mine ./project --daemon

Force direct execution:

    mempalace mine ./project --direct

The options are mutually exclusive and override environment/config policy.

The same options are available for:

- `init`;
- `mine`;
- `sweep`;
- `sync`.

## Background jobs

`--background` now follows the selected route rather than requiring the literal `--daemon` flag.

For example, this works when CLI routing is configured as `prefer` or `require`:

    mempalace mine ./project --background

A direct route with `--background` exits with an explicit configuration error.

## No ambiguous fallback

Once daemon submission begins, an error never causes the command to rerun directly.

The daemon may have durably accepted the job before the client observed a timeout or transport failure. Retrying the operation directly could duplicate memories or race the accepted job.

## Post-init mine

`mempalace init` already scans the project once to show the user a file-count and size estimate.

When the accepted mine is daemon-routed, this PR forwards that exact scanned file list in the daemon payload. The daemon therefore does not need to walk the project a second time.

## Sweep support

Before this PR, `sweep` was direct-only.

This PR adds daemon service support for:

- single transcript files;
- recursively swept directories;
- normal result summaries;
- partial directory failures;
- lock-contention errors;
- backend and palace isolation.

## Backward compatibility and rollout

The default CLI policy remains `direct`.

Existing users therefore receive no silent execution-topology change.

A supervised Tier 3 deployment can opt in with:

    MEMPALACE_CLI_WRITE_ROUTING=prefer

or prohibit direct routing with:

    MEMPALACE_CLI_WRITE_ROUTING=require

Configuration file:

    {
      "write_routing": {
        "cli": "require"
      }
    }

The production default can be reconsidered after the stacked rollout is reviewed and merged.

## Maintenance exclusions

The following remain outside ordinary write routing:

- repair;
- migration;
- wing migration;
- index rebuild;
- closet compression;
- embedder-identity changes.

These operations may replace indexes, rewrite broad metadata sets, or require cached handles to close. They need an exclusive-maintenance policy rather than an ordinary daemon queue job.

## Safety properties

- `require` never falls back to a direct writer.
- Explicit `--direct` remains available as a deliberate emergency/debug escape hatch.
- Explicit `--daemon` remains backward compatible.
- Background mode requires a daemon-selected route.
- Submission errors never cause direct retry.
- The init pre-scan is preserved across daemon routing.
- Sweep jobs share the existing daemon writer serialization.
- No changes are made to `mine_palace_lock()`.
- Hook routing from #2030 is not modified.

## Tests

Coverage includes:

- CLI direct/prefer/require resolution;
- explicit `--daemon` and `--direct` precedence;
- parser-level mutual exclusion;
- direct-background rejection;
- background use under daemon policies;
- mine daemon and direct paths;
- no fallback after daemon-submission failure;
- sync daemon routing;
- sweep daemon routing;
- post-init daemon routing with pre-scanned files;
- post-init direct behavior;
- daemon file and directory sweep execution;
- partial sweep failure reporting;
- daemon job dispatch;
- existing CLI, daemon, policy, config, hook, shell, and writer-lock regressions.

Run:

    python3 -m ruff format --check .
    python3 -m ruff check .
    python3 -m pytest tests/test_cli_write_routing.py tests/test_cli.py tests/test_daemon.py tests/test_write_routing.py tests/test_config.py -q
    python3 -m pytest tests/test_hook_write_routing.py tests/test_hooks_cli.py tests/test_hooks_shell.py tests/test_hooks_bash_compat.py -q
    python -m pytest tests/ -v

## Rollout sequence

1. Shared policy foundation — #2027, merged.
2. Hook routing — #2030, merged.
3. Routine CLI routing — this PR.
4. Exclusive maintenance behavior — separate follow-up.
5. Production-default decision — maintainer decision after the stack is validated.

## References

Contributes to the Tier 3 rollout in #1963.

Builds on #2027 and #2030, both merged.

Uses the daemon gateway direction from #1976 and #1270.

Related to #1888, #2002, #2026, and #2028.


## How to test

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
