### PR TITLE
fix(repair): take the mine-lock before archiving in repair --mode from-sqlite

### DIFF
--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -1471,6 +1471,43 @@ def rebuild_from_sqlite(
             )
             return {}
 
+    # Acquire the single-writer mine-lock BEFORE the archive/rename. The
+    # rebuild upserts into ``dest_palace`` through the same backend write
+    # path that takes ``mine_palace_lock`` per batch; if a daemon or a
+    # concurrent mine already holds it, those upserts used to fail *after*
+    # ``shutil.move`` had already stranded the existing palace aside
+    # (renamed to ``.pre-rebuild-…`` with no rebuilt replacement, leaving a
+    # partial/archived mess). Taking the lock up front makes contention
+    # fail CLEAN — no archive, no partial dest, the palace left untouched —
+    # and runs the whole rebuild as one writer (the inner per-batch
+    # acquires pass through re-entrantly on this thread).
+    from .palace import mine_palace_lock
+
+    with mine_palace_lock(dest_palace):
+        return _rebuild_from_sqlite_locked(
+            source_palace=source_palace,
+            dest_palace=dest_palace,
+            in_place=in_place,
+            batch_size=batch_size,
+        )
+
+
+def _rebuild_from_sqlite_locked(
+    *,
+    source_palace: str,
+    dest_palace: str,
+    in_place: bool,
+    batch_size: int,
+) -> dict[str, int]:
+    """Body of :func:`rebuild_from_sqlite`, run while holding
+    ``mine_palace_lock(dest_palace)`` so the archive/rename and the
+    upserts form one atomic single-writer operation.
+
+    Split out so the lock acquired in :func:`rebuild_from_sqlite` wraps
+    every destructive step (the archive ``shutil.move`` below included).
+    Raising :class:`MineAlreadyRunning` from the wrapping ``with`` happens
+    before this body runs, so a held lock never reaches the archive.
+    """
     archive_path: Optional[str] = None
     if in_place:
         ts = datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -1501,7 +1538,6 @@ def rebuild_from_sqlite(
             )
             return {}
         source_palace = archive_path
-        src_db = os.path.join(source_palace, "chroma.sqlite3")
 
         # In-place only: drop chromadb's process-wide System registry so
         # the new client at dest_palace builds a fresh System. Without

--- a/tests/test_repair_lock_safety.py
+++ b/tests/test_repair_lock_safety.py
@@ -1,0 +1,103 @@
+"""Tests for the repair-vs-mine-lock stranding fix.
+
+``mempalace repair --mode from-sqlite --archive-existing`` used to rename
+the existing palace aside (``palace.pre-rebuild-…``) and only *then* hit the
+single-writer ``mine_palace_lock`` when the first chromadb upsert ran — so a
+palace held by a live MCP server / daemon was stranded: archived, with no
+rebuilt replacement and a partial dest left behind.
+
+The fix takes ``mine_palace_lock(dest_palace)`` BEFORE the archive/rename, so
+contention raises ``MineAlreadyRunning`` while the palace is still untouched.
+
+POSIX-only: ``mine_palace_lock`` uses ``fcntl`` on Unix and ``msvcrt`` on
+Windows; the cross-process contention helper mirrors the other lock tests.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import sys
+import time
+
+import pytest
+
+from mempalace.palace import MineAlreadyRunning, mine_palace_lock
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="cross-process lock contention semantics differ on Windows",
+)
+
+
+def _get_mp_context():
+    # ``spawn`` everywhere — ``fork`` deadlocks a multi-threaded parent under
+    # 3.13 and macOS forbids fork-without-exec. Mirrors test_palace_locks.py.
+    return multiprocessing.get_context("spawn")
+
+
+def _hold_lock(palace_path: str, ready_flag: str, release_flag: str) -> int:
+    """Acquire ``mine_palace_lock``, signal readiness, wait for release."""
+    try:
+        with mine_palace_lock(palace_path):
+            open(ready_flag, "w").close()
+            for _ in range(500):
+                if os.path.exists(release_flag):
+                    return 0
+                time.sleep(0.01)
+            return 0
+    except MineAlreadyRunning:
+        return 1
+
+
+def _wait_for(path: str) -> bool:
+    for _ in range(500):
+        if os.path.exists(path):
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_rebuild_refuses_when_lock_held_leaves_palace_untouched(tmp_path, monkeypatch):
+    """A held mine-lock makes rebuild_from_sqlite fail CLEAN before archiving.
+
+    Asserts the three stranding-bug invariants: ``MineAlreadyRunning`` is
+    raised, NO ``*.pre-rebuild-*`` archive sibling is created, and the
+    original palace dir is left exactly as it was (its marker file intact).
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from mempalace.repair import rebuild_from_sqlite
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    # Satisfy rebuild_from_sqlite's source validation (in_place branch checks
+    # for chroma.sqlite3) so execution reaches the lock acquisition. The lock
+    # check fires before any chromadb read, so the file content is irrelevant.
+    marker = palace / "chroma.sqlite3"
+    marker.write_bytes(b"sentinel-not-touched")
+
+    ready = str(tmp_path / "ready")
+    release = str(tmp_path / "release")
+    ctx = _get_mp_context()
+    holder = ctx.Process(target=_hold_lock, args=(str(palace), ready, release))
+    holder.start()
+    try:
+        assert _wait_for(ready), "holder failed to acquire the palace lock"
+
+        with pytest.raises(MineAlreadyRunning):
+            rebuild_from_sqlite(
+                source_palace=str(palace),
+                dest_palace=str(palace),
+                archive_existing_dest=True,
+            )
+
+        # No archive sibling was created (the bug renamed it aside first).
+        archives = list(tmp_path.glob("palace.pre-rebuild-*"))
+        assert archives == [], f"palace was stranded into archive(s): {archives}"
+
+        # The palace dir is untouched: still present with its original file.
+        assert palace.is_dir()
+        assert marker.read_bytes() == b"sentinel-not-touched"
+    finally:
+        open(release, "w").close()
+        holder.join(timeout=5)


