### PR TITLE
Fix for hooks | Add Windows `py` launcher fallback to interpreter resolution

### DIFF
--- a/.claude-plugin/hooks/mempal-precompact-hook.sh
+++ b/.claude-plugin/hooks/mempal-precompact-hook.sh
@@ -17,6 +17,13 @@ run_mempalace_hook() {
     return $?
   fi
 
+  # Windows: the py launcher often works when python3/python resolve to broken
+  # Microsoft Store stubs (present on PATH, but exit non-zero on any use).
+  if command -v py >/dev/null 2>&1 && py -c "import mempalace" >/dev/null 2>&1; then
+    py -m mempalace hook run "$@"
+    return $?
+  fi
+
   echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
   return 1
 }

--- a/.claude-plugin/hooks/mempal-session-end-hook.sh
+++ b/.claude-plugin/hooks/mempal-session-end-hook.sh
@@ -26,6 +26,12 @@ run_mempalace_hook() {
     exec python -m mempalace hook run "$@"
   fi
 
+  # Windows: the py launcher often works when python3/python resolve to broken
+  # Microsoft Store stubs (present on PATH, but exit non-zero on any use).
+  if command -v py >/dev/null 2>&1 && py -c "import mempalace" >/dev/null 2>&1; then
+    exec py -m mempalace hook run "$@"
+  fi
+
   echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
   exit 1
 }

--- a/.claude-plugin/hooks/mempal-stop-hook.sh
+++ b/.claude-plugin/hooks/mempal-stop-hook.sh
@@ -17,6 +17,13 @@ run_mempalace_hook() {
     return $?
   fi
 
+  # Windows: the py launcher often works when python3/python resolve to broken
+  # Microsoft Store stubs (present on PATH, but exit non-zero on any use).
+  if command -v py >/dev/null 2>&1 && py -c "import mempalace" >/dev/null 2>&1; then
+    py -m mempalace hook run "$@"
+    return $?
+  fi
+
   echo "MemPalace hook error: could not find a runnable mempalace command or module" >&2
   return 1
 }


### PR DESCRIPTION
## What does this PR do?

Adds a Windows `py` launcher fallback to the interpreter resolution in the three Claude plugin hook wrappers (`mempal-stop-hook.sh`, `mempal-precompact-hook.sh`, `mempal-session-end-hook.sh`).

On Windows, `python3` and `python` can both resolve to Microsoft Store stub executables that exist on PATH but exit non-zero on any use - a state a Python upgrade can silently produce (real case: a Python Install Manager upgrade on my machine left both aliases broken while the `py` launcher kept working). The existing import-probe chain correctly rejects the stubs but then has nowhere left to go, so every hook dies with "_could not find a runnable mempalace command or module_" even though mempalace is installed and importable via `py -m`. This adds a final `py` branch using the same functional import probe as the existing branches. No behavior change on macOS/Linux (`py` is absent) or on healthy Windows installs (earlier branches win). +20 lines, bash only.

## How to test

**Real case**: on a Windows machine where `python --version` prints the Store stub message ("Python was not found...") but `py --version` works - before this patch, `echo '{}' | bash .claude-plugin/hooks/mempal-stop-hook.sh` prints the hook error; after, it resolves via `py -m mempalace` and runs normally.

**Simulation on any OS** (run in an environment where the `mempalace` CLI binary is not on PATH, so the resolver reaches the interpreter branches):

```
STUBS=$(mktemp -d)
printf '#!/bin/sh\nexit 49\n' > "$STUBS/python3"; cp "$STUBS/python3" "$STUBS/python"
ln -s "$(command -v python3)" "$STUBS/py"   # 'py' stands in for the Windows launcher
chmod +x "$STUBS"/*
echo '{}' | PATH="$STUBS:$PATH" bash .claude-plugin/hooks/mempal-stop-hook.sh
# before: MemPalace hook error: could not find a runnable mempalace command or module
# after:  hook executes via `py -m mempalace hook run`
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
  - 3097 passed, 285 skipped; 5 failures in `test_init.py::test_init_filters_sys_path_from_leaked_pythonpath` are pre-existing and fail identically on unpatched `main` in the same (Windows) environment; this change touches only the three bash wrappers, no Python.
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
  - "All checks passed!"