### PR TITLE
fix: expand tilde in Cursor transcript paths

### DIFF
--- a/hooks/cursor/lib/common.sh
+++ b/hooks/cursor/lib/common.sh
@@ -238,7 +238,7 @@ print(status)
     # Expand a leading ~ in the transcript path so downstream
     # ``[ -f "$path" ]`` checks resolve correctly.
     case "$MEMPAL_TRANSCRIPT" in
-        '~/'*) MEMPAL_TRANSCRIPT="$HOME/${MEMPAL_TRANSCRIPT#~/}" ;;
+        '~/'*) MEMPAL_TRANSCRIPT="$HOME/${MEMPAL_TRANSCRIPT#"~/"}" ;;
     esac
 }
 

--- a/tests/test_cursor_hooks_shell.py
+++ b/tests/test_cursor_hooks_shell.py
@@ -666,6 +666,17 @@ def _age_file(path: Path, days: int) -> None:
     os.utime(path, (old, old))
 
 
+class TestTranscriptPathExpansion:
+    def test_expands_leading_tilde_against_home(self, tmp_path):
+        payload = _stop_payload(transcript="~/sessions/conv-1.jsonl")
+        out = _run_common_snippet(
+            'mempal_parse_stdin "$TEST_CURSOR_PAYLOAD"; printf "%s" "$MEMPAL_TRANSCRIPT"',
+            tmp_path,
+            extra_env={"TEST_CURSOR_PAYLOAD": payload},
+        )
+        assert out == str(tmp_path / "sessions" / "conv-1.jsonl")
+
+
 class TestStateTtlDays:
     @pytest.mark.parametrize(
         "value,expected",


### PR DESCRIPTION
## Summary

Fix leading `~/` expansion in Cursor transcript paths and add regression coverage.

## Problem

When Cursor supplies a transcript path such as:

```text
~/sessions/conv-1.jsonl
```

the hook incorrectly expands it to:

```text
$HOME/~/sessions/conv-1.jsonl
```

The resulting path does not exist, so downstream file checks can fail to find the transcript.

## Root cause

The parameter expansion used an unquoted `~/` removal pattern:

```bash
${MEMPAL_TRANSCRIPT#~/}
```

Bash interprets the unquoted tilde specially instead of removing the literal `~/` prefix.

## Fix

Treat `~/` as a literal prefix before prepending `$HOME`:

```bash
${MEMPAL_TRANSCRIPT#"~/"}
```

Absolute transcript paths remain unchanged.

## Validation

- Added a regression test covering a `~/sessions/conv-1.jsonl` payload.
- Confirmed the test fails before the fix and passes afterward.
- Cursor hook shell tests: `100 passed`.
- `bash -n hooks/cursor/lib/common.sh`
- `git diff --check`
