### PR TITLE
fix: replace fcntl.flock spawn-mutex with a cross-platform primitive (Windows no-op today)

### DIFF
--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 from urllib import error as urlerror
 from urllib import request as urlrequest
 from urllib.parse import parse_qs, urlparse
@@ -45,10 +45,22 @@ SHUTDOWN_DRAIN_SECONDS = 10.0
 # holds verbatim payloads) doesn't grow without bound across a long-lived
 # daemon. Override via env for operators who want a longer/shorter window.
 JOB_RETENTION_DAYS = int(os.environ.get("MEMPALACE_DAEMON_RETENTION_DAYS", "7") or "7")
+_fcntl: Any
 try:
     import fcntl as _fcntl  # POSIX only; absent on Windows
 except ImportError:  # pragma: no cover - Windows fallback
     _fcntl = None
+_msvcrt: Any
+try:
+    import msvcrt as _msvcrt  # Windows only; absent on POSIX
+except ImportError:  # pragma: no cover - POSIX fallback
+    _msvcrt = None
+
+# Bounded wait for the Windows spawn-mutex poll loop (see _wait_lock_start_file).
+# msvcrt has no indefinite-blocking lock mode, so this stands in for POSIX
+# flock(LOCK_EX)'s unbounded wait with a generous but finite ceiling instead.
+_LOCK_WAIT_TIMEOUT = 30.0
+_LOCK_POLL_INTERVAL = 0.05
 
 
 def _chmod_private(path: Path) -> None:
@@ -999,6 +1011,65 @@ def _detached_kwargs(log_path: Path) -> dict[str, Any]:
     return kwargs
 
 
