### PR TITLE
fix(normalize): strip noise blocks with multi-paragraph bodies and indented tags

### DIFF
--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -45,6 +45,7 @@ _NOISE_TAGS = (
     "system-reminder",
     "command-message",
     "command-name",
+    "command-args",
     "task-notification",
     "user-prompt-submit-hook",
     "hook_output",
@@ -52,15 +53,16 @@ _NOISE_TAGS = (
 
 
 def _tag_pattern(name: str) -> "re.Pattern[str]":
-    # Opening tag must begin a line (optionally after a `> ` blockquote marker,
-    # since _messages_to_transcript prefixes lines with `> `). Body is lazy and
+    # Opening tag must begin a line — only a `> ` blockquote marker (added by
+    # _messages_to_transcript) and/or indentation may precede it, since Claude
+    # Code emits slash-command chrome with indented tags. Body is lazy and
     # may cross blank lines — task-notification and system-reminder blocks
     # legitimately carry multi-paragraph payloads (subagent results, recalled
     # memories) — but may not contain another opening of the same tag, so a
     # dangling open tag can never merge with a later block and eat the content
     # between them. Closing tag eats optional trailing whitespace + newline.
     return re.compile(
-        rf"(?m)^(?:> )?<{name}(?:\s[^>]*)?>"
+        rf"(?m)^(?:> )?[ \t]*<{name}(?:\s[^>]*)?>"
         rf"(?:(?!<{name}[\s>])[\s\S])*?"
         rf"</{name}>[ \t]*\n?"
     )

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -37,9 +37,9 @@ _SLACK_PROVENANCE_FOOTER = (
 # into transcripts. These waste drawer space and pollute search results.
 #
 # Verbatim is sacred — every pattern here is anchored to line boundaries and
-# refuses to cross blank lines, so a stray unclosed tag in one message can
-# never eat content from neighboring messages. When in doubt, leave text
-# alone.
+# a tag body may not swallow another opening of the same tag, so a stray
+# unclosed tag can never merge with a later block and eat the real content
+# between them. When in doubt, leave text alone.
 
 _NOISE_TAGS = (
     "system-reminder",
@@ -53,11 +53,16 @@ _NOISE_TAGS = (
 
 def _tag_pattern(name: str) -> "re.Pattern[str]":
     # Opening tag must begin a line (optionally after a `> ` blockquote marker,
-    # since _messages_to_transcript prefixes lines with `> `). Body is lazy but
-    # forbidden from crossing a blank line, so a dangling open tag can't span
-    # multiple messages. Closing tag eats optional trailing whitespace + newline.
+    # since _messages_to_transcript prefixes lines with `> `). Body is lazy and
+    # may cross blank lines — task-notification and system-reminder blocks
+    # legitimately carry multi-paragraph payloads (subagent results, recalled
+    # memories) — but may not contain another opening of the same tag, so a
+    # dangling open tag can never merge with a later block and eat the content
+    # between them. Closing tag eats optional trailing whitespace + newline.
     return re.compile(
-        rf"(?m)^(?:> )?<{name}(?:\s[^>]*)?>" rf"(?:(?!\n\s*\n)[\s\S])*?" rf"</{name}>[ \t]*\n?"
+        rf"(?m)^(?:> )?<{name}(?:\s[^>]*)?>"
+        rf"(?:(?!<{name}[\s>])[\s\S])*?"
+        rf"</{name}>[ \t]*\n?"
     )
 
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1835,6 +1835,42 @@ class TestStripNoiseRemovesSystemChrome:
             assert tag not in out, f"{tag} leaked into output"
             assert "Real." in out
 
+    def test_strips_block_with_blank_lines_in_body(self):
+        # Regression: a task-notification carrying a subagent's multi-paragraph
+        # result (blank lines inside the block) leaked wholesale into drawers
+        # because the old body pattern refused to cross blank lines.
+        text = (
+            "> User:\n"
+            "<task-notification>\n"
+            "<task-id>abc123</task-id>\n"
+            "<result># Report\n"
+            "\n"
+            "Paragraph one.\n"
+            "\n"
+            "Paragraph two.</result>\n"
+            "</task-notification>\n"
+            "> Real message."
+        )
+        out = strip_noise(text)
+        assert "task-notification" not in out
+        assert "Paragraph one" not in out
+        assert "Real message." in out
+
+    def test_dangling_open_tag_does_not_merge_with_later_block(self):
+        # A line-anchored dangling open tag must not merge with a later
+        # complete block of the same tag and eat the real content between.
+        text = (
+            "<system-reminder>dangling, never closed\n"
+            "> User: real content here\n"
+            "\n"
+            "<system-reminder>complete block</system-reminder>\n"
+            "> Tail."
+        )
+        out = strip_noise(text)
+        assert "real content here" in out
+        assert "Tail." in out
+        assert "complete block" not in out
+
     def test_collapses_excessive_blank_lines(self):
         text = "line one\n\n\n\n\n\nline two"
         out = strip_noise(text)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1871,6 +1871,20 @@ class TestStripNoiseRemovesSystemChrome:
         assert "Tail." in out
         assert "complete block" not in out
 
+    def test_strips_indented_slash_command_chrome(self):
+        # Claude Code emits slash-command chrome with indented tags; the line
+        # anchor must tolerate leading whitespace, and command-args is noise too.
+        text = (
+            "<command-name>/model</command-name>\n"
+            "            <command-message>model</command-message>\n"
+            "            <command-args></command-args>\n"
+            "> Real message."
+        )
+        out = strip_noise(text)
+        for tag in ("command-name", "command-message", "command-args"):
+            assert tag not in out, f"{tag} leaked"
+        assert "Real message." in out
+
     def test_collapses_excessive_blank_lines(self):
         text = "line one\n\n\n\n\n\nline two"
         out = strip_noise(text)


### PR DESCRIPTION
## Problem

Two escape paths let Claude Code harness chrome leak into mined drawers and pollute search/recall:

1. `<task-notification>` and `<system-reminder>` blocks carrying multi-paragraph payloads (subagent results, recalled memories) were never stripped: the tag-body pattern refused to cross blank lines, so exactly the largest noise blocks survived wholesale.
2. Claude Code emits slash-command chrome with indented tags (`<command-message>`, `<command-args>` after `<command-name>`), which the line-start anchor missed. `command-args` was also missing from the noise list entirely.

Found by mining ~90 real Claude Code sessions: thousands of drawers contained raw task-notification payloads, and semantic recall surfaced harness boilerplate instead of content.

## Fix

- Tag bodies may now span blank lines, guarded by a same-tag-reopen lookahead instead of the blank-line rule: a dangling open tag still cannot merge with a later block and eat the real content between them (the original span-eating protection this rule existed for).
- The line anchor tolerates leading whitespace after the optional `> ` blockquote marker.
- `command-args` added to `_NOISE_TAGS`.

## Testing

- 3 new regression tests (multi-paragraph block, dangling-tag safety, indented slash-command chrome).
- Full test suite green.
- Re-mined the same ~90 real sessions (20k+ drawers): zero noise blocks survive, inline prose mentioning the tags is still preserved.