### PR TITLE
perf(mcp): cache the HNSW capacity probe, invalidated by file signature (#1471)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -727,6 +727,112 @@ def _hnsw_metadata_age_seconds(palace_path: str, segment_id: str) -> Optional[fl
         return None
 
 
+# Probe verdicts keyed by ``(palace_path, collection_name)``; each value is
+# ``(fingerprint, segment_id, status, probed_at)``. Written as one tuple
+# assignment, so a concurrent reader either sees the previous entry or the new
+# one, never a half-updated pair. Two threads that miss together simply both
+# run the probe and the last writer wins — a benign race, and cheaper than
+# serializing every reader behind a lock.
+_capacity_cache: dict[tuple[str, str], tuple[tuple, Optional[str], dict, float]] = {}
+
+# Bumped by every :func:`reset_hnsw_capacity_cache`. A probe reads it before
+# running and refuses to store its verdict if it changed meanwhile, so a probe
+# already in flight when a reset lands cannot repopulate the entry the reset
+# was meant to discard (the ``tool_reconnect`` race).
+_capacity_cache_generation = 0
+
+# A long-lived server watches one palace and a handful of collections, so the
+# map stays tiny; the bound only exists so a process that walks many palaces
+# (benchmarks, batch tooling) cannot grow it without limit.
+_CAPACITY_CACHE_MAX_ENTRIES = 32
+
+# Ceiling on how long one verdict may be reused, as a backstop for filesystems
+# whose timestamps are too coarse to notice a quick rewrite: FAT32 stores mtime
+# at 2 s granularity, exFAT at 10 ms, and a write that lands inside existing
+# sqlite pages need not change the file size either. On ext4/APFS/NTFS the
+# signature already catches every write, so this ceiling never fires in
+# practice. It bounds the worst case; it is not the freshness mechanism.
+_CAPACITY_CACHE_MAX_AGE_SECONDS = 10.0
+
+
+def _stat_signature(path: str) -> tuple[int, int, int]:
+    """Return ``(inode, mtime_ns, size)`` for ``path``, all zeros when absent.
+
+    Catches every exception, not just ``OSError``: a palace path carrying an
+    embedded null byte makes ``os.stat`` raise ``ValueError``, and
+    :func:`hnsw_capacity_status` promises never to raise. An unreadable path
+    simply yields the "absent" signature and the probe reports ``unknown``.
+    """
+    try:
+        st = os.stat(path)
+    except Exception:
+        return (0, 0, 0)
+    return (st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+def _db_family_signature(palace_path: str) -> tuple:
+    """Signature of the sqlite files whose contents the probe depends on.
+
+    chromadb 1.5.x leaves ``chroma.sqlite3`` in ``journal_mode=delete``, so the
+    ``-wal`` sidecar usually does not exist and stat'ing it is one cheap miss.
+    It is covered anyway because the journal mode belongs to the database
+    rather than to this code: under WAL a writer appends rows the probe would
+    count while the main file's own mtime stays put, and the verdict would
+    otherwise be reused against data it never saw.
+
+    ``-shm`` is deliberately excluded. It is the WAL index in shared memory,
+    and sqlite restamps it every time a connection opens the database — even
+    read-only. Including it would make the probe invalidate its own cache on
+    every call, so on a WAL-mode palace the cache would never hit.
+    """
+    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    return (
+        _stat_signature(db_path),
+        _stat_signature(db_path + "-wal"),
+    )
+
+
+def _pickle_signature(palace_path: str, segment_id: Optional[str]) -> tuple[int, int, int]:
+    """Signature of the segment's ``index_metadata.pickle``."""
+    if not segment_id:
+        return (0, 0, 0)
+    return _stat_signature(os.path.join(palace_path, segment_id, "index_metadata.pickle"))
+
+
+def _segment_id_safe(palace_path: str, collection_name: str) -> Optional[str]:
+    """``_vector_segment_id`` that never raises, for the pre-probe signature."""
+    try:
+        return _vector_segment_id(palace_path, collection_name)
+    except Exception:
+        return None
+
+
+def _capacity_fingerprint(palace_path: str, segment_id: Optional[str]) -> tuple:
+    """Signature over every file the probe reads: the sqlite family + the pickle.
+
+    Both halves must be captured for the same ``segment_id`` so a rewrite of
+    ``index_metadata.pickle`` is caught. The probe reads that pickle partway
+    through, then makes two more sqlite calls, so a signature taken only after
+    the probe returned would record a mid-probe pickle rewrite as "unchanged"
+    while the verdict still reflected the pre-write file (#1471 review).
+    """
+    return (_db_family_signature(palace_path), _pickle_signature(palace_path, segment_id))
+
+
+def reset_hnsw_capacity_cache() -> None:
+    """Forget every cached capacity verdict.
+
+    The signature check already picks up on-disk changes on its own; this is
+    for callers that drop all cached palace state at once (``tool_reconnect``,
+    ``_force_chroma_cache_reset``) and for tests that want a probe to run
+    unconditionally. Bumps the generation so a probe already running cannot
+    re-store the entry this call just dropped.
+    """
+    global _capacity_cache_generation
+    _capacity_cache_generation += 1
+    _capacity_cache.clear()
+
+
 def hnsw_capacity_status(palace_path: str, collection_name: str = "mempalace_drawers") -> dict:
     """Compare sqlite embedding count against HNSW element count.
 
@@ -747,7 +853,70 @@ def hnsw_capacity_status(palace_path: str, collection_name: str = "mempalace_dra
     * ``message``          — human-readable summary
 
     Never raises — a probe that throws would defeat the point.
+
+    A fully-measured verdict is cached per ``(palace_path, collection_name)``
+    and reused while every file the probe reads is unchanged on disk (#1471).
+    Each call otherwise costs a ``COUNT(*)`` over the embeddings table and a
+    full unpickle of the segment metadata — the two dominant costs — plus a few
+    small sqlite reads, on a path every search, duplicate check and status call
+    runs through. A verdict the probe could not fully measure (``sqlite_count``
+    is ``None`` from a locked database, or there is no palace yet) is returned
+    but never cached, so a transient failure cannot pin a false reading.
+
+    Freshness comes from an ``(inode, mtime_ns, size)`` signature rather than a
+    wall-clock TTL, so an external writer — ``mempalace repair``, a peer mine,
+    another process — invalidates the verdict as soon as it touches the files,
+    instead of leaving the #1222 guard blind for a fixed window.
+    ``_CAPACITY_CACHE_MAX_AGE_SECONDS`` caps how long one verdict may be
+    reused, but only as a backstop for filesystems with coarse timestamps; the
+    signature is what makes the verdict fresh.
+
+    Unlike :meth:`ChromaBackend._client`, which tolerates a 0.01 s mtime
+    epsilon to avoid rebuilding an expensive client, this compares exactly:
+    re-running the probe costs milliseconds, whereas serving one stale verdict
+    can route a query into a diverged segment.
     """
+    key = (palace_path, collection_name)
+    cached = _capacity_cache.get(key)
+    if cached is not None:
+        fingerprint, cached_segment, status, probed_at = cached
+        if time.monotonic() - probed_at <= _CAPACITY_CACHE_MAX_AGE_SECONDS:
+            if _capacity_fingerprint(palace_path, cached_segment) == fingerprint:
+                return dict(status)
+
+    generation = _capacity_cache_generation
+    # Snapshot the files the probe is about to read, before it reads them, and
+    # again after — using the segment id the probe itself resolved. Caching
+    # only when both snapshots agree makes an external write during the probe
+    # (sqlite OR the pickle) fall through uncached rather than pin a verdict
+    # the disk no longer supports.
+    before = _capacity_fingerprint(palace_path, _segment_id_safe(palace_path, collection_name))
+    out = _hnsw_capacity_status_uncached(palace_path, collection_name)
+    segment_id = out.get("segment_id")
+    after = _capacity_fingerprint(palace_path, segment_id)
+    cacheable = (
+        before == after
+        # A None sqlite_count means the probe could not read the database
+        # (transient lock/error), not a real "unknown" — pinning it would go
+        # blind for the whole ceiling. A None segment id has no pickle path to
+        # watch, so its fingerprint can never notice a first flush.
+        and out.get("sqlite_count") is not None
+        and segment_id is not None
+        # A reset that landed while this probe ran already dropped the entry
+        # it was told to; do not resurrect it.
+        and generation == _capacity_cache_generation
+    )
+    if cacheable:
+        if len(_capacity_cache) >= _CAPACITY_CACHE_MAX_ENTRIES:
+            _capacity_cache.clear()
+        _capacity_cache[key] = (after, segment_id, dict(out), time.monotonic())
+    return out
+
+
+def _hnsw_capacity_status_uncached(
+    palace_path: str, collection_name: str = "mempalace_drawers"
+) -> dict:
+    """Run the capacity probe, bypassing the cache. See :func:`hnsw_capacity_status`."""
     out: dict[str, Any] = {
         "segment_id": None,
         "sqlite_count": None,

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -74,6 +74,7 @@ from .backends.chroma import (  # noqa: E402
     _HNSW_BLOAT_GUARD,
     _pin_hnsw_threads,
     hnsw_capacity_status,
+    reset_hnsw_capacity_cache,
 )
 from .backends import BackendMismatchError, PalaceRef, detect_backend_for_path  # noqa: E402
 from .query_sanitizer import sanitize_query  # noqa: E402
@@ -847,6 +848,12 @@ def _force_chroma_cache_reset() -> None:
     _palace_db_mtime = 0.0
     _metadata_cache = None
     _metadata_cache_time = 0
+    # This runs on the #1315 retry path, which drops caches precisely to
+    # re-observe the palace after a transient index error. The capacity verdict
+    # is another cached view of that same palace, so it must be dropped too, or
+    # the retry could be answered from the pre-error verdict (its 10 s ceiling
+    # outlasts the 2 s retry sleep).
+    reset_hnsw_capacity_cache()
     try:
         from .palace import get_backend_for_palace
 
@@ -3831,7 +3838,10 @@ def tool_reconnect():
     ChromaBackend._quarantined_paths.discard(_config.palace_path)
     # Force probe re-run on next _get_client by clearing the flag now;
     # _refresh_vector_disabled_flag will re-set it if the divergence
-    # still applies after the reconnect.
+    # still applies after the reconnect. The probe keeps its own cache
+    # (#1471), so drop that too — otherwise the "re-run" would be served
+    # from the verdict this reconnect is meant to discard.
+    reset_hnsw_capacity_cache()
     _vector_disabled = False
     _vector_disabled_reason = ""
     # Drain the per-path KnowledgeGraph cache so a replaced sqlite file is

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,10 +101,14 @@ def _reset_mcp_cache():
 
         try:
             # Reset the per-process quarantine gate so tests don't leak
-            # state through ChromaBackend._quarantined_paths.
-            from mempalace.backends.chroma import ChromaBackend
+            # state through ChromaBackend._quarantined_paths, and drop cached
+            # HNSW capacity verdicts (#1471) for the same reason — a test that
+            # reuses a palace path would otherwise inherit the previous test's
+            # verdict.
+            from mempalace.backends.chroma import ChromaBackend, reset_hnsw_capacity_cache
 
             ChromaBackend._quarantined_paths.clear()
+            reset_hnsw_capacity_cache()
         except (ImportError, AttributeError):
             pass
 

--- a/tests/test_hnsw_capacity.py
+++ b/tests/test_hnsw_capacity.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import pickle
+import shutil
 import sqlite3
 import time
 
@@ -19,6 +20,7 @@ from mempalace.backends.chroma import (
     _hnsw_element_count,
     _vector_segment_id,
     hnsw_capacity_status,
+    reset_hnsw_capacity_cache,
 )
 from mempalace.searcher import _bm25_only_via_sqlite
 
@@ -695,3 +697,442 @@ def test_capacity_status_ok_with_stale_metadata_under_explicit_threshold(tmp_pat
     assert info["threshold"] == 4
     assert info["status"] == "ok"
     assert info["diverged"] is False
+
+
+# ── Probe result cache (#1471) ────────────────────────────────────────
+
+
+class TestCapacityProbeCache:
+    """The probe is re-used while the files it reads are untouched.
+
+    Every search, duplicate check and status call runs the probe, and each
+    run costs four sqlite connections plus a full unpickle of the segment
+    metadata. Caching it is only safe if any on-disk change re-probes
+    immediately — a stale "ok" would walk a diverged segment straight into
+    the #1222 segfault the probe exists to prevent.
+    """
+
+    # Cache isolation comes from conftest's suite-wide ``_reset_mcp_cache``,
+    # which clears every module-level palace cache between tests — the same
+    # place ChromaBackend._quarantined_paths and the MCP client cache are reset.
+
+    @pytest.fixture
+    def probe_runs(self, monkeypatch):
+        """Record every call that reaches the uncached probe."""
+        from mempalace.backends import chroma as chroma_mod
+
+        calls: list[tuple[str, str]] = []
+        real = chroma_mod._hnsw_capacity_status_uncached
+
+        def counting(palace_path, collection_name="mempalace_drawers"):
+            calls.append((palace_path, collection_name))
+            return real(palace_path, collection_name)
+
+        monkeypatch.setattr(chroma_mod, "_hnsw_capacity_status_uncached", counting)
+        return calls
+
+    @staticmethod
+    def _balanced_palace(tmp_path, seg="seg-cache"):
+        _seed_chroma_db(str(tmp_path), sqlite_count=20_000, segment_id=seg)
+        _write_pickle(str(tmp_path), seg, hnsw_count=19_900)
+        return seg
+
+    def test_unchanged_palace_probes_once(self, tmp_path, probe_runs):
+        self._balanced_palace(tmp_path)
+        first = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        second = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        third = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 1
+        assert first == second == third
+        assert first["status"] == "ok"
+
+    def test_pickle_rewrite_reprobes_and_reports_divergence(self, tmp_path, probe_runs):
+        """The #1222 guard must not go blind behind the cache."""
+        seg = self._balanced_palace(tmp_path)
+        assert hnsw_capacity_status(str(tmp_path), COLLECTION)["diverged"] is False
+
+        # The segment loses almost every element — exactly the state that
+        # segfaults chromadb once a query touches it.
+        _write_pickle(str(tmp_path), seg, hnsw_count=2_000)
+
+        after = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 2, "a rewritten pickle must re-run the probe"
+        assert after["diverged"] is True
+        assert after["hnsw_count"] == 2_000
+
+    def test_sqlite_write_reprobes(self, tmp_path, probe_runs):
+        seg = self._balanced_palace(tmp_path)
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+
+        db_path = os.path.join(str(tmp_path), "chroma.sqlite3")
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                """INSERT INTO embeddings (id, segment_id, embedding_id, seq_id)
+                   VALUES (?, ?, ?, ?)""",
+                (999_999, seg, "d-extra", b"\x00\x00\x00\x00\x00\x00\x00\x01"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        after = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 2
+        assert after["sqlite_count"] == 20_001
+
+    def test_wal_sidecar_write_reprobes(self, tmp_path, probe_runs):
+        """Under WAL a writer leaves chroma.sqlite3's own mtime untouched.
+
+        chromadb 1.5.x uses ``journal_mode=delete``, so this models the palace
+        being opened in WAL mode by something else rather than today's default.
+        """
+        self._balanced_palace(tmp_path)
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+
+        db_path = os.path.join(str(tmp_path), "chroma.sqlite3")
+        before = os.stat(db_path)
+        with open(db_path + "-wal", "wb") as f:
+            f.write(b"\x00" * 4096)
+        assert os.stat(db_path).st_mtime_ns == before.st_mtime_ns, (
+            "precondition: the main DB file must be untouched by this write"
+        )
+
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 2, "a WAL-only write must still invalidate"
+
+    def test_cache_is_keyed_by_collection(self, tmp_path, probe_runs):
+        """repair.status probes drawers and closets against the same palace."""
+        self._balanced_palace(tmp_path)
+        drawers = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        closets = hnsw_capacity_status(str(tmp_path), "mempalace_closets")
+
+        assert len(probe_runs) == 2
+        assert drawers["sqlite_count"] == 20_000
+        # The closets collection does not exist in this palace, so its verdict
+        # must not be the drawers verdict served from a palace-only key.
+        assert closets["sqlite_count"] != 20_000
+
+    def test_reset_forces_a_reprobe(self, tmp_path, probe_runs):
+        self._balanced_palace(tmp_path)
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 1
+
+        reset_hnsw_capacity_cache()
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 2
+
+    def test_caller_mutation_does_not_corrupt_the_cache(self, tmp_path, probe_runs):
+        """mcp_server parks the verdict in a module global; keep them isolated.
+
+        Both directions matter: the dict handed to the caller that ran the
+        probe must not be the stored one, and neither must the dict handed to
+        every later caller served from the cache.
+        """
+        self._balanced_palace(tmp_path)
+        first = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        first["diverged"] = "tampered-by-prober"
+        first["message"] = "tampered-by-prober"
+
+        second = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert second["diverged"] is False
+        assert second["message"] != "tampered-by-prober"
+
+        # A cache hit must hand out a copy too, or this caller poisons the
+        # verdict every later reader sees.
+        second["diverged"] = "tampered-by-reader"
+        second["message"] = "tampered-by-reader"
+
+        third = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 1
+        assert third["diverged"] is False
+        assert third["message"] != "tampered-by-reader"
+
+    def test_write_during_the_probe_is_not_cached(self, tmp_path, monkeypatch):
+        """A verdict that pins to neither disk state must not be reused."""
+        from mempalace.backends import chroma as chroma_mod
+
+        self._balanced_palace(tmp_path)
+        db_path = os.path.join(str(tmp_path), "chroma.sqlite3")
+        real = chroma_mod._hnsw_capacity_status_uncached
+        runs: list[int] = []
+
+        def racing(palace_path, collection_name="mempalace_drawers"):
+            result = real(palace_path, collection_name)
+            runs.append(1)
+            if len(runs) == 1:
+                # Land a write after the probe read, before it returns.
+                with open(db_path + "-wal", "wb") as f:
+                    f.write(b"\x01" * 2048)
+            return result
+
+        monkeypatch.setattr(chroma_mod, "_hnsw_capacity_status_uncached", racing)
+
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(runs) == 2, "a palace written mid-probe must not be cached"
+
+        # The second probe ran without a racing write, so caching resumes.
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(runs) == 2, "a quiet palace must be cached again afterwards"
+
+    def test_verdict_is_not_reused_past_the_age_ceiling(self, tmp_path, probe_runs, monkeypatch):
+        """Backstop for filesystems whose timestamps are too coarse to notice."""
+        from mempalace.backends import chroma as chroma_mod
+
+        self._balanced_palace(tmp_path)
+        clock = [1_000.0]
+        monkeypatch.setattr(chroma_mod.time, "monotonic", lambda: clock[0])
+
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+        clock[0] += chroma_mod._CAPACITY_CACHE_MAX_AGE_SECONDS / 2
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 1, "still inside the ceiling: serve the cached verdict"
+
+        clock[0] += chroma_mod._CAPACITY_CACHE_MAX_AGE_SECONDS
+        hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 2, "past the ceiling: re-probe even with identical files"
+
+    def test_probe_still_never_raises_on_an_unstattable_path(self):
+        """The probe's stated contract is "never raises"; caching must keep it.
+
+        A palace path with an embedded null byte makes ``os.stat`` raise
+        ``ValueError`` rather than ``OSError``, which a signature helper that
+        only caught ``OSError`` would let escape.
+        """
+        result = hnsw_capacity_status("\x00bad", COLLECTION)
+        assert result["status"] == "unknown"
+        assert result["diverged"] is False
+
+    def test_first_probe_runs_even_when_process_uptime_is_tiny(
+        self, tmp_path, probe_runs, monkeypatch
+    ):
+        """The withdrawn PR #1756 skipped its very first probe.
+
+        That TTL compared ``time.monotonic()`` against a timestamp initialised
+        to ``0.0``, so on a process younger than the TTL the comparison said
+        "probed recently" before any probe had run. Here the age check is
+        reachable only through an existing cache entry, so a cold cache always
+        probes no matter what the clock reads.
+        """
+        from mempalace.backends import chroma as chroma_mod
+
+        self._balanced_palace(tmp_path)
+        monkeypatch.setattr(chroma_mod.time, "monotonic", lambda: 0.5)
+
+        info = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 1
+        assert info["status"] == "ok"
+        assert info["sqlite_count"] == 20_000
+
+    def test_first_flush_after_an_unknown_verdict_is_noticed(self, tmp_path, probe_runs):
+        """The common lifecycle: a fresh palace has no pickle until it flushes."""
+        seg = "seg-firstflush"
+        _seed_chroma_db(str(tmp_path), sqlite_count=20_000, segment_id=seg)
+
+        unflushed = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert unflushed["status"] == "unknown"
+        assert unflushed["hnsw_count"] is None
+
+        # The first flush writes a brand-new file in a sibling segment dir and
+        # never touches chroma.sqlite3's own mtime.
+        _write_pickle(str(tmp_path), seg, hnsw_count=2_000)
+
+        after = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 2, "the first flush must invalidate an 'unknown' verdict"
+        assert after["hnsw_count"] == 2_000
+        assert after["diverged"] is True
+
+    def test_segment_replacement_is_noticed(self, tmp_path, probe_runs):
+        """A dropped-and-recreated collection lands on a new VECTOR segment."""
+        old_seg = self._balanced_palace(tmp_path, seg="seg-old")
+        assert hnsw_capacity_status(str(tmp_path), COLLECTION)["segment_id"] == old_seg
+
+        new_seg = "seg-new"
+        db_path = os.path.join(str(tmp_path), "chroma.sqlite3")
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("UPDATE segments SET id = ? WHERE scope = 'VECTOR'", (new_seg,))
+            conn.execute("UPDATE embeddings SET segment_id = ?", (new_seg,))
+            conn.commit()
+        finally:
+            conn.close()
+        _write_pickle(str(tmp_path), new_seg, hnsw_count=19_900)
+
+        moved = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert moved["segment_id"] == new_seg
+
+        # The verdict must now track the NEW segment's pickle, not the old one.
+        _write_pickle(str(tmp_path), new_seg, hnsw_count=2_000)
+        runs_before = len(probe_runs)
+        diverged = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == runs_before + 1
+        assert diverged["diverged"] is True
+
+    def test_palace_removal_is_noticed(self, tmp_path, probe_runs):
+        """A palace deleted underneath a live server must not stay "ok"."""
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        _seed_chroma_db(str(palace), sqlite_count=20_000, segment_id="seg-gone")
+        _write_pickle(str(palace), "seg-gone", hnsw_count=19_900)
+        assert hnsw_capacity_status(str(palace), COLLECTION)["status"] == "ok"
+
+        shutil.rmtree(palace)
+
+        gone = hnsw_capacity_status(str(palace), COLLECTION)
+        assert len(probe_runs) == 2
+        assert gone["status"] == "unknown"
+        assert gone["diverged"] is False
+
+    def test_cache_never_exceeds_the_bound_at_any_point(self, tmp_path):
+        """Check the peak, not just the size left over at the end.
+
+        The final size after the clear-and-refill cycle is small whatever the
+        threshold comparison is, so asserting on it alone would pass with an
+        off-by-one bound.
+        """
+        from mempalace.backends import chroma as chroma_mod
+
+        peak = 0
+        for i in range(chroma_mod._CAPACITY_CACHE_MAX_ENTRIES + 5):
+            palace = tmp_path / f"palace-{i}"
+            palace.mkdir()
+            _seed_chroma_db(str(palace), sqlite_count=10, segment_id=f"seg-{i}")
+            hnsw_capacity_status(str(palace), COLLECTION)
+            peak = max(peak, len(chroma_mod._capacity_cache))
+
+        assert peak <= chroma_mod._CAPACITY_CACHE_MAX_ENTRIES
+
+    def test_concurrent_probes_are_safe_and_agree(self, tmp_path):
+        """The cache is deliberately lock-free; a racing miss must stay benign."""
+        import concurrent.futures
+
+        self._balanced_palace(tmp_path)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            verdicts = list(
+                pool.map(lambda _: hnsw_capacity_status(str(tmp_path), COLLECTION), range(32))
+            )
+
+        assert all(v["status"] == "ok" for v in verdicts)
+        assert {v["sqlite_count"] for v in verdicts} == {20_000}
+
+    def test_wal_mode_palace_still_gets_cache_hits(self, tmp_path, probe_runs):
+        """A WAL-mode palace must not invalidate its own cache on every call.
+
+        sqlite restamps the ``-shm`` WAL index every time a connection opens
+        the database, read-only included. A signature covering ``-shm`` would
+        therefore change under the probe's own reads, so the cache would miss
+        100% of the time on exactly the palaces this fix is meant to speed up.
+        """
+        self._balanced_palace(tmp_path)
+        db_path = os.path.join(str(tmp_path), "chroma.sqlite3")
+        conn = sqlite3.connect(db_path)
+        try:
+            mode = conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+        finally:
+            conn.close()
+        assert mode == "wal", "precondition: the palace must really be in WAL mode"
+
+        # The first reads settle the WAL file itself, which legitimately moves
+        # the signature; what matters is that it then stops moving.
+        for _ in range(2):
+            hnsw_capacity_status(str(tmp_path), COLLECTION)
+        settled = len(probe_runs)
+
+        for _ in range(4):
+            assert hnsw_capacity_status(str(tmp_path), COLLECTION)["status"] == "ok"
+
+        assert len(probe_runs) == settled, (
+            "reads alone must not keep invalidating the verdict on a WAL palace"
+        )
+
+    def test_pickle_rewrite_during_probe_is_not_cached(self, tmp_path):
+        """A pickle rewrite landing mid-probe must not be pinned as fresh.
+
+        The probe reads ``index_metadata.pickle`` partway through, then makes
+        two more sqlite calls. If the fingerprint were snapshotted only after
+        the probe returned, a rewrite that lands in that window would be
+        recorded as "unchanged" while the verdict still reflected the pre-write
+        file — the exact #1222 blindness the probe exists to prevent. We drive
+        the writer from ``_read_sync_threshold``, which the probe calls strictly
+        after the pickle read and strictly before it returns.
+        """
+        from mempalace.backends import chroma as chroma_mod
+
+        seg = "seg-race"
+        _seed_chroma_db(str(tmp_path), sqlite_count=20_000, segment_id=seg)
+        _write_pickle(str(tmp_path), seg, hnsw_count=19_900)  # healthy
+
+        real_rst = chroma_mod._read_sync_threshold
+        fired = []
+
+        def racing(pp, cn):
+            if not fired:
+                fired.append(1)
+                _write_pickle(str(tmp_path), seg, hnsw_count=2_000)  # collapse
+            return real_rst(pp, cn)
+
+        try:
+            chroma_mod._read_sync_threshold = racing
+            hnsw_capacity_status(str(tmp_path), COLLECTION)  # races, must not cache
+        finally:
+            chroma_mod._read_sync_threshold = real_rst
+
+        # No further writes: a later caller must see the collapsed truth, not a
+        # cached "ok" from the raced probe.
+        served = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert served["hnsw_count"] == 2_000
+        assert served["diverged"] is True
+
+    def test_locked_database_verdict_is_not_cached(self, tmp_path, probe_runs):
+        """A probe that could not read sqlite must not pin a false 'unknown'."""
+        from mempalace.backends import chroma as chroma_mod
+
+        self._balanced_palace(tmp_path)
+
+        real_count = chroma_mod._sqlite_embedding_count
+        locked = []
+
+        def flaky_count(pp, cn):
+            if not locked:
+                locked.append(1)
+                return None  # simulate "database is locked" swallowed to None
+            return real_count(pp, cn)
+
+        try:
+            chroma_mod._sqlite_embedding_count = flaky_count
+            first = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        finally:
+            chroma_mod._sqlite_embedding_count = real_count
+
+        assert first["sqlite_count"] is None  # the locked read
+        # The lock cleared; the next call must re-probe rather than serve the
+        # cached "could not read" verdict.
+        second = hnsw_capacity_status(str(tmp_path), COLLECTION)
+        assert len(probe_runs) == 2
+        assert second["sqlite_count"] == 20_000
+
+    def test_reset_during_probe_is_not_resurrected(self, tmp_path, probe_runs):
+        """A reset landing while a probe runs must win — the entry stays gone.
+
+        ``tool_reconnect`` clears the cache to force a fresh read; a probe that
+        started earlier must not repopulate the very entry the reset dropped.
+        """
+        from mempalace.backends import chroma as chroma_mod
+
+        self._balanced_palace(tmp_path)
+        real = chroma_mod._hnsw_capacity_status_uncached
+
+        def reset_midway(pp, cn="mempalace_drawers"):
+            result = real(pp, cn)
+            reset_hnsw_capacity_cache()  # a concurrent tool_reconnect
+            return result
+
+        try:
+            chroma_mod._hnsw_capacity_status_uncached = reset_midway
+            hnsw_capacity_status(str(tmp_path), COLLECTION)
+        finally:
+            chroma_mod._hnsw_capacity_status_uncached = real
+
+        assert chroma_mod._capacity_cache == {}, "the in-flight probe resurrected a reset entry"


### PR DESCRIPTION
## What does this PR do?

Fixes #1471. `hnsw_capacity_status()` (the #1222 segfault guard) runs on the hot read path: every MCP `mempalace_search`, `mempalace_check_duplicate` and `mempalace_status` call, and every CLI `search` via `searcher._hnsw_capacity_diverged`. Each call opens four short-lived sqlite connections and unpickles the segment's `index_metadata.pickle`, with no caching. On a large palace this dominates search latency: the probe is the only thing this PR changes on the search path, and on a 200k-drawer palace removing it from every repeat search saves the figures below.

This caches the probe result per `(palace_path, collection_name)` and reuses it while the files the probe reads are unchanged on disk. Invalidation is an `(inode, mtime_ns, size)` signature over `chroma.sqlite3`, its `-wal` sidecar and the segment's `index_metadata.pickle`, not a wall-clock TTL. An external writer (`mempalace repair`, a peer mine, a compaction) touches those files, so the verdict is dropped the moment the palace changes rather than after a fixed window. That keeps the #1222 guard from ever going blind: a freshly diverged segment is noticed on the very next call.

Per call, the probe goes from a `COUNT(*)` over the embeddings table plus a full unpickle of the segment metadata (both scaling with palace size) down to three `os.stat` calls on a hit (the sqlite file, its `-wal` sidecar, and the segment pickle), a constant. Measured through a live `mempalace-mcp` process (stdio) on a 200k-drawer palace in the divergence-positive state, the median repeat search dropped from roughly 110-440 ms to roughly 10-20 ms across runs; the absolute figures are load-dependent on my WSL box, but the cache-hit cost stays flat regardless of palace size because it no longer reads the data.

Same harness confirms freshness is preserved: after an external process rewrites the flushed index mid-session, `mempalace_status` reports the new `hnsw_count` immediately (2000 → 5000) with the cache in place, and a probe that races a mid-write or hits a locked database is returned but not cached.

### Design notes
- The cache lives in `backends/chroma.py`, not the MCP layer, so the CLI search path (`searcher._hnsw_capacity_diverged`) is covered by the same fix.
- `-shm` is intentionally **not** in the signature: sqlite restamps it on every database open, read-only included, so including it would make the probe invalidate its own cache on every call and never hit on a WAL-mode palace.
- Keyed by collection because `repair.status` probes both `mempalace_drawers` and `mempalace_closets` against the same palace.
- Invalidation compares the signature exactly (no mtime epsilon): re-running the probe costs milliseconds, whereas serving one stale "ok" can route a query into a diverged segment. A 10 s age ceiling is a backstop for coarse-timestamp filesystems (FAT/exFAT); the signature is the real freshness mechanism. The map is bounded to 32 entries for batch tools that walk many palaces.
- `tool_reconnect()` clears the cache alongside the other palace caches it already drops.
- The probe's own execution body is byte-for-byte unchanged; it is only wrapped and renamed to `_hnsw_capacity_status_uncached`.

This is a fresh implementation of the idea in the withdrawn #1756 (which used a 30 s TTL). Because freshness here is a file signature rather than a timestamp, the TTL pitfalls that PR was flagged for do not apply: a young process cannot skip its first probe (a cold cache always probes), and there is no timestamp that a raising probe could leave un-updated (the probe never raises, and the age ceiling is only a coarse-filesystem backstop). `test_first_probe_runs_even_when_process_uptime_is_tiny` pins the first of those.

Thanks @jphein for the report and the per-request diagnosis in #1471, and for laying out the design options (TTL decorator vs background snapshotter). The final approach is a third option (invalidate on a file signature), so I have not marked co-authorship, but the diagnosis is what made this straightforward.

## How to test

```bash
uv run pytest tests/test_hnsw_capacity.py -v
```

New coverage in `TestCapacityProbeCache`: unchanged-palace reuse; pickle/sqlite/`-wal` rewrites re-probe; WAL-mode palaces still hit the cache; segment replacement; first-flush-after-unknown; palace removal; collection keying; a pickle rewrite landing mid-probe is not cached; a probe that reads a locked database is not cached; a reset landing mid-probe is not resurrected; the age ceiling and the entry bound; and the "never raises" contract on an unstattable path.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
