### PR TITLE
fix(repair): recognize SQLite 3.53 FTS5 corruption

### DIFF
--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -638,13 +638,20 @@ def print_sqlite_integrity_abort(palace_path: str, errors: list[str]) -> None:
     print("    6. Re-run `mempalace repair --yes`.")
 
 
-# quick_check labels a corrupt FTS5 inverted index like:
+# quick_check labels a corrupt FTS5 inverted index like either:
 #   "malformed inverted index for FTS5 table main.embedding_fulltext_search"
+#   'fts5: corruption found reading blob 137438953474 from table
+#    "embedding_fulltext_search"'
+# The latter wording is emitted by SQLite 3.53.x (#1925).
 # That specific failure is recoverable in place: the index is derived from the
 # intact ``embedding_fulltext_search_content`` shadow table, so rebuilding it
 # restores full-text search without touching any drawer rows. Concurrent
 # killed-mid-write mines are the usual cause (#1596).
-_FTS5_MALFORMED_RE = re.compile(r"malformed inverted index for FTS5 table", re.IGNORECASE)
+_RECOVERABLE_FTS5_CORRUPTION_RE = re.compile(
+    r"(?:malformed inverted index for FTS5 table|"
+    r'fts5:\s*corruption found reading blob \d+ from table "embedding_fulltext_search")',
+    re.IGNORECASE,
+)
 
 
 def _errors_are_isolated_fts5(errors: list[str]) -> bool:
@@ -655,7 +662,7 @@ def _errors_are_isolated_fts5(errors: list[str]) -> bool:
     quick_check also reports page/row corruption, the data itself may be damaged
     and rebuilding the index over it would mask real loss — that still aborts.
     """
-    return bool(errors) and all(_FTS5_MALFORMED_RE.search(e) for e in errors)
+    return bool(errors) and all(_RECOVERABLE_FTS5_CORRUPTION_RE.search(e) for e in errors)
 
 
 def maybe_autoheal_fts5_index(palace_path: str, errors: list[str], *, progress=print) -> list[str]:

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -2009,13 +2009,18 @@ def _make_fts5_palace(tmp_path, *, corrupt: bool) -> str:
 
 def test_errors_are_isolated_fts5_classification():
     fts = "malformed inverted index for FTS5 table main.embedding_fulltext_search"
+    fts_blob = (
+        'fts5: corruption found reading blob 137438953474 from table "embedding_fulltext_search"'
+    )
     page = "Page 4 of B-tree 12345: database disk image is malformed"
     assert repair._errors_are_isolated_fts5([fts])
+    assert repair._errors_are_isolated_fts5([fts_blob])
     assert repair._errors_are_isolated_fts5([fts, fts])
     assert not repair._errors_are_isolated_fts5([])
     assert not repair._errors_are_isolated_fts5([page])
     # Any non-FTS5 error in the set means the data itself may be damaged.
     assert not repair._errors_are_isolated_fts5([fts, page])
+    assert not repair._errors_are_isolated_fts5([fts_blob, page])
 
 
 def test_maybe_autoheal_fts5_index_heals_isolated_corruption(tmp_path):


### PR DESCRIPTION
## Summary

- recognize SQLite 3.53.x's `fts5: corruption found reading blob ...` wording as the same isolated, recoverable FTS5 index corruption already handled by repair
- keep mixed FTS5 plus page/row corruption classified as unsafe to auto-heal
- add regression coverage for the new diagnostic shape

## Root cause

`PRAGMA quick_check` changed the wording it emits for a corrupt FTS5 index on SQLite 3.53.x. MemPalace only matched the older `malformed inverted index for FTS5 table` text, so repair treated the derived-index failure as broader SQLite corruption and aborted instead of rebuilding the index.

Closes #1925.

## Validation

- `python -m pytest tests/test_repair.py -q` — 90 passed
- `ruff check mempalace/repair.py tests/test_repair.py`
- `ruff format --check mempalace/repair.py tests/test_repair.py`
- full non-benchmark suite: 2,988 passed, 268 skipped; 12 unrelated Windows environment failures (WSL Bash cannot resolve the Windows worktree path; Strawberry OpenSSL points at a missing build-time `openssl.cnf`)