### PR TITLE
feat: many palaces, one machine — config-dir lever, source-adapter registry

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -160,33 +160,100 @@ def _hnsw_payload_appears_sane(seg_dir: str) -> bool:
     return ratio is None or ratio <= _HNSW_LINK_TO_DATA_MAX_RATIO
 
 
-# HNSW batch/sync thresholds applied at collection creation.
+# HNSW batch/sync thresholds applied at collection creation — chromadb's own
+# documented defaults (chromadb/api/configuration.py:263-273,
+# chromadb/api/collection_configuration.py:451-454,
+# chromadb/segment/impl/vector/hnsw_params.py:79-80, and
+# https://docs.trychroma.com/docs/collections/configure).
 #
-# chromadb's Rust HNSW segment writes index_metadata.pickle and
-# link_lists.bin only when internal counters cross both thresholds
-# (batch_size gates _apply_batch; sync_threshold gates _persist).
-# Records below both thresholds stay in memory and are lost on exit.
+# Both ran at 2 to answer #1579 (a sub-threshold mine left index_metadata.pickle
+# absent, and quarantine_stale_hnsw renamed the segment away). Three findings on
+# chromadb 1.5.9 (PersistentClient / Rust bindings, single writer) retire that:
 #
-# Previously 50k/50k to work around link_lists.bin sparse-file bloat
-# in pre-1.5.x Python chromadb (#344).  chromadb >=1.5.4 Rust bindings
-# (the minimum mempalace supports) do not exhibit that bloat; verified
-# at batch_size=2 with 20k records: link_lists.bin = 171 KB, no
-# sparse-file inflation.
+#   * 2 SITS OUTSIDE CHROMA'S OWN DECLARED VALID RANGE. hnsw_params.py:21-22
+#     validates both knobs as `isinstance(p, int) and p > 2`. Not an inequality
+#     between the two — a floor on each.
 #
-# The 50k guard caused #1579: mines under 50k drawers never triggered
-# _persist(), leaving index_metadata.pickle absent and link_lists.bin
-# empty.  quarantine_stale_hnsw then renamed the segment on every cold
-# open after a 300s mtime gap, accumulating .drift-* directories.
+#   * IT COSTS WRITE AMPLIFICATION, measured. Bytes written (/proc/self/io) for
+#     one mine of N records, 64-dim, num_threads=1, identical corpus and seed:
 #
