### PR TITLE
feat: add reviewed /mempalace:kg command for knowledge-graph commits

### DIFF
--- a/commands/mempalace-kg.md
+++ b/commands/mempalace-kg.md
@@ -1,0 +1,10 @@
+---
+description: Commit this session's established facts to the knowledge graph, after showing them to you for review.
+---
+
+Invoke the `mempalace` skill from this plugin and run the `kg` instructions, then follow them.
+
+Concretely: run `mempalace instructions kg` in a terminal, then carry out the steps it prints.
+
+Facts enter the graph only after you approve them. A wrong triple is read back by later
+sessions as fact, so this is deliberately a reviewed commit rather than an automatic one.

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -2005,7 +2005,7 @@ def main():
         help="Output skill instructions to stdout",
     )
     instructions_sub = p_instructions.add_subparsers(dest="instructions_name")
-    for instr_name in ["init", "search", "mine", "help", "status"]:
+    for instr_name in ["init", "search", "mine", "help", "status", "kg"]:
         instructions_sub.add_parser(instr_name, help=f"Output {instr_name} instructions")
 
     # repair

--- a/mempalace/instructions/kg.md
+++ b/mempalace/instructions/kg.md
@@ -1,0 +1,63 @@
+# MemPalace KG — commit facts to the knowledge graph
+
+Turn what this session actually established into knowledge-graph triples, **reviewed by the
+user before they land**.
+
+## Why this is a command and not a hook
+
+Drawers and the knowledge graph fail differently. A drawer that stores a claim later shown
+wrong is still an honest record of what was said. A KG triple asserting that claim is read
+back by future sessions as **fact**, and a wrong one is actively harmful — it does not just
+fail to help, it steers the next decision wrong.
+
+Sessions routinely reverse themselves. A metric can be treated as authoritative for weeks
+and be retired in an afternoon once its floor is measured; an arm can look like the winner
+until its control reproduces the score. Anything that auto-extracted triples mid-session
+would have committed the pre-reversal version and then kept serving it. So the graph takes
+facts only by explicit, reviewed commit.
+
+## Step 1: Propose
+
+Read back over the session and draft candidate triples: `subject → predicate → object`,
+plus `valid_from` (YYYY-MM-DD) when the fact has a start date.
+
+Propose only facts that are:
+- **settled** — not a hypothesis, a partial measurement, or something a pending run may flip;
+- **durable** — useful to a session weeks from now, not an artifact of today's cwd or queue;
+- **attributable** — traceable to a measurement, a file, or an explicit user decision.
+
+Skip: in-progress work, numbers that a control arm has not yet checked, anything phrased as
+"seems" or "probably". Those belong in a drawer or a memory file, not the graph.
+
+Prefer specific predicates (`achieves_real_robot_SR`, `was_retired_because`,
+`is_worktree_of`) over vague ones (`relates_to`, `has`). The predicate carries the meaning
+when the triple is read back with no surrounding context.
+
+Note: subject/predicate/object reject some punctuation. Spell out `+` and `,` — write
+`gather tb4`, not `gather+tb4`.
+
+## Step 2: Show the user
+
+Present the candidates as a compact table — subject, predicate, object, valid_from — and
+say plainly which ones you are least sure about and why. Then ask which to commit.
+
+Do not commit anything before the user answers. If they trim the list, commit only what
+they kept.
+
+## Step 3: Commit
+
+For each approved candidate call `mempalace_kg_add`. Report the count committed.
+
+## Step 4: Supersede, do not duplicate
+
+If a new fact replaces an older one, call `mempalace_kg_invalidate` on the old triple in the
+same pass. A graph holding both the retired and the current version of a fact is worse than
+one holding neither, because a query returns both and the reader cannot tell which is live.
+
+Check first with `mempalace_kg_query` on the subject.
+
+## Step 5: Persist beyond the palace
+
+The graph lives outside the palace directory and outside any git repo. If the project keeps
+an export script (`export_kg.py` writing `kg/triples.jsonl`), run it so the new facts reach
+the backup — drawers can be re-mined from source markdown, hand-authored triples cannot.

--- a/mempalace/instructions_cli.py
+++ b/mempalace/instructions_cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 INSTRUCTIONS_DIR = Path(__file__).parent / "instructions"
 
-AVAILABLE = ["init", "search", "mine", "help", "status"]
+AVAILABLE = ["init", "search", "mine", "help", "status", "kg"]
 
 
 def run_instructions(name: str):

--- a/skills/mempalace/SKILL.md
+++ b/skills/mempalace/SKILL.md
@@ -29,9 +29,17 @@ MemPalace provides dynamic, version-correct instructions via the CLI. To get ins
 mempalace instructions <command>
 ```
 
-Where `<command>` is one of: `help`, `init`, `mine`, `search`, `status`.
+Where `<command>` is one of: `help`, `init`, `mine`, `search`, `status`, `kg`.
 
 Run the appropriate instructions command, then follow the returned instructions step by step.
+
+## Committing facts to the knowledge graph
+
+`kg` is the reviewed path for writing knowledge-graph triples. It proposes candidate facts
+from the session, shows them to the user, and only calls `mempalace_kg_add` on the ones
+approved. Drawers can hold a claim that later turns out wrong and still be an honest record;
+a KG triple is read back by future sessions as fact, so a wrong one actively misleads. That
+is why the graph is written by an explicit command and not by an automatic hook.
 
 ## Recalling past work
 


### PR DESCRIPTION
The palace had no path for writing knowledge-graph triples: drawers get filed automatically by mining, but every triple had to be added by hand through the MCP tool, so in practice the graph stayed empty while the drawers grew.

Adding an automatic extractor would have been the wrong fix. Drawers and the graph fail differently — a drawer holding a claim later shown wrong is still an honest record of what was said, while a triple asserting it is read back by future sessions as fact and steers the next decision wrong. Sessions do reverse themselves: a metric can serve as the pre-registered criterion for weeks and be retired once its degenerate floor is measured. An extractor running mid-session would have committed the pre-reversal value and kept serving it.

So the graph takes facts only by explicit, reviewed commit: propose candidates, show them to the user, add only what is approved, and invalidate superseded triples in the same pass rather than leaving both versions queryable.

- mempalace/instructions/kg.md   the instruction text
- instructions_cli.py, cli.py    register "kg" (both AVAILABLE and the argparse choices)
- commands/mempalace-kg.md       slash command
- skills/mempalace/SKILL.md      document when to reach for it

## What does this PR do?

## How to test

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [ ] No hardcoded paths
- [ ] Linter passes (`ruff check .`)
