### PR TITLE
perf(miner): O(N) incremental line-number tally in chunk_text (#2054)

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -653,6 +653,28 @@ def chunk_text(
     start = 0
     chunk_index = 0
 
+    # Running newline tallies for the 1-indexed (line_start, line_end)
+    # locators emitted below. These replace the previous per-chunk
+    # ``content.count("\n", 0, pos)`` full-prefix rescans, which were O(pos)
+    # each and O(N*K) over K chunks: a 287 MB / ~433k-chunk file scanned
+    # ~1.2e14 bytes and ran for days, indistinguishable from a hang (#2054).
+    # ``start`` and ``end`` each advance monotonically for any
+    # ``chunk_overlap < chunk_size // 2`` (the default 800/100 config and
+    # every sane override), so counting only the newly-scanned span is O(N)
+    # total. Each position sequence keeps its own anchor; a backward step
+    # (a paragraph-boundary pull under a pathological near-``chunk_size``
+    # overlap, or a negative index) falls back to the exact full-prefix
+    # count. That fallback is defensive and does not fire on a terminating
+    # mine: the current windowing cannot send a filed chunk's ``start``
+    # backward without also entering a pre-existing infinite loop (overlap
+    # >= chunk_size // 2), so the else-branches read as uncovered. They keep
+    # every value byte-identical to the old form if the windowing ever gains
+    # a loop guard that admits backward steps.
+    _nl_before_start = 0
+    _start_anchor = 0
+    _nl_before_end = 0
+    _end_anchor = 0
+
     while start < len(content):
         end = min(start + chunk_size, len(content))
 
@@ -671,13 +693,25 @@ def chunk_text(
             # Tier 6a — 1-indexed line range in the stripped source.
             # Approximate locator (±1 at boundaries is fine for "jump to
             # roughly here"); exact-quote positioning is a future tier.
-            # Use the bounds form of ``str.count`` (counts on the original
-            # string with start/end limits) instead of slicing — slicing
-            # would allocate a new substring per chunk and produce O(N^2)
-            # work on a 500MB file with 50K chunks. Per PR #1579 review
-            # (gemini-code-assist, medium priority).
-            line_start = content.count("\n", 0, start) + 1
-            line_end = content.count("\n", 0, end) + 1
+            # ``str.count`` with bounds (not slicing) still avoids allocating
+            # a substring per chunk, the original PR #1579 review concern
+            # (gemini-code-assist, medium priority). The incremental anchors
+            # additionally avoid rescanning the whole prefix each time, the
+            # actual O(N*K) cost (#2054). Two anchors because ``start`` and
+            # ``end`` are distinct monotonic sequences; a backward step
+            # re-derives the value exactly from position 0.
+            if start >= _start_anchor:
+                _nl_before_start += content.count("\n", _start_anchor, start)
+                _start_anchor = start
+                line_start = _nl_before_start + 1
+            else:
+                line_start = content.count("\n", 0, start) + 1
+            if end >= _end_anchor:
+                _nl_before_end += content.count("\n", _end_anchor, end)
+                _end_anchor = end
+                line_end = _nl_before_end + 1
+            else:
+                line_end = content.count("\n", 0, end) + 1
             chunks.append(
                 {
                     "content": chunk,

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -2042,6 +2042,79 @@ class TestChunkTextLineRanges:
         assert chunks[0]["line_end"] == 5
 
 
+def _naive_chunk_line_ranges(content, *, chunk_size, chunk_overlap, min_chunk_size):
+    """Pre-#2054 reference implementation of chunk_text's line locators.
+
+    Same windowing as ``chunk_text`` but recomputes ``(line_start, line_end)``
+    with the original full-prefix ``content.count("\\n", 0, pos)`` form. The
+    incremental-anchor rewrite must stay byte-identical to this on every input,
+    so this is the golden reference the tests below compare against.
+    """
+    content = content.strip()
+    if not content:
+        return []
+    out = []
+    start = 0
+    while start < len(content):
+        end = min(start + chunk_size, len(content))
+        if end < len(content):
+            newline_pos = content.rfind("\n\n", start, end)
+            if newline_pos > start + chunk_size // 2:
+                end = newline_pos
+            else:
+                newline_pos = content.rfind("\n", start, end)
+                if newline_pos > start + chunk_size // 2:
+                    end = newline_pos
+        chunk = content[start:end].strip()
+        if len(chunk) >= min_chunk_size:
+            out.append((content.count("\n", 0, start) + 1, content.count("\n", 0, end) + 1))
+        start = end - chunk_overlap if end < len(content) else end
+    return out
+
+
+class TestChunkTextLineRangesIncremental:
+    """#2054: the O(N) incremental newline tally must match the old O(N*K)
+    full-prefix ``str.count`` form byte-for-byte across varied corpora and
+    configs. Configs stay at ``overlap < size//2`` so ``start``/``end`` advance
+    monotonically (the fast path); the code's from-scratch fallback for a
+    backward step is a defensive guard; a real backward step would also trip a
+    pre-existing infinite loop in the windowing itself, which is out of scope
+    for this locator-perf fix.
+    """
+
+    def test_line_ranges_match_full_prefix_reference(self):
+        import random
+
+        from mempalace.miner import chunk_text
+
+        rng = random.Random(2054)
+        corpora = [
+            "\n".join(f"line {i}" for i in range(1, 501)),  # many short lines
+            "\n\n".join(f"para {i} " + "x" * rng.randint(0, 300) for i in range(60)),
+            "no newlines at all " * 500,  # zero newlines
+            "\n" * 200 + "tail",  # leading blank lines
+            "".join(rng.choice("ab \n\n") for _ in range(5000)),  # random newline density
+            "αβγ\nδεζ\n" * 400,  # non-ASCII
+        ]
+        configs = [
+            (800, 100, 50),  # default config
+            (200, 20, 10),
+            (400, 50, 5),
+            (1000, 200, 30),
+            (2000, 0, 1),  # zero overlap
+        ]
+        for content in corpora:
+            for cs, co, mc in configs:
+                chunks = chunk_text(
+                    content, "/x.md", chunk_size=cs, chunk_overlap=co, min_chunk_size=mc
+                )
+                got = [(c["line_start"], c["line_end"]) for c in chunks]
+                expected = _naive_chunk_line_ranges(
+                    content, chunk_size=cs, chunk_overlap=co, min_chunk_size=mc
+                )
+                assert got == expected, f"cs={cs} co={co} mc={mc}: {got[:6]} != {expected[:6]}"
+
+
 class TestBuildDrawerMetadataLineRange:
     """Tier 6a — _build_drawer_metadata stores optional line_start / line_end.
 


### PR DESCRIPTION
Fixes #2054

## What does this PR do?

`chunk_text` computed every chunk's 1-indexed `line_start` / `line_end` with a full-prefix rescan:

```python
line_start = content.count("\n", 0, start) + 1
line_end   = content.count("\n", 0, end) + 1
```

Each `count("\n", 0, pos)` is O(pos), so over K chunks the locator work is O(N*K). On large files this dominates and looks like a hang: the report measured a 287 MB source (~433k chunks at the default chunk size) scanning ~1.2e14 bytes and running for days at 100% CPU (#2054). The `MAX_CHUNKS_PER_FILE` guard runs after `chunk_text` returns, so the full quadratic cost is paid before an oversized file is ever skipped.

The fix keeps `line_start` / `line_end` byte-identical but makes the newline tally incremental. `start` and `end` each advance monotonically for any `chunk_overlap < chunk_size // 2` (the default 800/100 config and every sane override), so counting only the newly-scanned span is O(N) total. Each position sequence keeps its own anchor; a backward step re-derives the value from position 0, so every emitted value stays identical to the old form on every input. The windowing logic (chunk boundaries, overlap, the `MAX_CHUNKS_PER_FILE` guard) is unchanged.

Out of scope but worth flagging since #2054 is a hang report: a second, separate hang path survives this change. `chunk_overlap >= chunk_size // 2` stays a legal config (validation only rejects `>= chunk_size`), and on content with a paragraph break in the wrong spot the windowing itself can loop forever (`start = end - chunk_overlap` stops advancing). It predates this PR and is untouched here; a follow-up could tighten the guard in both `chunk_text` and `MempalaceConfig._validated_chunk_config` to `>= chunk_size // 2`.

This builds on earlier work on the same locator path. #1584 introduced the Tier 6a `line_start` / `line_end` ranges and already moved the newline count from slicing to the bounded `str.count` form, which removed the per-chunk substring allocation but kept the O(N*K) time. #1024 made the chunk parameters configurable and added the `chunk_overlap >= chunk_size` guard. This PR removes the remaining O(N*K) time cost; the `>= chunk_size // 2` loop that still survives (noted above) is the untightened edge of that same #1024 guard.

Thanks @RyanWei for the py-spy trace, the root-cause pinpoint, and the incremental-tally direction. The final patch diverges from the sketch in the issue: it uses two independent anchors plus a from-scratch fallback rather than one running counter, because a single counter assuming a monotonic `start` is wrong when `chunk_overlap >= chunk_size // 2` (a legal config that a paragraph-boundary pull can send backward).

## How to test

Locator logic is pure stdlib, so it can be checked without importing mempalace:

- Byte-identity: across 6 corpora (many short lines, sparse paragraphs, zero newlines, leading blanks, random newline density, non-ASCII) x 5 configs (producing 1547 / 3094 / 4640 chunks at 1 / 2 / 3 MB), the new ranges match the previous full-prefix form exactly.
- Asymptotics: the old form's time grows quadratically with file size while the new form stays flat (hundredths of a second). On a CPU-bound run the speedup is roughly 100x at 1 MB and widens past 250x by 3 MB; exact timings vary by machine, but the widening ratio is the O(N*K) to O(N) shift.

End to end through the CLI:

- `mempalace mine <20 MB / 321k-line file> --dry-run --max-chunks-per-file 0` files 32020 chunks in a couple of seconds (the same file previously ground for days).
- A real mine of a 200-line file stores 27 drawers whose `line_start` / `line_end` cover lines 1..200 monotonically.

New test `tests/test_miner.py::TestChunkTextLineRangesIncremental` is a golden-reference check asserting byte-identity to the pre-fix formula.

## Checklist
- [x] Tests pass (`uv run pytest tests/ --ignore=tests/benchmarks`: 3357 passed, 31 skipped)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`, CI pin 0.15.14; `ruff format --check` clean)
