### PR TITLE
fix(entity): filter generic technical nouns from entity candidates (#476)

### DIFF
--- a/mempalace/data/tech_terms.json
+++ b/mempalace/data/tech_terms.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "description": "Generic software-architecture nouns and language/runtime type names that are capitalized in technical prose and code but are NOT proper nouns. Without this filter they get false-positive detected as projects: a README that says 'the Handler calls the Manager' yields 'Handler' and 'Manager' as entities. Complements coca_content_words.json, which covers common *English* content words — these are shop-talk terms that never enter a general-English frequency list, so they cannot be added there without breaking that file's COCA-top-2000 provenance. POS coverage: common noun (n), verb (v) used as a type/trait name. Excludes real product and technology names (React, Rust, Tauri): those are legitimate entities a user may want detected, and multi-word ones are protected by known_systems.json.",
+  "source": "Curated from the terms named in issues #476 (Handler, Node, Service, Manager, Client, Server, Worker, Plugin, Module, Interface, Event, Config, Builder, Factory) and #348 (String, Vec, Debug, Serialize, Deserialize, Clone, Tree, Phase, Flow). Terms already covered by coca_content_words.json (service, client, worker, event, error, request, response, update, tree, debug, phase, flow) or by the entity stopwords in i18n/en.json (server) are deliberately NOT duplicated here. Plural forms are listed for the architecture nouns, whose plurals are idiomatic ('the Handlers retry'), because the candidate extractor matches whole words and treats 'Handlers' as a separate candidate; type and trait names are left singular, since 'Vecs' and 'Clones' do not occur in the prose these issues describe.",
+  "known_tradeoffs": "'node' is named by both issues but is deliberately NOT filtered. The candidate extractor splits 'Node.js' on the dot and yields 'Node', so filtering it would stop 'Node.js' from being detected at all — the filter would suppress a real technology, which is exactly what this list is supposed to avoid. Tier 3 cannot rescue it either: known_systems.json holds multi-word names only. Graph and DOM 'Node' therefore still reaches candidates, and closing that needs a fix the single-word path cannot express. 'builder' and 'factory' are kept, since their standalone use in prose is overwhelmingly generic and the products spelled with a domain ('Builder.io') do not reduce to the bare word.",
+  "case_handling": "Matching is case-insensitive. Callers must lowercase the candidate before lookup, exactly as with coca_content_words.json.",
+  "tier_2_interaction": "This file is applied alongside coca_content_words.json at the Tier 2 single-word filtering step, on all three extraction sites (entity_detector.extract_candidates, palace closet-line extraction, miner per-drawer entity metadata). It is deliberately NOT applied to the multi-word path: the phrase filter drops a whole phrase when any constituent word matches, so filtering compounds here would erase legitimate names like 'Node Package Manager' or 'Interface Builder'.",
+  "words": [
+    "handler",
+    "handlers",
+    "manager",
+    "managers",
+    "plugin",
+    "plugins",
+    "module",
+    "modules",
+    "interface",
+    "interfaces",
+    "config",
+    "configs",
+    "builder",
+    "builders",
+    "factory",
+    "factories",
+    "string",
+    "strings",
+    "vec",
+    "clone",
+    "serialize",
+    "deserialize"
+  ]
+}

--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -78,6 +78,44 @@ def _get_coca_filter() -> frozenset[str]:
         return frozenset()
 
 
