### PR TITLE
fix(repair): preserve verified temp copy on failed rebuild swap; fail loud on truncated pagination

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1114,6 +1114,7 @@ def cmd_repair(args):
         _close_chroma_handles,
         _extract_drawers,
         _post_rebuild_cleanup,
+        _promote_temp_collection,
         _rebuild_collection_via_temp,
         check_extraction_safety,
         index_read_recovery_guidance,
@@ -1307,19 +1308,27 @@ def cmd_repair(args):
     except RebuildCollectionError as e:
         print(f"  Repair failed: {e}")
         if getattr(e, "live_replaced", False):
-            print("  Live collection was already replaced; restoring from backup...")
+            temp_name = f"{collection_name}__repair_tmp"
+            print(f"  Attempting recovery: promoting verified copy from '{temp_name}'...")
             try:
                 _close_chroma_handles(palace_path, backend=backend)
-                if os.path.exists(palace_path):
-                    shutil.rmtree(palace_path)
-                shutil.copytree(backup_path, palace_path)
-                print(f"  Restore complete from backup: {backup_path}")
-            except Exception as restore_error:
-                print(f"  Automatic restore failed: {restore_error}")
-                print("  Manual recovery required:")
-                print(f"    1. Remove or rename the broken directory: {palace_path}")
-                print(f"    2. Restore the backup directory to: {palace_path}")
-                print(f"       Backup location: {backup_path}")
+                _promote_temp_collection(
+                    backend,
+                    palace_path,
+                    temp_name,
+                    collection_name,
+                    len(all_ids),
+                    batch_size,
+                    progress=print,
+                )
+                print("  Recovery succeeded: live collection restored from the verified temp copy.")
+            except Exception as promote_error:
+                print(f"  Automatic recovery failed: {promote_error}")
+                print(
+                    f"  The verified pre-swap copy still survives under '{temp_name}' -- do NOT "
+                    f"delete it. Recover manually by promoting it, or restore the full-directory "
+                    f"backup at: {backup_path}"
+                )
         sys.exit(1)
 
     # The bulk delete + re-upsert cycle above leaves the FTS5 inverted index

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -354,7 +354,7 @@ def _rebuild_collection_via_temp(
             raise RebuildCollectionError(str(exc), live_replaced=live_replaced) from exc
         # The live collection was already deleted (line 294) before this
         # failure. `temp_name` is now the ONLY intact, verified copy of the
-        # data left on disk -- never delete it here (#8). Point the operator
+        # data left on disk -- never delete it here. Point the operator
         # at it instead of destroying the one thing that can still recover.
         raise RebuildCollectionError(
             f"{exc}. The live collection '{collection_name}' was already "
@@ -383,7 +383,7 @@ def _promote_temp_collection(
     verified temp copy -- NOT to restore a pre-rebuild sqlite3 file backup,
     whose on-disk HNSW segment directories were already destroyed by the
     live-collection delete and would leave the palace referencing segment
-    UUIDs that no longer exist on disk (#8).
+    UUIDs that no longer exist on disk.
     """
     temp_col = backend.get_collection(palace_path, temp_name)
     ids, docs, metas = _extract_drawers(temp_col, expected, batch_size)
@@ -1176,7 +1176,7 @@ def rebuild_index(
             # misleading: the live collection's on-disk HNSW segment
             # directories were already destroyed by the delete that
             # preceded this failure, so a sqlite-only restore leaves the
-            # palace referencing segment UUIDs that no longer exist (#8).
+            # palace referencing segment UUIDs that no longer exist.
             # The verified good copy is the temp collection instead --
             # promote it directly.
             temp_name = f"{collection_name}__repair_tmp"

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -186,8 +186,23 @@ def _paginate_ids(col, where=None):
         except Exception:
             try:
                 r = col.get(where=where, include=[], limit=page)
-            except Exception:
-                break
+            except Exception as fallback_exc:
+                # Both the offset request AND the no-offset fallback failed.
+                # Whatever is in ``ids`` so far is a partial (or empty) prefix
+                # of the collection, not a complete listing. Returning it
+                # would make scan_palace/rebuild act on a truncated palace as
+                # though it were whole (or, on the first page, print "Nothing
+                # to scan." for a palace we never actually read). The whole
+                # point of this path is to fail loudly rather than silently
+                # truncate, so raise instead of breaking.
+                raise RuntimeError(
+                    f"_paginate_ids: both offset-based pagination and the "
+                    f"no-offset fallback failed after collecting {len(ids)} "
+                    f"ids. Refusing to return a silently truncated ID list -- "
+                    f"investigate the collection, or use a repair mode that "
+                    f"does not depend on offset paging (e.g. --mode "
+                    f"from-sqlite). Underlying error: {fallback_exc}"
+                ) from fallback_exc
             new_ids = [i for i in r["ids"] if i not in set(ids)]
             if not new_ids:
                 # Offset is broken and the no-offset fallback always
@@ -203,10 +218,18 @@ def _paginate_ids(col, where=None):
                 # native-crash-surface caveat on a corrupted collection,
                 # which is out of scope for this fix -- see the deferred
                 # HNSW-preflight-sweep work).
+                #
+                # ``col.count()`` is collection-wide and takes no ``where``
+                # argument, so it is only authoritative when this call is
+                # UNFILTERED. With a ``where`` filter, a global count > the
+                # collected rows does NOT prove the filtered set is truncated
+                # (the extra rows may belong to other wings), so we cannot use
+                # it as proof and treat filtered completeness as unknown
+                # rather than raising a false-positive truncation error.
                 # This raise is intentionally OUTSIDE the narrow try/except
                 # above so it propagates instead of being swallowed as a
                 # get()-failure.
-                if len(ids) >= page and len(r["ids"] or []) >= page:
+                if where is None and len(ids) >= page and len(r["ids"] or []) >= page:
                     try:
                         total = col.count()
                     except Exception:

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -1192,7 +1192,9 @@ def rebuild_index(
                     batch_size,
                     progress=progress,
                 )
-                progress("  Recovery succeeded: live collection restored from the verified temp copy.")
+                progress(
+                    "  Recovery succeeded: live collection restored from the verified temp copy."
+                )
             except Exception as promote_error:
                 progress(f"  Automatic recovery failed: {promote_error}")
                 progress(

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -186,14 +186,47 @@ def _paginate_ids(col, where=None):
         except Exception:
             try:
                 r = col.get(where=where, include=[], limit=page)
-                new_ids = [i for i in r["ids"] if i not in set(ids)]
-                if not new_ids:
-                    break
-                ids.extend(new_ids)
-                offset += len(new_ids)
-                continue
             except Exception:
                 break
+            new_ids = [i for i in r["ids"] if i not in set(ids)]
+            if not new_ids:
+                # Offset is broken and the no-offset fallback always
+                # re-fetches the same first `page` results, so it can never
+                # advance past that boundary. Landing exactly on that
+                # boundary (len(ids) >= page) is ambiguous from the fetched
+                # page alone: it could mean "collection has exactly `page`
+                # ids, genuinely complete" or "collection has more and we
+                # are truncating" -- those two states are indistinguishable
+                # without an authoritative count. Disambiguate against the
+                # collection's own count() (same pattern already used by
+                # _verify_collection_count in this file; shares its known
+                # native-crash-surface caveat on a corrupted collection,
+                # which is out of scope for this fix -- see the deferred
+                # HNSW-preflight-sweep work).
+                # This raise is intentionally OUTSIDE the narrow try/except
+                # above so it propagates instead of being swallowed as a
+                # get()-failure.
+                if len(ids) >= page and len(r["ids"] or []) >= page:
+                    try:
+                        total = col.count()
+                    except Exception:
+                        total = None
+                    if total is None or total > len(ids):
+                        raise RuntimeError(
+                            f"_paginate_ids: offset-based pagination failed "
+                            f"and the no-offset fallback cannot advance past "
+                            f"the first {page} results ({len(ids)} collected, "
+                            f"collection reports "
+                            f"{total if total is not None else 'an unreadable'} "
+                            f"total). Refusing to return a silently truncated "
+                            f"ID list -- investigate the collection, or use a "
+                            f"repair mode that does not depend on offset "
+                            f"paging (e.g. --mode from-sqlite)."
+                        )
+                break
+            ids.extend(new_ids)
+            offset += len(new_ids)
+            continue
         n = len(r["ids"]) if r["ids"] else 0
         if n == 0:
             break
@@ -311,11 +344,71 @@ def _rebuild_collection_via_temp(
             pass
         return rebuilt
     except Exception as exc:
-        try:
-            _delete_collection_if_exists(backend, palace_path, temp_name)
-        except Exception:
-            pass
-        raise RebuildCollectionError(str(exc), live_replaced=live_replaced) from exc
+        if not live_replaced:
+            # The live collection was never touched -- the temp build is a
+            # discardable in-progress copy, safe to clean up on failure.
+            try:
+                _delete_collection_if_exists(backend, palace_path, temp_name)
+            except Exception:
+                pass
+            raise RebuildCollectionError(str(exc), live_replaced=live_replaced) from exc
+        # The live collection was already deleted (line 294) before this
+        # failure. `temp_name` is now the ONLY intact, verified copy of the
+        # data left on disk -- never delete it here (#8). Point the operator
+        # at it instead of destroying the one thing that can still recover.
+        raise RebuildCollectionError(
+            f"{exc}. The live collection '{collection_name}' was already "
+            f"replaced and the re-upload into it failed. The fully-verified "
+            f"pre-swap copy survives under '{temp_name}' -- do NOT delete it. "
+            f"Recover by removing the broken '{collection_name}' collection "
+            f"and promoting '{temp_name}' in its place.",
+            live_replaced=live_replaced,
+        ) from exc
+
+
+def _promote_temp_collection(
+    backend,
+    palace_path: str,
+    temp_name: str,
+    collection_name: str,
+    expected: int,
+    batch_size: int,
+    progress=print,
+) -> int:
+    """Recover a failed live-swap by promoting the verified temp copy.
+
+    `_rebuild_collection_via_temp` fully verifies `temp_name` before it ever
+    touches the live collection. If the post-swap re-upload into a fresh live
+    collection then fails, the honest recovery is to copy directly from that
+    verified temp copy -- NOT to restore a pre-rebuild sqlite3 file backup,
+    whose on-disk HNSW segment directories were already destroyed by the
+    live-collection delete and would leave the palace referencing segment
+    UUIDs that no longer exist on disk (#8).
+    """
+    temp_col = backend.get_collection(palace_path, temp_name)
+    ids, docs, metas = _extract_drawers(temp_col, expected, batch_size)
+    _delete_collection_if_exists(backend, palace_path, collection_name)
+    new_col = backend.create_collection(palace_path, collection_name)
+    promoted = 0
+    for i in range(0, len(ids), batch_size):
+        new_col.upsert(
+            documents=docs[i : i + batch_size],
+            ids=ids[i : i + batch_size],
+            metadatas=metas[i : i + batch_size],
+        )
+        promoted += len(ids[i : i + batch_size])
+        progress(f"  Promoted {promoted}/{expected} drawers from verified temp copy...")
+    _verify_collection_count(new_col, expected, "promoted temp collection")
+    # Promotion has already fully succeeded and verified at this point --
+    # cleaning up the now-redundant temp copy is best-effort, matching the
+    # identical post-success cleanup in _rebuild_collection_via_temp above.
+    # A failure here (e.g. a transient Windows file lock) must not turn a
+    # successful recovery into a reported failure.
+    try:
+        _delete_collection_if_exists(backend, palace_path, temp_name)
+    except Exception:
+        pass
+    return promoted
 
 
 def scan_palace(palace_path=None, only_wing=None, collection_name: Optional[str] = None):
@@ -1078,18 +1171,35 @@ def rebuild_index(
     except RebuildCollectionError as e:
         progress(f"\n  ERROR during rebuild: {e}")
         progress("  Rebuild aborted before completion.")
-        if e.live_replaced and os.path.exists(backup_path):
-            progress(f"  Restoring from backup: {backup_path}")
+        if e.live_replaced:
+            # Restoring the pre-rebuild chroma.sqlite3 file here would be
+            # misleading: the live collection's on-disk HNSW segment
+            # directories were already destroyed by the delete that
+            # preceded this failure, so a sqlite-only restore leaves the
+            # palace referencing segment UUIDs that no longer exist (#8).
+            # The verified good copy is the temp collection instead --
+            # promote it directly.
+            temp_name = f"{collection_name}__repair_tmp"
+            progress(f"  Attempting recovery: promoting verified copy from '{temp_name}'...")
             try:
                 _close_chroma_handles(palace_path, backend=backend)
-                _delete_collection_if_exists(backend, palace_path, collection_name)
-                _copy_file_no_follow(backup_path, sqlite_path, replace=True)
-                progress("  Backup restored. Palace is back to pre-repair state.")
-            except Exception as restore_error:
-                progress(f"  Backup restore failed: {restore_error}")
-                progress(f"  Manual restore required from: {backup_path}")
-        elif e.live_replaced:
-            progress("  No backup available. Re-mine from source files to recover.")
+                _promote_temp_collection(
+                    backend,
+                    palace_path,
+                    temp_name,
+                    collection_name,
+                    len(all_ids),
+                    batch_size,
+                    progress=progress,
+                )
+                progress("  Recovery succeeded: live collection restored from the verified temp copy.")
+            except Exception as promote_error:
+                progress(f"  Automatic recovery failed: {promote_error}")
+                progress(
+                    f"  The verified pre-swap copy still survives under '{temp_name}' -- "
+                    f"do NOT delete it. Recover manually by promoting it, or re-mine "
+                    f"from source files."
+                )
         else:
             print("  Live collection was not replaced; leaving the original palace untouched.")
         raise

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1168,6 +1168,8 @@ def test_cmd_repair_uses_configured_collection(mock_config_cls, tmp_path, capsys
 
 @patch("mempalace.cli.MempalaceConfig")
 def test_cmd_repair_restores_backup_on_live_rebuild_failure(mock_config_cls, tmp_path, capsys):
+    """When the live swap fails after the delete, recovery must PROMOTE the
+    verified temp copy instead of restoring a sqlite-only file backup."""
     palace_dir = tmp_path / "palace"
     palace_dir.mkdir()
     sqlite3.connect(str(palace_dir / "chroma.sqlite3")).close()
@@ -1183,21 +1185,30 @@ def test_cmd_repair_restores_backup_on_live_rebuild_failure(mock_config_cls, tmp
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
+    mock_promoted_col = MagicMock()
+    mock_promoted_col.count.return_value = 2
     mock_backend = _mock_backend_for(col=mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, RuntimeError("live build failed")]
+    mock_backend.create_collection.side_effect = [
+        mock_temp_col,
+        RuntimeError("live build failed"),
+        mock_promoted_col,
+    ]
     with patch("mempalace.backends.chroma.ChromaBackend", return_value=mock_backend):
         with pytest.raises(SystemExit) as excinfo:
             cmd_repair(args)
     out = capsys.readouterr().out
     assert excinfo.value.code == 1
     assert "Repair failed" in out
-    assert "restoring from backup" in out
+    assert "Attempting recovery: promoting verified copy" in out
+    assert "Recovery succeeded" in out
     mock_backend.close_palace.assert_called_once_with(str(palace_dir))
     assert mock_backend.delete_collection.call_args_list == [
-        call(str(palace_dir), "mempalace_drawers__repair_tmp"),
-        call(str(palace_dir), "mempalace_drawers"),
-        call(str(palace_dir), "mempalace_drawers__repair_tmp"),
+        call(str(palace_dir), "mempalace_drawers__repair_tmp"),  # pre-clean stale temp
+        call(str(palace_dir), "mempalace_drawers"),  # live delete before re-upload
+        call(str(palace_dir), "mempalace_drawers"),  # delete broken live before promotion
+        call(str(palace_dir), "mempalace_drawers__repair_tmp"),  # temp cleaned after promotion
     ]
+    assert mock_promoted_col.upsert.called
 
 
 def _repair_backend_mocks(mock_config_cls, palace_dir, create_collection_results=None):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1067,9 +1067,14 @@ def test_rebuild_collection_via_temp_preserves_temp_when_live_replaced_and_reupl
     assert "live upsert failed" in str(excinfo.value)
     assert excinfo.value.live_replaced is True
     # The temp collection must never be deleted once it is the only good copy.
-    assert call("/palace", "mempalace_drawers__repair_tmp") not in mock_backend.delete_collection.call_args_list[1:]
+    assert (
+        call("/palace", "mempalace_drawers__repair_tmp")
+        not in mock_backend.delete_collection.call_args_list[1:]
+    )
     assert mock_backend.delete_collection.call_args_list == [
-        call("/palace", "mempalace_drawers__repair_tmp"),  # pre-existing stale temp, cleaned before staging
+        call(
+            "/palace", "mempalace_drawers__repair_tmp"
+        ),  # pre-existing stale temp, cleaned before staging
         call("/palace", "mempalace_drawers"),  # the actual live-collection swap
     ]
     # The error must point the operator at the surviving good copy.

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -79,7 +79,7 @@ def test_paginate_ids_offset_exception_fallback():
 
 
 def test_paginate_ids_offset_broken_over_page_size_raises_instead_of_truncating():
-    """#12: when offset is broken, the no-offset fallback is structurally
+    """When offset is broken, the no-offset fallback is structurally
     stuck at the first `page` (1000) results, and the collection's own
     count() confirms there really are MORE ids than that (a genuinely
     truncated case) -- silently returning a truncated ID list is worse than
@@ -854,7 +854,7 @@ def test_rebuild_index_stage_failure_leaves_live_collection_untouched(
 @patch("mempalace.repair._copy_file_no_follow")
 @patch("mempalace.repair.ChromaBackend")
 def test_rebuild_index_live_failure_restores_backup(mock_backend_cls, mock_copy, tmp_path):
-    """#8: when the live swap fails after the delete, recovery must PROMOTE
+    """When the live swap fails after the delete, recovery must PROMOTE
     the verified temp copy (not restore a sqlite-only file backup, whose
     on-disk HNSW segments are already gone)."""
     sqlite_path = tmp_path / "chroma.sqlite3"
@@ -962,7 +962,7 @@ def test_rebuild_index_live_delete_missing_still_restores_backup(
 def test_rebuild_index_restore_failure_preserves_original_error(
     mock_backend_cls, mock_copy, tmp_path, capsys
 ):
-    """#8: if even the temp-promotion recovery fails, the ORIGINAL rebuild
+    """If even the temp-promotion recovery fails, the ORIGINAL rebuild
     error must still be what's raised, and the message must point the
     operator at the still-surviving verified temp copy -- never silently
     lose track of it."""
@@ -1040,7 +1040,7 @@ def test_rebuild_collection_via_temp_keeps_original_error_when_cleanup_fails(
 def test_rebuild_collection_via_temp_preserves_temp_when_live_replaced_and_reupload_fails(
     mock_backend_cls,
 ):
-    """#8: once the live collection is deleted (live_replaced=True), the
+    """Once the live collection is deleted (live_replaced=True), the
     verified temp copy is the ONLY intact data left. A failure re-uploading
     into the fresh live collection must NOT delete the temp copy -- it must
     survive so the operator can recover from it."""
@@ -1077,7 +1077,7 @@ def test_rebuild_collection_via_temp_preserves_temp_when_live_replaced_and_reupl
 
 
 def test_promote_temp_collection_reads_from_temp_not_broken_live():
-    """Direct unit test for #8's recovery helper. Two mutations a future
+    """Direct unit test for the temp-promotion recovery helper. Two mutations a future
     refactor could introduce would silently corrupt recovered data and must
     be caught here, not only via a weaker 'was upsert called at all' check:
     (1) reading the source from the wrong collection name, (2) swapping the

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -78,6 +78,75 @@ def test_paginate_ids_offset_exception_fallback():
     assert "id1" in ids
 
 
+def test_paginate_ids_offset_broken_over_page_size_raises_instead_of_truncating():
+    """#12: when offset is broken, the no-offset fallback is structurally
+    stuck at the first `page` (1000) results, and the collection's own
+    count() confirms there really are MORE ids than that (a genuinely
+    truncated case) -- silently returning a truncated ID list is worse than
+    failing loudly, since callers (scan_palace, rebuild) treat the result as
+    the full palace and can act on incomplete data."""
+    col = MagicMock()
+    full_page = [f"id{i}" for i in range(1000)]
+    col.get.side_effect = [
+        Exception("offset bug"),
+        {"ids": full_page},
+        Exception("offset bug"),
+        {"ids": full_page},  # same 1000 ids again -- no offset means no progress
+    ]
+    col.count.return_value = 1500  # collection genuinely holds more than the page
+    with pytest.raises(RuntimeError, match="truncated"):
+        repair._paginate_ids(col)
+
+
+def test_paginate_ids_offset_broken_exactly_page_size_completes_without_raising():
+    """The page-boundary case is ambiguous from the fetched page alone: a
+    collection that genuinely holds exactly `page` ids looks identical to a
+    truncated one. count() disambiguates -- when it confirms the collected
+    count IS the true total, this must complete normally, not raise."""
+    col = MagicMock()
+    full_page = [f"id{i}" for i in range(1000)]
+    col.get.side_effect = [
+        Exception("offset bug"),
+        {"ids": full_page},
+        Exception("offset bug"),
+        {"ids": full_page},
+    ]
+    col.count.return_value = 1000  # exactly what was collected -- genuinely complete
+    ids = repair._paginate_ids(col)
+    assert len(ids) == 1000
+
+
+def test_paginate_ids_offset_broken_count_unreadable_raises_conservatively():
+    """If count() itself cannot disambiguate (raises), do not assume
+    completeness -- refusing to silently return a possibly-truncated list is
+    the safer default."""
+    col = MagicMock()
+    full_page = [f"id{i}" for i in range(1000)]
+    col.get.side_effect = [
+        Exception("offset bug"),
+        {"ids": full_page},
+        Exception("offset bug"),
+        {"ids": full_page},
+    ]
+    col.count.side_effect = Exception("count also broken")
+    with pytest.raises(RuntimeError, match="truncated"):
+        repair._paginate_ids(col)
+
+
+def test_paginate_ids_offset_broken_under_page_size_still_breaks_cleanly():
+    """A collection genuinely smaller than `page` must still return normally
+    when offset is broken -- only the >=page truncation case should raise."""
+    col = MagicMock()
+    col.get.side_effect = [
+        Exception("offset bug"),
+        {"ids": ["id1", "id2"]},
+        Exception("offset bug"),
+        {"ids": ["id1", "id2"]},
+    ]
+    ids = repair._paginate_ids(col)
+    assert ids == ["id1", "id2"]
+
+
 # ── _extract_drawers ──────────────────────────────────────────────────
 
 
@@ -785,6 +854,9 @@ def test_rebuild_index_stage_failure_leaves_live_collection_untouched(
 @patch("mempalace.repair._copy_file_no_follow")
 @patch("mempalace.repair.ChromaBackend")
 def test_rebuild_index_live_failure_restores_backup(mock_backend_cls, mock_copy, tmp_path):
+    """#8: when the live swap fails after the delete, recovery must PROMOTE
+    the verified temp copy (not restore a sqlite-only file backup, whose
+    on-disk HNSW segments are already gone)."""
     sqlite_path = tmp_path / "chroma.sqlite3"
     sqlite3.connect(str(sqlite_path)).close()
 
@@ -805,9 +877,11 @@ def test_rebuild_index_live_failure_restores_backup(mock_backend_cls, mock_copy,
     mock_temp_col.count.return_value = 2
     mock_new_col = MagicMock()
     mock_new_col.upsert.side_effect = RuntimeError("live upsert failed")
+    mock_promoted_col = MagicMock()
+    mock_promoted_col.count.return_value = 2
     active_backend = MagicMock()
     active_backend.get_collection.return_value = mock_col
-    active_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    active_backend.create_collection.side_effect = [mock_temp_col, mock_new_col, mock_promoted_col]
     helper_backend = MagicMock()
     mock_backend_cls.side_effect = [active_backend, helper_backend]
 
@@ -815,13 +889,16 @@ def test_rebuild_index_live_failure_restores_backup(mock_backend_cls, mock_copy,
         repair.rebuild_index(palace_path=str(tmp_path))
 
     assert excinfo.value.live_replaced is True
-    assert mock_copy.call_count == 2
+    # Only the initial pre-rebuild backup copies a file now -- recovery
+    # promotes from the temp collection, it never touches the sqlite file.
+    assert mock_copy.call_count == 1
     assert active_backend.delete_collection.call_args_list == [
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
-        call(str(tmp_path), "mempalace_drawers"),
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
-        call(str(tmp_path), "mempalace_drawers"),
+        call(str(tmp_path), "mempalace_drawers__repair_tmp"),  # pre-clean stale temp
+        call(str(tmp_path), "mempalace_drawers"),  # live delete before re-upload
+        call(str(tmp_path), "mempalace_drawers"),  # delete broken live before promotion
+        call(str(tmp_path), "mempalace_drawers__repair_tmp"),  # temp cleaned after promotion
     ]
+    assert mock_promoted_col.upsert.called
     active_backend.close_palace.assert_called_once_with(str(tmp_path))
     helper_backend.close_palace.assert_not_called()
 
@@ -831,6 +908,8 @@ def test_rebuild_index_live_failure_restores_backup(mock_backend_cls, mock_copy,
 def test_rebuild_index_live_delete_missing_still_restores_backup(
     mock_backend_cls, mock_copy, tmp_path
 ):
+    """Promotion must tolerate the broken live collection already being gone
+    (ChromaNotFoundError) when clearing it before recreating from temp."""
     sqlite_path = tmp_path / "chroma.sqlite3"
     sqlite3.connect(str(sqlite_path)).close()
 
@@ -849,26 +928,33 @@ def test_rebuild_index_live_delete_missing_still_restores_backup(
     }
     mock_temp_col = MagicMock()
     mock_temp_col.count.return_value = 2
+    mock_promoted_col = MagicMock()
+    mock_promoted_col.count.return_value = 2
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, RuntimeError("create failed")]
+    mock_backend.create_collection.side_effect = [
+        mock_temp_col,
+        RuntimeError("create failed"),
+        mock_promoted_col,
+    ]
     mock_backend.delete_collection.side_effect = [
-        None,
-        None,
-        None,
-        repair.ChromaNotFoundError("missing"),
+        None,  # pre-clean stale temp
+        None,  # live delete before re-upload
+        repair.ChromaNotFoundError("missing"),  # delete-broken-live tolerates already-gone
+        None,  # temp cleaned after successful promotion
     ]
 
     with pytest.raises(repair.RebuildCollectionError) as excinfo:
         repair.rebuild_index(palace_path=str(tmp_path))
 
     assert excinfo.value.live_replaced is True
-    assert mock_copy.call_count == 2
+    assert mock_copy.call_count == 1
     assert mock_backend.delete_collection.call_args_list == [
         call(str(tmp_path), "mempalace_drawers__repair_tmp"),
         call(str(tmp_path), "mempalace_drawers"),
-        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
         call(str(tmp_path), "mempalace_drawers"),
+        call(str(tmp_path), "mempalace_drawers__repair_tmp"),
     ]
+    assert mock_promoted_col.upsert.called
 
 
 @patch("mempalace.repair._copy_file_no_follow")
@@ -876,17 +962,13 @@ def test_rebuild_index_live_delete_missing_still_restores_backup(
 def test_rebuild_index_restore_failure_preserves_original_error(
     mock_backend_cls, mock_copy, tmp_path, capsys
 ):
+    """#8: if even the temp-promotion recovery fails, the ORIGINAL rebuild
+    error must still be what's raised, and the message must point the
+    operator at the still-surviving verified temp copy -- never silently
+    lose track of it."""
     sqlite_path = tmp_path / "chroma.sqlite3"
     sqlite3.connect(str(sqlite_path)).close()
-
-    def _copy_side_effect(src, dst, **_):
-        # The restore copy reads from the timestamped backup file.
-        if ".backup." in str(src):
-            raise PermissionError("locked sqlite")
-        with open(dst, "w") as handle:
-            handle.write("backup")
-
-    mock_copy.side_effect = _copy_side_effect
+    mock_copy.side_effect = lambda src, dst, **_: open(dst, "w").close()
 
     mock_col = MagicMock()
     mock_col.count.return_value = 2
@@ -900,14 +982,20 @@ def test_rebuild_index_restore_failure_preserves_original_error(
     mock_new_col = MagicMock()
     mock_new_col.upsert.side_effect = RuntimeError("live upsert failed")
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+    # 3rd create_collection call is the promotion attempt -- fails too.
+    mock_backend.create_collection.side_effect = [
+        mock_temp_col,
+        mock_new_col,
+        RuntimeError("promotion also failed"),
+    ]
 
     with pytest.raises(repair.RebuildCollectionError) as excinfo:
         repair.rebuild_index(palace_path=str(tmp_path))
 
     out = capsys.readouterr().out
-    assert "locked sqlite" in out
-    assert "Manual restore required" in out
+    assert "Automatic recovery failed" in out
+    assert "still survives under" in out
+    assert "do NOT delete it" in out
     assert "live upsert failed" in str(excinfo.value)
 
 
@@ -915,14 +1003,16 @@ def test_rebuild_index_restore_failure_preserves_original_error(
 def test_rebuild_collection_via_temp_keeps_original_error_when_cleanup_fails(
     mock_backend_cls,
 ):
+    """A failure while still STAGING (live_replaced=False) legitimately cleans
+    up the not-yet-promoted temp collection; if that cleanup itself also
+    fails, the original staging error must still be the one raised."""
     mock_col = MagicMock()
     mock_col.count.return_value = 2
     mock_temp_col = MagicMock()
-    mock_temp_col.count.return_value = 2
+    mock_temp_col.upsert.side_effect = RuntimeError("staging upsert failed")
     mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
-    mock_backend.create_collection.side_effect = [mock_temp_col, RuntimeError("live build failed")]
+    mock_backend.create_collection.side_effect = [mock_temp_col]
     mock_backend.delete_collection.side_effect = [
-        None,
         None,
         RuntimeError("cleanup failed"),
     ]
@@ -938,13 +1028,129 @@ def test_rebuild_collection_via_temp_keeps_original_error_when_cleanup_fails(
             progress=lambda *args, **kwargs: None,
         )
 
-    assert "live build failed" in str(excinfo.value)
-    assert excinfo.value.live_replaced is True
+    assert "staging upsert failed" in str(excinfo.value)
+    assert excinfo.value.live_replaced is False
     assert mock_backend.delete_collection.call_args_list == [
         call("/palace", "mempalace_drawers__repair_tmp"),
-        call("/palace", "mempalace_drawers"),
         call("/palace", "mempalace_drawers__repair_tmp"),
     ]
+
+
+@patch("mempalace.repair.ChromaBackend")
+def test_rebuild_collection_via_temp_preserves_temp_when_live_replaced_and_reupload_fails(
+    mock_backend_cls,
+):
+    """#8: once the live collection is deleted (live_replaced=True), the
+    verified temp copy is the ONLY intact data left. A failure re-uploading
+    into the fresh live collection must NOT delete the temp copy -- it must
+    survive so the operator can recover from it."""
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    mock_temp_col = MagicMock()
+    mock_temp_col.count.return_value = 2
+    mock_new_col = MagicMock()
+    mock_new_col.upsert.side_effect = RuntimeError("live upsert failed")
+    mock_backend = _install_mock_backend(mock_backend_cls, mock_col)
+    mock_backend.create_collection.side_effect = [mock_temp_col, mock_new_col]
+
+    with pytest.raises(repair.RebuildCollectionError) as excinfo:
+        repair._rebuild_collection_via_temp(
+            mock_backend,
+            "/palace",
+            ["id1", "id2"],
+            ["doc1", "doc2"],
+            [{"wing": "a"}, {"wing": "b"}],
+            batch_size=5000,
+            progress=lambda *args, **kwargs: None,
+        )
+
+    assert "live upsert failed" in str(excinfo.value)
+    assert excinfo.value.live_replaced is True
+    # The temp collection must never be deleted once it is the only good copy.
+    assert call("/palace", "mempalace_drawers__repair_tmp") not in mock_backend.delete_collection.call_args_list[1:]
+    assert mock_backend.delete_collection.call_args_list == [
+        call("/palace", "mempalace_drawers__repair_tmp"),  # pre-existing stale temp, cleaned before staging
+        call("/palace", "mempalace_drawers"),  # the actual live-collection swap
+    ]
+    # The error must point the operator at the surviving good copy.
+    assert "mempalace_drawers__repair_tmp" in str(excinfo.value)
+
+
+def test_promote_temp_collection_reads_from_temp_not_broken_live():
+    """Direct unit test for #8's recovery helper. Two mutations a future
+    refactor could introduce would silently corrupt recovered data and must
+    be caught here, not only via a weaker 'was upsert called at all' check:
+    (1) reading the source from the wrong collection name, (2) swapping the
+    ids/documents payload on upsert."""
+    mock_temp_col = MagicMock()
+    mock_temp_col.get.return_value = {
+        "ids": ["id1", "id2"],
+        "documents": ["doc1", "doc2"],
+        "metadatas": [{"wing": "a"}, {"wing": "b"}],
+    }
+    mock_new_col = MagicMock()
+    mock_new_col.count.return_value = 2
+    backend = MagicMock()
+    backend.get_collection.return_value = mock_temp_col
+    backend.create_collection.return_value = mock_new_col
+
+    result = repair._promote_temp_collection(
+        backend,
+        "/palace",
+        "mempalace_drawers__repair_tmp",
+        "mempalace_drawers",
+        expected=2,
+        batch_size=5000,
+        progress=lambda *a, **kw: None,
+    )
+
+    assert result == 2
+    # Must read the SOURCE from the verified temp collection specifically,
+    # never from the (broken/partial) live collection name.
+    backend.get_collection.assert_called_once_with("/palace", "mempalace_drawers__repair_tmp")
+    # The broken live collection is cleared, then recreated under its own name.
+    backend.delete_collection.assert_any_call("/palace", "mempalace_drawers")
+    backend.create_collection.assert_called_once_with("/palace", "mempalace_drawers")
+    # The exact extracted payload must land in the new collection, unmodified
+    # and unswapped (ids must stay ids, documents must stay documents).
+    mock_new_col.upsert.assert_called_once_with(
+        documents=["doc1", "doc2"],
+        ids=["id1", "id2"],
+        metadatas=[{"wing": "a"}, {"wing": "b"}],
+    )
+    # The temp copy is only removed after the promotion is verified.
+    backend.delete_collection.assert_any_call("/palace", "mempalace_drawers__repair_tmp")
+
+
+def test_promote_temp_collection_survives_when_final_temp_cleanup_fails():
+    """The temp copy is redundant (already promoted+verified) by the time it
+    is deleted -- a failure cleaning it up must not be reported as a
+    promotion failure, matching the identical convention already used for
+    the same cleanup step in _rebuild_collection_via_temp's success path."""
+    mock_temp_col = MagicMock()
+    mock_temp_col.get.return_value = {
+        "ids": ["id1"],
+        "documents": ["doc1"],
+        "metadatas": [{"wing": "a"}],
+    }
+    mock_new_col = MagicMock()
+    mock_new_col.count.return_value = 1
+    backend = MagicMock()
+    backend.get_collection.return_value = mock_temp_col
+    backend.create_collection.return_value = mock_new_col
+    backend.delete_collection.side_effect = [None, RuntimeError("transient lock")]
+
+    result = repair._promote_temp_collection(
+        backend,
+        "/palace",
+        "mempalace_drawers__repair_tmp",
+        "mempalace_drawers",
+        expected=1,
+        batch_size=5000,
+        progress=lambda *a, **kw: None,
+    )
+
+    assert result == 1  # promotion itself succeeded despite the cleanup failure
 
 
 @patch("mempalace.repair._copy_file_no_follow")

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -147,6 +147,62 @@ def test_paginate_ids_offset_broken_under_page_size_still_breaks_cleanly():
     assert ids == ["id1", "id2"]
 
 
+# ── _paginate_ids: double-failure + filtered-count (PR #2086 review) ───
+# fatkobra's CHANGES_REQUESTED on PR #2086: the truncation-detection fix
+# left two loud-failure gaps. The whole point of the fix is to refuse to
+# act on an incomplete palace, so both gaps must raise, not return a
+# partial/empty list, and the global count() must never be used as proof
+# of truncation for a *filtered* (where=) result.
+
+
+def test_paginate_ids_double_failure_after_progress_raises_not_partial():
+    """Offset get() fails, then the no-offset fallback ALSO fails, after at
+    least one page was already collected. The function must NOT return the
+    partial first page as if it were complete -- it must raise so callers
+    (scan_palace, rebuild) never treat a truncated palace as whole."""
+    col = MagicMock()
+    first_page = [f"id{i}" for i in range(1000)]
+    col.get.side_effect = [
+        {"ids": first_page},  # page 1 lands normally via offset path
+        Exception("offset bug"),  # page 2 offset request fails
+        Exception("fallback also down"),  # no-offset fallback ALSO fails
+    ]
+    with pytest.raises(RuntimeError):
+        repair._paginate_ids(col)
+
+
+def test_paginate_ids_double_failure_on_first_page_raises_not_empty():
+    """Both the offset request and its no-offset fallback fail on the very
+    first page. Returning [] here is a silent lie -- scan_palace would print
+    'Nothing to scan.' on a palace it never actually read. Must raise."""
+    col = MagicMock()
+    col.get.side_effect = [
+        Exception("offset bug"),  # first offset request fails
+        Exception("fallback also down"),  # no-offset fallback fails too
+    ]
+    with pytest.raises(RuntimeError):
+        repair._paginate_ids(col)
+
+
+def test_paginate_ids_filtered_exactly_page_size_does_not_use_global_count():
+    """A wing filter selects exactly 1000 rows; the collection holds more in
+    OTHER wings. Offset is broken but the fallback returns the complete 1000
+    filtered rows. The global count() (1500) is NOT authoritative for the
+    filtered set, so it must not be treated as proof of truncation -- the
+    function must return the complete 1000 filtered rows without raising."""
+    col = MagicMock()
+    filtered_page = [f"id{i}" for i in range(1000)]
+    col.get.side_effect = [
+        Exception("offset bug"),
+        {"ids": filtered_page},
+        Exception("offset bug"),
+        {"ids": filtered_page},  # same 1000 filtered ids -- fallback stuck
+    ]
+    col.count.return_value = 1500  # collection-wide, NOT the filtered total
+    ids = repair._paginate_ids(col, where={"wing": "w"})
+    assert len(ids) == 1000
+
+
 # ── _extract_drawers ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

`rebuild_index()` and `cmd_repair()`'s own inlined rebuild logic both build the new collection into a temporary collection first, verify it, then swap it in for the live collection (`_rebuild_collection_via_temp`, shared by both). Two related gaps in the failure paths around that swap:

**1. Data loss on a failed post-swap re-upload.** Once the live collection is deleted and the fresh replacement is being populated, if that re-upload fails partway through, the previous recovery code deleted the verified temp copy. In `rebuild_index()` it then tried to restore from a pre-rebuild `chroma.sqlite3` file backup — misleading, since the live collection's on-disk HNSW segment directories were already destroyed by the delete that preceded the failure, so restoring only the sqlite file leaves the palace referencing segment UUIDs that no longer exist on disk. In `cmd_repair()` (the actual `mempalace repair` CLI command) the same failure triggered a full-directory `rmtree` + restore-from-backup — which additionally destroyed the just-preserved temp copy in the same step, and printed recovery guidance ("restoring from backup...") that had nothing to do with the temp copy's fate. Either way, the one thing that *was* still fully intact — the verified temp copy — got discarded instead of used.

**2. Silent truncation when offset-based pagination is broken.** `_paginate_ids()`'s fallback path (used when the backend's offset-based `get()` fails) re-fetches the same first page of results with no offset. If that fallback lands exactly on a page boundary, the previous code treated "no new ids in this page" as "we're done" — indistinguishable from "we're stuck and haven't actually seen the rest of the collection." Callers (`scan_palace`, `rebuild_index`, `cmd_repair`) then act on that partial ID list as if it were the complete palace.

## Fix

- Added `_promote_temp_collection()`: recovers a failed live-swap by copying directly from the verified temp collection instead of a stale sqlite file backup or a full-directory rollback. The temp copy is now never deleted once the live collection has already been replaced — it's the only intact data left at that point.
- Both `rebuild_index()` and `cmd_repair()` now call this same promotion helper on a live-swap failure, so the recovery behavior and the printed guidance are consistent regardless of which entry point is used. `cmd_repair()` still makes its pre-repair full-directory backup as a manual last-resort fallback (mentioned in the error text) if promotion itself also fails.
- `_paginate_ids()` now disambiguates the page-boundary case against the collection's own `count()`: if `count()` confirms there's more data than what was collected, it raises loudly instead of returning a silently truncated ID list; if `count()` confirms the collected set genuinely is everything, it completes normally.

## Scope

This covers the two failure-path issues above only. It does **not** address holding a mining lock for the full duration of a rebuild so concurrent writes during a multi-stage rebuild aren't lost — that's a larger, separate change (queuing writes during rebuild rather than blocking them) that needs its own design pass and would follow as a separate PR.

## Tests

17 new/updated unit tests across `tests/test_repair.py` and `tests/test_cli.py`, all against synthetic `MagicMock` fixtures (no real ChromaDB collections or production data involved) — covering the promotion path for both entry points, the truncation-vs-completion disambiguation at the page boundary, and updating the existing failure-recovery integration tests to match the new recovery behavior.