### PR DESCRIPTION
Addresses #2108.

### Who is asking

Same context as #2107, restated so this PR stands alone. Four instances(extendable) of one system on one machine:
three sovereign "content palaces" (one per sensorium) **plus** whatever install the operator already
runs at `~/.mempalace`. 

**Peers, never satellites.** We consume mempalace as a library from our own
NDJSON holder processes, with the embedding contract inverted — vectors arrive on the
wire, so no model loads in the store process. Everything here comes out of running that shape with
many parallel agent worldlines writing one palace.

### Opening by naming your work, because this composes with it rather than replacing it

**`write_routing` (#1963) decides WHETHER a write takes the daemon path. This decides HOW MANY
daemons may exist, and HOW writers queue once they arrive.**

The two compose into something neither gives alone: the flock guarantees **one** daemon exists;
`write_routing=require` guarantees every write goes **through** it. Together, single-writer discipline
that holds under load. `prefer` cannot reach that by itself, because its fallback re-opens direct
multi-writer access at exactly the moment contention peaks — daemon busy, or daemon starting.

### Three commits

1. **`feat(daemon)`** — a flock on a per-palace lock file makes the warm daemon a singleton. A second
   start finds the lock held and declines rather than standing a rival writer over the same HNSW
   segment. Found with orphaned warm daemons piling up, each holding its own handle.
2. **`fix(repair)`** — take the mine-lock *before* the archive in `repair --mode from-sqlite`, so a
   concurrent mine cannot interleave with the archive step.
3. **`fix(cli)`** — a quiet bounded backoff for mine-lock contention. `mine_palace_lock` stays
   deliberately non-blocking and still raises `MineAlreadyRunning` for in-process callers; this
   collapses a harvest's repeated "held by PID …" spam to one notice plus exponential backoff, bounded
   by `MEMPALACE_MINE_LOCK_WAIT` (default 30s; `0` keeps today's fail-fast with a clean give-up
   message), matching the deadline-loop idiom your daemon stale-takeover and closet_llm retry already
   use. Behaviour otherwise unchanged: it eventually mines, or exits non-zero once the budget is
   spent. Never spins forever, never spams.

### Scope

This PR touches `daemon.py`, `repair.py`, `cli.py`, and their tests.

### On `flock` as the mechanism

`flock` releases automatically when the holder dies, which is the failure mode that produced the
orphans. A PID file with liveness probing, an abstract unix socket, or a lock row in sqlite would
each serve as well — if you would rather stand the singleton on one of those, say so and I will
rebuild it that way.

### Verification

Rebased onto `develop` @ `aa89bd8`.

- `ruff check .` → clean · `ruff format --check .` → 194 files already formatted
- `pytest tests/test_daemon.py tests/test_repair_lock_safety.py tests/test_cli.py` → **124 passed**
- `pytest tests/ --ignore=tests/benchmarks` → **3407 passed, 31 skipped, 5 failed**

**On those 5 failures:** all five are `test_init_filters_sys_path_from_leaked_pythonpath`, and they
fail **identically on clean `develop` in the same worktree** — I ran that control because the test
reacts to *where* it runs rather than to the code under it. Zero regressions here; the cause is a
leaked `PYTHONPATH` in my environment, which is the very thing the test asserts about.

Local ruff reads 0.15.20 against your pinned 0.15.14, so please let CI have the final word on lint.

