### PR TITLE
feat(kg): add mempalace_kg_wing_links — area links from shared entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Usage and tool reference:
 
 ## MCP server
 
-36 MCP tools cover palace reads/writes, knowledge-graph operations,
+37 MCP tools cover palace reads/writes, knowledge-graph operations,
 cross-wing navigation, drawer management, and agent diaries. Installation
 and the full tool list:
 [mempalaceofficial.com/reference/mcp-tools](https://mempalaceofficial.com/reference/mcp-tools.html).

--- a/mempalace/README.md
+++ b/mempalace/README.md
@@ -16,7 +16,7 @@ The Python package that powers MemPalace. All modules, all logic.
 | `dialect.py` | AAAK compression — entity codes, emotion markers, 30x lossless ratio |
 | `knowledge_graph.py` | Temporal entity-relationship graph — SQLite, time-filtered queries, fact invalidation |
 | `palace_graph.py` | Room-based navigation graph — BFS traversal, tunnel detection across wings |
-| `mcp_server.py` | MCP server — 34 tools, AAAK auto-teach, Palace Protocol, agent diary |
+| `mcp_server.py` | MCP server — 37 tools, AAAK auto-teach, Palace Protocol, agent diary |
 | `onboarding.py` | Guided first-run setup — asks about people/projects, generates AAAK bootstrap + wing config |
 | `entity_registry.py` | Entity code registry — maps names to AAAK codes, handles ambiguous names |
 | `entity_detector.py` | Auto-detect people and projects from file content |

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -653,6 +653,20 @@ class KnowledgeGraph:
             "relationship_types": predicates,
         }
 
+    def current_triples_with_source(self):
+        """(subject, object, source_drawer_id) for every CURRENT fact that carries
+        drawer provenance. Lets a caller locate each entity in a wing (via the
+        drawer's `wing` metadata) — the basis for knowledge-graph-derived area links.
+        Facts without a source_drawer_id (older, pre-provenance) are skipped."""
+        with self._lock:
+            conn = self._conn()
+            rows = conn.execute(
+                "SELECT subject, object, source_drawer_id FROM triples "
+                "WHERE valid_to IS NULL AND source_drawer_id IS NOT NULL "
+                "AND source_drawer_id != ''"
+            ).fetchall()
+        return [(r["subject"], r["object"], r["source_drawer_id"]) for r in rows]
+
     # ── Seed from known facts ─────────────────────────────────────────────
 
     def seed_from_entity_facts(self, entity_facts: dict):

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2170,6 +2170,80 @@ def tool_traverse_graph(start_room: str, max_hops: int = 2):
     return traverse(start_room, col=col, max_hops=max_hops)
 
 
+def tool_kg_wing_links(limit: int = 40):
+    """Area-to-area links derived from the knowledge graph: two wings are linked
+    when they share (or are related through) the same ENTITY. A stronger signal
+    than a shared room *name* — the connection is what the memories are about.
+
+    Weighted by specificity: an entity that appears in many wings contributes
+    little (it links everything, so it means little); one shared by just two wings
+    counts full. Only facts with drawer provenance (source_drawer_id) can be placed
+    in a wing, so pre-provenance facts don't participate.
+    """
+    limit = max(1, min(int(limit or 40), 200))
+    col = _get_collection()
+    if not col:
+        return _collection_error_or_no_palace()
+
+    # drawer_id -> wing, over the whole collection
+    d2w = {}
+    offset = 0
+    while True:
+        batch = col.get(limit=1000, offset=offset, include=["metadatas"])
+        ids = batch.get("ids") or []
+        metas = batch.get("metadatas") or []
+        if not ids:
+            break
+        for i, did in enumerate(ids):
+            meta = _safe_meta(metas[i] if i < len(metas) else {})
+            wing = meta.get("wing")
+            if wing:
+                d2w[did] = wing
+        if len(ids) < 1000:
+            break
+        offset += 1000
+
+    try:
+        triples = _call_kg(lambda kg: kg.current_triples_with_source())
+    except Exception as e:  # noqa: BLE001 - degrade to no links rather than 500
+        return {"error": str(e)}
+
+    # entity -> set(wings it is mentioned in)
+    ent_wings = {}
+    for subj, obj, did in triples:
+        wing = d2w.get(did)
+        if not wing:
+            continue
+        for ent in (subj, obj):
+            if ent:
+                ent_wings.setdefault(ent, set()).add(wing)
+
+    import math
+
+    pair_w = {}
+    pair_ent = {}
+    for ent, wings in ent_wings.items():
+        n = len(wings)
+        if n < 2:
+            continue
+        contrib = 1.0 / math.log2(1 + n)  # specificity down-weight
+        ws = sorted(wings)
+        for i in range(len(ws)):
+            for j in range(i + 1, len(ws)):
+                key = (ws[i], ws[j])
+                pair_w[key] = pair_w.get(key, 0.0) + contrib
+                prev = pair_ent.get(key)
+                if prev is None or n < prev[1]:
+                    pair_ent[key] = (ent, n)  # most-specific shared entity = label
+
+    links = [
+        {"a": a, "b": b, "weight": round(w, 3), "entity": pair_ent[(a, b)][0]}
+        for (a, b), w in pair_w.items()
+    ]
+    links.sort(key=lambda link: link["weight"], reverse=True)
+    return {"links": links[:limit], "count": len(links)}
+
+
 def tool_find_tunnels(wing_a: str = None, wing_b: str = None):
     """Find rooms that bridge two wings — the hallways connecting domains."""
     try:
