### PR TITLE
feat(wal): opt-in verbatim payloads so dropped writes stay recoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Features
 
-- **Opt-in verbatim write-ahead log payloads.** `wal_store_full_payload` (or `MEMPALACE_WAL_STORE_FULL_PAYLOAD`) records write payloads in the WAL instead of replacing them with `[REDACTED N chars]`, so a write lost to a storage-layer fault can be reconstructed from the log. Off by default and fails closed, leaving existing behaviour unchanged; intended for self-hosted single-user palaces, where the WAL is already `0o600` inside a `0o700` directory.
+- **Opt-in verbatim write-ahead log payloads.** `wal_store_full_payload` (or `MEMPALACE_WAL_STORE_FULL_PAYLOAD`) records write payloads in the WAL instead of replacing them with `[REDACTED N chars]`, so a write lost to a storage-layer fault can be reconstructed from the log. Enabling it also lifts the 200-character preview cap that `add_drawer`, `delete_drawer`, `update_drawer`, and `diary_write` applied before logging — otherwise a multi-kilobyte entry would still be recoverable only as its first 200 characters. Off by default and fails closed, leaving existing behaviour byte-identical; intended for self-hosted single-user palaces, where the WAL is already `0o600` inside a `0o700` directory.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Features
+
+- **Opt-in verbatim write-ahead log payloads.** `wal_store_full_payload` (or `MEMPALACE_WAL_STORE_FULL_PAYLOAD`) records write payloads in the WAL instead of replacing them with `[REDACTED N chars]`, so a write lost to a storage-layer fault can be reconstructed from the log. Off by default and fails closed, leaving existing behaviour unchanged; intended for self-hosted single-user palaces, where the WAL is already `0o600` inside a `0o700` directory.
+
 ---
 
 ## [3.6.0] — 2026-07-14

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -235,6 +235,10 @@ _MILVUS_CONSISTENCY_LEVELS = {
 # ``MempalaceConfig.max_backups``.
 DEFAULT_MAX_BACKUPS = 10
 
+# Whether the write-ahead log stores write payloads verbatim instead of
+# redacting them. Off by default — see ``MempalaceConfig.wal_store_full_payload``.
+DEFAULT_WAL_STORE_FULL_PAYLOAD = False
+
 
 def normalize_milvus_consistency_level(value) -> str:
     raw = str(value).strip() if value else DEFAULT_MILVUS_CONSISTENCY_LEVEL
@@ -884,6 +888,42 @@ class MempalaceConfig:
             self._file_config.get("max_backups", DEFAULT_MAX_BACKUPS), minimum=0
         )
         return DEFAULT_MAX_BACKUPS if coerced is None else coerced
+
+    @property
+    def wal_store_full_payload(self) -> bool:
+        """Whether the WAL records write payloads verbatim instead of redacting them.
+
+        The write-ahead log normally replaces the value of every content-bearing
+        parameter with ``[REDACTED N chars]``. That keeps memory text out of a
+        file an operator might attach to a bug report, but it also means the WAL
+        cannot answer the one question it is uniquely placed to answer after a
+        storage-layer fault: *what were we trying to write?* When a backend
+        acknowledges a write it never persisted, the redacted WAL proves only
+        that a write of some length was attempted, so the content is
+        unrecoverable even though MemPalace logged the call.
+
+        Enabling this trades that confidentiality for recoverability. It is
+        intended for self-hosted single-user palaces, where the operator and the
+        data subject are the same person and losing memory costs more than
+        writing it to a second local file. The WAL is created ``0o600`` inside a
+        ``0o700`` directory, so turning this on does not widen filesystem
+        exposure — it only changes what an operator who shares the file would be
+        sharing. Leave it off for shared or team servers.
+
+        Reads ``MEMPALACE_WAL_STORE_FULL_PAYLOAD`` env first, then
+        ``wal_store_full_payload`` in ``config.json``, then the default of
+        ``False``. Accepts ``true``/``1``/``yes``/``on`` (case-insensitive);
+        anything else is false, so a typo fails closed to redaction.
+        """
+        env_val = os.environ.get("MEMPALACE_WAL_STORE_FULL_PAYLOAD")
+        if env_val is not None:
+            return env_val.strip().lower() in ("true", "1", "yes", "on")
+        value = self._file_config.get("wal_store_full_payload", DEFAULT_WAL_STORE_FULL_PAYLOAD)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in ("true", "1", "yes", "on")
+        return DEFAULT_WAL_STORE_FULL_PAYLOAD
 
     @property
     def hook_silent_save(self):

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -937,7 +937,7 @@ def _refresh_vector_disabled_flag() -> None:
 # CLI sync path and the daemon service layer can audit writes without importing
 # this module, whose import installs MCP stdio protection (os.dup2(2, 1) and
 # sys.stdout = sys.stderr) that would misroute their output.