-# Lowered to 2 (empirical Rust-side minimum for chromadb >=1.5.4; the
-# Rust bindings reject 1 with InvalidArgumentError) so any mine of 2+
-# drawers triggers a natural persist.  Existing palaces created under
-# the old 50k guard keep those thresholds in their collection metadata
-# until the user runs repair --mode from-sqlite --archive-existing.
-_HNSW_BLOAT_GUARD = {
-    "hnsw:batch_size": 2,
-    "hnsw:sync_threshold": 2,
+#         N        2/2        100/1000     ratio
+#         10,000    47.1 MB    28.1 MB     1.67x
+#         20,000   127.4 MB    60.0 MB     2.12x
+#         40,000   390.3 MB   134.0 MB     2.91x
+#
+#     Two runs at N=20,000 reproduced within 0.1%. sync_threshold dominates:
+#     3/3 measured identical to 2/2, and 1000/1000 identical to 100/1000. The
+#     ratio grows with collection size, so the cost is worst on the largest
+#     palaces.
+#
+#   * IT BUYS NOTHING. A 5-record collection at 100/1000 — far below the
+#     threshold, so no persist ever fires — reads back whole from a FRESH
+#     PROCESS (count and vector query both answer). On that artifact
+#     link_lists.bin is 0 bytes with no index_metadata.pickle, which is #1579's
+#     trigger shape exactly, and quarantine_stale_hnsw() creates no drift dir:
+#     _segment_appears_healthy reads it as never-persisted rather than as a torn
+#     persist.
+#
+# NOT claimed here: that a small sync_threshold is a known chroma failure mode.
+# No such report was found in chroma's issues or docs, and chroma's own guidance
+# runs the other way (raise sync_threshold for bulk inserts). The Python
+# persist path that #1579 and chroma#6975 describe does not execute under the
+# Rust bindings at all — hnswlib is not a dependency of this line.
+#
+# A palace keeps whatever thresholds it was created under;
+# `repair --mode from-sqlite --archive-existing` re-creates it under these.
+_HNSW_WRITE_DEFAULTS = {
+    "hnsw:batch_size": 100,
+    "hnsw:sync_threshold": 1000,
 }
+
+
+def _hnsw_creation_metadata(options: Optional[dict]) -> dict:
+    """Build the ``metadata=`` dict for a fresh collection from caller options.
+
+    Centralizes the HNSW knobs so a multi-collection palace can tune each
+    collection at creation while the base keeps every config value in the
+    ``collection_metadata`` table where the divergence guard, the cosine-space
+    detector (``ChromaCollection.distance_metric``), and ``_read_sync_threshold``
+    already read it. The legacy ``metadata=`` keys are kept deliberately: the
+    modern ``configuration=`` API stores the same parameters in
+    ``configuration_json`` instead, leaving ``collection.metadata`` empty and
+    silently blinding all of that existing tooling.
+
+    Caller option -> chromadb metadata key:
+
+    * ``hnsw_space``       -> ``hnsw:space``        (default ``"cosine"``)
+    * ``num_threads``      -> ``hnsw:num_threads``  (default 1; serializes inserts)
+    * ``ef_construction``  -> ``hnsw:construction_ef``
+    * ``max_neighbors``    -> ``hnsw:M``
+    * ``sync_threshold``   -> ``hnsw:sync_threshold``
+    * ``batch_size``       -> ``hnsw:batch_size``
+
+    ``sync_threshold``/``batch_size`` default to chromadb's own values
+    (:data:`_HNSW_WRITE_DEFAULTS`), which amortize the index flush across a
+    mine. A caller tunes them per collection; a caller writing far fewer
+    records than the threshold still keeps them (the Rust writer holds the
+    sub-threshold tail durable — see :data:`_HNSW_WRITE_DEFAULTS`).
+    ``ef_construction``/``max_neighbors`` are omitted when the caller does not
+    set them, so chromadb applies its own defaults.
+    """
+    opts = options if isinstance(options, dict) else {}
+    md: dict[str, Any] = {
+        "hnsw:space": opts.get("hnsw_space", "cosine"),
+        "hnsw:num_threads": int(opts.get("num_threads", 1)),
+        **_HNSW_WRITE_DEFAULTS,
+    }
+    if "ef_construction" in opts and opts["ef_construction"] is not None:
+        md["hnsw:construction_ef"] = int(opts["ef_construction"])
+    if "max_neighbors" in opts and opts["max_neighbors"] is not None:
+        md["hnsw:M"] = int(opts["max_neighbors"])
+    if "sync_threshold" in opts and opts["sync_threshold"] is not None:
+        md["hnsw:sync_threshold"] = int(opts["sync_threshold"])
+    if "batch_size" in opts and opts["batch_size"] is not None:
+        md["hnsw:batch_size"] = int(opts["batch_size"])
+    return md
+
 
 # Below this size, data_level0.bin is too small for a meaningful HNSW graph.
 # Used by _hnsw_link_lists_is_usable_for_payload (empty link_lists is fine
@@ -633,9 +700,10 @@ def _hnsw_element_count(palace_path: str, segment_id: str) -> Optional[int]:
 # read the collection metadata (older palaces missing the row, sqlite
 # unreadable). 2000 = 2 × chromadb's default sync_threshold of 1000.
 #
-# Why dynamic: legacy palaces may still carry ``sync_threshold = 50_000``
-# (the pre-#1579 guard), so flush-lag can grow up to 50K on those palaces.
-# New palaces use sync_threshold=2 (#1579) and flush almost immediately.
+# Why dynamic: a palace carries whatever ``sync_threshold`` it was created
+# under, and flush-lag grows to that threshold before a persist fires — up
+# to 50K on a palace created under an old large guard, and 2 on one created
+# under the small guard that #1308 traces back to.
 # A fixed 2000 floor would flag actively-written legacy palaces as
 # DIVERGED the moment their queue exceeded 10% of sqlite_count, even
 # though chromadb is behaving correctly. The floor must scale with the
@@ -2355,11 +2423,7 @@ class ChromaBackend(BaseBackend):
             except _ChromaNotFoundError:
                 collection = client.create_collection(
                     collection_name,
-                    metadata={
-                        "hnsw:space": hnsw_space,
-                        "hnsw:num_threads": 1,
-                        **_HNSW_BLOAT_GUARD,
-                    },
+                    metadata=_hnsw_creation_metadata(options),
                     **ef_kwargs,
                 )
             except ValueError as e:
@@ -2449,11 +2513,7 @@ class ChromaBackend(BaseBackend):
         ef_kwargs = {"embedding_function": ef} if ef is not None else {}
         collection = self._client(palace_path).create_collection(
             collection_name,
-            metadata={
-                "hnsw:space": hnsw_space,
-                "hnsw:num_threads": 1,
-                **_HNSW_BLOAT_GUARD,
-            },
+            metadata=_hnsw_creation_metadata({"hnsw_space": hnsw_space}),
             **ef_kwargs,
         )
         return ChromaCollection(collection, palace_path=palace_path)

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -545,6 +545,79 @@ def _maybe_run_mine_after_init(args, cfg) -> None:
         sys.exit(1)
 
 
+def _mine_via_source_adapter(args, palace_path):
+    """Route ``mine --source NAME`` through the RFC 002 source-adapter registry.
+
+    Opt-in seam: when an explicit ``--source`` names a registered adapter, mine
+    resolves it from ``mempalace.sources.registry``, runs its ``ingest()``, and
+    files each ``DrawerRecord`` through a ``PalaceContext``. When no ``--source``
+    is given, ``cmd_mine`` keeps its legacy ``--mode`` dispatch — the
+    filesystem/conversations miners have not moved onto the contract yet, so the
+    registry path stays opt-in and changes no existing behavior. This wires the
+    registry the spec reserves.
+    """
+    from .knowledge_graph import KnowledgeGraph
+    from .palace import MineAlreadyRunning, get_collection, mine_palace_lock
+    from .sources.base import DrawerRecord, SourceItemMetadata, SourceRef
+    from .sources.context import PalaceContext
+    from .sources.registry import get_adapter, resolve_adapter_for_source
+
+    name = resolve_adapter_for_source(explicit=args.source)
+    try:
+        adapter = get_adapter(name)
+    except KeyError as exc:
+        print(f"mempalace: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    # Routing precedence (§2.5): explicit --wing flows to the adapter via
+    # SourceRef.options; the adapter honors it. Secrets never go here (§2.2).
+    options = {}
+    if getattr(args, "wing", None):
+        options["wing"] = args.wing
+    ref = SourceRef(local_path=os.path.abspath(os.path.expanduser(args.dir)), options=options)
+
+    filed = 0
+    skipped = 0
+    try:
+        with mine_palace_lock(palace_path):
+            collection = get_collection(palace_path, create=True)
+            kg = KnowledgeGraph(db_path=os.path.join(palace_path, "knowledge_graph.sqlite3"))
+            ctx = PalaceContext(
+                drawer_collection=collection,
+                knowledge_graph=kg,
+                palace_path=palace_path,
+                config=MempalaceConfig(),
+                adapter_name=getattr(adapter, "name", name),
+                adapter_version=getattr(adapter, "adapter_version", ""),
+            )
+
+            skip_item = False
+            for result in adapter.ingest(source=ref, palace=ctx):
+                if isinstance(result, SourceItemMetadata):
+                    skip_item = False
+                    ctx._skip_requested = False
+                    existing = collection.get(where={"source_file": result.source_file}, limit=1)
+                    metas = (existing or {}).get("metadatas") or []
+                    if adapter.is_current(item=result, existing_metadata=metas[0] if metas else None):
+                        ctx.skip_current_item()
+                        skip_item = True
+                elif isinstance(result, DrawerRecord):
+                    if skip_item or ctx._skip_requested:
+                        skipped += 1
+                        continue
+                    if not args.dry_run:
+                        ctx.upsert_drawer(result)
+                    filed += 1
+            adapter.close()
+    except MineAlreadyRunning as exc:
+        print(f"mempalace: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    verb = "Would file" if args.dry_run else "Drawers filed:"
+    tail = f"  (skipped {skipped} up-to-date)" if skipped else ""
+    print(f"  source={name}  {verb} {filed}{tail}")
+
+
 def cmd_mine(args):
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     include_ignored = []
@@ -553,6 +626,10 @@ def cmd_mine(args):
 
     if getattr(args, "background", False) and not getattr(args, "daemon", False):
         print("mempalace: --background requires --daemon", file=sys.stderr)
+        sys.exit(2)
+
+    if getattr(args, "source", None) and getattr(args, "daemon", False):
+        print("mempalace: --source does not support --daemon yet", file=sys.stderr)
         sys.exit(2)
 
     if getattr(args, "daemon", False):
@@ -581,6 +658,12 @@ def cmd_mine(args):
             palace_dir=palace_path,
             llm_provider=None,
         )
+
+    # RFC 002 source-adapter seam: an explicit --source routes mine through the
+    # registry; absent it, the legacy --mode dispatch below runs unchanged.
+    if getattr(args, "source", None):
+        _mine_via_source_adapter(args, palace_path)
+        return
 
     from .palace import MineAlreadyRunning, MineValidationError
 
@@ -1811,6 +1894,16 @@ def main():
             "Ingest mode: 'projects' for code/docs (default), 'convos' for chat "
             "exports, 'extract' for office documents (PDF/DOCX/RTF/etc., requires "
             "mempalace[extract])"
+        ),
+    )
+    p_mine.add_argument(
+        "--source",
+        default=None,
+        metavar="NAME",
+        help=(
+            "RFC 002 source adapter to mine through (e.g. a third-party "
+            "mempalace-source-<name> package). Explicit selection only — no "
+            "auto-detect. Omit to use the legacy --mode dispatch."
         ),
     )
     p_mine.add_argument("--wing", default=None, help="Wing name (default: directory name)")

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -354,15 +354,28 @@ class MempalaceConfig:
         """Initialize config.
 
         Args:
-            config_dir: Override config directory (useful for testing).
-                        Defaults to ~/.mempalace.
+            config_dir: Explicit config directory. Takes precedence over the
+                        ``MEMPALACE_CONFIG_DIR`` environment variable, which in
+                        turn takes precedence over the ~/.mempalace default.
             palace_path: Explicit palace data directory. This is primarily
                          used by CLI operations that received ``--palace``;
                          it takes precedence over environment and file config.
         """