+# ==================== TECH-TERM FILTER (Tier 2 linguistics cleanup) ====================
+#
+# Generic architecture nouns ("Handler", "Manager", "Module") and language /
+# runtime type names ("String", "Vec", "Clone") read as proper nouns in
+# technical prose, so a README saying "the Handler calls the Manager" yields
+# both as projects (#476, #348).
+#
+# These are shop-talk, not general English, so they cannot go into
+# ``coca_content_words.json`` without breaking its COCA-top-2000 provenance —
+# hence a sibling data file with the same shape and the same case handling.
+# Real technology names (React, Rust, Node.js) are deliberately absent: those
+# are entities a user may legitimately want detected.
+#
+# Data file: ``mempalace/data/tech_terms.json``. Loaded once on first call via
+# ``_get_tech_terms``. Applied only on the single-word path, next to the COCA
+# filter — never to the multi-word path, whose phrase filter drops an entire
+# phrase when any constituent word matches ("Node Package Manager").
+
+
+@functools.lru_cache(maxsize=1)
+def _get_tech_terms() -> frozenset[str]:
+    """Return the technical-term filter set (lowercased).
+
+    Loads ``mempalace/data/tech_terms.json`` on first call and caches the
+    resulting frozenset. Subsequent calls are O(1). Returns an empty
+    frozenset if the data file is missing or malformed — extraction then
+    degrades gracefully (no tech-term filter applied) rather than crashing,
+    matching ``_get_coca_filter``.
+    """
+    data_path = Path(__file__).parent / "data" / "tech_terms.json"
+    try:
+        raw = json.loads(data_path.read_text(encoding="utf-8"))
+        words = raw.get("words", [])
+        return frozenset(w.lower() for w in words if isinstance(w, str))
+    except (OSError, json.JSONDecodeError, AttributeError, TypeError):
+        return frozenset()
+
+
 # ==================== KNOWN-SYSTEMS COMPOUND LEXICON (Tier 3 linguistics cleanup) ====================
 #
 # Multi-word product / system names that must be detected atomically — NOT
@@ -285,6 +323,7 @@ def extract_candidates(text: str, languages=("en",)) -> dict:
     patterns = get_entity_patterns(langs)
     stopwords = _get_stopwords(langs)
     coca_filter = _get_coca_filter()
+    tech_terms = _get_tech_terms()
 
     counts: defaultdict = defaultdict(int)
 
@@ -307,10 +346,13 @@ def extract_candidates(text: str, languages=("en",)) -> dict:
             if wl in stopwords:
                 continue
             # Tier 2 linguistics cleanup: block common English content words
-            # (Code, Brutal, Phase, Line, Note, ...) from entity candidacy.
-            # Multi-word path below is intentionally not filtered so
-            # compound names like "Claude Code" still get detected.
-            if wl in coca_filter:
+            # (Code, Brutal, Phase, Line, Note, ...) and generic technical
+            # nouns (Handler, Manager, Module, String, ...) from entity
+            # candidacy. Multi-word path below is intentionally not filtered
+            # so compound names like "Claude Code" still get detected — and
+            # so a phrase is never dropped for containing "Node" or
+            # "Manager" ("Node Package Manager").
+            if wl in coca_filter or wl in tech_terms:
                 continue
             if len(word) < 2:
                 continue

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from collections import defaultdict
 from typing import Optional
 
-from .entity_detector import _apply_known_systems_prepass, _get_coca_filter
+from .entity_detector import _apply_known_systems_prepass, _get_coca_filter, _get_tech_terms
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
@@ -997,6 +997,7 @@ def _extract_entities_for_metadata(content: str) -> str:
             matched.add(name)
 
     coca_filter = _get_coca_filter()
+    tech_terms = _get_tech_terms()
     window = content[:_ENTITY_EXTRACT_WINDOW]
     # Tier 3 linguistics cleanup — known-systems compound pre-pass. Detects
     # multi-word product names atomically and masks them from the window so
@@ -1010,9 +1011,10 @@ def _extract_entities_for_metadata(content: str) -> str:
         if w in _ENTITY_STOPLIST:
             continue
         # Tier 2 linguistics cleanup — drop common English content words
-        # ("Code", "Line", "Note", "Phase", …) from per-drawer entity
+        # ("Code", "Line", "Note", "Phase", …) and generic technical nouns
+        # ("Handler", "Manager", "Module", …) from per-drawer entity
         # metadata so they don't poison hallways/tunnels/search.
-        if w.lower() in coca_filter:
+        if w.lower() in coca_filter or w.lower() in tech_terms:
             continue
         freq[w] = freq.get(w, 0) + 1
     for w, c in freq.items():

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -26,7 +26,7 @@ from .backends import (
     resolve_backend_for_palace,
 )
 from .backends.embedding_wrapper import EmbeddingCollection