+def _try_lock_start_file(lock_fh: IO[Any]) -> bool:
+    """Non-blocking attempt to acquire the spawn-mutex on ``lock_fh``.
+
+    Returns True if this caller now holds the exclusive lock. Uses
+    ``fcntl.flock`` on POSIX and ``msvcrt.locking`` on Windows -- both are
+    advisory locks on the open file description/handle that release
+    automatically when it is closed, including on process crash (verified:
+    a force-killed holder on Windows releases the lock immediately, with no
+    stale-lock cleanup needed).
+    """
+    if _fcntl is not None:
+        try:
+            _fcntl.flock(lock_fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+            return True
+        except OSError:
+            return False
+    if _msvcrt is not None:  # pragma: no cover - Windows only
+        try:
+            _msvcrt.locking(lock_fh.fileno(), _msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+    return False  # pragma: no cover - no locking primitive on this platform
+
+
+def _wait_lock_start_file(lock_fh: IO[Any]) -> None:
+    """Block until the spawn-mutex on ``lock_fh`` can be acquired.
+
+    ``fcntl.flock(LOCK_EX)`` blocks indefinitely. ``msvcrt`` has no
+    equivalent (``LK_LOCK`` only retries for ~10s before giving up), so the
+    Windows path polls the non-blocking primitive with its own, longer
+    bounded timeout instead.
+
+    Raises ``DaemonError`` (never a raw ``OSError``) so callers can handle it
+    the same way as every other daemon failure -- ``cli.py``'s ``cmd_daemon``
+    and ``_submit_daemon_cli_job`` both catch only ``DaemonError``, so a raw
+    ``OSError`` here would escape as an unhandled traceback.
+    """
+    if _fcntl is not None:
+        try:
+            _fcntl.flock(lock_fh.fileno(), _fcntl.LOCK_EX)
+        except OSError as exc:
+            raise DaemonError(f"failed waiting for the daemon spawn lock: {exc}") from exc
+        return
+    if _msvcrt is not None:  # pragma: no cover - Windows only
+        deadline = time.monotonic() + _LOCK_WAIT_TIMEOUT
+        while True:
+            try:
+                _msvcrt.locking(lock_fh.fileno(), _msvcrt.LK_NBLCK, 1)
+                return
+            except OSError as exc:
+                if time.monotonic() >= deadline:
+                    raise DaemonError(
+                        f"timed out after {_LOCK_WAIT_TIMEOUT:g}s waiting for another "
+                        f"daemon start to finish: {exc}"
+                    ) from exc
+                time.sleep(_LOCK_POLL_INTERVAL)
+
+
 def start_daemon(
     palace_path: str,
     *,
@@ -1023,18 +1094,25 @@ def start_daemon(
 
     # Spawn mutual exclusion: two concurrent `daemon start` callers would both
     # observe no running daemon and both spawn a child, double-claiming jobs.
-    # A non-blocking flock serializes the check-then-spawn; the loser waits for
-    # the winner to finish coming up, then re-checks and reuses that daemon.
-    lock_fh = open(sd / "start.lock", "w") if _fcntl is not None else None
-    if _fcntl is not None and lock_fh is not None:
+    # A non-blocking exclusive lock serializes the check-then-spawn; the loser
+    # waits for the winner to finish coming up, then re-checks and reuses that
+    # daemon. Cross-platform: fcntl.flock on POSIX, msvcrt.locking on Windows.
+    lock_fh = open(sd / "start.lock", "w") if (_fcntl is not None or _msvcrt is not None) else None
+    if lock_fh is not None:
         _chmod_private(sd / "start.lock")
-        try:
-            _fcntl.flock(lock_fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
-        except OSError:
+        if not _try_lock_start_file(lock_fh):
             # Another start is in flight — wait for it, then reuse its daemon.
-            _fcntl.flock(lock_fh.fileno(), _fcntl.LOCK_EX)
-            existing = get_client_if_running(palace_path)
+            # Both exits here leave the function before the readiness-probe
+            # ``try`` below, so neither is covered by its ``finally``: close the
+            # handle explicitly or it leaks into the caller's process.
+            try:
+                _wait_lock_start_file(lock_fh)
+                existing = get_client_if_running(palace_path)
+            except BaseException:
+                lock_fh.close()
+                raise
             if existing is not None:
+                lock_fh.close()
                 return existing
             # The other starter failed without bringing the daemon up; fall
             # through and spawn ourselves (we now hold the lock).

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -582,6 +582,267 @@ def test_start_daemon_kills_orphan_on_readiness_timeout(tmp_path, monkeypatch):
     assert fake.killed is True
 
 
+def test_try_lock_start_file_returns_false_when_already_locked(tmp_path):
+    """The non-blocking spawn-mutex primitive must actually contend.
+
+    Regression guard for #47/#83: the old code only ever attempted this via
+    ``fcntl``, which is ``None`` on Windows, so the whole guard silently
+    no-oped there. This exercises whatever primitive the current platform
+    provides (``msvcrt`` on Windows, ``fcntl`` on POSIX) directly.
+    """
+    path = tmp_path / "start.lock"
+    f1 = open(path, "w")
+    f2 = open(path, "w")
+    try:
+        assert daemon._try_lock_start_file(f1) is True
+        assert daemon._try_lock_start_file(f2) is False
+    finally:
+        f1.close()
+        f2.close()
+
+
+def test_wait_lock_start_file_unblocks_after_release(tmp_path):
+    """The blocking spawn-mutex wait must actually wake once the holder lets go."""
+    path = tmp_path / "start.lock"
+    f1 = open(path, "w")
+    f2 = open(path, "w")
+    assert daemon._try_lock_start_file(f1) is True
+    assert daemon._try_lock_start_file(f2) is False
+
+    released = threading.Event()
+
+    def release_soon():
+        time.sleep(0.2)
+        f1.close()
+        released.set()
+
+    releaser = threading.Thread(target=release_soon)
+    releaser.start()
+    try:
+        daemon._wait_lock_start_file(f2)
+    finally:
+        releaser.join(timeout=5)
+        f2.close()
+    assert released.is_set()
+
+
+def test_start_daemon_closes_lock_handle_when_reusing_winner_daemon(tmp_path, monkeypatch):
+    """The lock file handle must not leak on the "reuse the winner's daemon" path.
+
+    ``start_daemon``'s ``finally`` that closes ``lock_fh`` is attached to the
+    readiness-probe ``try``, which begins *after* the spawn. Every path that
+    leaves the function before that point -- this one, and the lock-wait
+    failure below -- skipped the close entirely and leaked an open handle to
+    ``start.lock`` into the caller's process.
+    """
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    daemon.ensure_token(str(palace))
+
+    seen = {}
+
+    def capturing_try_lock(fh):
+        seen["fh"] = fh
+        return False  # force the "another start is in flight" branch
+
+    sentinel = object()
+    calls = []
+
+    def fake_get_client(*a, **kw):
+        calls.append(1)
+        # First call (before the lock) sees nothing; after waiting out the
+        # winner, its daemon is up and we reuse it.
+        return sentinel if len(calls) > 1 else None
+
+    monkeypatch.setattr(daemon, "_try_lock_start_file", capturing_try_lock)
+    monkeypatch.setattr(daemon, "_wait_lock_start_file", lambda fh: None)
+    monkeypatch.setattr(daemon, "get_client_if_running", fake_get_client)
+
+    result = daemon.start_daemon(str(palace))
+
+    assert result is sentinel
+    assert seen["fh"].closed, "lock file handle leaked on the reuse-existing-daemon path"
+
+
+def test_wait_lock_start_file_translates_posix_flock_error(tmp_path, monkeypatch):
+    """The POSIX branch must translate a flock OSError into DaemonError too.
+
+    Runs on every platform (the fcntl module is faked), so the POSIX-side
+    translation keeps regression coverage on the Windows CI job as well --
+    the timeout tests below are msvcrt-gated and skip on Linux/macOS, which
+    would otherwise leave this branch untested everywhere.
+    """
+
+    class _FakeFcntl:
+        LOCK_EX = 2
+        LOCK_NB = 4
+
+        @staticmethod
+        def flock(fd, operation):
+            raise OSError(4, "Interrupted system call")
+
+    monkeypatch.setattr(daemon, "_fcntl", _FakeFcntl)
+    fh = open(tmp_path / "start.lock", "w")
+    try:
+        with pytest.raises(daemon.DaemonError):
+            daemon._wait_lock_start_file(fh)
+    finally:
+        fh.close()
+
+
+@pytest.mark.skipif(
+    daemon._msvcrt is None,
+    reason="the bounded wait ceiling only exists on the Windows/msvcrt path",
+)
+def test_wait_lock_start_file_raises_daemon_error_on_timeout(tmp_path, monkeypatch):
+    """Hitting the Windows wait ceiling must surface as DaemonError, not OSError.
+
+    Every production auto-start entrypoint (cli.py's cmd_daemon and
+    _submit_daemon_cli_job) catches only DaemonError, so a raw
+    OSError/PermissionError escapes as an unhandled traceback instead of the
+    module's normal "mempalace: daemon error: ..." exit-1 behavior.
+    """
+    monkeypatch.setattr(daemon, "_LOCK_WAIT_TIMEOUT", 0.2)
+    path = tmp_path / "start.lock"
+    holder = open(path, "w")
+    waiter = open(path, "w")
+    try:
+        assert daemon._try_lock_start_file(holder) is True
+        with pytest.raises(daemon.DaemonError):
+            daemon._wait_lock_start_file(waiter)
+    finally:
+        holder.close()
+        waiter.close()
+
+
+@pytest.mark.skipif(
+    daemon._msvcrt is None,
+    reason="the bounded wait ceiling only exists on the Windows/msvcrt path",
+)
+def test_start_daemon_lock_wait_timeout_is_daemon_error_and_closes_handle(tmp_path, monkeypatch):
+    """The wait-ceiling path must translate the error AND release the handle."""
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    daemon.ensure_token(str(palace))
+    monkeypatch.setattr(daemon, "_LOCK_WAIT_TIMEOUT", 0.2)
+    monkeypatch.setattr(daemon, "get_client_if_running", lambda *a, **kw: None)
+
+    seen = {}
+    real_try_lock = daemon._try_lock_start_file
+
+    def capturing_try_lock(fh):
+        seen["fh"] = fh
+        return real_try_lock(fh)
+
+    monkeypatch.setattr(daemon, "_try_lock_start_file", capturing_try_lock)
+
+    sd = daemon.state_dir(str(palace))
+    sd.mkdir(parents=True, exist_ok=True)
+    holder = open(sd / "start.lock", "w")
+    try:
+        # Someone else holds the spawn mutex and never lets go.
+        assert real_try_lock(holder) is True
+        with pytest.raises(daemon.DaemonError):
+            daemon.start_daemon(str(palace))
+        assert seen["fh"].closed, "lock file handle leaked on the lock-wait-timeout path"
+    finally:
+        holder.close()
+
+
+def test_start_daemon_serializes_concurrent_spawners(tmp_path, monkeypatch):
+    """Two racing auto-start callers must not both spawn a daemon.
+
+    Regression test for #47/#83: start_daemon()'s spawn mutex was built
+    exclusively on fcntl.flock, which is unavailable on Windows (`_fcntl` is
+    `None` there — the operator's actual production platform), so the whole
+    ``if _fcntl is not None`` guard was skipped and two near-simultaneous
+    callers (e.g. two hooks firing back-to-back) both observed no running
+    daemon and both spawned a child, leaking an orphaned, unstoppable second
+    daemon process. This uses the real on-disk lock file and whatever
+    locking primitive the current platform provides (not mocked) so it
+    actually exercises the fix; only ``subprocess.Popen`` and the readiness
+    probe (``DaemonClient``) are faked.
+    """
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    daemon.ensure_token(str(palace))
+
+    spawn_count = 0
+    spawn_count_lock = threading.Lock()
+    daemon_up = threading.Event()
+    sentinel_client = object()
+
+    # Force the two threads' *first* (pre-lock) liveness check to rendezvous,
+    # so both deterministically observe "not running yet" at the same instant
+    # -- closing the race window instead of relying on scheduler luck.
+    pre_check_barrier = threading.Barrier(2)
+    pre_check_count = 0
+    pre_check_count_lock = threading.Lock()
+
+    def fake_get_client_if_running(*a, **kw):
+        nonlocal pre_check_count
+        with pre_check_count_lock:
+            pre_check_count += 1
+            my_turn = pre_check_count
+        if my_turn <= 2:
+            pre_check_barrier.wait(timeout=5)
+        return sentinel_client if daemon_up.is_set() else None
+
+    class FakeProc:
+        returncode = None
+
+        def poll(self):
+            return None
+
+    def fake_popen(*a, **kw):
+        nonlocal spawn_count
+        with spawn_count_lock:
+            spawn_count += 1
+        return FakeProc()
+
+    class FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def health(self):
+            daemon_up.set()
+            return {"status": "ok"}
+
+    monkeypatch.setattr(daemon, "get_client_if_running", fake_get_client_if_running)
+    monkeypatch.setattr(daemon.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(daemon, "DaemonClient", FakeClient)
+
+    results = [None, None]
+    errors = []
+    start_barrier = threading.Barrier(2)
+
+    def call(index):
+        start_barrier.wait(timeout=5)
+        try:
+            results[index] = daemon.start_daemon(str(palace), timeout=5.0)
+        except Exception as exc:  # noqa: BLE001 - surfaced via `errors` below
+            errors.append(exc)
+
+    # daemon=True: if a regression ever deadlocks start_daemon, these threads
+    # must not keep the pytest process alive past the join timeout below.
+    t1 = threading.Thread(target=call, args=(0,), daemon=True)
+    t2 = threading.Thread(target=call, args=(1,), daemon=True)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not errors, f"start_daemon raised: {errors}"
+    assert spawn_count == 1, (
+        f"expected exactly one daemon spawn, got {spawn_count} "
+        "(the spawn mutex failed to serialize concurrent callers)"
+    )
+    assert all(r is not None for r in results)
+
+
 # --- service.run_* happy-path coverage ---
 # These close the draft PR's follow-up ("Add focused happy-path tests for
 # service.run_mine / run_diary_write / run_mcp_tool") and, now that the daemon


### PR DESCRIPTION
## Problem

`start_daemon()`'s spawn mutual-exclusion guard is built entirely on `fcntl.flock`. The comment above it states why it exists:

> two concurrent `daemon start` callers would both observe no running daemon and both spawn a child, double-claiming jobs

But `fcntl` is POSIX-only, so `_fcntl` is `None` on Windows and the whole `if _fcntl is not None` block is skipped there. On Windows there is no mutual exclusion of any kind — the exact race the comment describes is completely unguarded.

When it fires, two near-simultaneous auto-start callers (two hooks firing back-to-back, or a hook plus a manual `daemon start`) both call `subprocess.Popen`. Both children write `endpoint.json` and `pid.json`; whichever process is not referenced by the final `endpoint.json` becomes a permanently orphaned daemon, since `stop_daemon()` only ever targets the pid recorded there. It holds a Python process, an HTTP port, and a live sqlite connection indefinitely, and there is no supported way to stop it.

## Fix

Add `_try_lock_start_file()` / `_wait_lock_start_file()`, which use `fcntl.flock` on POSIX and `msvcrt.locking` on Windows, and rewire `start_daemon()` to them.

Both are advisory locks tied to the open file handle and release automatically when it closes, including on abnormal process termination. I measured this on Windows before relying on it:

- `msvcrt.locking(LK_NBLCK, 1)` succeeds on a handle opened in `"w"` mode
- a second handle to the same file correctly fails with `OSError` while the first holds the lock
- the lock is released immediately when the holder is force-killed, so no stale-lock cleanup is needed
- `close()` alone releases it, without an explicit `LK_UNLCK`

`msvcrt` has no indefinite-blocking mode (`LK_LOCK` gives up after ~10s), so the Windows wait polls the non-blocking primitive up to a 30s ceiling instead of blocking forever like `flock(LOCK_EX)`.

### Error contract

Both helpers raise `DaemonError` rather than a raw `OSError`. `cli.py`'s `cmd_daemon` and `_submit_daemon_cli_job` catch only `DaemonError`, so an `OSError` escaping from here would surface as an unhandled traceback instead of the usual `mempalace: daemon error: ...` / exit 1 path.

### Handle lifetime

This also closes the lock file handle on the two paths that leave `start_daemon` before the readiness-probe `try/finally` that owns it: the lock-wait failure, and the "reuse the winner's daemon" `return existing`. The latter leaked an open handle to `start.lock` on every contended start before this change, on POSIX too.

## Tests

- `_try_lock_start_file` actually contends (second handle is refused) and `_wait_lock_start_file` wakes once the holder releases — exercising whichever primitive the running platform provides, not a mock.
- Two concurrent `start_daemon()` callers race through the **real on-disk lock**, with only `subprocess.Popen` and the readiness probe faked; asserts exactly one spawn. A `threading.Barrier` forces both callers to observe "no daemon running" at the same instant, so the race window is deterministic rather than scheduler-dependent. This test fails on the current code with `got 2` spawns.
- The lock handle is released on both early-exit paths.
- Both platforms translate a lock failure into `DaemonError`. The POSIX test fakes the `fcntl` module so it runs on every CI platform rather than only Linux/macOS.

## Notes for reviewers

Two adjacent issues are deliberately **not** included here, to keep this change focused:

- `_detached_kwargs()` / `subprocess.Popen()` sit outside any `try` that closes `lock_fh`. If `Popen` raises, the handle leaks. This is unchanged from `develop` and affects the uncontended first-spawn path too, so it is orthogonal to this fix.
- `_LOCK_WAIT_TIMEOUT` (the Windows-only poll ceiling) is decoupled from `start_daemon`'s caller-supplied `timeout`. Under contention on Windows, a caller passing a short `timeout` can still wait up to 30s in the lock phase. Now that this surfaces as a clean `DaemonError` it is a latency surprise rather than a correctness problem, but plumbing `timeout` through would be a reasonable follow-up.

Happy to fold either in if you would prefer them handled together.
