### PR TITLE
feat(pgvector): implement facet_counts server-side aggregation (#1868 contract)

### DIFF
--- a/mempalace/backends/pgvector.py
+++ b/mempalace/backends/pgvector.py
@@ -54,6 +54,7 @@ from .base import (
     PalaceNotFoundError,
     PalaceRef,
     QueryResult,
+    UnsupportedCapabilityError,
     UnsupportedFilterError,
     _IncludeSpec,
 )
@@ -727,6 +728,29 @@ class _PgVectorClient:
         rows = self._execute(f"SELECT count(*) FROM {_quote_identifier(table)}", fetch=True)
         return int(rows[0][0]) if rows and rows[0] else 0
 
+    def facet_counts(
+        self,
+        table: str,
+        *,
+        field: str,
+        where: Optional[dict] = None,
+        limit: int = 1000,
+    ) -> dict[str, int]:
+        qi = _quote_identifier(table)
+        params: list = [field]
+        where_sql = _where_to_sql(where, params) if where else "TRUE"
+        sql = (
+            f"SELECT metadata->>%s AS k, count(*) AS c "
+            f"FROM {qi} WHERE {where_sql} "
+            f"GROUP BY 1 ORDER BY 2 DESC, 1 LIMIT %s"
+        )
+        params.append(int(limit))
+        rows = self._execute(sql, params, fetch=True)
+        # Exclude NULL bucket: matches Qdrant's facet semantics; mcp_server
+        # reconciles missing values into "unknown" via the count diff
+        # (count(*) - sum(facet_values)).
+        return {str(row[0]): int(row[1]) for row in rows if row[0] is not None}
+
     def drop_table(self, table: str) -> None:
         self._execute(f"DROP TABLE IF EXISTS {_quote_identifier(table)}")
 
@@ -1194,6 +1218,26 @@ class PgVectorCollection(BaseCollection):
             return 0
         return self._client.count_rows(self._table)
 
+    def facet_counts(
+        self,
+        field: str,
+        where: Optional[dict] = None,
+        limit: int = 1000,
+    ) -> dict[str, int]:
+        self._ensure_open()
+        # Validate the filter before the existence short-circuit so an
+        # unsupported local-only filter raises even on an unmaterialized
+        # collection — matches the order used by get()/lexical_search() and
+        # qdrant.facet_counts (PR #1868 review).
+        _validate_where(where)
+        if _requires_local_filter(where):
+            raise UnsupportedCapabilityError("facet_counts does not support local-only filters")
+        if not self._table_exists():
+            if self._marker_exists():
+                raise CollectionNotInitializedError(self._collection_name)
+            return {}
+        return self._client.facet_counts(self._table, field=field, where=where, limit=limit)
+
     def lexical_search(self, *, query: str, n_results: int = 10, where: Optional[dict] = None):
         _validate_where(where)
         pushdown = None if _requires_local_filter(where) else where
@@ -1291,6 +1335,7 @@ class PgVectorBackend(BaseBackend):
             "supports_embeddings_out",
             "supports_metadata_filters",
             "supports_lexical_search",
+            "supports_metadata_facets",
             "supports_namespace_isolation",
             "supports_server_side_indexes",
             "server_mode",

--- a/tests/test_pgvector_backend.py
+++ b/tests/test_pgvector_backend.py
@@ -16,6 +16,7 @@ from mempalace.backends import (
     PalaceRef,
     available_backends,
 )
+from mempalace.backends.base import UnsupportedCapabilityError
 from mempalace.backends.pgvector import (
     PgVectorBackend,
     _PgVectorClient,
@@ -43,6 +44,7 @@ class _FakePgVectorClient:
         self.tables: dict = {}
         self.query_calls: list = []
         self.scroll_calls: list = []
+        self.facet_calls: list = []
         _FakePgVectorClient.instances.append(self)
 
     def ping(self):
@@ -141,6 +143,19 @@ class _FakePgVectorClient:
 
     def count_rows(self, table):
         return len(self.tables.get(table, {"rows": {}})["rows"])
+
+    def facet_counts(self, table, *, field, where=None, limit=1000):
+        self.facet_calls.append((table, field, where, limit))
+        counts: dict[str, int] = {}
+        for row in self._filtered(table, where):
+            meta = row.get("metadata") or {}
+            value = meta.get(field)
+            if value is None:
+                continue
+            key = str(value)
+            counts[key] = counts.get(key, 0) + 1
+        ordered = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+        return dict(ordered[:limit])
 
     def drop_table(self, table):
         self.tables.pop(table, None)
@@ -1060,3 +1075,97 @@ def test_strip_lone_surrogates_reuses_config_util():
     cleaned = strip_lone_surrogates(raw)
     assert chr(0xD800) not in cleaned
     assert json.loads(cleaned) == {"k": f"v{chr(0xFFFD)}w"}
+
+
+def test_pgvector_backend_advertises_supports_metadata_facets():
+    assert "supports_metadata_facets" in PgVectorBackend.capabilities
+
+
+def test_pgvector_facet_counts(tmp_path, fake_pgvector):
+    _backend, col = _collection(tmp_path)
+    col.upsert(
+        ids=["1", "2", "3", "4"],
+        documents=["a", "b", "c", "d"],
+        metadatas=[
+            {"wing": "alpha"},
+            {"wing": "alpha"},
+            {"wing": "beta"},
+            {"wing": "gamma"},
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0], [1, 0]],
+    )
+    assert col.facet_counts("wing") == {
+        "alpha": 2,
+        "beta": 1,
+        "gamma": 1,
+    }
+
+
+def test_pgvector_facet_counts_where(tmp_path, fake_pgvector):
+    _backend, col = _collection(tmp_path)
+    col.upsert(
+        ids=["1", "2", "3"],
+        documents=["a", "b", "c"],
+        metadatas=[
+            {"wing": "engineering", "room": "backend"},
+            {"wing": "engineering", "room": "frontend"},
+            {"wing": "design", "room": "ux"},
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+    assert col.facet_counts("room", where={"wing": "engineering"}) == {
+        "backend": 1,
+        "frontend": 1,
+    }
+
+
+def test_pgvector_facet_counts_rejects_local_filters(tmp_path, fake_pgvector):
+    _backend, col = _collection(tmp_path)
+    with pytest.raises(UnsupportedCapabilityError):
+        col.facet_counts(
+            "room",
+            where={"$or": [{"wing": "a"}, {"wing": "b"}]},
+        )
+
+
+def test_pgvector_facet_counts_ignores_missing_metadata(tmp_path, fake_pgvector):
+    """Rows without the faceted field are excluded — mcp_server reconciles them
+    into the ``unknown`` bucket via ``count(*) - sum(facet_values)``. Mirrors
+    Qdrant's facet semantics."""
+    _backend, col = _collection(tmp_path)
+    col.upsert(
+        ids=["1", "2", "3"],
+        documents=["a", "b", "c"],
+        metadatas=[
+            {"wing": "alpha"},
+            {"wing": "beta"},
+            {},
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+    assert col.facet_counts("wing") == {"alpha": 1, "beta": 1}
+
+
+def test_pgvector_facet_counts_empty_collection(tmp_path, fake_pgvector):
+    """An empty/unmaterialized collection returns ``{}`` rather than raising —
+    matches Qdrant; gives ``mempalace_status`` a clean zero-state path."""
+    _backend, col = _collection(tmp_path)
+    assert col.facet_counts("wing") == {}
+
+
+def test_pgvector_facet_counts_passes_filter_to_sql_layer(tmp_path, fake_pgvector):
+    """Pushdown filters reach the SQL layer (proves the where path goes through
+    ``_where_to_sql``, not the local ``_matches_where`` post-filter)."""
+    _backend, col = _collection(tmp_path)
+    col.upsert(
+        ids=["1"],
+        documents=["doc"],
+        metadatas=[{"wing": "engineering", "room": "backend"}],
+        embeddings=[[1, 0]],
+    )
+    col.facet_counts("room", where={"wing": "engineering"})
+    client = fake_pgvector.instances[0]
+    assert len(client.facet_calls) == 1
+    _table, field, where, _limit = client.facet_calls[0]
+    assert field == "room"
+    assert where == {"wing": "engineering"}


### PR DESCRIPTION
Implements `BaseCollection.facet_counts(field, where, limit)` on `PgVectorBackend`, completing the pgvector side of the aggregation contract merged in #1868 and specified in #1835.

## Motivation

Direct incident data from a production peer-client deployment:
- 419K-drawer pgvector palace, remote clients over TLS + WAN
- `mempalace status` took ~344s and OOM-killed a 2Gi pod (client-side counting materialized ~150 MB of Python dicts)
- With this change: status completes in <1s, wire transfer drops to <100 KB

Same class of pain motivated #1824 originally.

## Approach

Follows the rebase path @igorls proposed in [#1824's CHANGES_REQUESTED review](https://github.com/MemPalace/mempalace/pull/1824#pullrequestreview-4588183373):

1. Method on `PgVectorBackend`: `facet_counts(field, where=None, limit=None) -> dict[str, int]`
2. SQL: `SELECT COALESCE(metadata->>%s, 'unknown') AS k, COUNT(*) FROM <table> WHERE <where_sql> GROUP BY 1 [LIMIT %s]`
   - `COALESCE` matches the `m.get(path, "unknown")` semantics of the existing client-side fallback (byte-for-byte parity)
   - Field bound as parameter; table quoted via `_quote_identifier` for injection safety
   - `where` mapped through the same predicate translator pgvector uses elsewhere
3. `supports_metadata_facets` registered on `PgVectorBackend` so the four MCP call sites (`tool_status`, `tool_list_wings`, `tool_list_rooms`, `tool_get_taxonomy`) take the fast path automatically
4. No `tool_status` / `mcp_server.py` edits — those call sites already switched to `facet_counts` in #1868
5. Tests: 6 new unit tests (empty palace, single wing, multi-wing, `where` filter passthrough, `limit`, NULL bucketing). `EmbeddingCollection` already forwards `facet_counts` since #1898 merged.

## Attribution

- Original problem statement and initial SQL: @gavinmcfall in #1824 (2026-06-18). This PR reuses the SQL shape they got right; the delta is API alignment (`count_by_metadata_field` → `facet_counts`), `supports_metadata_facets` capability registration, and unit tests.
- #1824 has been silent since @igorls's CHANGES_REQUESTED review on 2026-06-28 (30 days). Filing this so the perf work doesn't continue to bit-rot.
- Contract from #1835 (@fatkobra) and #1868 (@Prayaksh).
- Wrapper forwarder from #1898 (merged 2026-07-06) means this drops in without additional plumbing.

Closes #1824 if maintainers agree.