### PR TITLE
fix(entity): guard candidate extraction against ReDoS on base64/minif…

### DIFF
--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -272,6 +272,30 @@ SKIP_FILENAMES = {
 # ==================== CANDIDATE EXTRACTION ====================
 
 
+# Proper nouns are short and space-delimited; a whitespace-free run of 30+
+# characters is base64, a minified blob, or a code identifier — never an
+# entity. This pattern is linear (a single greedy quantifier over a character
+# class, no alternation or nesting) so it cannot itself backtrack.
+_LONG_TOKEN_RE = re.compile(r"\S{30,}")
+
+
+def _strip_long_tokens(text: str) -> str:
+    """Collapse whitespace-free runs of 30+ chars to a single space.
+
+    The i18n ``candidate_pattern`` uses nested ambiguous quantifiers
+    (``(?:[A-Z][a-z]+|[A-Z]{2,})+``) that can partition a long
+    whitespace-free mixed-case run in exponentially many ways. Natural
+    language never triggers this, but base64 blobs and minified code embed
+    thousands of whitespace-free characters and pin ``re.findall`` at 100%
+    CPU for hours, hanging ``mempalace mine`` indefinitely (issue #2063).
+
+    Removing such runs before the candidate regexes ever see them drops a
+    5000-char blob from hours to well under a millisecond, with no effect on
+    natural-language extraction (proper nouns are far shorter than 30 chars).
+    """
+    return _LONG_TOKEN_RE.sub(" ", text)
+
+
 def extract_candidates(text: str, languages=("en",)) -> dict:
     """
     Extract all capitalized proper noun candidates from text.
@@ -281,6 +305,10 @@ def extract_candidates(text: str, languages=("en",)) -> dict:
     for English, Latin+diacritics for pt-br, Cyrillic for Russian,
     Devanagari for Hindi). Matches from all languages are unioned.
     """
+    # Guard the candidate regexes against catastrophic backtracking on
+    # base64 / minified content before any pattern runs (issue #2063).
+    text = _strip_long_tokens(text)
+
     langs = _normalize_langs(languages)
     patterns = get_entity_patterns(langs)
     stopwords = _get_stopwords(langs)

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -26,7 +26,11 @@ from .backends import (
     resolve_backend_for_palace,
 )
 from .backends.embedding_wrapper import EmbeddingCollection
-from .entity_detector import _apply_known_systems_prepass, _get_coca_filter
+from .entity_detector import (
+    _apply_known_systems_prepass,
+    _get_coca_filter,
+    _strip_long_tokens,
+)
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -530,6 +534,9 @@ def _candidate_entity_words(text: str) -> list:
             except re.error:
                 continue
         _CANDIDATE_RX_CACHE = rxs
+    # Guard against catastrophic backtracking (issue #2063) before the
+    # candidate patterns run on arbitrary drawer content.
+    text = _strip_long_tokens(text)
     words = []
     for rx in _CANDIDATE_RX_CACHE:
         words.extend(rx.findall(text))

--- a/tests/test_entity_detector.py
+++ b/tests/test_entity_detector.py
@@ -3,6 +3,7 @@
 import contextlib
 import json
 import os
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,6 +11,7 @@ from mempalace.entity_detector import (
     PROSE_EXTENSIONS,
     STOPWORDS,
     _print_entity_list,
+    _strip_long_tokens,
     classify_entity,
     confirm_entities,
     detect_entities,
@@ -1059,3 +1061,55 @@ def test_zh_tw_known_limitation_inline_name_no_boundary():
     result = extract_candidates(text, languages=("zh-TW",))
     # Extraction is expected to miss this adversarial case.
     assert "朱宜振" not in result
+
+
+# ── catastrophic-backtracking guard (issue #2063) ─────────────
+
+
+def _run_within(fn, timeout=10.0):
+    """Run ``fn`` in a worker thread and fail if it does not finish in time.
+
+    A regression that reintroduces the catastrophic backtracking would hang
+    ``re.findall`` for hours; this bounds the test instead of hanging CI.
+    """
+    box = {}
+
+    def target():
+        box["value"] = fn()
+
+    t = threading.Thread(target=target, daemon=True)
+    t.start()
+    t.join(timeout)
+    assert not t.is_alive(), "call did not complete in time — candidate regex hung"
+    return box["value"]
+
+
+def test_strip_long_tokens_collapses_long_runs():
+    # A run of 30+ non-whitespace chars is collapsed to a single space.
+    assert _strip_long_tokens("A" * 30) == " "
+    # 29 chars is under the threshold and is left untouched.
+    assert _strip_long_tokens("A" * 29) == "A" * 29
+    blob = "x" * 100
+    out = _strip_long_tokens("before " + blob + " after")
+    assert blob not in out
+    assert "before" in out and "after" in out
+
+
+def test_strip_long_tokens_preserves_natural_language():
+    text = "Riley said hello to Devon about the GraphQL migration."
+    assert _strip_long_tokens(text) == text
+
+
+def test_extract_candidates_neutralizes_pathological_blob():
+    """Base64 / minified content must not hang candidate extraction (#2063).
+
+    ``Xa`` enters the candidate pattern, the long uppercase run explodes the
+    nested ``(?:[A-Z][a-z]+|[A-Z]{2,})+`` quantifier, and the trailing digit
+    defeats the closing word boundary — unguarded, ``re.findall`` never
+    returns. The guard strips the whitespace-free run before the regex runs.
+    """
+    blob = "Xa" + ("B" * 45) + "1"
+    text = "Riley said hi. Riley laughed. Riley smiled. " + blob + " and Riley waved."
+    result = _run_within(lambda: extract_candidates(text))
+    assert "Riley" in result  # natural-language extraction still works
+    assert blob not in result  # the blob never becomes an entity

--- a/tests/test_palace.py
+++ b/tests/test_palace.py
@@ -185,3 +185,28 @@ def test_open_collection_or_explain_distinguishes_collection_subclass(tmp_path, 
     assert result is None
     assert any("initialized but empty" in line for line in lines)
     assert not any("No palace found" in line for line in lines)
+
+
+def test_candidate_entity_words_neutralizes_pathological_blob():
+    """The per-drawer mining path must not hang on base64 / minified content.
+
+    ``_candidate_entity_words`` runs the same nested-quantifier candidate
+    patterns as ``entity_detector`` and is called for every drawer during
+    mining, so a base64 blob would pin the miner at 100% CPU indefinitely
+    (issue #2063). The guard strips the long whitespace-free run first.
+    """
+    import threading
+
+    from mempalace.palace import _candidate_entity_words
+
+    blob = "Xa" + ("B" * 45) + "1"
+    box: dict = {}
+
+    def target():
+        box["value"] = _candidate_entity_words("Alice " + blob + " Bob")
+
+    t = threading.Thread(target=target, daemon=True)
+    t.start()
+    t.join(10.0)
+    assert not t.is_alive(), "candidate extraction hung on base64 blob"
+    assert blob not in box["value"]


### PR DESCRIPTION
…ied content

The i18n candidate_pattern's nested ambiguous quantifiers `(?:[A-Z][a-z]+|[A-Z]{2,})+` partition long whitespace-free mixed-case runs (base64 blobs, minified code) in exponentially many ways, causing catastrophic backtracking that pins `mempalace mine` at 100% CPU indefinitely.

Add `_strip_long_tokens()` to collapse `\S{30,}` runs to a single space before the candidate regexes run, applied at both entry points: `extract_candidates()` and `palace._candidate_entity_words()` (the per-drawer mining hot path). The guard pattern is linear and cannot itself backtrack. Natural-language extraction is unaffected — proper nouns are far shorter than 30 chars.

Reproduced with `"Xa" + "B"*42 + "1"`; adds regression tests with thread-watchdog timeouts so a regression fails fast instead of hanging.

Fixes #2063.

## What does this PR do?

## How to test

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