@@ -4152,6 +4226,16 @@ TOOLS = {
             "required": ["start_room"],
         },
         "handler": tool_traverse_graph,
+    },
+    "mempalace_kg_wing_links": {
+        "description": "Area-to-area links derived from the knowledge graph: two wings linked by a shared or related entity (specificity-weighted so ubiquitous entities don't link everything). Powers the 3D memory map's knowledge-graph edges. Read-only.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "Max links to return (default 40, max 200)"},
+            },
+        },
+        "handler": tool_kg_wing_links,
     },
     "mempalace_find_tunnels": {
         "description": "Find rooms that bridge two wings — the hallways connecting different domains. E.g. what topics connect wing_code to wing_team?",

--- a/tests/test_knowledge_graph_extra.py
+++ b/tests/test_knowledge_graph_extra.py
@@ -103,3 +103,25 @@ class TestQueryRelationshipWithTime:
         objects = [r["object"] for r in results]
         assert "Acme" in objects
         assert "NewCo" not in objects
+
+
+# ── current_triples_with_source (kg_wing_links basis) ─────────────────────────
+
+def test_current_triples_with_source_only_provenanced(kg):
+    kg.add_triple("Amber", "lives_at", "Villa", source_drawer_id="dr1")
+    kg.add_triple("Jon", "owns", "Villa", source_drawer_id="dr2")
+    kg.add_triple("Ghost", "x", "Y")  # no source_drawer_id
+    kg.add_triple("Empty", "x", "Z", source_drawer_id="")  # blank source
+    rows = kg.current_triples_with_source()
+    # Only facts with a non-empty source_drawer_id participate (Ghost + Empty excluded).
+    assert len(rows) == 2
+    assert all(r[2] for r in rows)  # every returned row carries a source_drawer_id
+    subjects = " ".join(r[0] for r in rows).lower()
+    assert "amber" in subjects and "jon" in subjects
+
+
+def test_current_triples_with_source_excludes_expired(kg):
+    kg.add_triple("A", "rel", "B", source_drawer_id="dr1")
+    kg.invalidate("A", "rel", "B")  # supersede -> valid_to set
+    rows = kg.current_triples_with_source()
+    assert rows == []

--- a/tests/test_readme_claims.py
+++ b/tests/test_readme_claims.py
@@ -59,22 +59,41 @@ def _doc_tool_names() -> list:
 
 
 class TestToolCount:
-    """README claims '19 tools available through MCP' in multiple places."""
+    """The docs state a tool count; it must equal len(TOOLS)."""
+
+    # "36 tools" and "36 MCP tools" alike. The old pattern `(\d+)\s+tools`
+    # required the digits immediately before "tools", so "36 MCP tools" matched
+    # nothing and the test passed vacuously while the count was wrong — a green
+    # run that wasn't evidence the counts lined up.
+    _COUNT_RE = re.compile(r"(\d+)\s+(?:MCP\s+)?tools", re.IGNORECASE)
 
     def test_readme_tool_count_matches_code(self):
-        """Claim: README says 19 tools. Actual TOOLS dict may differ.
+        """Claim: the docs state a tool count. Actual TOOLS dict is the truth.
 
-        This test asserts the REAL tool count so the README can be updated.
-        If TOOLS has 25 entries, the README should say 25, not 19.
+        Scans README.md and the MCP tools reference for "<n> tools" / "<n> MCP
+        tools" and asserts every stated count equals len(TOOLS). Also asserts at
+        least one claim was found, so a phrasing the regex misses can't let this
+        pass silently.
         """
         actual_count = len(_tools_dict_keys())
-        readme = _readme()
-        # Find all "19 tools" claims in README
-        claimed_counts = re.findall(r"(\d+)\s+tools", readme)
-        for claimed in claimed_counts:
-            assert int(claimed) == actual_count, (
-                f"README claims {claimed} tools but TOOLS dict has {actual_count}. "
-                f"Update every occurrence of '{claimed} tools' to '{actual_count} tools'."
+        sources = {
+            README_PATH.name: _readme(),
+            MCP_TOOLS_DOC_PATH.relative_to(REPO_ROOT).as_posix(): _read(MCP_TOOLS_DOC_PATH),
+        }
+        claims = [
+            (src, int(n))
+            for src, text in sources.items()
+            for n in self._COUNT_RE.findall(text)
+        ]
+        assert claims, (
+            "No tool-count claim found in README.md or the MCP tools reference. "
+            "Expected a phrase like '<n> tools' / '<n> MCP tools' so the stated "
+            "count stays pinned to len(TOOLS)."
+        )
+        for src, claimed in claims:
+            assert claimed == actual_count, (
+                f"{src} claims {claimed} tools but TOOLS dict has {actual_count}. "
+                f"Update every occurrence to '{actual_count} tools'."
             )
 
 

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Detailed parameter schemas for all 36 MCP tools.
+Detailed parameter schemas for all 37 MCP tools.
 
 ## Palace — Read Tools
 
@@ -299,6 +299,18 @@ Knowledge graph overview.
 **Parameters:** None
 
 **Returns:** `{ entities, triples, current_facts, expired_facts, relationship_types }`
+
+---
+
+### `mempalace_kg_wing_links`
+
+Area-to-area links derived from the knowledge graph: two wings are linked when they share (or are related through) the same entity. A stronger signal than a shared room *name* — a specific shared entity is meaningful, whereas a generic room name like "Notes" is often coincidence. Links are weighted by specificity (`1 / log2(1 + n_wings)`), so an entity that appears in many wings contributes little while one shared by just two wings counts full; each link is labelled with its most-specific shared entity. Only facts carrying drawer provenance (`source_drawer_id`) can be located in a wing, so pre-provenance facts don't participate. Read-only.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `limit` | integer | No | Max links to return (default 40, max 200) |
+
+**Returns:** `{ links: [{ a, b, weight, entity }], count }`
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds a read-only MCP tool, **`mempalace_kg_wing_links`**, that derives *area-to-area* links from the knowledge graph: two wings are linked when they **share (or are related through) the same entity**. This is a stronger signal than the existing `find_tunnels`, which links wings that merely have a room of the same *name* (a specific shared name is meaningful; a generic one like "Notes" is often coincidence). It powers a "Knowledge-graph links" view in the 1Presence 3D memory map.

**How it works**
- New `KnowledgeGraph.current_triples_with_source()` — returns `(subject, object, source_drawer_id)` for every *current* fact that carries drawer provenance. A `source_drawer_id` resolves to a wing (the drawer's `wing` metadata), so each entity can be *located* in one or more wings. Facts without provenance (older, pre-`source_drawer_id`) are skipped.
- `tool_kg_wing_links()` builds `entity → {wings}` from that join, then weights each wing-pair by **specificity**: `1 / log2(1 + n_wings)`, so an entity that appears in many wings (a hub like a person's own name) contributes little — it links everything, so it means little — while an entity shared by just two wings counts full. Each link is labelled with its most-specific shared entity. Returns the top-weighted links.

**Why specificity weighting matters:** without it, a ubiquitous entity would link nearly every wing to every other — the exact hairball this is meant to avoid.

## How to test

```
uv run pytest tests/test_knowledge_graph_extra.py -v
```

Adds tests for the provenance filter (facts without `source_drawer_id` are excluded) and expired-fact exclusion (`valid_to IS NULL` only). I also verified the full join + specificity math against a live in-memory `KnowledgeGraph`: a 2-wing entity outranks a 3-wing entity's pairs (`1/log2(3) = 0.63 > 1/log2(4) = 0.50`), confirming the down-weighting. `ruff check` passes on all three files.

## Checklist
- [x] Tests pass (`tests/test_knowledge_graph_extra.py`; the tool's collection scan needs `chromadb`, which CI provides)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .` — clean on changed files)

## Notes
- **Read-only** (not in `_MUTATING_TOOLS`); it scans the collection metadata + KG triples, no writes.
- Coverage depends on `source_drawer_id` provenance — facts predating that column don't participate. On a palace with sparse provenance the link set will be small; that's honest (better to draw few real links than many fabricated ones).