### PR TITLE
fix(config): allow '&' and connective punctuation in wing/room names

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -25,7 +25,16 @@ from .write_routing import (
 # in file paths, SQLite, or ChromaDB metadata.
 
 MAX_NAME_LENGTH = 128
-_SAFE_NAME_RE = re.compile(r"^(?:[^\W_]|[^\W_][\w .'-]{0,126}[^\W_])$")
+# Allowed characters for wing/room/entity names. Alphanumerics of any script,
+# plus a small set of connective punctuation that emergent + curated names
+# legitimately contain: space . , : ' & ( ) - . `&` in particular is common in
+# real area names ("Archive & Storage", "Health & Fitness", "Legal & Disputes"),
+# and reads (list_drawers etc.) rejecting a name the store already holds made
+# those wings unreadable. First/last char must still be alphanumeric (no leading
+# "_" or trailing punctuation), and path traversal (`..` `/` `\\`) + NUL bytes are
+# blocked separately below — those, not this class, are the security boundary.
+# (Mirrors the broader set `sanitize_kg_value` already permits.)
+_SAFE_NAME_RE = re.compile(r"^(?:[^\W_]|[^\W_][\w .,:'&()-]{0,126}[^\W_])$")
 
 # MCP clients (e.g. Claude Desktop, WorkBuddy) occasionally relay lone UTF-16
 # surrogates (U+D800–U+DFFF) when proxying binary-in-Unicode or corrupted

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -335,6 +335,34 @@ def test_sanitize_name_cyrillic():
     assert sanitize_name("Алексей") == "Алексей"
 
 
+def test_sanitize_name_accepts_ampersand():
+    # Real curated/emergent wings routinely contain "&" — reads must not reject a
+    # name the store already holds. (Regression: MCP list_drawers 503'd with
+    # "wing contains invalid characters" for wings like "Archive & Storage".)
+    assert sanitize_name("Archive & Storage") == "Archive & Storage"
+    assert sanitize_name("Health & Fitness") == "Health & Fitness"
+
+
+def test_sanitize_name_accepts_comma_colon_parens():
+    assert sanitize_name("Q1, Q2 goals") == "Q1, Q2 goals"
+    assert sanitize_name("role: engineer") == "role: engineer"
+    assert sanitize_name("Notes (2026) archive") == "Notes (2026) archive"
+
+
+def test_sanitize_name_still_rejects_trailing_punctuation():
+    # First/last char must remain alphanumeric — the broadened set applies to the
+    # interior only, so a name can't start/end with the new punctuation.
+    for bad in ("& leading", "trailing )", "trailing_"):
+        with pytest.raises(ValueError):
+            sanitize_name(bad)
+
+
+def test_sanitize_name_still_rejects_shell_metacharacters():
+    for bad in ("a;b", "a|b", "a$b", "a`b"):
+        with pytest.raises(ValueError):
+            sanitize_name(bad)
+
+
 def test_sanitize_name_rejects_leading_underscore():
     with pytest.raises(ValueError):
         sanitize_name("_foo")


### PR DESCRIPTION
## What does this PR do?

`sanitize_name()` validates wing/room/entity names against `_SAFE_NAME_RE`, which only permitted alphanumerics (any script) plus space `.` `'` `-`. Emergent and curated area names routinely contain `&` — e.g. "Archive & Storage", "Health & Fitness", "Legal & Disputes", "AI & Technology Landscape".

Because the **read** tools (`list_drawers`, `get_drawer`, search, tunnels) also run `sanitize_name` on the wing/room filter, listing drawers in such a wing raised `ValueError("wing contains invalid characters")` → the MCP tool returned `{"error": ...}` and the caller surfaced a 503. In other words, **a name the store already holds became unreadable.** (These wings predate the current regex, or were created via a path that doesn't sanitize.)

This broadens the **interior** character class to add `& , : ( )` — the same connective punctuation `sanitize_kg_value` already permits. The guarantees are unchanged:
- **first/last char must still be alphanumeric** (no leading `_`, no trailing punctuation);
- **path traversal** (`..` `/` `\`) and **NUL bytes** are still blocked by the separate checks above the regex — those, not this class, are the security boundary;
- shell metacharacters (`;` `|` `$` `` ` ``) remain rejected.

## How to test

```
uv run pytest tests/test_config.py -v
```

New regression tests cover: `&` accepted ("Archive & Storage", "Health & Fitness"); comma/colon/mid-name parens accepted; trailing punctuation and leading `&`/`_` still rejected; shell metacharacters still rejected. Verified the patched `sanitize_name` directly against the pass/reject sets above (all green); `ruff check` passes on both files.

## Checklist
- [x] Tests pass (added to `tests/test_config.py`; verified directly — full-suite `conftest` needs `chromadb`, which CI provides)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .` — clean on changed files)

---

### Optional follow-up (not in this PR)
A deeper fix would be to **not apply the write-time character allow-list on the read path** at all — a stored wing is trusted data, so `list_drawers`/`get_drawer`/search only need the length + NUL + path-traversal guards, not the character set. Happy to do that separately if you'd prefer that direction; this PR keeps the change minimal and conservative.