-from .entity_detector import _apply_known_systems_prepass, _get_coca_filter
+from .entity_detector import _apply_known_systems_prepass, _get_coca_filter, _get_tech_terms
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -570,15 +570,17 @@ def build_closet_lines(source_file, drawer_ids, content, wing, room, drawer_meta
     working_window, compound_counts = _apply_known_systems_prepass(window)
 
     coca_filter = _get_coca_filter()
+    tech_terms = _get_tech_terms()
     words = _candidate_entity_words(working_window)
     word_freq: dict = dict(compound_counts)
     for w in words:
         if w in _ENTITY_STOPLIST:
             continue
         # Tier 2 linguistics cleanup — drop common English content words
-        # ("Code", "Line", "Note", "Phase", …) so they don't appear in
+        # ("Code", "Line", "Note", "Phase", …) and generic technical nouns
+        # ("Handler", "Manager", "Module", …) so they don't appear in
         # closet pointers as fake entities.
-        if w.lower() in coca_filter:
+        if w.lower() in coca_filter or w.lower() in tech_terms:
             continue
         word_freq[w] = word_freq.get(w, 0) + 1
     entities = sorted(

--- a/tests/test_entity_detector.py
+++ b/tests/test_entity_detector.py
@@ -1059,3 +1059,196 @@ def test_zh_tw_known_limitation_inline_name_no_boundary():
     result = extract_candidates(text, languages=("zh-TW",))
     # Extraction is expected to miss this adversarial case.
     assert "朱宜振" not in result
+
+
+# ── tech-term filter (#476, #348) ────────────────────────────────────────
+
+
+def test_tech_terms_file_loads_with_expected_shape():
+    """The tech-term data file ships with the same schema as its COCA sibling."""
+    import mempalace
+
+    pkg_dir = Path(mempalace.__file__).parent
+    p = pkg_dir / "data" / "tech_terms.json"
+    assert p.exists(), f"tech-term wordlist must exist at {p}"
+    d = json.loads(p.read_text(encoding="utf-8"))
+    assert d.get("schema_version") == 1, (
+        f"schema_version must be 1; got {d.get('schema_version')!r}"
+    )
+    words = d.get("words")
+    assert isinstance(words, list) and words, "words must be a non-empty list"
+    assert all(isinstance(w, str) for w in words), "every entry must be a string"
+    assert all(w == w.lower() for w in words), (
+        "entries must be stored lowercased — lookup lowercases the candidate"
+    )
+    assert len(words) == len(set(words)), "entries must be unique"
+
+
+def test_extract_candidates_filters_generic_architecture_nouns():
+    """#476: 'the Handler calls the Manager' must not yield Handler/Manager
+    as projects. These read as proper nouns in technical prose only because
+    they are capitalized."""
+    text = (
+        "The Handler dispatches to the Manager. The Handler retries once. "
+        "The Manager owns the Module. The Module exposes an Interface. "
+        "The Handler logs. The Manager logs. The Module reloads. "
+        "The Interface is stable. The Plugin registers. The Plugin unloads. "
+        "The Plugin reloads. The Interface is versioned."
+    )
+    result = extract_candidates(text)
+    for term in ("Handler", "Manager", "Module", "Interface", "Plugin"):
+        assert term not in result, (
+            f"{term!r} is a generic architecture noun and must be filtered; got: {sorted(result)!r}"
+        )
+
+
+def test_extract_candidates_filters_language_type_names():
+    """#348: Rust/TypeScript type and trait names are not user projects."""
+    text = (
+        "String is owned. String derefs. String allocates. "
+        "Vec grows. Vec reallocs. Vec drops. "
+        "Clone is derived. Clone is cheap. Clone is explicit. "
+        "Serialize is derived. Serialize runs. Serialize emits."
+    )
+    result = extract_candidates(text)
+    for term in ("String", "Vec", "Clone", "Serialize"):
+        assert term not in result, (
+            f"{term!r} is a language type/trait name and must be filtered; got: {sorted(result)!r}"
+        )
+
+
+def test_extract_candidates_keeps_multi_word_phrase_with_tech_term_component():
+    """The tech-term filter is single-word only. A compound product name whose
+    parts are filtered individually must still be detected — otherwise adding
+    'interface' and 'builder' would erase 'Interface Builder'."""
+    text = (
+        "Interface Builder ships it. Interface Builder loads. "
+        "Interface Builder saves. Interface Builder exports. "
+        "Interface Builder renders."
+    )
+    result = extract_candidates(text)
+    assert "Interface Builder" in result, (
+        "multi-word phrase must survive even though both words are tech terms; "
+        f"got: {sorted(result)!r}"
+    )
+
+
+def test_tech_terms_do_not_shadow_real_technology_names():
+    """Real product/technology names stay detectable — the filter targets
+    generic nouns, not the tools a user actually works with.
+
+    Asserted on extraction, not just on list membership: a term absent from
+    the data file still has to come out of extract_candidates for the
+    guarantee to mean anything.
+    """
+    from mempalace.entity_detector import _get_tech_terms
+
+    terms = _get_tech_terms()
+    for real in ("react", "rust", "tauri", "django", "kubernetes"):
+        assert real not in terms, f"{real!r} is a real technology name and must remain detectable"
+
+    text = (
+        "React renders it. React updates. React hydrates. "
+        "Rust compiles it. Rust borrows. Rust drops. "
+        "Tauri bundles it. Tauri builds. Tauri signs."
+    )
+    result = extract_candidates(text)
+    for real in ("React", "Rust", "Tauri"):
+        assert real in result, (
+            f"{real!r} must survive extraction — suppressing a real technology "
+            f"trades one wrong answer for another; got: {sorted(result)!r}"
+        )
+
+
+def test_tech_terms_disjoint_from_coca_wordlist():
+    """The two lists have different provenance (shop-talk vs COCA top-2000),
+    so an entry must not be duplicated across them."""
+    from mempalace.entity_detector import _get_coca_filter, _get_tech_terms
+
+    overlap = _get_tech_terms() & _get_coca_filter()
+    assert not overlap, (
+        f"tech_terms.json duplicates COCA entries {sorted(overlap)!r} — "
+        "keep each term in exactly one list"
+    )
+
+
+def test_tech_terms_filter_degrades_gracefully_when_file_missing():
+    """A missing/corrupt data file must not crash extraction — it just stops
+    filtering, mirroring _get_coca_filter.
+
+    Extraction itself is exercised under the failure, not only the loader:
+    a loader that returns an empty set is worthless if the caller then
+    raises.
+    """
+    from mempalace.entity_detector import _get_tech_terms
+
+    text = "Riley shipped it. Riley reviewed it. Riley merged it. The Handler retried."
+
+    _get_tech_terms.cache_clear()
+    try:
+        with patch("mempalace.entity_detector.Path.read_text", side_effect=OSError("gone")):
+            assert _get_tech_terms() == frozenset()
+            # The unfiltered path must still produce results rather than raise.
+            assert "Riley" in extract_candidates(text)
+    finally:
+        _get_tech_terms.cache_clear()
+
+    # A structurally valid file whose "words" is the wrong type must also be
+    # survivable, not just an unreadable one.
+    _get_tech_terms.cache_clear()
+    try:
+        with patch("mempalace.entity_detector.Path.read_text", return_value='{"words": null}'):
+            assert _get_tech_terms() == frozenset()
+            assert "Riley" in extract_candidates(text)
+    finally:
+        _get_tech_terms.cache_clear()
+
+    _get_tech_terms.cache_clear()
+    try:
+        with patch("pathlib.Path.read_text", side_effect=OSError("gone")):
+            assert _get_tech_terms() == frozenset()
+    finally:
+        _get_tech_terms.cache_clear()
+
+
+def test_closet_lines_apply_tech_term_filter():
+    """palace.build_closet_lines is the second extraction site. Without the
+    filter there, generic nouns land in AAAK closet pointers even though
+    extract_candidates rejects them.
+
+    'Alice' is the control: she must survive, so a pass cannot come from the
+    function simply returning nothing.
+    """
+    from mempalace.palace import build_closet_lines
+
+    text = (
+        "Alice reviewed the Handler. Alice rewrote the Handler. "
+        "The Module imports Config. The Module reloads Config. "
+        "Alice shipped it. The Handler retried. The Module cached Config."
+    )
+    joined = " ".join(build_closet_lines("notes.md", ["d1"], text, "work", "day"))
+    assert "Alice" in joined, f"control entity must survive; got: {joined!r}"
+    for term in ("Handler", "Module", "Config"):
+        assert term not in joined, f"{term!r} must not reach closet pointers; got: {joined!r}"
+
+
+def test_drawer_entity_metadata_applies_tech_term_filter():
+    """miner._extract_entities_for_metadata is the third extraction site.
+    Unfiltered generic nouns there poison hallways, tunnels and search.
+
+    'Alice' is the control, and the known-entity registry is emptied so the
+    assertion tests the filter rather than the caller's own registry pass.
+    """
+    from mempalace import miner
+
+    text = (
+        "Alice reviewed the Handler. Alice rewrote the Handler. "
+        "The Module imports Config. The Module reloads Config. "
+        "Alice shipped it. The Handler retried. The Module cached Config."
+    )
+    with patch("mempalace.miner._load_known_entities", return_value=frozenset()):
+        entities = miner._extract_entities_for_metadata(text)
+    names = {n for n in entities.split(";") if n}
+    assert "Alice" in names, f"control entity must survive; got: {names!r}"
+    for term in ("Handler", "Module", "Config"):
+        assert term not in names, f"{term!r} must not reach drawer entity metadata; got: {names!r}"


### PR DESCRIPTION
## What does this PR do?

The entity detector treats generic technical nouns as project names. A README that says "the Handler dispatches to the Manager" files `Handler` and `Manager` as entities, and a Rust codebase contributes `String`, `Clone` and `Serialize`. Those names reach `known_entities.json`, closet pointers and per-drawer metadata, where they compete with the real people and projects a palace is meant to be keyed by.

Tier 2 already filters common English content words through `coca_content_words.json`, but architecture jargon never appears in a general-English frequency list, so roughly half of the terms named in the two issues sail straight past it. Measured on 271 files (2.7 MB) drawn from 12 unrelated projects with an equal per-project budget, TypeScript, Python, JavaScript and Markdown mixed, the split is clean.

Already handled by the existing lists, counting raw occurrences in the corpus: `Phase` (144), `Error` (114), `Update` (70), `Response` (65), `Worker` (58), `Service` (28), `Request` (25), `Event` (24), `One` (20), `Flow` (14), `Debug` (12), `Server` (9), `Client` (8).

Still surfacing as entity candidates: `Config` (45), `String` (31), `Plugin` (15), `Handler` (12), `Module` (10), `Node` (7), `Clone` (7), `Interface` (3), `Serialize` (3). This PR takes all of those except `Node`, for the reason below.

This adds `mempalace/data/tech_terms.json`, a sibling of the COCA list with the same schema and case handling, and applies it at the Tier 2 step on all three extraction sites: `entity_detector.extract_candidates`, the closet-line extraction in `palace.py`, and the per-drawer entity metadata in `miner.py`. All three already consult the COCA filter, so this rides the existing check instead of adding a pass.

The shape is not new here. `coca_content_words.json` arrived with #1605 and `known_systems.json` with #1613, both curated data files in the same directory, each loaded once through a small cached accessor and consulted during extraction. This is the third of that kind and follows their schema, their case handling and their degrade-to-empty behaviour, so what it adds is a list rather than a mechanism.

Three boundaries are deliberate.

**A separate file, not new COCA entries.** `coca_content_words.json` documents its provenance as the COCA top-2000 content-word list. `Vec` and `Deserialize` are not English content words, so folding them in would make that claim false.

**Not added to the entity stopwords in `i18n/en.json`.** Those also apply to the multi-word path, where a phrase is dropped if any constituent word matches. Adding `interface` and `builder` there would erase `Interface Builder`, and `node` and `manager` would erase `Node Package Manager`. The new filter runs on the single-word path only, and a test pins that.

**Real technology names stay out.** `React`, `Rust`, `Tauri` and `Node.js` are things a user genuinely works with and may want surfaced, so suppressing them would trade one wrong answer for another. This is why #348 is referenced rather than closed. Its generic half (`String`, `Vec`, `Clone`, `Serialize`) is handled here; `React`, `Rust` and `Tauri` are left detectable on purpose, and its request to tighten the code-file fallback path is untouched.

`Node` is the interesting casualty of that rule. Both issues name it, and it is genuinely noisy, but the extractor splits `Node.js` on the dot and yields `Node`, so filtering the word stops `Node.js` from being detected at all. Measured on the corpus: with `node` in the list, `Node.js` produces no candidate; without it, the mention survives. Suppressing a real technology is the failure this list exists to avoid, so `node` is left out and graph/DOM `Node` still leaks. Tier 3 cannot rescue it either, since `known_systems.json` holds multi-word names only. Closing that properly needs something the single-word path cannot express, and it belongs in its own change.

Two limits are worth stating outright.

`entity_registry.extract_unknown_candidates` also calls `_candidate_entity_words`, which makes it a fourth place candidates are produced. It is left alone: it screens against its own `COMMON_ENGLISH_WORDS` set, it feeds Wikipedia research from a user's query rather than from mined content, and nothing in the shipping code calls it today.

A filtered word that the user has *registered* as a real project still reaches drawer metadata but not closet pointers, because `_extract_entities_for_metadata` consults the known-entity registry before filtering and `build_closet_lines` has no such pass. That asymmetry predates this PR: registering `Service` or `Phase`, both already in the COCA list, behaves the same way on current develop. What changes is that the filtered words are now more plausible project names, so the existing gap is easier to hit. Teaching `build_closet_lines` the known-entity bypass would fix it for both lists at once and is better done on its own, since it changes behaviour for COCA words that have shipped for months.

After the change, the candidate set on that corpus goes from 988 to 977. Eleven names disappear (`Clone`, `Config`, `Handler`, `Handlers`, `Interface`, `Interfaces`, `Module`, `Modules`, `Plugin`, `Serialize`, `String`) and nothing new appears. `Telegram` (383), `Cloudflare` (133), `TypeScript` (51), `Python` (67), `JavaScript` (18) and `Tauri` (5) are all still detected.

The direction is worth confirming rather than assuming. #1616 proposes spaCy NER for this same problem, and if that is the preferred path then a curated list matters much less and this can be closed as a stopgap.

The list is also deliberately small, and it does not exhaust the problem. On the measured corpus most of what remains is genuine (`Telegram` 383, `GitHub` 165, `Cloudflare` 133), but generic names still get through (`Orchestrator` 231, `Array` 151, `Bot` 74), and a TypeScript-heavy tree produces far more of the same kind (`Buffer`, `PathLike`, `EventEmitter`, `Duplex`). Asking for a wider list is a reasonable response to this PR, as is taking a stricter view of what #348 needs before it can close.

#518 targets the same false positives and has been open since May. It puts the terms into the `entity.stopwords` list in `i18n/en.json`, which is the path that also filters phrases, so the two approaches differ in where the terms land rather than in intent. Happy to close this one if that direction is preferred.

Thanks to @jphein and @matrix9neonebuchadnezzar2199-sketch for the reports. The design here diverged from the patch sketched in #476, which proposed extending the stopword set and adding a sentence-start exclusion: the stopword set turned out to be the one place these terms cannot go, and the corpus measurement showed the existing lists already cover about half of what the issue lists.

## How to test

```bash
python -m pytest tests/test_entity_detector.py -v
```

The nine new tests cover the data file's schema, both term families from the issues, the multi-word carve-out (`Interface Builder` must survive), real technology names still coming out of extraction, disjointness from the COCA list, graceful degradation when the data file is missing or malformed, and one test per extraction site. The last two matter: removing the filter from `palace.py` and `miner.py` leaves the entity-detector tests green, so without them two of the three sites would ship untested.

To see it on your own tree, run the detector over a project's prose before and after:

```python
from mempalace.entity_detector import extract_candidates
print(sorted(extract_candidates(open("README.md").read())))
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

Fixes #476
Refs #348