-from .wal import _wal_log  # noqa: E402
+from .wal import _wal_log, wal_payload  # noqa: E402
 
 
 def _get_client():
@@ -2567,7 +2567,7 @@ def tool_add_drawer(
             "room": room,
             "added_by": added_by,
             "content_length": len(content),
-            "content_preview": content[:200],
+            "content_preview": wal_payload(content),
         },
     )
 
@@ -2684,7 +2684,7 @@ def tool_delete_drawer(drawer_id: str):
                 "drawer_id": drawer_id,
                 "deleted_ids": record["ids"],
                 "deleted_meta": record["metadata"],
-                "content_preview": record["content"][:200],
+                "content_preview": wal_payload(record["content"]),
             },
         )
 
@@ -3241,7 +3241,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
                 "new_wing": new_meta.get("wing", ""),
                 "new_room": new_meta.get("room", ""),
                 "content_changed": content is not None,
-                "content_preview": new_doc[:200] if content is not None else None,
+                "content_preview": wal_payload(new_doc) if content is not None else None,
             },
         )
 
@@ -3519,7 +3519,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
             "agent_name": agent_name,
             "topic": topic,
             "entry_id": entry_id,
-            "entry_preview": entry[:200],
+            "entry_preview": wal_payload(entry),
         },
     )
 

--- a/mempalace/wal.py
+++ b/mempalace/wal.py
@@ -100,6 +100,27 @@ def _ensure_wal() -> None:
     _WAL_INITIALIZED_DIR = wal_dir
 
 
+def wal_payload(value, limit: int = 200):
+    """Size a content value for the WAL: full when opted in, else a preview.
+
+    Callers historically passed ``value[:200]`` so the WAL held a bounded
+    preview. Redaction then replaced that preview outright, which is why the
+    truncation was invisible — a redacted 200-char slice and a redacted 20 KB
+    entry look identical in the log.
+
+    With ``wal_store_full_payload`` enabled the truncation becomes the binding
+    limit instead, so it has to lift too: recovering the first 200 characters
+    of a multi-kilobyte diary entry is not recovering it. Returns the value
+    untouched when full payloads are enabled, and the historical
+    ``value[:limit]`` preview otherwise.
+    """
+    if value is None:
+        return None
+    if _store_full_payload():
+        return value
+    return value[:limit]
+
+
 def _wal_log(operation: str, params: dict, result: dict = None):
     """Append a write operation to the write-ahead log.
 

--- a/mempalace/wal.py
+++ b/mempalace/wal.py
@@ -28,6 +28,35 @@ _WAL_REDACT_KEYS = frozenset(
     {"content", "content_preview", "document", "entry", "entry_preview", "query", "text"}
 )
 
+# Resolved once per process by ``_store_full_payload``; None means "not yet
+# resolved". Cached because ``MempalaceConfig`` reads config.json in its
+# constructor, and the WAL is on the hot path of every write — re-reading the
+# file per call would put disk I/O inside the hook latency budget.
+_WAL_FULL_PAYLOAD = None
+
+
+def _store_full_payload() -> bool:
+    """Whether to log write payloads verbatim rather than redacting them.
+
+    Defaults to redaction and fails closed: any error resolving the setting —
+    unreadable config, import failure — keeps the historical behaviour rather
+    than writing memory text to disk because a lookup broke.
+
+    ``MempalaceConfig`` is imported lazily inside the function to preserve this
+    module's contract of having no import side effects (see the module
+    docstring and ``test_wal_import_has_no_mcp_server_side_effect``).
+    """
+    global _WAL_FULL_PAYLOAD
+    if _WAL_FULL_PAYLOAD is None:
+        try:
+            from .config import MempalaceConfig
+
+            _WAL_FULL_PAYLOAD = bool(MempalaceConfig().wal_store_full_payload)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"WAL payload-mode lookup failed, defaulting to redaction: {e}")
+            _WAL_FULL_PAYLOAD = False
+    return _WAL_FULL_PAYLOAD
+
 
 def _ensure_wal() -> None:
     """Create (and re-harden) the WAL directory lazily, on the first write.