-        self._config_dir = (
-            Path(config_dir) if config_dir else Path(os.path.expanduser("~/.mempalace"))
-        )
+        # Explicit arg > MEMPALACE_CONFIG_DIR > ~/.mempalace, mirroring how
+        # ``palace_path`` resolves. A host that embeds mempalace as a library
+        # needs to point a spawned process at its own config root: without an
+        # env lever the directory hardwires to ~/.mempalace, so every spawned
+        # process reads a user-level config it does not own. The config file
+        # supplies backend, collection_name, embedding_model, write_routing and
+        # ~20 more, so an embedding host inherits all of them by default.
+        env_config_dir = os.environ.get("MEMPALACE_CONFIG_DIR")
+        if config_dir:
+            resolved_config_dir = str(config_dir)
+        elif env_config_dir and env_config_dir.strip():
+            resolved_config_dir = env_config_dir.strip()
+        else:
+            resolved_config_dir = "~/.mempalace"
+        self._config_dir = Path(os.path.expanduser(resolved_config_dir))
         self._config_file = self._config_dir / "config.json"
         self._people_map_file = self._config_dir / "people_map.json"
         self._palace_path_override = (

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -71,7 +71,7 @@ from chromadb.errors import NotFoundError as _ChromaNotFoundError  # noqa: E402
 from .backends.chroma import (  # noqa: E402
     ChromaBackend,
     ChromaCollection,
-    _HNSW_BLOAT_GUARD,
+    _HNSW_WRITE_DEFAULTS,
     _pin_hnsw_threads,
     hnsw_capacity_status,
     reset_hnsw_capacity_cache,
@@ -1176,7 +1176,7 @@ def _get_collection(create=False):
                         metadata={
                             "hnsw:space": "cosine",
                             "hnsw:num_threads": 1,
-                            **_HNSW_BLOAT_GUARD,
+                            **_HNSW_WRITE_DEFAULTS,
                         },
                         **ef_kwargs,
                     )

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -1315,6 +1315,11 @@ def search_memories(
             "effective_distance": round(effective_dist, 4),
             "closet_boost": round(boost, 3),
             "matched_via": matched_via,
+            # The drawer's stored metadata rides through whole: consumers that
+            # filter or re-rank hits (session-aware recall, provenance rules,
+            # custom pipelines) need the fields they stamped at ingest — a hit
+            # flattened to display fields blinds every downstream filter.
+            "metadata": dict(meta or {}),
             # Internal: retain the full source_file path + chunk_index so the
             # enrichment step below doesn't have to reverse-lookup via
             # basename-suffix matching (which silently collides when two

--- a/mempalace/sources/__init__.py
+++ b/mempalace/sources/__init__.py
@@ -35,6 +35,7 @@ from .base import (
     TransformationViolationError,
 )
 from .context import PalaceContext, ProgressHook
+from .ndjson import NdjsonSourceAdapter
 from .registry import (
     available_adapters,
     get_adapter,
@@ -45,6 +46,11 @@ from .registry import (
     unregister,
 )
 
+# First-party in-tree adapters register on import (RFC 002 §3.2 — explicit
+# registration, not the third-party entry-point group). This makes
+# ``mine --source ndjson`` resolve without an install step.
+register(NdjsonSourceAdapter.name, NdjsonSourceAdapter)
+
 __all__ = [
     "AdapterClosedError",
     "AdapterSchema",
@@ -54,6 +60,7 @@ __all__ = [
     "FieldSpec",
     "IngestMode",
     "IngestResult",
+    "NdjsonSourceAdapter",
     "PalaceContext",
     "ProgressHook",
     "RouteHint",

--- a/mempalace/sources/ndjson.py
+++ b/mempalace/sources/ndjson.py
@@ -1,0 +1,118 @@
+"""NDJSON source adapter (RFC 002) — ingest a JSON-Lines spool of pre-extracted records.
+
+For any pipeline that has already extracted and chunked content elsewhere and wants
+to hand MemPalace ready-to-file records: each line of the spool is one record, filed
+as one drawer. The adapter is byte-preserving — it stores ``content`` verbatim and
+declares no transformations (the foundational promise; see ``CLAUDE.md`` "Verbatim
+always"). It carries no opinion about *where* the records came from.
+
+One NDJSON line is one record::
+
+    {"content": "...", "source_file": "...", "metadata": {...}, "chunk_index": 0}
+
+``content`` and ``source_file`` are required strings; ``metadata`` (flat scalars) and
+``chunk_index`` (int) are optional. ``metadata`` passes through verbatim — producers
+may attach any flat-scalar fields, opaque to this adapter. When ``chunk_index`` is
+absent the adapter assigns a running per-``source_file`` ordinal so two records that
+share a ``source_file`` never collide on the deterministic drawer id
+(``sha256(source_file)_chunk``).
+
+``SourceRef.local_path`` points at the spool file. The optional ``--wing`` routing
+flag (``SourceRef.options['wing']``) fills the ``wing`` metadata key only where a
+record left it unset (RFC 002 §2.5 — the record's own routing wins).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Iterator
+
+from .base import (
+    AdapterSchema,
+    BaseSourceAdapter,
+    DrawerRecord,
+    IngestResult,
+    SourceAdapterError,
+    SourceNotFoundError,
+    SourceRef,
+)
+
+
+class NdjsonSourceAdapter(BaseSourceAdapter):
+    """File a newline-delimited JSON spool of pre-extracted records into verbatim drawers.
+
+    First-party, in-tree — registered manually (RFC 002 §3.2), not via the
+    third-party entry-point group.
+    """
+
+    name = "ndjson"
+    adapter_version = "0.1.0"
+    capabilities = frozenset({"byte_preserving"})
+    supported_modes = frozenset({"whole_record"})
+    declared_transformations = frozenset()  # verbatim — the producer pre-chunked
+    default_privacy_class = "pii_potential"
+
+    def ingest(
+        self,
+        *,
+        source: SourceRef,
+        palace: "object",  # PalaceContext — broad to avoid the import cycle
+    ) -> Iterator[IngestResult]:
+        path = source.local_path
+        if not path or not os.path.isfile(path):
+            raise SourceNotFoundError(
+                f"ndjson: spool file not found: {path!r} (expected a newline-delimited JSON file)"
+            )
+
+        # Honor the --wing routing precedence (§2.5): a record's own wing wins;
+        # the flag fills in only where the producer left routing unannotated.
+        fallback_wing = source.options.get("wing") if source.options else None
+
+        # Per-source_file ordinal so absent chunk_index values never collide on
+        # the deterministic drawer id. Provided chunk_index values pass through.
+        ordinals: dict[str, int] = {}
+
+        with open(path, encoding="utf-8") as fh:
+            for line_no, raw in enumerate(fh, start=1):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise SourceAdapterError(
+                        f"ndjson: malformed JSON at {path}:{line_no}: {exc}"
+                    ) from exc
+                if not isinstance(record, dict):
+                    raise SourceAdapterError(f"ndjson: line {path}:{line_no} is not a JSON object")
+
+                content = record.get("content")
+                source_file = record.get("source_file")
+                if not isinstance(content, str) or not isinstance(source_file, str):
+                    raise SourceAdapterError(
+                        f"ndjson: line {path}:{line_no} lacks string 'content' and 'source_file'"
+                    )
+
+                metadata = dict(record.get("metadata") or {})
+                if fallback_wing and "wing" not in metadata:
+                    metadata["wing"] = fallback_wing
+
+                provided = record.get("chunk_index")
+                if isinstance(provided, int):
+                    chunk_index = provided
+                else:
+                    chunk_index = ordinals.get(source_file, 0)
+                ordinals[source_file] = chunk_index + 1
+
+                yield DrawerRecord(
+                    content=content,
+                    source_file=source_file,
+                    chunk_index=chunk_index,
+                    metadata=metadata,
+                )
+
+    def describe_schema(self) -> AdapterSchema:
+        # No fixed structured schema: metadata is producer-defined and flows
+        # through verbatim (upsert_drawer does not reject undeclared fields).
+        return AdapterSchema(version="1.0", fields={})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,6 +227,7 @@ def seeded_collection(collection):
                 "chunk_index": 0,
                 "added_by": "miner",
                 "filed_at": "2026-01-01T00:00:00",
+                "origin_handle": "session-alpha",
             },
             {
                 "wing": "project",

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -523,13 +523,12 @@ def test_chroma_backend_creates_collection_with_cosine_distance(tmp_path):
     assert col.metadata.get("hnsw:space") == "cosine"
 
 
-def test_chroma_backend_sets_hnsw_bloat_guard_on_creation(tmp_path):
+def test_chroma_backend_sets_hnsw_write_defaults_on_creation(tmp_path):
     """HNSW batch/sync thresholds must land on freshly-created collection metadata.
 
-    Low thresholds (2/2 per #1579) make chromadb's Rust HNSW segment
-    persist index_metadata and link_lists after any mine of 2+ drawers.
-    Asserting both keys land on the persisted metadata also covers the
-    #1161 "config silently dropped" concern at CI time.
+    That both keys land covers #1161 (config silently dropped). The VALUES guard
+    #1308: sync_threshold sets a mine's write amplification, and batch_size must
+    stay strictly below it (#2526).
     """
     palace_path = tmp_path / "palace"
 
@@ -541,35 +540,43 @@ def test_chroma_backend_sets_hnsw_bloat_guard_on_creation(tmp_path):
 
     client = chromadb.PersistentClient(path=str(palace_path))
     col = client.get_collection("mempalace_drawers")
-    assert col.metadata.get("hnsw:batch_size") == 2
-    assert col.metadata.get("hnsw:sync_threshold") == 2
+    batch = col.metadata.get("hnsw:batch_size")
+    sync = col.metadata.get("hnsw:sync_threshold")
+    assert batch == 100
+    assert sync == 1000
+    assert batch < sync, "chroma requires batch_size < sync_threshold (#2526)"
 
 
-def test_chroma_backend_create_collection_sets_hnsw_bloat_guard(tmp_path):
-    """Same guard must apply via the legacy create_collection() path."""
+def test_chroma_backend_create_collection_sets_hnsw_write_defaults(tmp_path):
+    """The same defaults must apply via the legacy create_collection() path."""
     palace_path = tmp_path / "palace"
 
     ChromaBackend().create_collection(str(palace_path), "mempalace_drawers")
 
     client = chromadb.PersistentClient(path=str(palace_path))
     col = client.get_collection("mempalace_drawers")
-    assert col.metadata.get("hnsw:batch_size") == 2
-    assert col.metadata.get("hnsw:sync_threshold") == 2
+    assert col.metadata.get("hnsw:batch_size") == 100
+    assert col.metadata.get("hnsw:sync_threshold") == 1000
 
 
-def test_sub_threshold_mine_persists_hnsw_metadata(tmp_path):
-    """Regression for #1579: small mines must persist HNSW metadata.
+def test_sub_threshold_mine_survives_reopen_and_escapes_quarantine(tmp_path):
+    """Regression for #1579, asserted as the PROPERTY, not the mechanism.
 
-    _HNSW_BLOAT_GUARD sets batch_size=2 and sync_threshold=2 so that any
-    upsert of 2+ records crosses both thresholds, triggering chromadb's
-    _apply_batch and _persist.  Without this, index_metadata and link_lists
-    stay empty and quarantine_stale_hnsw renames the segment on cold open.
+    #1579 is a durability bug: a sub-threshold mine lost its drawers when
+    quarantine_stale_hnsw renamed the segment away on cold open. So assert what
+    the user needs — the drawers read back from a FRESH backend, and quarantine
+    leaves the segment alone.
+
+    Asserting the mechanism instead (index_metadata.pickle present after 3
+    records) only holds at sync_threshold=2, which buys #1308. Under chromadb's
+    own thresholds the Rust writer keeps the tail durable WITHOUT a pickle, so
+    the pickle is rightly absent here and asserting on it would fail a healthy
+    palace.
     """
     palace_path = str(tmp_path / "palace")
     backend = ChromaBackend()
     try:
         col = backend.get_collection(palace_path, "mempalace_drawers", create=True)
-
         col.upsert(
             ids=["a", "b", "c"],
             documents=["doc a", "doc b", "doc c"],
@@ -579,34 +586,65 @@ def test_sub_threshold_mine_persists_hnsw_metadata(tmp_path):
     finally:
         backend.close()
 
-    found_healthy_segment = False
-    for entry in (tmp_path / "palace").iterdir():
-        if not entry.is_dir() or entry.name.startswith("."):
-            continue
-        meta = entry / "index_metadata.pickle"
-        link = entry / "link_lists.bin"
-        data = entry / "data_level0.bin"
-        if data.exists() and data.stat().st_size > _HNSW_MISSING_METADATA_DATA_FLOOR:
-            assert meta.exists(), "index_metadata missing after sub-threshold upsert"
-            assert link.exists() and link.stat().st_size > 0, "link_lists empty"
-            assert _segment_appears_healthy(str(entry))
-            found_healthy_segment = True
-
-    assert found_healthy_segment, "no VECTOR segment with data found"
-
-    # stale_seconds=0.0 forces the stage-2 integrity gate (_segment_appears_healthy)
-    # to run on every segment regardless of mtime delta, proving the fix directly.
+    # Quarantine runs on cold open; stale_seconds=0.0 forces the integrity gate
+    # onto every segment regardless of mtime delta, so the gate itself is proven.
     moved = quarantine_stale_hnsw(palace_path, stale_seconds=0.0)
-    assert moved == [], f"quarantine fired on freshly-persisted segment: {moved}"
+    assert moved == [], f"quarantine fired on a healthy sub-threshold segment: {moved}"
+
+    for entry in (tmp_path / "palace").iterdir():
+        if entry.is_dir() and not entry.name.startswith("."):
+            assert _segment_appears_healthy(str(entry))
+
+    # The durability claim: a FRESH backend still finds every drawer, and the
+    # vector index still answers.
+    reopened = ChromaBackend()
+    try:
+        col = reopened.get_collection(palace_path, "mempalace_drawers")
+        assert col.count() == 3, "sub-threshold mine lost drawers across reopen"
+        hits = col.query(query_embeddings=[[0.1] * _TEST_EMBED_DIM], n_results=3)
+        assert len(hits["ids"][0]) == 3, "vector index empty after reopen"
+    finally:
+        reopened.close()
+
+
+def test_hnsw_write_defaults_bound_index_rewrites(tmp_path):
+    """Regression for #1308: the thresholds must bound write amplification.
+
+    chromadb rewrites the ENTIRE on-disk index once sync_threshold records
+    accumulate, so a mine of N drawers costs N/sync_threshold full rewrites of a
+    multi-megabyte segment. At 2, a 26k-drawer mine fires ~13,000 — enough to
+    wedge the compactor and to tear a persist mid-pickle.
+
+    Arithmetic, not a live mine: a realistic corpus must cost rewrites in the
+    tens, never the thousands.
+    """
+    palace_path = tmp_path / "palace"
+    ChromaBackend().get_collection(
+        str(palace_path), collection_name="mempalace_drawers", create=True
+    )
+    client = chromadb.PersistentClient(path=str(palace_path))
+    col = client.get_collection("mempalace_drawers")
+
+    sync = col.metadata.get("hnsw:sync_threshold")
+    batch = col.metadata.get("hnsw:batch_size")
+
+    assert batch < sync, "chroma requires batch_size < sync_threshold (#2526)"
+
+    realistic_corpus = 26_000
+    rewrites = realistic_corpus / sync
+    assert rewrites <= 100, (
+        f"sync_threshold={sync} costs ~{rewrites:.0f} full index rewrites over a "
+        f"{realistic_corpus}-drawer mine — that is the #1308 corruption path"
+    )
 
 
 def test_single_record_upsert_not_quarantined(tmp_path):
     """A single-record upsert must not trigger quarantine.
 
-    With batch_size=2 chromadb only persists HNSW metadata after the second
-    record.  A one-record segment has no index_metadata.pickle and no
-    link_lists.bin data; _segment_appears_healthy must treat that combination
-    as sub-threshold (never persisted), not as corruption.
+    A one-record segment sits below the HNSW thresholds, so chromadb never
+    persists: no index_metadata.pickle, no link_lists.bin data.
+    _segment_appears_healthy must read that combination as sub-threshold
+    (never persisted), not as corruption.
     """
     palace_path = str(tmp_path / "palace")
     backend = ChromaBackend()
@@ -657,7 +695,7 @@ def test_get_collection_create_true_preserves_existing_metadata(tmp_path):
     backend.get_collection(palace, collection_name="mempalace_drawers", create=True)
     col = backend.get_collection(palace, collection_name="mempalace_drawers", create=True)
     assert col._collection.metadata["hnsw:space"] == "cosine"
-    assert col._collection.metadata.get("hnsw:batch_size") == 2
+    assert col._collection.metadata.get("hnsw:batch_size") == 100
 
 
 def test_fix_blob_seq_ids_converts_blobs_to_integers(tmp_path):

--- a/tests/test_config_dir_env.py
+++ b/tests/test_config_dir_env.py
@@ -1,0 +1,63 @@
+"""MEMPALACE_CONFIG_DIR — the config-directory lever, mirroring MEMPALACE_PALACE_PATH.
+
+A host that embeds mempalace as a sidecar spawns it as a process, so it can pass env and argv and
+nothing else. Without an env lever the config directory hardwires to ~/.mempalace and every spawned
+process reads a user-level config it does not own — carrying backend, collection_name,
+embedding_model, write_routing and ~20 more keys across a boundary the embedding was meant to hold.
+
+These cover the resolution order the docstring promises: explicit arg > env > default.
+"""
+
+import json
+import os
+
+from mempalace.config import MempalaceConfig
+
+
+def test_env_var_sets_the_config_dir(tmp_path, monkeypatch):
+    """MEMPALACE_CONFIG_DIR redirects both config-dir-derived files."""
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", str(tmp_path))
+    cfg = MempalaceConfig()
+    assert cfg._config_dir == tmp_path
+    assert cfg._config_file == tmp_path / "config.json"
+    assert cfg._people_map_file == tmp_path / "people_map.json"
+
+
+def test_env_var_config_file_actually_loads(tmp_path, monkeypatch):
+    """A config.json under the env-named dir feeds the resolved values — the point of the lever."""
+    (tmp_path / "config.json").write_text(json.dumps({"collection_name": "sidecar_only"}))
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", str(tmp_path))
+    cfg = MempalaceConfig()
+    assert cfg._file_config.get("collection_name") == "sidecar_only"
+
+
+def test_explicit_arg_outranks_the_env_var(tmp_path, monkeypatch):
+    """Explicit arg > env, matching how palace_path resolves an explicit --palace over its env."""
+    env_dir = tmp_path / "from_env"
+    arg_dir = tmp_path / "from_arg"
+    env_dir.mkdir()
+    arg_dir.mkdir()
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", str(env_dir))
+    cfg = MempalaceConfig(config_dir=str(arg_dir))
+    assert cfg._config_dir == arg_dir
+
+
+def test_unset_env_keeps_the_home_default(monkeypatch):
+    """Absent the env var the directory stands where it always stood — behaviour-preserving."""
+    monkeypatch.delenv("MEMPALACE_CONFIG_DIR", raising=False)
+    cfg = MempalaceConfig()
+    assert cfg._config_dir == type(cfg._config_dir)(os.path.expanduser("~/.mempalace"))
+
+
+def test_blank_env_falls_through_to_the_default(monkeypatch):
+    """An exported-but-empty value reads as unset rather than as the current directory."""
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", "   ")
+    cfg = MempalaceConfig()
+    assert cfg._config_dir == type(cfg._config_dir)(os.path.expanduser("~/.mempalace"))
+
+
+def test_env_var_expands_a_tilde(monkeypatch):
+    """`~` expands, so an operator may export a home-relative path."""
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", "~/some-sidecar-root")
+    cfg = MempalaceConfig()
+    assert str(cfg._config_dir) == os.path.expanduser("~/some-sidecar-root")

--- a/tests/test_hnsw_capacity.py
+++ b/tests/test_hnsw_capacity.py
@@ -289,9 +289,9 @@ def test_capacity_status_quiet_for_empty_palace(tmp_path):
 def test_capacity_status_tolerates_lag_under_large_sync_threshold(tmp_path):
     """Regression for the PR #1191 / PR #1227 conflict.
 
-    Palaces created via mempalace's _HNSW_BLOAT_GUARD (sync_threshold=
-    50_000) naturally accumulate up to ~50K queued entries between
-    flushes. The pickle-vs-sqlite probe must scale its tolerance to
+    A palace carrying a large sync_threshold (50_000) naturally accumulates
+    up to ~50K queued entries between flushes. The pickle-vs-sqlite probe
+    must scale its tolerance to
     ``2 × sync_threshold`` so this expected lag is not flagged as
     corruption — otherwise vector search disables for ~80% of the
     write cycle on any actively-mined ≥100K palace.

--- a/tests/test_mine_source_registry.py
+++ b/tests/test_mine_source_registry.py
@@ -1,0 +1,90 @@
+"""RFC 002 source-adapter CLI seam: ``mine --source NAME`` routes through the
+registry and files adapter-authored ``DrawerRecord``s via ``PalaceContext``.
+
+This covers the seam wired into ``cmd_mine`` — the registry/ingest-loop path is
+opt-in and leaves the legacy ``--mode`` dispatch untouched.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from typing import Iterator
+
+import pytest
+
+from mempalace.sources.base import (
+    AdapterSchema,
+    BaseSourceAdapter,
+    DrawerRecord,
+    FieldSpec,
+    IngestResult,
+    SourceItemMetadata,
+    SourceRef,
+)
+from mempalace.sources.registry import register, reset_adapters, unregister
+
+
+class _FakeAdapter(BaseSourceAdapter):
+    name = "fake-test"
+    adapter_version = "0.1.0"
+    capabilities = frozenset({"byte_preserving"})
+    supported_modes = frozenset({"whole_record"})
+    declared_transformations = frozenset()
+    default_privacy_class = "internal"
+
+    def ingest(self, *, source: SourceRef, palace) -> Iterator[IngestResult]:
+        yield SourceItemMetadata(source_file="fake://item/1", version="v1")
+        yield DrawerRecord(
+            content="the operator said the verb leads",
+            source_file="fake://item/1",
+            metadata={"wing": "wing_test", "room": "general", "lar_demo": "1"},
+        )
+
+    def describe_schema(self) -> AdapterSchema:
+        return AdapterSchema(
+            version="1.0",
+            fields={"lar_demo": FieldSpec(type="string", required=False, description="demo field")},
+        )
+
+
+@pytest.fixture
+def _fake_adapter():
+    register("fake-test", _FakeAdapter)
+    yield
+    reset_adapters()
+    unregister("fake-test")
+
+
+def test_mine_source_files_pre_annotated_record(tmp_dir, palace_path, _fake_adapter):
+    from mempalace.cli import _mine_via_source_adapter
+    from mempalace.palace import get_collection
+
+    args = Namespace(source="fake-test", dir=tmp_dir, wing=None, dry_run=False)
+    _mine_via_source_adapter(args, palace_path)
+
+    col = get_collection(palace_path, create=True)
+    got = col.get(where={"source_file": "fake://item/1"})
+    assert got["documents"] == ["the operator said the verb leads"]
+    meta = got["metadatas"][0]
+    assert meta["lar_demo"] == "1"  # adapter-authored metadata lands verbatim
+    assert meta["adapter_name"] == "fake-test"  # stamped by PalaceContext, not by the adapter
+    assert meta["adapter_version"] == "0.1.0"
+
+
+def test_mine_source_dry_run_files_nothing(tmp_dir, palace_path, _fake_adapter):
+    from mempalace.cli import _mine_via_source_adapter
+    from mempalace.palace import get_collection
+
+    args = Namespace(source="fake-test", dir=tmp_dir, wing=None, dry_run=True)
+    _mine_via_source_adapter(args, palace_path)
+
+    col = get_collection(palace_path, create=True)
+    assert col.get(where={"source_file": "fake://item/1"})["ids"] == []
+
+
+def test_mine_source_unknown_adapter_exits(tmp_dir, palace_path):
+    from mempalace.cli import _mine_via_source_adapter
+
+    args = Namespace(source="does-not-exist", dir=tmp_dir, wing=None, dry_run=False)
+    with pytest.raises(SystemExit):
+        _mine_via_source_adapter(args, palace_path)

--- a/tests/test_ndjson_source_adapter.py
+++ b/tests/test_ndjson_source_adapter.py
@@ -1,0 +1,169 @@
+"""Tests for the first-party ``ndjson`` source adapter (RFC 002).
+
+A pipeline that pre-extracts records writes a JSON-Lines spool and runs
+``mempalace mine --source ndjson <spool>``; this adapter reads it back into
+verbatim drawers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from argparse import Namespace
+
+import pytest
+
+from mempalace.sources import available_adapters
+from mempalace.sources.base import SourceAdapterError, SourceNotFoundError, SourceRef
+from mempalace.sources.ndjson import NdjsonSourceAdapter
+
+
+def _write_spool(tmp_dir, records) -> str:
+    path = os.path.join(tmp_dir, "batch-0.ndjson")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(json.dumps(r) for r in records) + "\n")
+    return path
+
+
+def test_ndjson_is_registered_first_party():
+    # Registered on import of mempalace.sources — no install step needed.
+    assert "ndjson" in available_adapters()
+
+
+def test_ingest_reads_spool_verbatim(tmp_dir):
+    spool = _write_spool(
+        tmp_dir,
+        [
+            {
+                "content": "the record stored exactly as written",
+                "source_file": "feed://abc/item/1",
+                "metadata": {"opaque_field": "kept", "wing": "wing_a"},
+            }
+        ],
+    )
+    adapter = NdjsonSourceAdapter()
+    out = list(adapter.ingest(source=SourceRef(local_path=spool), palace=None))
+
+    assert len(out) == 1
+    drawer = out[0]
+    assert drawer.content == "the record stored exactly as written"  # verbatim
+    assert drawer.source_file == "feed://abc/item/1"
+    assert drawer.chunk_index == 0
+    assert drawer.metadata["opaque_field"] == "kept"  # producer metadata flows through
+    assert drawer.metadata["wing"] == "wing_a"
+
+
+def test_absent_chunk_index_gets_per_source_ordinal(tmp_dir):
+    # Two records sharing a source_file with no chunk_index must NOT collide on
+    # the deterministic drawer id (sha256(source_file)_chunk).
+    spool = _write_spool(
+        tmp_dir,
+        [
+            {"content": "first", "source_file": "feed://x"},
+            {"content": "second", "source_file": "feed://x"},
+            {"content": "other", "source_file": "feed://y"},
+        ],
+    )
+    out = list(NdjsonSourceAdapter().ingest(source=SourceRef(local_path=spool), palace=None))
+
+    triples = [(d.source_file, d.chunk_index, d.content) for d in out]
+    assert triples == [
+        ("feed://x", 0, "first"),
+        ("feed://x", 1, "second"),
+        ("feed://y", 0, "other"),
+    ]
+
+
+def test_provided_chunk_index_passes_through(tmp_dir):
+    spool = _write_spool(
+        tmp_dir,
+        [{"content": "c", "source_file": "feed://x", "chunk_index": 7}],
+    )
+    out = list(NdjsonSourceAdapter().ingest(source=SourceRef(local_path=spool), palace=None))
+    assert out[0].chunk_index == 7
+
+
+def test_wing_option_fills_only_when_absent(tmp_dir):
+    spool = _write_spool(
+        tmp_dir,
+        [
+            {"content": "a", "source_file": "s://1"},
+            {"content": "b", "source_file": "s://2", "metadata": {"wing": "wing_own"}},
+        ],
+    )
+    out = list(
+        NdjsonSourceAdapter().ingest(
+            source=SourceRef(local_path=spool, options={"wing": "wing_flag"}), palace=None
+        )
+    )
+    assert out[0].metadata["wing"] == "wing_flag"  # filled from the flag
+    assert out[1].metadata["wing"] == "wing_own"  # the record's own wing wins
+
+
+def test_blank_lines_skipped(tmp_dir):
+    path = os.path.join(tmp_dir, "batch.ndjson")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write('\n{"content": "c", "source_file": "s"}\n\n')
+    out = list(NdjsonSourceAdapter().ingest(source=SourceRef(local_path=path), palace=None))
+    assert len(out) == 1
+
+
+def test_malformed_json_raises(tmp_dir):
+    path = os.path.join(tmp_dir, "bad.ndjson")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("{not json}\n")
+    with pytest.raises(SourceAdapterError):
+        list(NdjsonSourceAdapter().ingest(source=SourceRef(local_path=path), palace=None))
+
+
+def test_missing_required_fields_raises(tmp_dir):
+    spool = _write_spool(tmp_dir, [{"content": "no source_file"}])
+    with pytest.raises(SourceAdapterError):
+        list(NdjsonSourceAdapter().ingest(source=SourceRef(local_path=spool), palace=None))
+
+
+def test_missing_spool_raises_not_found(tmp_dir):
+    with pytest.raises(SourceNotFoundError):
+        list(
+            NdjsonSourceAdapter().ingest(
+                source=SourceRef(local_path=os.path.join(tmp_dir, "nope.ndjson")), palace=None
+            )
+        )
+
+
+def test_end_to_end_mine_source_ndjson_files_drawers(tmp_dir, palace_path):
+    from mempalace.cli import _mine_via_source_adapter
+    from mempalace.palace import get_collection
+
+    spool = _write_spool(
+        tmp_dir,
+        [
+            {
+                "content": "pre-extracted record line",
+                "source_file": "feed://e2e/1",
+                "metadata": {"opaque_field": "kept"},
+            }
+        ],
+    )
+    args = Namespace(source="ndjson", dir=spool, wing=None, dry_run=False)
+    _mine_via_source_adapter(args, palace_path)
+
+    col = get_collection(palace_path, create=True)
+    got = col.get(where={"source_file": "feed://e2e/1"})
+    assert got["documents"] == ["pre-extracted record line"]
+    meta = got["metadatas"][0]
+    assert meta["opaque_field"] == "kept"
+    assert meta["adapter_name"] == "ndjson"  # stamped by PalaceContext, not by the adapter
+    assert meta["adapter_version"] == "0.1.0"
+
+
+def test_end_to_end_dry_run_files_nothing(tmp_dir, palace_path):
+    from mempalace.cli import _mine_via_source_adapter
+    from mempalace.palace import get_collection
+
+    spool = _write_spool(tmp_dir, [{"content": "c", "source_file": "feed://dry/1"}])
+    args = Namespace(source="ndjson", dir=spool, wing=None, dry_run=True)
+    _mine_via_source_adapter(args, palace_path)
+
+    col = get_collection(palace_path, create=True)
+    assert col.get(where={"source_file": "feed://dry/1"})["ids"] == []

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -73,6 +73,19 @@ class TestSearchMemories:
         assert len(result["results"]) > 0
         assert result["query"] == "JWT authentication"
 
+    def test_hits_carry_their_stored_metadata(self, palace_path, seeded_collection):
+        """Consumers that filter or re-rank hits need the fields they stamped at
+        ingest; a hit flattened to display fields blinds every downstream filter."""
+        result = search_memories("JWT authentication", palace_path)
+        hit = result["results"][0]
+        assert "metadata" in hit
+        assert hit["metadata"].get("origin_handle") == "session-alpha"
+        assert hit["metadata"].get("wing") == "project"
+        # a drawer without custom stamps still carries its stored metadata whole
+        other = search_memories("React frontend", palace_path)["results"][0]
+        assert "origin_handle" not in other["metadata"]
+        assert other["metadata"].get("room") == "frontend"
+
     def test_wing_filter(self, palace_path, seeded_collection):
         result = search_memories("planning", palace_path, wing="notes")
         assert all(r["wing"] == "notes" for r in result["results"])


### PR DESCRIPTION
Addresses #2110. Stacked on #2107 — ② calls `_hnsw_creation_metadata()`, introduced there, so this
branch is cut from `fix/2106-hnsw-guard-corrupts-what-it-protects` and its diff includes #2107 until
that lands.

### Who is asking

Same context as #2107 and #2109. We create instances of your code as libraries in ours:

```
  sensoriums/memory/content          ← does the job an upstream install does
  sensoriums/mark-twin/content
  sensoriums/kumulipo/content
  ~/.mempalace                       ← the operator's own install, when present
```

Three sovereign content palaces, one per sensorium (extendable), plus whatever the operator already
runs. **Peers, never satellites.** We consume mempalace as a library from our own NDJSON holder
processes, with the embedding contract inverted: vectors arrive on the wire, so no model loads in the
store process.

Everything below answers one question — **what does a second, third, fourth instance need?**

### What this donates

**① `MEMPALACE_CONFIG_DIR`.** `MempalaceConfig.__init__` takes `config_dir` documented "useful for
testing", with no env or CLI lever, while `palace_path` already honors `MEMPALACE_PALACE_PATH`. Every
instance on a machine therefore reads the same `~/.mempalace/config.json` — backend, collection_name,
embedding_model, write_routing, the milvus/qdrant/pgvector sets, ~24 keys — so one install configures
the others. Resolution mirrors `palace_path` exactly: explicit arg > env > default. Unset changes
nothing.

**② Caller-supplied embedding function.** `get_collection(options.embedding_function)` passes the
value verbatim: a function is used, `None` skips the model entirely and survives reopen, absent leaves
today's path unchanged. Running many palaces, a model per store process costs more than the stores do;
a host that embeds upstream hands the vector over and asks the store to hold it.

> **A finding worth having even if ② does not land:** the modern `CreateHNSWConfiguration` API leaves
> `collection.metadata` empty — parameters go to `configuration_json` — which silently blinds the
> divergence guard, the cosine detector (`ChromaCollection.distance_metric`), and
> `_read_sync_threshold`, all of which read `collection_metadata`. Legacy `metadata=` stays correct.

**③ Source-adapter registry, ndjson adapter, daemon-queue routing.** Your miners find the content. A
host running its own extraction already holds it, in its own shape, and `--source NAME` lets it
deliver records directly. The ndjson adapter proves the shape on a JSON-Lines spool. Pre-extracted
records carry the original words — the verbatim promise holds end to end.

**④ Stored metadata on search hits** (+5 lines), so one call answers completely.

Each alone reads as a convenience. Together they answer the question a reviewer actually rules on:
*does mempalace support standing more than one of itself?*

### Status: draft

`feat: route mine --source NAME through the daemon queue` leaves state that makes
`tests/test_sync.py::TestSyncMcpTool` fail when `tests/test_mine_source_registry.py` runs first — 7
failures in a full run, none when either file runs alone. Dropping that one commit makes the branch
green; I would rather fix it. Tell me which you prefer.

### Verification

- `ruff check .` clean · `ruff format --check .` → 197 files already formatted
- `pytest tests/ --ignore=tests/benchmarks` → 3423 passed, 31 skipped, 12 failed: the 7 above, plus 5
  `test_init_filters_sys_path_from_leaked_pythonpath` that fail identically on the base in the same
  worktree (a leaked `PYTHONPATH` here — what that test asserts about).

Local ruff reads 0.15.20 against your pinned 0.15.14; let CI have the final word on lint.
