### PR TITLE
fix: validate diary_write wing inside the error guard

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -3495,12 +3495,17 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
         agent_name = sanitize_name(agent_name, "agent_name").lower()
         entry = sanitize_content(entry)
         topic = sanitize_name(topic, "topic")
+        # Validated inside the guard: an invalid wing raised an uncaught
+        # ValueError that surfaced to the caller as an opaque -32000
+        # "Internal tool error" instead of the actionable message the other
+        # sanitized params get. Passing the field name keeps the error
+        # "wing contains invalid characters" rather than "name ...".
+        if wing:
+            wing = sanitize_name(wing, "wing")
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
-    if wing:
-        wing = sanitize_name(wing)
-    else:
+    if not wing:
         wing = f"wing_{agent_name.replace(' ', '_')}"
     room = "diary"
     col = _get_collection(create=True)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3442,6 +3442,30 @@ class TestDiaryTools:
         assert r["entries"][0]["topic"] == "architecture"
         assert "authentication" in r["entries"][0]["content"]
 
+    def test_diary_write_invalid_wing_returns_error_not_raises(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        """An invalid wing must return {"success": False}, not raise.
+
+        The wing was sanitized outside the try/except, so a ValueError
+        escaped tool_diary_write and the MCP dispatcher's blanket handler
+        turned it into an opaque -32000 "Internal tool error".
+        """
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_diary_write
+
+        r = tool_diary_write(
+            agent_name="TestAgent",
+            entry="entry body",
+            topic="general",
+            wing="../escape",
+        )
+        assert r["success"] is False
+        # Error names the offending field rather than the generic "name".
+        assert "wing" in r["error"]
+
     def test_diary_read_empty(self, monkeypatch, config, palace_path, kg):
         _patch_mcp_server(monkeypatch, config, kg)
         _client, _col = _get_collection(palace_path, create=True)


### PR DESCRIPTION
## Problem

`tool_diary_write` sanitizes `agent_name`, `entry`, and `topic` inside a `try/except ValueError`, but sanitizes `wing` immediately *after* that block:

```python
try:
    agent_name = sanitize_name(agent_name, "agent_name").lower()
    entry = sanitize_content(entry)
    topic = sanitize_name(topic, "topic")
except ValueError as e:
    return {"success": False, "error": str(e)}

if wing:
    wing = sanitize_name(wing)   # <-- outside the guard
```

An invalid `wing` therefore raises an uncaught `ValueError`, which falls through to the blanket `except Exception` in the `tools/call` dispatcher and reaches the caller as an opaque `-32000 Internal tool error` — with nothing indicating that `wing` was the problem.

`tool_diary_read` already validates `wing` inside its own guard, so this looks like an asymmetry rather than an intended design.

Found while debugging a client that passed a `wing` containing a path separator. The `-32000` gave no signal, so the wrong parameter was suspected for a while.

## Fix

Move the `wing` sanitization inside the existing `try`, and pass the field name through so the error names the offending parameter:

- before: `ValueError: name contains invalid path characters` (uncaught → `-32000`)
- after: `{"success": false, "error": "wing contains invalid path characters"}`

The `else` branch becomes `if not wing:` since `wing` is now assigned inside the `try`.

## Test

Adds `test_diary_write_invalid_wing_returns_error_not_raises`. Verified non-vacuous — reverting the source change fails the test with the uncaught `ValueError`.

```
uv run pytest tests/test_mcp_server.py -q   ->  281 passed
uv run ruff check . / ruff format --check   ->  clean
```

No behavior change for valid or omitted wings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)