@@ -72,11 +101,17 @@ def _ensure_wal() -> None:
 
 
 def _wal_log(operation: str, params: dict, result: dict = None):
-    """Append a write operation to the write-ahead log."""
+    """Append a write operation to the write-ahead log.
+
+    Content-bearing params are redacted unless ``wal_store_full_payload`` is
+    enabled, in which case they are recorded verbatim so a write lost to a
+    storage-layer fault can be reconstructed from the log.
+    """
     # Redact sensitive content from params before logging
+    full_payload = _store_full_payload()
     safe_params = {}
     for k, v in params.items():
-        if k in _WAL_REDACT_KEYS:
+        if k in _WAL_REDACT_KEYS and not full_payload:
             safe_params[k] = f"[REDACTED {len(v)} chars]" if isinstance(v, str) else "[REDACTED]"
         else:
             safe_params[k] = v

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -251,6 +251,53 @@ def test_wal_full_payload_defaults_off_and_fails_closed(tmp_path, monkeypatch):
     assert wal._store_full_payload() is False
 
 
+def test_wal_payload_truncates_only_when_redacting(tmp_path, monkeypatch):
+    """The 200-char preview cap lifts with the flag, and holds without it.
+
+    Truncation and redaction stacked invisibly: a redacted 200-char slice and a
+    redacted 20 KB entry are the same string in the log. Once payloads are
+    stored, the cap becomes the binding limit on what is recoverable, so
+    recovering a long entry means lifting it.
+    """
+    from mempalace import wal
+
+    long_entry = "x" * 5000
+
+    monkeypatch.setattr(wal, "_WAL_FULL_PAYLOAD", False)
+    assert wal.wal_payload(long_entry) == "x" * 200
+
+    monkeypatch.setattr(wal, "_WAL_FULL_PAYLOAD", True)
+    assert wal.wal_payload(long_entry) == long_entry
+    assert wal.wal_payload(None) is None
+
+
+def test_long_diary_entry_fully_recoverable_from_wal(
+    tmp_path, monkeypatch, config, palace_path, kg
+):
+    """A diary entry past the preview cap survives in full, not as its first 200 chars.
+
+    Real diary entries run to several kilobytes, so a 200-char cap would leave
+    the WAL holding a few percent of a lost write while still reporting the
+    write as logged.
+    """
+    import json
+
+    from tests.test_mcp_server import _patch_mcp_server
+
+    _patch_mcp_server(monkeypatch, config, kg)
+    wal, wal_file = _wal_at(tmp_path, monkeypatch, True)
+
+    from mempalace.mcp_server import tool_diary_write
+
+    long_entry = "SESSION:2026-07-19|" + ("recoverable." * 500)
+    assert len(long_entry) > 200
+    assert tool_diary_write(agent_name="tester", entry=long_entry, topic="wal")["success"] is True
+
+    entries = [json.loads(line) for line in wal_file.read_text().splitlines() if line.strip()]
+    previews = [e["params"]["entry_preview"] for e in entries if e["operation"] == "diary_write"]
+    assert long_entry in previews, [p[:80] for p in previews]
+
+
 def test_diary_write_payload_recoverable_from_wal(tmp_path, monkeypatch, config, palace_path, kg):
     """End-to-end: a real diary_write leaves a reconstructable WAL record.
 

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -168,3 +168,112 @@ def test_wal_log_redacts_non_string_values(tmp_path, monkeypatch):
     entry = json.loads(wal_file.read_text().strip())
     assert entry["params"]["document"] == "[REDACTED]"
     assert entry["params"]["safe"] == "ok"
+
+
+def _wal_at(tmp_path, monkeypatch, full_payload):
+    """Point the WAL at tmp_path with an explicit payload mode.
+
+    The payload mode is a process-lifetime cache, so it is set through
+    monkeypatch to keep it from leaking into other tests in the session.
+    """
+    from mempalace import wal
+
+    wal_file = tmp_path / "wal" / "write_log.jsonl"
+    monkeypatch.setattr(wal, "_WAL_FILE", wal_file)
+    monkeypatch.setattr(wal, "_WAL_INITIALIZED_DIR", None)
+    monkeypatch.setattr(wal, "_WAL_FULL_PAYLOAD", full_payload)
+    return wal, wal_file
+
+
+def test_wal_stores_full_payload_when_enabled(tmp_path, monkeypatch):
+    """With the flag on, content-bearing params are logged verbatim.
+
+    This is the property that makes a silent storage-layer drop recoverable:
+    the 2026-04-30 MemPalace data loss was unrecoverable precisely because the
+    WAL held "[REDACTED 200 chars]" instead of the text of each lost write.
+    """
+    import json
+
+    wal, wal_file = _wal_at(tmp_path, monkeypatch, True)
+
+    secret = "the exact diary text that must survive a dropped write"
+    wal._wal_log("diary_write", {"entry": secret, "query": "find me", "safe": "ok"})
+
+    entry = json.loads(wal_file.read_text().strip())
+    assert entry["params"]["entry"] == secret
+    assert not entry["params"]["entry"].startswith("[REDACTED")
+    assert entry["params"]["query"] == "find me"
+    assert entry["params"]["safe"] == "ok"
+
+
+def test_wal_redacts_when_flag_disabled(tmp_path, monkeypatch):
+    """Backward compatibility: flag off reproduces the historical behaviour."""
+    import json
+
+    wal, wal_file = _wal_at(tmp_path, monkeypatch, False)
+
+    wal._wal_log("diary_write", {"entry": "secret diary text", "safe": "ok"})
+
+    entry = json.loads(wal_file.read_text().strip())
+    assert entry["params"]["entry"] == "[REDACTED 17 chars]"
+    assert entry["params"]["safe"] == "ok"
+
+
+def test_wal_full_payload_reads_env(tmp_path, monkeypatch):
+    """The setting resolves from the environment and caches for the process."""
+    from mempalace import wal
+
+    monkeypatch.setattr(wal, "_WAL_FULL_PAYLOAD", None)
+    monkeypatch.setenv("MEMPALACE_WAL_STORE_FULL_PAYLOAD", "true")
+    assert wal._store_full_payload() is True
+
+    # Cached: flipping the env afterwards must not change the resolved value.
+    monkeypatch.setenv("MEMPALACE_WAL_STORE_FULL_PAYLOAD", "false")
+    assert wal._store_full_payload() is True
+
+
+def test_wal_full_payload_defaults_off_and_fails_closed(tmp_path, monkeypatch):
+    """Unset env redacts; a broken config lookup redacts rather than leaking."""
+    from mempalace import wal
+
+    monkeypatch.setattr(wal, "_WAL_FULL_PAYLOAD", None)
+    monkeypatch.delenv("MEMPALACE_WAL_STORE_FULL_PAYLOAD", raising=False)
+    monkeypatch.setattr(wal, "_WAL_FILE", tmp_path / "wal" / "write_log.jsonl")
+    assert wal._store_full_payload() is False
+
+    monkeypatch.setattr(wal, "_WAL_FULL_PAYLOAD", None)
+    import mempalace.config as config_mod
+
+    def _boom(*args, **kwargs):
+        raise OSError("config unreadable")
+
+    monkeypatch.setattr(config_mod, "MempalaceConfig", _boom)
+    assert wal._store_full_payload() is False
+
+
+def test_diary_write_payload_recoverable_from_wal(tmp_path, monkeypatch, config, palace_path, kg):
+    """End-to-end: a real diary_write leaves a reconstructable WAL record.
+
+    Exercises the actual tool rather than _wal_log directly, so the redact-key
+    name used by tool_diary_write ("entry_preview") stays covered — that key is
+    what was redacted during the 2.5-month silent-drop window.
+    """
+    import json
+
+    from tests.test_mcp_server import _patch_mcp_server
+
+    _patch_mcp_server(monkeypatch, config, kg)
+    wal, wal_file = _wal_at(tmp_path, monkeypatch, True)
+
+    from mempalace.mcp_server import tool_diary_write
+
+    secret = "SESSION:2026-07-19|payload that must be recoverable|★★★"
+    result = tool_diary_write(agent_name="tester", entry=secret, topic="wal")
+    assert result["success"] is True
+
+    entries = [json.loads(line) for line in wal_file.read_text().splitlines() if line.strip()]
+    diary = [e for e in entries if e["operation"] == "diary_write"]
+    assert diary, f"no diary_write WAL record in {entries}"
+    previews = [e["params"]["entry_preview"] for e in diary]
+    assert not any(p.startswith("[REDACTED") for p in previews), previews
+    assert any(secret in p for p in previews), previews

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -164,6 +164,40 @@ The MCP server also accepts `--palace`:
 python -m mempalace.mcp_server --palace /custom/palace
 ```
 
+## Write-ahead log payloads
+
+MemPalace appends every write operation to `~/.mempalace/wal/write_log.jsonl`. By
+default the content-bearing fields (`entry`, `content`, `document`, `query`, …)
+are replaced with `[REDACTED N chars]`, so the log records that a write happened
+and how big it was, but not what it said.
+
+That default is right for shared and team servers. It has one cost: if the
+storage layer ever acknowledges a write it does not persist, the WAL can prove a
+write was attempted but cannot tell you what to restore.
+
+For a self-hosted single-user palace — where the operator and the data subject
+are the same person, and losing a memory costs more than writing it to a second
+local file — set:
+
+```json
+{
+  "wal_store_full_payload": true
+}
+```
+
+or `MEMPALACE_WAL_STORE_FULL_PAYLOAD=true`. Write payloads are then recorded
+verbatim and a dropped write is reconstructable from the log.
+
+The WAL file is created `0o600` inside a `0o700` directory either way, so this
+setting does not widen filesystem exposure — it changes what you would be
+handing over if you attached the log to a bug report. Leave it off if the palace
+serves more than one person.
+
+::: warning
+Turn this on *before* you need it. The WAL cannot retroactively un-redact
+records that were written while the setting was off.
+:::
+
 ## Environment Variables
 
 | Variable | Description |
@@ -171,4 +205,5 @@ python -m mempalace.mcp_server --palace /custom/palace
 | `MEMPALACE_PALACE_PATH` | Override palace path (same as `--palace`) |
 | `MEMPAL_DIR` | Directory for auto-mining in hooks |
 | `MEMPALACE_MAX_BACKUPS` | Override `max_backups` retention count (`0` disables pruning) |
+| `MEMPALACE_WAL_STORE_FULL_PAYLOAD` | Log write payloads verbatim instead of redacting them (default off) — see [Write-ahead log payloads](#write-ahead-log-payloads) |
 | `MEMPALACE_BACKEND` | Select the storage backend (default `chroma`) — see [Storage backends](#storage-backends) for each backend's connection variables |


### PR DESCRIPTION
## Problem

The WAL replaces every content-bearing param with `[REDACTED N chars]`:

```python
safe_params[k] = f"[REDACTED {len(v)} chars]" if isinstance(v, str) else "[REDACTED]"
```

Sensible as a default. But it removes the WAL's ability to answer the one question it is uniquely placed to answer after a storage-layer fault: **what were we trying to write?**

This is not hypothetical. On a self-hosted palace, a ChromaDB `max_seq_id` watermark desync made `col.add()` report success and persist nothing for **2.5 months** (2026-04-30 → 2026-07-19). `automatically_purge` empties `embeddings_queue`; `seq_id` is `INTEGER PRIMARY KEY` without `AUTOINCREMENT`, so rowids restart at 1, while the watermark still held `1229782938920431664` — every new record looked already-applied and was dropped before reaching the queue. Reads and search kept working the whole time, so nothing looked broken, and `mempalace_diary_write` returned `{"success": true, "entry_id": ...}` throughout.

When it was finally caught, the WAL held a record of all **98** lost calls (81 `diary_write` + 17 `add_drawer`) and the content of **none** of them. Every preview was the literal string `[REDACTED 200 chars]`. The writes were logged and still unrecoverable.

3.6.0's schema-strict dispatcher fixed the *other* half of that incident (callers sending `content`/`title` being silently stripped to an opaque `-32000`). This is the remaining half: making the log useful when storage lies.

## Change

`wal_store_full_payload` (env `MEMPALACE_WAL_STORE_FULL_PAYLOAD`), default `false`. When enabled, redact keys are written verbatim.

## Why a flag rather than always storing payloads

The WAL is already created `0o600` inside a `0o700` directory, so file permissions are not what redaction defends against — it defends against an operator attaching the log to a bug report or support dump. That is a real concern for shared and team palaces, especially now that `mempalace serve` exists. So the conservative default stays and single-user self-hosted installs opt in.

Rejected alternatives:
- *Always store, rely on `0o600`* — simpler, but silently changes what every existing install writes to disk, including team servers.
- *Encrypt with a local-only key* — key management outweighs the benefit for the single-user case this targets.

## Implementation notes

- **Cached per process.** `MempalaceConfig` reads `config.json` in its constructor and the WAL is on the hot path of every write; a per-call read would put disk I/O inside the hook latency budget.
- **Fails closed.** Any error resolving the setting keeps redaction rather than writing memory text to disk because a lookup broke.
- **Lazy import.** `MempalaceConfig` is imported inside the function to preserve this module's no-import-side-effects contract (`test_wal_import_has_no_mcp_server_side_effect`).

## Backward compatibility

Flag off (the default) is byte-identical to current behaviour — `test_wal_redacts_when_flag_disabled` pins that, and the pre-existing redaction tests are untouched and still pass.

## Tests

Five new tests in `tests/test_wal.py`, including the end-to-end regression you'd want here: a real `tool_diary_write` call, then read the WAL back and assert the payload is not `[REDACTED*]`. It covers `entry_preview` specifically — the key that was redacted during the incident window.

Both behavioural tests are non-vacuous — with the guard reverted they fail, and the end-to-end one reproduces the exact symptom:

```
E       AssertionError: ['[REDACTED 55 chars]']
```

Full suite: 3361 passed, 31 skipped. `ruff check` and `ruff format --check` clean.

## Docs

`website/guide/configuration.md` gains a "Write-ahead log payloads" section explaining the tradeoff and when to enable, plus the env-var table row. Warns that the setting must be on *before* it is needed — the WAL cannot retroactively un-redact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)