### PR TITLE
fix(search): return round-trippable drawer IDs

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -60,6 +60,24 @@ def _first_or_empty(results, key: str) -> list:
     return outer[0] or []
 
 
+def _aligned_query_ids(results, document_count: int) -> list:
+    """Return query IDs padded to match the document result column.
+
+    Production backends return an ID for every document. Some legacy test
+    mocks omit IDs, so pad with ``None`` instead of letting ``zip`` discard
+    otherwise valid mocked results.
+    """
+    ids = list(_first_or_empty(results, "ids"))
+    if len(ids) < document_count:
+        ids.extend([None] * (document_count - len(ids)))
+    return ids[:document_count]
+
+
+def _result_drawer_id(meta, stored_drawer_id):
+    """Return the ID that round-trips through ``mempalace_get_drawer``."""
+    return (meta or {}).get("parent_drawer_id") or stored_drawer_id
+
+
 def _tokenize(text: str) -> list:
     """Lowercase + strip to alphanumeric tokens of length ≥ 2.
 
@@ -752,9 +770,10 @@ def _bm25_only_via_sqlite(
         placeholders = ",".join(["?"] * len(candidate_ids))
         meta_rows = conn.execute(
             f"""
-            SELECT id, key, string_value, int_value
-            FROM embedding_metadata
-            WHERE id IN ({placeholders})
+            SELECT m.id, e.embedding_id, m.key, m.string_value, m.int_value
+            FROM embedding_metadata AS m
+            JOIN embeddings AS e ON e.id = m.id
+            WHERE m.id IN ({placeholders})
             """,
             candidate_ids,
         ).fetchall()
@@ -763,8 +782,16 @@ def _bm25_only_via_sqlite(
 
     # Group metadata rows into per-drawer dicts.
     drawers: dict[int, dict] = {}
-    for emb_id, key, sval, ival in meta_rows:
-        d = drawers.setdefault(emb_id, {"_id": emb_id, "metadata": {}, "text": ""})
+    for emb_id, stored_drawer_id, key, sval, ival in meta_rows:
+        d = drawers.setdefault(
+            emb_id,
+            {
+                "_id": emb_id,
+                "_stored_drawer_id": stored_drawer_id,
+                "metadata": {},
+                "text": "",
+            },
+        )
         if key == "chroma:document":
             d["text"] = sval or ""
         else:
@@ -784,6 +811,7 @@ def _bm25_only_via_sqlite(
         full_source = meta.get("source_file", "") or ""
         candidates.append(
             {
+                "drawer_id": _result_drawer_id(meta, d["_stored_drawer_id"]),
                 "text": d["text"],
                 "wing": meta.get("wing", "unknown"),
                 "room": meta.get("room", "unknown"),
@@ -887,6 +915,7 @@ def _merge_bm25_union_candidates(
         full_source = meta.get("source_file", "") or ""
         bm25_extra.append(
             {
+                "drawer_id": _result_drawer_id(meta, hit.id),
                 "text": hit.document or "",
                 "wing": meta.get("wing", "unknown"),
                 "room": meta.get("room", "unknown"),
@@ -1125,9 +1154,12 @@ def _query_drawers_with_filter_fallback(
             n_results=min(n_results * 15, 500),
             include=["documents", "metadatas", "distances"],
         )
-        fdocs, fmetas, fdists = [], [], []
-        for doc, meta, dist in zip(
-            _first_or_empty(raw, "documents"),
+        raw_docs = _first_or_empty(raw, "documents")
+        raw_ids = _aligned_query_ids(raw, len(raw_docs))
+        fids, fdocs, fmetas, fdists = [], [], [], []
+        for stored_drawer_id, doc, meta, dist in zip(
+            raw_ids,
+            raw_docs,
             _first_or_empty(raw, "metadatas"),
             _first_or_empty(raw, "distances"),
         ):
@@ -1138,10 +1170,16 @@ def _query_drawers_with_filter_fallback(
                 continue
             if source_file and meta.get("source_file") != source_file:
                 continue
+            fids.append(stored_drawer_id)
             fdocs.append(doc)
             fmetas.append(meta)
             fdists.append(dist)
-        return {"documents": [fdocs], "metadatas": [fmetas], "distances": [fdists]}
+        return {
+            "ids": [fids],
+            "documents": [fdocs],
+            "metadatas": [fmetas],
+            "distances": [fdists],
+        }
 
 
 def search_memories(
@@ -1271,8 +1309,11 @@ def search_memories(
     CLOSET_DISTANCE_CAP = 1.5  # cosine dist > 1.5 = too weak to use as signal
 
     scored: list = []
-    for doc, meta, dist in zip(
-        _first_or_empty(drawer_results, "documents"),
+    drawer_docs = _first_or_empty(drawer_results, "documents")
+    stored_drawer_ids = _aligned_query_ids(drawer_results, len(drawer_docs))
+    for stored_drawer_id, doc, meta, dist in zip(
+        stored_drawer_ids,
+        drawer_docs,
         _first_or_empty(drawer_results, "metadatas"),
         _first_or_empty(drawer_results, "distances"),
     ):
@@ -1301,6 +1342,7 @@ def search_memories(
         # inverting the ranking so the best hybrid matches sort last.
         effective_dist = max(0.0, min(2.0, dist - boost))
         entry = {
+            "drawer_id": _result_drawer_id(meta, stored_drawer_id),
             "text": doc,
             "wing": meta.get("wing", "unknown"),
             "room": meta.get("room", "unknown"),

--- a/tests/test_search_drawer_id.py
+++ b/tests/test_search_drawer_id.py
@@ -1,0 +1,330 @@
+"""Regression tests for round-trippable search result drawer IDs (#2080)."""
+
+from unittest.mock import MagicMock, patch
+
+from mempalace.backends import LexicalHit, LexicalResult
+from mempalace.searcher import (
+    _aligned_query_ids,
+    _finalize_candidate_hits,
+    _query_drawers_with_filter_fallback,
+    search_memories,
+)
+
+
+def _results_by_source(result: dict) -> dict:
+    return {hit["source_file"]: hit for hit in result["results"]}
+
+
+def test_vector_results_use_parent_for_chunks_and_stored_id_for_singles():
+    drawers_col = MagicMock()
+    drawers_col.distance_metric = "cosine"
+    drawers_col.query.return_value = {
+        "ids": [
+            [
+                "logical-parent_chunk_000001",
+                "single-drawer",
+            ]
+        ],
+        "documents": [
+            [
+                "chunk text",
+                "single text",
+            ]
+        ],
+        "metadatas": [
+            [
+                {
+                    "wing": "work",
+                    "room": "notes",
+                    "source_file": "/palace/chunked.md",
+                    "parent_drawer_id": "logical-parent",
+                    "chunk_index": 1,
+                },
+                {
+                    "wing": "work",
+                    "room": "notes",
+                    "source_file": "/palace/single.md",
+                },
+            ]
+        ],
+        "distances": [[0.1, 0.2]],
+    }
+
+    with patch(
+        "mempalace.searcher.get_collection",
+        return_value=drawers_col,
+    ):
+        with patch(
+            "mempalace.searcher.get_closets_collection",
+            side_effect=RuntimeError("no closets"),
+        ):
+            result = search_memories(
+                "drawer identity",
+                "/unused",
+                n_results=5,
+            )
+
+    by_source = _results_by_source(result)
+
+    assert by_source["chunked.md"]["drawer_id"] == "logical-parent"
+    assert by_source["single.md"]["drawer_id"] == "single-drawer"
+
+    assert all("_parent_drawer_id" not in hit for hit in result["results"])
+
+
+def test_aligned_query_ids_pads_legacy_mock_results():
+    assert _aligned_query_ids({}, 2) == [None, None]
+
+    result_without_ids = {
+        "documents": [["first", "second"]],
+        "metadatas": [[{}, {}]],
+        "distances": [[0.1, 0.2]],
+    }
+
+    assert _aligned_query_ids(result_without_ids, 2) == [None, None]
+
+
+def test_filtered_query_fallback_keeps_ids_aligned_with_filtered_hits():
+    drawers_col = MagicMock()
+    drawers_col.query.side_effect = [
+        RuntimeError("Error finding id"),
+        {
+            "ids": [["drop-id", "keep-id"]],
+            "documents": [
+                [
+                    "drop document",
+                    "keep document",
+                ]
+            ],
+            "metadatas": [
+                [
+                    {
+                        "wing": "drop",
+                        "room": "notes",
+                        "source_file": "drop.md",
+                    },
+                    {
+                        "wing": "keep",
+                        "room": "notes",
+                        "source_file": "keep.md",
+                    },
+                ]
+            ],
+            "distances": [[0.2, 0.1]],
+        },
+    ]
+
+    query_kwargs = {
+        "query_texts": ["needle"],
+        "n_results": 6,
+        "include": [
+            "documents",
+            "metadatas",
+            "distances",
+        ],
+        "where": {"wing": "keep"},
+    }
+
+    result = _query_drawers_with_filter_fallback(
+        drawers_col,
+        query_kwargs,
+        "needle",
+        2,
+        "keep",
+        None,
+    )
+
+    assert drawers_col.query.call_count == 2
+    assert result["ids"] == [["keep-id"]]
+    assert result["documents"] == [["keep document"]]
+    assert result["metadatas"][0][0]["source_file"] == "keep.md"
+    assert result["distances"] == [[0.1]]
+
+
+def test_vector_drawer_id_round_trips_to_complete_chunked_drawer(
+    seeded_collection,
+):
+    parent_id = "logical-roundtrip-2080"
+    chunk_ids = [
+        f"{parent_id}_chunk_000000",
+        f"{parent_id}_chunk_000001",
+    ]
+    chunk_documents = [
+        "roundtrip2080 first half ",
+        "roundtrip2080 second half",
+    ]
+
+    seeded_collection.add(
+        ids=chunk_ids,
+        documents=chunk_documents,
+        metadatas=[
+            {
+                "wing": "work",
+                "room": "notes",
+                "source_file": "/palace/roundtrip-2080.md",
+                "parent_drawer_id": parent_id,
+                "chunk_index": 0,
+            },
+            {
+                "wing": "work",
+                "room": "notes",
+                "source_file": "/palace/roundtrip-2080.md",
+                "parent_drawer_id": parent_id,
+                "chunk_index": 1,
+            },
+        ],
+    )
+
+    search_col = MagicMock()
+    search_col.distance_metric = "cosine"
+    search_col.query.return_value = {
+        "ids": [[chunk_ids[1]]],
+        "documents": [[chunk_documents[1]]],
+        "metadatas": [
+            [
+                {
+                    "wing": "work",
+                    "room": "notes",
+                    "source_file": "/palace/roundtrip-2080.md",
+                    "parent_drawer_id": parent_id,
+                    "chunk_index": 1,
+                }
+            ]
+        ],
+        "distances": [[0.1]],
+    }
+
+    with patch(
+        "mempalace.searcher.get_collection",
+        return_value=search_col,
+    ):
+        with patch(
+            "mempalace.searcher.get_closets_collection",
+            side_effect=RuntimeError("no closets"),
+        ):
+            result = search_memories(
+                "roundtrip2080",
+                "/unused",
+                n_results=5,
+            )
+
+    assert len(result["results"]) == 1
+    hit = result["results"][0]
+    assert hit["drawer_id"] == parent_id
+
+    from mempalace import mcp_server
+
+    with patch.object(
+        mcp_server,
+        "_get_collection",
+        return_value=seeded_collection,
+    ):
+        fetched = mcp_server.tool_get_drawer(hit["drawer_id"])
+
+    assert fetched["drawer_id"] == parent_id
+    assert fetched["content"] == "".join(chunk_documents)
+    assert fetched["chunks"] == 2
+    assert fetched["chunk_ids"] == chunk_ids
+
+
+def test_bm25_sqlite_results_use_parent_or_stored_id(
+    palace_path,
+    seeded_collection,
+):
+    seeded_collection.add(
+        ids=[
+            "bm25-parent_chunk_000000",
+            "bm25-single-2080",
+        ],
+        documents=[
+            "needle2080 appears in a chunked drawer",
+            "needle2080 appears in an ordinary drawer",
+        ],
+        metadatas=[
+            {
+                "wing": "work",
+                "room": "notes",
+                "source_file": "/palace/chunked-2080.md",
+                "parent_drawer_id": "bm25-parent",
+                "chunk_index": 0,
+            },
+            {
+                "wing": "work",
+                "room": "notes",
+                "source_file": "/palace/single-2080.md",
+            },
+        ],
+    )
+
+    result = search_memories(
+        "needle2080",
+        palace_path,
+        n_results=10,
+        vector_disabled=True,
+        collection_name="mempalace_drawers",
+    )
+
+    assert "error" not in result
+
+    by_source = _results_by_source(result)
+
+    assert by_source["chunked-2080.md"]["drawer_id"] == "bm25-parent"
+    assert by_source["single-2080.md"]["drawer_id"] == "bm25-single-2080"
+
+
+def test_union_results_use_parent_or_lexical_hit_id():
+    drawers_col = MagicMock()
+    drawers_col.distance_metric = "cosine"
+    drawers_col.lexical_search.return_value = LexicalResult(
+        hits=[
+            LexicalHit(
+                id="union-parent_chunk_000001",
+                document="chunk drawer identity text",
+                metadata={
+                    "wing": "work",
+                    "room": "notes",
+                    "source_file": "/palace/chunked.md",
+                    "parent_drawer_id": "union-parent",
+                    "chunk_index": 1,
+                },
+                score=2.0,
+            ),
+            LexicalHit(
+                id="union-single",
+                document="single drawer identity text",
+                metadata={
+                    "wing": "work",
+                    "room": "notes",
+                    "source_file": "/palace/single.md",
+                    "chunk_index": 0,
+                },
+                score=1.0,
+            ),
+        ]
+    )
+
+    hits, error = _finalize_candidate_hits(
+        candidate_strategy="union",
+        hits=[],
+        drawers_col=drawers_col,
+        query="drawer identity",
+        wing=None,
+        room=None,
+        n_results=5,
+        max_distance=0.0,
+    )
+
+    assert error is None
+    drawers_col.lexical_search.assert_called_once()
+
+    by_source = {hit["source_file"]: hit for hit in hits}
+
+    assert by_source["chunked.md"]["drawer_id"] == "union-parent"
+    assert by_source["single.md"]["drawer_id"] == "union-single"
+
+    assert all(
+        "_source_file_full" not in hit
+        and "_chunk_index" not in hit
+        and "_parent_drawer_id" not in hit
+        for hit in hits
+    )


### PR DESCRIPTION
## What does this PR do?

- add a round-trippable `drawer_id` to every `search_memories()` result path
- return `parent_drawer_id` for chunked MCP drawers
- fall back to the stored row ID for ordinary, mined, and legacy drawers
- preserve query IDs through the filtered-query recovery path
- add regression coverage for vector, SQLite BM25-only, and backend lexical-union results

## Problem

A single ID choice does not work for every stored drawer.

A raw physical chunk ID is insufficient for a chunked MCP drawer because
`mempalace_get_drawer` resolves that physical row directly and returns only
that chunk. Conversely, mined and ordinary single-row drawers generally do
not have a `parent_drawer_id`.

The public result contract therefore needs to be conditional per hit:

```python
drawer_id = parent_drawer_id or stored_drawer_id
```

This makes the returned ID directly usable with `mempalace_get_drawer` for
both chunked and non-chunked drawers.

## Implementation

### Vector and hybrid results

The IDs returned by the backend query are aligned with the document column.
Each result exposes its logical parent when one exists and otherwise exposes
its own stored ID.

The ID list is defensively padded for compatibility with legacy test mocks
that return documents but omit query IDs.

### Filtered-query recovery

The unfiltered retry plus Python-side metadata filtering now preserves IDs
alongside documents, metadata, and distances.

Without this, a filtered search that entered the recovery path would still
lose the drawer identity.

### SQLite BM25-only fallback

The metadata query now joins `embedding_metadata` to `embeddings` and
retrieves `embeddings.embedding_id`.

This is the stored public Chroma ID. The internal numeric SQLite row ID is
not exposed to callers.

### Backend lexical union

`_merge_bm25_union_candidates()` uses `LexicalHit.id` as the stored-ID
fallback and uses `parent_drawer_id` when the lexical hit represents a
chunked logical drawer.

### MCP retrieval

This PR does not change the MCP drawer retrieval implementation. It fixes
the ID produced by search so the existing `mempalace_get_drawer` logical
chunk-group reconstruction is reached for chunked drawers.

## Tests

Regression coverage verifies:

- a chunked vector hit returns `parent_drawer_id`;
- a non-chunked vector hit returns its stored row ID;
- a real non-chunked Chroma result exposes its expected stored ID;
- the ID returned for a chunked search hit round-trips through
  `mempalace_get_drawer` and reconstructs the complete content;
- IDs remain aligned when the filtered-query recovery path removes
  non-matching results;
- SQLite BM25-only results use parent-or-stored-ID semantics;
- backend lexical-union results use parent-or-`LexicalHit.id` semantics;
- internal `_parent_drawer_id` remains absent from the public response.

## Relationship to #1219

#1219 exposes the raw ID returned by the normal vector query.

This PR implements the broader contract reported in #2080:

- chunked results need the logical parent ID;
- ordinary and mined results need their own stored ID;
- the same behavior must hold in the vector/hybrid, SQLite BM25-only, and
  backend lexical-union result builders;
- the filtered-query recovery path must preserve IDs as well.

This is not intended to disregard #1219. Maintainers can decide whether this
PR should replace that implementation or whether the existing PR should be
adapted.

Fixes #2080

Related to #1026  
Related to #1219

## How to test

```text
  python3 -m ruff format --check .
  python3 -m ruff check .
  python3 -m pytest tests/test_search_drawer_id.py -v
  python -m pytest tests/ -v
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
