### PR TITLE
feat(convos): add normalized transcript ingestion contract

### DIFF
--- a/docs/normalized-conversations.md
+++ b/docs/normalized-conversations.md
@@ -1,0 +1,71 @@
+# Normalized conversation imports
+
+MemPalace can ingest a transcript that an operator has already canonicalized
+without running generic format inference, noise removal, or spell correction.
+This is an opt-in contract for trusted export pipelines. It is not a shortcut
+for arbitrary chat files.
+
+For `session.md`, place an adjacent `session.md.meta.json` sidecar:
+
+```json
+{
+  "schema": "mempalace-normalized-conversation/v1",
+  "room": "communication",
+  "authored_from": "2026-07-29T23:55:00Z",
+  "authored_to": "2026-07-30T00:05:00Z",
+  "source_fingerprint": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "transformations": "hermes-compaction-dedup;hermes-synthetic-filter;secret-redaction",
+  "exporter_version": "1.0.0",
+  "hermes_profile": "amber",
+  "hermes_session_id": "session-123",
+  "hermes_source": "telegram"
+}
+```
+
+The sidecar is closed and flat. Unknown fields, nested values, unsafe room or
+identifier values, missing timezone offsets, symlinks, and unknown schema
+versions fail the source. Hall categories such as `facts`, `events`,
+`decisions`, and `preferences` are not valid subject rooms.
+
+Each transcript exchange begins with one bounded provenance envelope and
+exactly one `>` user marker:
+
+```markdown
+<!-- mempalace-exchange {"messages":[{"id":"41","role":"user","timestamp":"2026-07-29T23:55:00Z"},{"id":"42","role":"assistant","timestamp":"2026-07-29T23:56:00Z"}]} -->
+> exact transformed user text
+Exact transformed assistant text.
+```
+
+The first message is the user turn. One or more assistant messages may follow.
+Message identifiers must be unique across the entire transcript. MemPalace
+keeps every transcript character verbatim, including line endings and
+assistant Markdown blockquotes. It stamps the ordered identifiers and the
+minimum and maximum message timestamps on each resulting drawer.
+
+Mine normalized exports only in exchange mode:
+
+```bash
+mempalace mine /retained/staging/amber --mode convos --extract exchange --wing wing_amber
+```
+
+`--extract general` refuses a directory containing the normalized contract.
+The transcript bytes and every sidecar field form one composite source
+version. A sidecar-only correction therefore rebuilds the stable source path.
+Unchanged pairs skip. A replacement is staged under source-versioned drawer
+IDs that also include the active chunk size, normalization version, and ID
+recipe. It is verified before the prior complete generation is retired. A
+failed stage leaves that prior generation readable. An interrupted target
+generation is detected by its recipe and source chunk count, removed without
+touching the prior generation, and rebuilt deterministically on retry.
+
+Two raw MCP tools support an operator-controlled reconciliation workflow:
+
+- `mempalace_normalized_conversation_delta` reports new, changed, unchanged,
+  and removed normalized sources without changing palace state.
+- `mempalace_commit_applied_coverage` atomically advances one wing's
+  content-free watermark only after the operator has verified the complete
+  profile apply.
+
+`mempalace_status` reads the applied coverage registry. Status never advances
+it. These raw tools should remain behind the server's operator authentication;
+do not expose them through an agent-facing policy adapter.

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -13,14 +13,26 @@ import sys
 import json
 import logging
 import stat
-from pathlib import Path
-from datetime import datetime
 from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from itertools import islice
+from pathlib import Path
 from typing import Optional
 
 from .collision_scan import assert_no_collisions
 from .ids import ID_RECIPE, make_convo_drawer_id, make_convo_sentinel_id
 from .normalize import normalize
+from .normalized_conversations import (
+    SCHEMA as NORMALIZED_CONVERSATION_SCHEMA,
+    NormalizedConversation,
+    NormalizedConversationProbe,
+    count_normalized_conversation_chunks,
+    has_normalized_sidecar,
+    iter_normalized_conversation_chunks,
+    load_normalized_conversation,
+    probe_normalized_conversation,
+)
 from .entities import entities_metadata
 from .palace import (
     NORMALIZE_VERSION,
@@ -179,6 +191,279 @@ def _source_file_delete_ids(collection, source_file: str, extract_mode: str) -> 
             break
         offset += len(batch_ids)
     return ids
+
+
+def _normalized_generation_key(source_version: str, chunk_size: int) -> tuple:
+    return (source_version, chunk_size, NORMALIZE_VERSION, ID_RECIPE)
+
+
+@dataclass
+class NormalizedSourceState:
+    """Compact, wing-local completeness state for one normalized source."""
+
+    actual_count: int = 0
+    generations: set = field(default_factory=set)
+    expected_counts: set = field(default_factory=set)
+    ids_by_generation: dict = field(default_factory=lambda: defaultdict(list))
+    counts_by_generation: dict = field(default_factory=lambda: defaultdict(int))
+    expected_by_generation: dict = field(default_factory=lambda: defaultdict(set))
+
+    def record(self, metadata: dict, drawer_id: Optional[str] = None) -> None:
+        version = metadata.get("source_version")
+        chunk_size = metadata.get("source_chunk_size")
+        generation = (
+            version,
+            chunk_size,
+            metadata.get("normalize_version"),
+            metadata.get("id_recipe"),
+        )
+        expected = metadata.get("source_chunk_count")
+        self.actual_count += 1
+        self.generations.add(generation)
+        self.expected_counts.add(expected)
+        self.counts_by_generation[generation] += 1
+        self.expected_by_generation[generation].add(expected)
+        if drawer_id is not None:
+            self.ids_by_generation[generation].append(drawer_id)
+
+    def record_count(
+        self,
+        source_version,
+        chunk_size,
+        normalize_version,
+        id_recipe,
+        expected_count,
+        count: int,
+    ) -> None:
+        generation = (source_version, chunk_size, normalize_version, id_recipe)
+        self.actual_count += count
+        self.generations.add(generation)
+        self.expected_counts.add(expected_count)
+        self.counts_by_generation[generation] += count
+        self.expected_by_generation[generation].add(expected_count)
+
+    def generation_is_complete(
+        self, source_version: str, chunk_size: int, expected_count: int
+    ) -> bool:
+        generation = _normalized_generation_key(source_version, chunk_size)
+        return (
+            expected_count > 0
+            and self.counts_by_generation.get(generation, 0) == expected_count
+            and self.expected_by_generation.get(generation, set()) == {expected_count}
+        )
+
+    def is_only_complete(self, source_version: str, chunk_size: int) -> bool:
+        return (
+            self.actual_count > 0
+            and self.generations == {_normalized_generation_key(source_version, chunk_size)}
+            and len(self.expected_counts) == 1
+            and next(iter(self.expected_counts), None) == self.actual_count
+        )
+
+
+def _normalized_source_state(
+    collection,
+    source_file: str,
+    wing: str,
+    extract_mode: str,
+    *,
+    collect_ids: bool = False,
+) -> NormalizedSourceState:
+    state = NormalizedSourceState()
+    offset = 0
+    while True:
+        batch = collection.get(
+            where={"$and": [{"source_file": source_file}, {"wing": wing}]},
+            limit=1000,
+            offset=offset,
+            include=["metadatas"],
+        )
+        batch_ids = batch.get("ids") or []
+        for drawer_id, meta in zip(batch_ids, batch.get("metadatas") or []):
+            meta = meta or {}
+            if not _metadata_matches_extract_mode(meta, extract_mode):
+                continue
+            state.record(meta, drawer_id if collect_ids else None)
+        if not batch_ids:
+            break
+        offset += len(batch_ids)
+    return state
+
+
+def _prefetch_normalized_sources(
+    collection, wing: str, extract_mode: str
+) -> dict[str, NormalizedSourceState]:
+    """Fetch compact completeness state for all normalized sources once."""
+
+    states: dict[str, NormalizedSourceState] = {}
+    offset = 0
+    while True:
+        batch = collection.get(
+            where={
+                "$and": [
+                    {"normalized_schema": NORMALIZED_CONVERSATION_SCHEMA},
+                    {"wing": wing},
+                ]
+            },
+            limit=1000,
+            offset=offset,
+            include=["metadatas"],
+        )
+        batch_ids = batch.get("ids") or []
+        for meta in batch.get("metadatas") or []:
+            meta = meta or {}
+            source_file = meta.get("source_file")
+            if not source_file or not _metadata_matches_extract_mode(meta, extract_mode):
+                continue
+            states.setdefault(source_file, NormalizedSourceState()).record(meta)
+        if not batch_ids:
+            break
+        offset += len(batch_ids)
+    return states
+
+
+def normalized_conversation_delta(
+    convo_dir: str,
+    palace_path: str,
+    *,
+    wing: str,
+    extract_mode: str = "exchange",
+) -> dict:
+    """Report normalized source reconciliation without writing palace state."""
+
+    import sqlite3
+
+    from .config import MempalaceConfig, sqlite_read_uri
+
+    if extract_mode != "exchange":
+        raise ValueError("normalized conversation delta requires extract_mode=exchange")
+    source_root = Path(convo_dir).expanduser().resolve(strict=True)
+    stored: dict[str, NormalizedSourceState] = {}
+    palace_config = MempalaceConfig(palace_path=palace_path)
+    db_path = Path(palace_path) / "chroma.sqlite3"
+    if not db_path.is_file():
+        raise ValueError("read-only delta reporting currently requires an existing Chroma palace")
+    connection = sqlite3.connect(sqlite_read_uri(str(db_path)), uri=True)
+    try:
+        rows = connection.execute(
+            """
+            SELECT sf.string_value,
+                   sv.string_value,
+                   scs.int_value,
+                   nv.int_value,
+                   ir.string_value,
+                   scc.int_value,
+                   em.string_value,
+                   COUNT(*)
+              FROM embeddings e
+              JOIN segments s
+                ON e.segment_id = s.id AND s.scope = 'METADATA'
+              JOIN collections c
+                ON s.collection = c.id
+              JOIN embedding_metadata sf
+                ON sf.id = e.id AND sf.key = 'source_file'
+              JOIN embedding_metadata w
+                ON w.id = e.id AND w.key = 'wing'
+              JOIN embedding_metadata ns
+                ON ns.id = e.id AND ns.key = 'normalized_schema'
+              LEFT JOIN embedding_metadata sv
+                ON sv.id = e.id AND sv.key = 'source_version'
+              LEFT JOIN embedding_metadata scs
+                ON scs.id = e.id AND scs.key = 'source_chunk_size'
+              LEFT JOIN embedding_metadata nv
+                ON nv.id = e.id AND nv.key = 'normalize_version'
+              LEFT JOIN embedding_metadata ir
+                ON ir.id = e.id AND ir.key = 'id_recipe'
+              LEFT JOIN embedding_metadata scc
+                ON scc.id = e.id AND scc.key = 'source_chunk_count'
+              LEFT JOIN embedding_metadata em
+                ON em.id = e.id AND em.key = 'extract_mode'
+             WHERE c.name = ?
+               AND w.string_value = ?
+               AND ns.string_value = ?
+             GROUP BY sf.string_value, sv.string_value, scs.int_value,
+                      nv.int_value, ir.string_value, scc.int_value,
+                      em.string_value
+            """,
+            (palace_config.collection_name, wing, NORMALIZED_CONVERSATION_SCHEMA),
+        )
+        for (
+            source_file,
+            source_version,
+            source_chunk_size,
+            normalize_version,
+            id_recipe,
+            source_chunk_count,
+            stored_mode,
+            count,
+        ) in rows:
+            if not source_file or not _metadata_matches_extract_mode(
+                {"extract_mode": stored_mode}, extract_mode
+            ):
+                continue
+            stored.setdefault(source_file, NormalizedSourceState()).record_count(
+                source_version,
+                source_chunk_size,
+                normalize_version,
+                id_recipe,
+                source_chunk_count,
+                int(count),
+            )
+    finally:
+        connection.close()
+    stored = {
+        source_file: state
+        for source_file, state in stored.items()
+        if _path_within_root(Path(source_file), source_root)
+    }
+
+    current_paths: set[str] = set()
+    new: list[str] = []
+    changed: list[str] = []
+    unchanged: list[str] = []
+    projected_counts: dict[str, int] = {}
+    for path in scan_convos(str(source_root)):
+        if not has_normalized_sidecar(path):
+            continue
+        conversation = load_normalized_conversation(
+            path,
+            source_root,
+            extract_mode=extract_mode,
+        )
+        source_file = str(path)
+        current_paths.add(source_file)
+        projected_counts[source_file] = count_normalized_conversation_chunks(
+            conversation,
+            chunk_size=palace_config.chunk_size,
+        )
+        source_state = stored.get(source_file, NormalizedSourceState())
+        complete = source_state.is_only_complete(
+            conversation.source_version,
+            palace_config.chunk_size,
+        )
+        if complete:
+            unchanged.append(source_file)
+        elif source_state.actual_count:
+            changed.append(source_file)
+        else:
+            new.append(source_file)
+
+    removed = sorted(set(stored) - current_paths)
+    old_changed = sum(stored[path].actual_count for path in changed)
+    removed_drawers = sum(stored[path].actual_count for path in removed)
+    new_drawers = sum(projected_counts[path] for path in new)
+    changed_drawers = sum(projected_counts[path] for path in changed)
+    return {
+        "new": sorted(new),
+        "changed": sorted(changed),
+        "unchanged": sorted(unchanged),
+        "removed": removed,
+        "new_drawers": new_drawers,
+        "replacement_drawers": old_changed,
+        "changed_drawers": changed_drawers,
+        "removed_drawers": removed_drawers,
+        "net_drawers": new_drawers + changed_drawers - old_changed - removed_drawers,
+    }
 
 
 # =============================================================================
@@ -487,39 +772,89 @@ def _extract_authored_at(filepath):
 
 
 def _file_chunks_locked(
-    collection, source_file, chunks, wing, room, agent, extract_mode, authored_at=None
+    collection,
+    source_file,
+    chunks,
+    wing,
+    room,
+    agent,
+    extract_mode,
+    authored_at=None,
+    normalized: Optional[NormalizedConversation] = None,
+    chunk_count: Optional[int] = None,
+    source_chunk_size: Optional[int] = None,
 ):
-    """Lock the source file, purge stale drawers, and upsert fresh chunks.
+    """Lock one source and replace it without removing the last complete generation.
 
     Combines the per-file serialization that prevents concurrent agents from
-    duplicating work (via mine_lock) with the rebuild contract
-    (purge-before-insert so stale drawers never survive) that fires on
-    either a normalize-version bump OR a changed/grown source file (mtime
-    differs from what's stored) -- transcripts are not assumed immutable,
-    since a Claude Code session keeps appending to its own file while
-    active and /compact or /clear can rewrite one in place.
+    duplicating work with two replacement contracts. Generic sources retain
+    their established purge-before-upsert behavior. Normalized sources use
+    source-versioned IDs: remove only an incomplete target generation, stage
+    and verify the complete target, then retire older generations. A failed
+    stage therefore leaves the prior complete generation available.
 
     Returns (drawers_added, room_counts_delta, skipped).
     """
     room_counts_delta: dict = defaultdict(int)
     drawers_added = 0
+    expected_chunk_count = len(chunks) if chunk_count is None else chunk_count
+    normalized_chunk_size = source_chunk_size if source_chunk_size is not None else 0
     with mine_lock(source_file):
         # Re-check after lock — another agent may have just finished this file
         # at the current schema/mtime. A stale hit here returns False, so we
         # still fall through to the purge+rebuild path below.
-        if file_already_mined(collection, source_file, check_mtime=True, extract_mode=extract_mode):
+        if normalized is not None:
+            source_state = _normalized_source_state(
+                collection,
+                source_file,
+                wing,
+                extract_mode,
+                collect_ids=True,
+            )
+            already_mined = source_state.is_only_complete(
+                normalized.source_version,
+                normalized_chunk_size,
+            )
+        else:
+            source_state = None
+            already_mined = file_already_mined(
+                collection,
+                source_file,
+                check_mtime=True,
+                extract_mode=extract_mode,
+            )
+        if already_mined:
             return 0, room_counts_delta, True
 
-        # Purge stale drawers first. Fires both on a normalize-schema bump
-        # (file_already_mined() returned False for pre-v2 drawers) and on a
-        # changed/grown transcript (mtime differs) — clean them out so the
-        # source doesn't end up with mixed old/new drawers.
-        try:
-            delete_ids = _source_file_delete_ids(collection, source_file, extract_mode)
-            if delete_ids:
-                collection.delete(ids=delete_ids)
-        except Exception:
-            logger.debug("Stale-drawer purge failed for %s", source_file, exc_info=True)
+        if normalized is None:
+            try:
+                delete_ids = _source_file_delete_ids(collection, source_file, extract_mode)
+                if delete_ids:
+                    collection.delete(ids=delete_ids)
+            except Exception:
+                logger.debug("Stale-drawer purge failed for %s", source_file, exc_info=True)
+        elif not source_state.generation_is_complete(
+            normalized.source_version,
+            normalized_chunk_size,
+            expected_chunk_count,
+        ):
+            incomplete_target_ids = source_state.ids_by_generation.get(
+                _normalized_generation_key(normalized.source_version, normalized_chunk_size),
+                [],
+            )
+            if incomplete_target_ids:
+                collection.delete(ids=incomplete_target_ids)
+                cleared = _normalized_source_state(
+                    collection,
+                    source_file,
+                    wing,
+                    extract_mode,
+                )
+                if cleared.counts_by_generation.get(
+                    _normalized_generation_key(normalized.source_version, normalized_chunk_size),
+                    0,
+                ):
+                    raise RuntimeError("normalized target-generation purge left stale drawer(s)")
 
         # Batch chunks into bounded upserts so large transcripts keep most of
         # the embedding speedup without one huge Chroma/SQLite request. Keep
@@ -530,16 +865,30 @@ def _file_chunks_locked(
             source_mtime = os.path.getmtime(source_file)
         except OSError:
             source_mtime = None
-        for batch_start in range(0, len(chunks), DRAWER_UPSERT_BATCH_SIZE):
+        target_needs_upsert = normalized is None or not source_state.generation_is_complete(
+            normalized.source_version,
+            normalized_chunk_size,
+            expected_chunk_count,
+        )
+        chunk_iterator = iter(chunks) if target_needs_upsert else iter(())
+        while batch := list(islice(chunk_iterator, DRAWER_UPSERT_BATCH_SIZE)):
             batch_docs: list = []
             batch_ids: list = []
             batch_metas: list = []
-            for chunk in chunks[batch_start : batch_start + DRAWER_UPSERT_BATCH_SIZE]:
+            for chunk in batch:
                 chunk_room = chunk.get("memory_type", room) if extract_mode == "general" else room
                 if extract_mode == "general":
                     room_counts_delta[chunk_room] += 1
                 drawer_id = make_convo_drawer_id(
-                    wing, chunk_room, source_file, extract_mode, chunk["chunk_index"]
+                    wing,
+                    chunk_room,
+                    source_file,
+                    extract_mode,
+                    chunk["chunk_index"],
+                    source_version=(normalized.source_version if normalized is not None else None),
+                    source_chunk_size=normalized_chunk_size,
+                    normalize_version=NORMALIZE_VERSION,
+                    id_recipe=ID_RECIPE,
                 )
                 batch_docs.append(chunk["content"])
                 batch_ids.append(drawer_id)
@@ -552,7 +901,13 @@ def _file_chunks_locked(
                     "added_by": agent,
                     "filed_at": filed_at,
                     "entities": entities_metadata(chunk["content"]),
-                    "authored_at": authored_at if authored_at is not None else filed_at,
+                    "authored_at": (
+                        chunk.get("authored_to")
+                        if normalized is not None
+                        else authored_at
+                        if authored_at is not None
+                        else filed_at
+                    ),
                     "ingest_mode": "convos",
                     "extract_mode": extract_mode,
                     "normalize_version": NORMALIZE_VERSION,
@@ -560,6 +915,27 @@ def _file_chunks_locked(
                 }
                 if source_mtime is not None:
                     meta["source_mtime"] = source_mtime
+                if normalized is not None:
+                    meta.update(
+                        {
+                            "authored_from": chunk["authored_from"],
+                            "authored_to": chunk["authored_to"],
+                            "message_from": chunk["message_from"],
+                            "message_to": chunk["message_to"],
+                            "message_ids": chunk["message_ids"],
+                            "message_count": chunk["message_count"],
+                            "source_version": normalized.source_version,
+                            "source_chunk_size": normalized_chunk_size,
+                            "source_chunk_count": expected_chunk_count,
+                            "source_fingerprint": normalized.metadata.source_fingerprint,
+                            "transformations": normalized.metadata.transformations,
+                            "exporter_version": normalized.metadata.exporter_version,
+                            "hermes_profile": normalized.metadata.hermes_profile,
+                            "hermes_session_id": normalized.metadata.hermes_session_id,
+                            "hermes_source": normalized.metadata.hermes_source,
+                            "normalized_schema": normalized.metadata.schema,
+                        }
+                    )
                 batch_metas.append(meta)
             assert_no_collisions(list(zip(batch_ids, batch_metas)), collection)
             try:
@@ -572,6 +948,41 @@ def _file_chunks_locked(
             except Exception as e:
                 if "already exists" not in str(e).lower():
                     raise
+
+        if normalized is not None:
+            staged = _normalized_source_state(
+                collection,
+                source_file,
+                wing,
+                extract_mode,
+                collect_ids=True,
+            )
+            if not staged.generation_is_complete(
+                normalized.source_version,
+                normalized_chunk_size,
+                expected_chunk_count,
+            ):
+                raise RuntimeError("normalized target generation is incomplete after staging")
+            stale_ids = [
+                drawer_id
+                for generation, version_ids in staged.ids_by_generation.items()
+                if generation
+                != _normalized_generation_key(normalized.source_version, normalized_chunk_size)
+                for drawer_id in version_ids
+            ]
+            if stale_ids:
+                collection.delete(ids=stale_ids)
+            committed = _normalized_source_state(
+                collection,
+                source_file,
+                wing,
+                extract_mode,
+            )
+            if not committed.is_only_complete(
+                normalized.source_version,
+                normalized_chunk_size,
+            ):
+                raise RuntimeError("normalized source replacement left stale drawer(s)")
     return drawers_added, room_counts_delta, False
 
 
@@ -721,6 +1132,74 @@ def _compute_hallways_for_wing_safe(wing, collection, drawers_filed, config=None
         print(f"  (hallways skipped: {exc})")
 
 
+def _probe_normalized_conversation(filepath: Path, source_root: Path, extract_mode: str):
+    if has_normalized_sidecar(filepath):
+        return probe_normalized_conversation(
+            filepath,
+            source_root,
+            extract_mode=extract_mode,
+        )
+    return None
+
+
+def _conversation_source_is_unchanged(
+    source_file: str,
+    probe: Optional[NormalizedConversationProbe],
+    chunk_size: int,
+    mined_mtimes: dict,
+    normalized_states: dict,
+) -> bool:
+    if probe is not None:
+        state = normalized_states.get(source_file, NormalizedSourceState())
+        return state.is_only_complete(probe.source_version, chunk_size)
+    return _is_unchanged_since_last_mine(source_file, mined_mtimes)
+
+
+def _chunk_conversation_content(
+    content: str,
+    normalized: Optional[NormalizedConversation],
+    extract_mode: str,
+    chunk_size: int,
+    min_chunk_size: int,
+) -> list:
+    if normalized is not None:
+        return iter_normalized_conversation_chunks(normalized, chunk_size=chunk_size)
+    if extract_mode == "general":
+        from .general_extractor import extract_memories
+
+        return extract_memories(content, chunk_size=chunk_size)
+    return chunk_exchanges(
+        content,
+        chunk_size=chunk_size,
+        min_chunk_size=min_chunk_size,
+    )
+
+
+def _conversation_room(
+    content: str,
+    normalized: Optional[NormalizedConversation],
+    extract_mode: str,
+) -> Optional[str]:
+    if normalized is not None:
+        return normalized.metadata.room
+    if extract_mode != "general":
+        return detect_convo_room(content)
+    return None
+
+
+def _prefetch_conversation_states(files, collection, dry_run: bool, wing: str, extract_mode: str):
+    if dry_run:
+        return {}, {}
+    normalized_files = {path for path in files if has_normalized_sidecar(path)}
+    mined_mtimes = {}
+    if len(normalized_files) != len(files):
+        mined_mtimes = prefetch_mined_set(collection, extract_mode=extract_mode)
+    normalized_states = {}
+    if normalized_files:
+        normalized_states = _prefetch_normalized_sources(collection, wing, extract_mode)
+    return mined_mtimes, normalized_states
+
+
 def _mine_convos_impl(
     convo_dir: str,
     palace_path: str,
@@ -770,8 +1249,12 @@ def _mine_convos_impl(
     # 2000-file sweep used to spend >1h just deciding to skip.
     # prefetch_mined_set() does the same decisions in a single scan; loop
     # body becomes an O(1) dict lookup + a cheap local mtime comparison.
-    mined_mtimes: dict = (
-        prefetch_mined_set(collection, extract_mode=extract_mode) if not dry_run else {}
+    mined_mtimes, normalized_states = _prefetch_conversation_states(
+        files,
+        collection,
+        dry_run,
+        wing,
+        extract_mode,
     )
 
     total_drawers = 0
@@ -783,16 +1266,27 @@ def _mine_convos_impl(
     for i, filepath in enumerate(files, 1):
         files_processed = i
         source_file = str(filepath)
+        probe = _probe_normalized_conversation(
+            filepath,
+            convo_path,
+            extract_mode,
+        )
 
         # Skip only if already filed at the current NORMALIZE_VERSION AND
         # unchanged on disk since. Transcripts are NOT assumed immutable:
         # a Claude Code session keeps appending to the same file while
         # active, and /compact or /clear can rewrite one in place -- so
         # "we've seen this source_file before" alone is not sufficient.
-        # Falling through re-mines: _file_chunks_locked purges this
-        # source_file's stale drawers before inserting fresh ones, so this
-        # never leaves duplicates behind.
-        if not dry_run and _is_unchanged_since_last_mine(source_file, mined_mtimes):
+        # Falling through re-mines. Normalized sources stage and verify a new
+        # source-versioned generation before retiring stale drawers; generic
+        # sources retain their established purge-and-upsert path.
+        if not dry_run and _conversation_source_is_unchanged(
+            source_file,
+            probe,
+            cfg_chunk_size,
+            mined_mtimes,
+            normalized_states,
+        ):
             files_skipped += 1
             continue
 
@@ -800,42 +1294,52 @@ def _mine_convos_impl(
             files_skipped += 1
             continue
 
-        # Normalize format
-        try:
-            content = normalize(str(filepath))
-        except (OSError, ValueError):
-            if not dry_run:
-                _register_file(collection, source_file, wing, agent, extract_mode)
-            continue
+        normalized = None
+        content = None
+        if probe is not None:
+            normalized = load_normalized_conversation(
+                filepath,
+                convo_path,
+                extract_mode=extract_mode,
+            )
+            content = normalized.transcript
 
-        if not content or len(content.strip()) < cfg_min_chunk_size:
+        # A validated normalized export is already canonical and must remain
+        # byte-for-byte intact. Every other source keeps the generic format
+        # detection, noise filtering, and optional spellcheck behavior.
+        if normalized is None:
+            try:
+                content = normalize(str(filepath))
+            except (OSError, ValueError):
+                if not dry_run:
+                    _register_file(collection, source_file, wing, agent, extract_mode)
+                continue
+        if not content or (normalized is None and len(content.strip()) < cfg_min_chunk_size):
             if not dry_run:
                 _register_file(collection, source_file, wing, agent, extract_mode)
             continue
 
         # Chunk — either exchange pairs or general extraction
-        if extract_mode == "general":
-            from .general_extractor import extract_memories
+        chunks = _chunk_conversation_content(
+            content,
+            normalized,
+            extract_mode,
+            cfg_chunk_size,
+            cfg_min_chunk_size,
+        )
+        chunk_count = (
+            count_normalized_conversation_chunks(normalized, chunk_size=cfg_chunk_size)
+            if normalized is not None
+            else len(chunks)
+        )
 
-            chunks = extract_memories(content, chunk_size=cfg_chunk_size)
-            # Each chunk already has memory_type; use it as the room name
-        else:
-            chunks = chunk_exchanges(
-                content,
-                chunk_size=cfg_chunk_size,
-                min_chunk_size=cfg_min_chunk_size,
-            )
-
-        if not chunks:
+        if chunk_count == 0:
             if not dry_run:
                 _register_file(collection, source_file, wing, agent, extract_mode)
             continue
 
         # Detect room from content (general mode uses memory_type instead)
-        if extract_mode != "general":
-            room = detect_convo_room(content)
-        else:
-            room = None  # set per-chunk below
+        room = _conversation_room(content, normalized, extract_mode)
 
         if dry_run:
             if extract_mode == "general":
@@ -845,8 +1349,8 @@ def _mine_convos_impl(
                 types_str = ", ".join(f"{t}:{n}" for t, n in type_counts.most_common())
                 print(f"    [DRY RUN] {filepath.name} → {len(chunks)} memories ({types_str})")
             else:
-                print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
-            total_drawers += len(chunks)
+                print(f"    [DRY RUN] {filepath.name} → room:{room} ({chunk_count} drawers)")
+            total_drawers += chunk_count
             # Track room counts
             if extract_mode == "general":
                 for c in chunks:
@@ -861,8 +1365,8 @@ def _mine_convos_impl(
         if extract_mode != "general":
             room_counts[room] += 1
 
-        # Lock + purge stale + file fresh chunks. Lock serializes concurrent
-        # agents; purge removes pre-v2 drawers so the schema bump applies.
+        # Lock + reconcile stale + file fresh chunks. The lock serializes
+        # concurrent agents for this source.
         drawers_added, room_delta, skipped = _file_chunks_locked(
             collection,
             source_file,
@@ -872,6 +1376,9 @@ def _mine_convos_impl(
             agent,
             extract_mode,
             authored_at=_extract_authored_at(filepath),
+            normalized=normalized,
+            chunk_count=chunk_count,
+            source_chunk_size=(cfg_chunk_size if normalized is not None else None),
         )
         if skipped:
             files_skipped += 1

--- a/mempalace/ids.py
+++ b/mempalace/ids.py
@@ -81,7 +81,16 @@ def make_drawer_id_from_content(wing: str, room: str, content: str) -> str:
 
 
 def make_convo_drawer_id(
-    wing: str, room: str, source_file: str, extract_mode: str, chunk_index: int
+    wing: str,
+    room: str,
+    source_file: str,
+    extract_mode: str,
+    chunk_index: int,
+    *,
+    source_version: str = None,
+    source_chunk_size: int = None,
+    normalize_version: int = None,
+    id_recipe: str = None,
 ) -> str:
     """Drawer ID for the conversation miner path.
 
@@ -89,12 +98,23 @@ def make_convo_drawer_id(
     to '|' for codebase-wide consistency and to remove the Windows-path
     / URL-source edge case that ':' carried.
 
-    Hash input is ``f"{source_file}|{extract_mode}|{chunk_index}"``.
+    Generic sources hash ``source_file``, ``extract_mode``, and ``chunk_index``.
+    Normalized sources also include their complete generation recipe so a
+    replacement can be staged and verified before the last complete
+    generation is retired.
     """
-    return (
-        f"drawer_{wing}_{room}_"
-        f"{_delimited_sha256((source_file, extract_mode, str(chunk_index)), _HASH_TRUNC_DRAWER)}"
-    )
+    parts = (source_file, extract_mode, str(chunk_index))
+    if source_version is not None:
+        parts = (
+            source_file,
+            extract_mode,
+            source_version,
+            str(source_chunk_size),
+            str(normalize_version),
+            str(id_recipe),
+            str(chunk_index),
+        )
+    return f"drawer_{wing}_{room}_{_delimited_sha256(parts, _HASH_TRUNC_DRAWER)}"
 
 
 def make_convo_sentinel_id(source_file: str, extract_mode: str) -> str:

--- a/mempalace/instructions/mine.md
+++ b/mempalace/instructions/mine.md
@@ -25,6 +25,8 @@ Mines code files, documentation, and notes from a project directory.
     mempalace mine <dir> --mode convos
 
 Mines conversation exports from Claude, ChatGPT, or Slack into the palace.
+An operator pipeline that emits the reviewed normalized-conversation sidecar
+contract must use exchange mode. See `docs/normalized-conversations.md`.
 
 ### General extraction (auto-classify)
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -78,6 +78,7 @@ from .backends.chroma import (  # noqa: E402
 )
 from .backends import BackendMismatchError, PalaceRef, detect_backend_for_path  # noqa: E402
 from .query_sanitizer import sanitize_query  # noqa: E402
+from .normalized_conversations import coverage_receipt_json_schema  # noqa: E402
 from .searcher import (  # noqa: E402
     _distance_to_similarity,
     _metric_for_collection,
@@ -396,6 +397,7 @@ _MUTATING_TOOLS = frozenset(
         "mempalace_checkpoint",
         "mempalace_delete_by_source",
         "mempalace_mine",
+        "mempalace_commit_applied_coverage",
         "mempalace_sync",
         "mempalace_update_drawer",
         "mempalace_diary_write",
@@ -1518,7 +1520,7 @@ def _tool_status_via_sqlite() -> dict:
 
     db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
     if not os.path.isfile(db_path):
-        return _no_palace()
+        return _attach_applied_coverage(_no_palace())
     collection_name = _config.collection_name
 
     wings: dict = {}
@@ -1575,6 +1577,21 @@ def _tool_status_via_sqlite() -> dict:
             "hnsw_count": _vector_capacity_status.get("hnsw_count"),
             "divergence": _vector_capacity_status.get("divergence"),
         }
+    return _attach_applied_coverage(result)
+
+
+def _attach_applied_coverage(result: dict) -> dict:
+    """Attach the operator-committed watermark without changing it."""
+
+    try:
+        from .normalized_conversations import read_applied_coverage
+
+        result["applied_coverage"] = read_applied_coverage(_config.palace_path)
+    except Exception as exc:
+        logger.warning("applied coverage registry read failed: %s", exc)
+        result["applied_coverage"] = {}
+        result["applied_coverage_error"] = str(exc)
+        result["partial"] = True
     return result
 
 
@@ -1772,21 +1789,23 @@ def tool_status():
             wings[w] = wings.get(w, 0) + sum(room_counts.values())
             for r, n in room_counts.items():
                 rooms[r] = rooms.get(r, 0) + n
-        return {
-            "total_drawers": total,
-            "wings": wings,
-            "rooms": rooms,
-            "protocol": PALACE_PROTOCOL,
-            "aaak_dialect": AAAK_SPEC,
-            "backend": _selected_backend_name(),
-        }
+        return _attach_applied_coverage(
+            {
+                "total_drawers": total,
+                "wings": wings,
+                "rooms": rooms,
+                "protocol": PALACE_PROTOCOL,
+                "aaak_dialect": AAAK_SPEC,
+                "backend": _selected_backend_name(),
+            }
+        )
 
     # Use create=True only when a palace DB already exists on disk -- this
     # bootstraps the ChromaDB collection on a valid-but-empty palace without
     # accidentally creating a palace in a non-existent directory (#830).
     col = _get_collection(create=db_exists)
     if not col:
-        return _collection_error_or_no_palace()
+        return _attach_applied_coverage(_collection_error_or_no_palace())
     count = col.count()
     wings = {}
     rooms = {}
@@ -1844,7 +1863,7 @@ def tool_status():
         logger.exception("tool_status metadata fetch failed")
         result["error"] = str(e)
         result["partial"] = True
-    return result
+    return _attach_applied_coverage(result)
 
 
 # ── AAAK Dialect Spec ─────────────────────────────────────────────────────────
@@ -2915,6 +2934,62 @@ def tool_mine(
     finally:
         if not dry_run:
             _metadata_cache = None
+
+
+def tool_normalized_conversation_delta(
+    source: str,
+    wing: str,
+    extract: str = "exchange",
+):
+    """Return a read-only normalized-source reconciliation report."""
+
+    if not _config.palace_path:
+        return {
+            "success": False,
+            "error": "no palace configured",
+            "error_class": "PalaceNotConfigured",
+        }
+    src = os.path.expanduser(source) if source else ""
+    if not src or not os.path.isdir(src):
+        return {"success": False, "error": f"source directory not found: {source!r}"}
+    try:
+        from .convo_miner import normalized_conversation_delta
+
+        report = normalized_conversation_delta(
+            src,
+            _config.palace_path,
+            wing=sanitize_name(wing, "wing"),
+            extract_mode=extract,
+        )
+        return {"success": True, "dry_run": True, "report": report}
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_class": type(exc).__name__,
+        }
+
+
+def tool_commit_applied_coverage(receipt: dict):
+    """Atomically commit an operator-verified, content-free wing watermark."""
+
+    if not _config.palace_path:
+        return {
+            "success": False,
+            "error": "no palace configured",
+            "error_class": "PalaceNotConfigured",
+        }
+    try:
+        from .normalized_conversations import commit_applied_coverage
+
+        committed = commit_applied_coverage(_config.palace_path, receipt)
+        return {"success": True, "coverage": committed}
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_class": type(exc).__name__,
+        }
 
 
 def _purge_source_closets(source_file: str, *, commit: bool) -> int:
@@ -4452,6 +4527,42 @@ TOOLS = {
             "required": ["source"],
         },
         "handler": tool_mine,
+    },
+    "mempalace_normalized_conversation_delta": {
+        "description": (
+            "Operator inspection for normalized conversation staging. Reports "
+            "new, changed, unchanged, and removed sources without writing."
+        ),
+        "input_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "source": {"type": "string", "description": "Normalized staging directory."},
+                "wing": {"type": "string", "description": "Exact destination wing."},
+                "extract": {
+                    "type": "string",
+                    "enum": ["exchange"],
+                    "description": "Normalized conversations support exchange mode only.",
+                },
+            },
+            "required": ["source", "wing"],
+        },
+        "handler": tool_normalized_conversation_delta,
+    },
+    "mempalace_commit_applied_coverage": {
+        "description": (
+            "Operator-only commit of a content-free coverage receipt after a "
+            "profile apply and mixed-version verification both pass."
+        ),
+        "input_schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "receipt": coverage_receipt_json_schema(),
+            },
+            "required": ["receipt"],
+        },
+        "handler": tool_commit_applied_coverage,
     },
     "mempalace_delete_by_source": {
         "description": "Bulk-delete every drawer mined from one source_file (exact match). Use to clean up benchmark/test data accidentally mined into a user wing (#1722). Returns a dry-run match count and sample by default; pass dry_run=false to commit. Irreversible.",

--- a/mempalace/normalized_conversations.py
+++ b/mempalace/normalized_conversations.py
@@ -1,0 +1,642 @@
+"""Validated, verbatim conversation exports produced by trusted operators.
+
+The format is deliberately opt-in. A transcript is treated as normalized only
+when an adjacent ``.meta.json`` sidecar exists and both files satisfy this
+module's closed schema. Generic conversation imports never pass through here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import tempfile
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "mempalace-normalized-conversation/v1"
+SIDECAR_SUFFIX = ".meta.json"
+MAX_SIDECAR_BYTES = 64 * 1024
+MAX_TRANSCRIPT_BYTES = 128 * 1024 * 1024
+MAX_ENVELOPE_BYTES = 16 * 1024
+MAX_MESSAGES_PER_EXCHANGE = 64
+
+_SIDECAR_FIELDS = {
+    "schema",
+    "room",
+    "authored_from",
+    "authored_to",
+    "source_fingerprint",
+    "transformations",
+    "exporter_version",
+    "hermes_profile",
+    "hermes_session_id",
+    "hermes_source",
+}
+_HALL_CATEGORY_ROOMS = {
+    "advice",
+    "decisions",
+    "discoveries",
+    "emotional_context",
+    "events",
+    "facts",
+    "milestones",
+    "preferences",
+    "problems",
+}
+_ROOM_RE = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:[-_.][a-z0-9]+)*$")
+_VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+){1,3}(?:[-+][A-Za-z0-9.-]+)?$")
+_FINGERPRINT_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_TRANSFORMATIONS_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*(?:;[a-z0-9]+(?:-[a-z0-9]+)*)*$")
+_EXCHANGE_PREFIX = "<!-- mempalace-exchange "
+_COVERAGE_SCHEMA = "mempalace-applied-coverage/v1"
+_COVERAGE_FILENAME = "normalized-conversation-coverage.json"
+_COVERAGE_FIELDS = {
+    "schema",
+    "wing",
+    "applied_snapshot_at",
+    "covered_sources",
+    "authored_from",
+    "authored_to",
+    "accepted_session_count",
+    "quarantine_count",
+    "verified_profile_receipt",
+    "source_version",
+}
+
+
+def coverage_receipt_json_schema() -> dict[str, Any]:
+    """Return the MCP-compatible schema for one applied coverage receipt."""
+
+    properties = {field: {"type": "string"} for field in sorted(_COVERAGE_FIELDS)}
+    properties.update(
+        {
+            "schema": {"type": "string", "const": _COVERAGE_SCHEMA},
+            "wing": {"type": "string", "pattern": r"^wing_[a-z0-9]+$"},
+            "applied_snapshot_at": {"type": "string", "format": "date-time"},
+            "authored_from": {"type": "string", "format": "date-time"},
+            "authored_to": {"type": "string", "format": "date-time"},
+            "covered_sources": {
+                "type": "string",
+                "pattern": (
+                    r"^[a-z0-9]+(?:[-_.][a-z0-9]+)*"
+                    r"(?:;[a-z0-9]+(?:[-_.][a-z0-9]+)*)*$"
+                ),
+            },
+            "verified_profile_receipt": {
+                "type": "string",
+                "pattern": r"^sha256:[0-9a-f]{64}$",
+            },
+            "source_version": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": r"^[^/\\\u0000]+$",
+            },
+        }
+    )
+    for field in ("accepted_session_count", "quarantine_count"):
+        properties[field] = {"type": "integer", "minimum": 0}
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": properties,
+        "required": sorted(_COVERAGE_FIELDS),
+    }
+
+
+class NormalizedConversationError(ValueError):
+    """Raised when an opt-in normalized conversation fails validation."""
+
+
+@dataclass(frozen=True)
+class NormalizedExchange:
+    start: int
+    stop: int
+    authored_from: str
+    authored_to: str
+    message_from: str
+    message_to: str
+    message_ids: str
+    message_count: int
+
+
+@dataclass(frozen=True)
+class NormalizedMetadata:
+    schema: str
+    room: str
+    authored_from: str
+    authored_to: str
+    source_fingerprint: str
+    transformations: str
+    exporter_version: str
+    hermes_profile: str
+    hermes_session_id: str
+    hermes_source: str
+
+
+@dataclass(frozen=True)
+class NormalizedConversation:
+    transcript_path: Path
+    sidecar_path: Path
+    transcript: str
+    metadata: NormalizedMetadata
+    exchanges: tuple[NormalizedExchange, ...]
+    source_version: str
+
+
+@dataclass(frozen=True)
+class NormalizedConversationProbe:
+    """Validated metadata and composite identity without transcript parsing."""
+
+    transcript_path: Path
+    sidecar_path: Path
+    metadata: NormalizedMetadata
+    source_version: str
+
+
+def sidecar_path_for(transcript_path: Path) -> Path:
+    """Return the only sidecar path recognized for ``transcript_path``."""
+
+    return transcript_path.with_name(transcript_path.name + SIDECAR_SUFFIX)
+
+
+def has_normalized_sidecar(transcript_path: Path) -> bool:
+    """Return whether the adjacent opt-in sidecar path exists.
+
+    A symlink still returns true so the loader can reject it explicitly rather
+    than silently falling back to generic parsing.
+    """
+
+    return os.path.lexists(sidecar_path_for(Path(transcript_path)))
+
+
+def _parse_iso(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise NormalizedConversationError(f"{field} must be a non-empty ISO timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise NormalizedConversationError(f"{field} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise NormalizedConversationError(f"{field} must include a timezone")
+    return parsed
+
+
+def _safe_read(path: Path, root: Path, *, max_bytes: int, label: str) -> bytes:
+    try:
+        if path.is_symlink():
+            raise NormalizedConversationError(f"{label} must not be a symlink")
+        resolved_root = root.expanduser().resolve(strict=True)
+        resolved_path = path.expanduser().resolve(strict=True)
+        resolved_path.relative_to(resolved_root)
+    except NormalizedConversationError:
+        raise
+    except (OSError, ValueError) as exc:
+        raise NormalizedConversationError(f"{label} path must stay within source root") from exc
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise NormalizedConversationError(f"unable to open {label}") from exc
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise NormalizedConversationError(f"{label} must be a regular file")
+        if file_stat.st_size > max_bytes:
+            raise NormalizedConversationError(f"{label} exceeds maximum size")
+        with os.fdopen(fd, "rb", closefd=False) as handle:
+            raw = handle.read(max_bytes + 1)
+        if len(raw) > max_bytes:
+            raise NormalizedConversationError(f"{label} exceeds maximum size")
+        return raw
+    finally:
+        os.close(fd)
+
+
+def _load_sidecar(sidecar_path: Path, root: Path) -> NormalizedMetadata:
+    raw = _safe_read(sidecar_path, root, max_bytes=MAX_SIDECAR_BYTES, label="sidecar")
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise NormalizedConversationError("sidecar must be valid UTF-8 JSON") from exc
+    if not isinstance(payload, dict):
+        raise NormalizedConversationError("sidecar must be a JSON object")
+    if set(payload) != _SIDECAR_FIELDS:
+        missing = sorted(_SIDECAR_FIELDS - set(payload))
+        unknown = sorted(set(payload) - _SIDECAR_FIELDS)
+        raise NormalizedConversationError(
+            f"sidecar field mismatch; missing={missing}, unknown={unknown}"
+        )
+    if any(not isinstance(value, str) for value in payload.values()):
+        raise NormalizedConversationError("sidecar fields must all be flat strings")
+    if payload["schema"] != SCHEMA:
+        raise NormalizedConversationError("unsupported normalized conversation schema")
+
+    room = payload["room"]
+    if not _ROOM_RE.fullmatch(room) or room in _HALL_CATEGORY_ROOMS:
+        raise NormalizedConversationError("room must be a reviewed subject slug")
+    authored_from = _parse_iso(payload["authored_from"], "authored_from")
+    authored_to = _parse_iso(payload["authored_to"], "authored_to")
+    if authored_from > authored_to:
+        raise NormalizedConversationError("authored_from must not exceed authored_to")
+    if not _FINGERPRINT_RE.fullmatch(payload["source_fingerprint"]):
+        raise NormalizedConversationError("source_fingerprint must be sha256:<hex>")
+    if not _TRANSFORMATIONS_RE.fullmatch(payload["transformations"]):
+        raise NormalizedConversationError("transformations must be semicolon-delimited slugs")
+    if not _VERSION_RE.fullmatch(payload["exporter_version"]):
+        raise NormalizedConversationError("exporter_version must be a version string")
+    for field in ("hermes_profile", "hermes_source"):
+        if not _SLUG_RE.fullmatch(payload[field]):
+            raise NormalizedConversationError(f"{field} must be a safe slug")
+    session_id = payload["hermes_session_id"]
+    if (
+        not session_id
+        or len(session_id) > 256
+        or any(char in session_id for char in ("/", "\\", "\x00"))
+        or ".." in session_id
+    ):
+        raise NormalizedConversationError("hermes_session_id is invalid")
+    return NormalizedMetadata(**payload)
+
+
+def _validate_messages(payload: Any) -> tuple[list[dict[str, str]], list[datetime]]:
+    if not isinstance(payload, dict) or set(payload) != {"messages"}:
+        raise NormalizedConversationError("exchange envelope must contain only messages")
+    messages = payload["messages"]
+    if not isinstance(messages, list) or not 2 <= len(messages) <= MAX_MESSAGES_PER_EXCHANGE:
+        raise NormalizedConversationError(
+            f"exchange messages must contain 2-{MAX_MESSAGES_PER_EXCHANGE} entries"
+        )
+    timestamps: list[datetime] = []
+    identifiers: set[str] = set()
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict) or set(message) != {"id", "role", "timestamp"}:
+            raise NormalizedConversationError("each message provenance entry has invalid fields")
+        if any(not isinstance(value, str) or not value for value in message.values()):
+            raise NormalizedConversationError("message provenance values must be strings")
+        identifier = message["id"]
+        if (
+            len(identifier) > 256
+            or any(char in identifier for char in ("/", "\\", "\x00"))
+            or ".." in identifier
+        ):
+            raise NormalizedConversationError("message id is invalid")
+        if identifier in identifiers:
+            raise NormalizedConversationError("message ids must be unique within an exchange")
+        identifiers.add(identifier)
+        role = message["role"]
+        if role not in {"user", "assistant"}:
+            raise NormalizedConversationError("message role must be user or assistant")
+        if index == 0 and role != "user":
+            raise NormalizedConversationError("first message in an exchange must be user")
+        if index > 0 and role != "assistant":
+            raise NormalizedConversationError("only the first exchange message may be user")
+        timestamps.append(_parse_iso(message["timestamp"], "message timestamp"))
+    return list(messages), timestamps
+
+
+def _parse_exchanges(transcript: str) -> tuple[NormalizedExchange, ...]:
+    starts = [match.start() for match in re.finditer(r"(?m)^<!-- mempalace-exchange ", transcript)]
+    if not starts or starts[0] != 0:
+        raise NormalizedConversationError("transcript must begin with an exchange envelope")
+
+    exchanges: list[NormalizedExchange] = []
+    transcript_message_ids: set[str] = set()
+    for position, start in enumerate(starts):
+        stop = starts[position + 1] if position + 1 < len(starts) else len(transcript)
+        newline = transcript.find("\n", start, stop)
+        envelope_stop = stop if newline == -1 else newline
+        envelope_line = transcript[start:envelope_stop].rstrip("\r")
+        if len(envelope_line.encode("utf-8")) > MAX_ENVELOPE_BYTES:
+            raise NormalizedConversationError("exchange envelope is too large")
+        if not envelope_line.startswith(_EXCHANGE_PREFIX) or not envelope_line.endswith(" -->"):
+            raise NormalizedConversationError("exchange envelope is malformed")
+        try:
+            envelope = json.loads(envelope_line[len(_EXCHANGE_PREFIX) : -4])
+        except json.JSONDecodeError as exc:
+            raise NormalizedConversationError("exchange envelope JSON is invalid") from exc
+        messages, timestamps = _validate_messages(envelope)
+        exchange_message_ids = {message["id"] for message in messages}
+        if transcript_message_ids & exchange_message_ids:
+            raise NormalizedConversationError("message ids must be unique across the transcript")
+        transcript_message_ids.update(exchange_message_ids)
+
+        body_start = envelope_stop + (1 if newline != -1 else 0)
+        body_line_stop = transcript.find("\n", body_start, stop)
+        first_body_line = transcript[
+            body_start : stop if body_line_stop == -1 else body_line_stop
+        ].rstrip("\r")
+        if body_start >= stop or not first_body_line.startswith(">"):
+            raise NormalizedConversationError(
+                "each exchange must have exactly one leading user marker"
+            )
+
+        minimum_timestamp = min(timestamps)
+        maximum_timestamp = max(timestamps)
+        authored_from = minimum_timestamp.isoformat()
+        authored_to = maximum_timestamp.isoformat()
+        # Keep the export's canonical spelling when the bound matches an
+        # original timestamp, including its chosen UTC ``Z`` representation.
+        for message, parsed in zip(messages, timestamps):
+            if parsed == minimum_timestamp:
+                authored_from = message["timestamp"]
+                break
+        for message, parsed in reversed(list(zip(messages, timestamps))):
+            if parsed == maximum_timestamp:
+                authored_to = message["timestamp"]
+                break
+        message_ids = [message["id"] for message in messages]
+        exchanges.append(
+            NormalizedExchange(
+                start=start,
+                stop=stop,
+                authored_from=authored_from,
+                authored_to=authored_to,
+                message_from=message_ids[0],
+                message_to=message_ids[-1],
+                message_ids=";".join(message_ids),
+                message_count=len(message_ids),
+            )
+        )
+    return tuple(exchanges)
+
+
+def _canonical_sidecar(metadata: NormalizedMetadata) -> bytes:
+    return json.dumps(asdict(metadata), sort_keys=True, separators=(",", ":")).encode()
+
+
+def _source_version(transcript_bytes: bytes, metadata: NormalizedMetadata) -> str:
+    digest = hashlib.sha256(
+        b"mempalace-normalized-conversation-source/v1\0"
+        + transcript_bytes
+        + b"\0"
+        + _canonical_sidecar(metadata)
+    ).hexdigest()
+    return f"sha256:{digest}"
+
+
+def probe_normalized_conversation(
+    transcript_path: Path, source_root: Path, *, extract_mode: str
+) -> NormalizedConversationProbe:
+    """Validate a pair and compute identity without parsing its exchanges."""
+
+    transcript_path = Path(transcript_path)
+    source_root = Path(source_root)
+    sidecar_path = sidecar_path_for(transcript_path)
+    if extract_mode != "exchange":
+        raise NormalizedConversationError(
+            "normalized Hermes conversations require extract_mode=exchange; "
+            "extract_mode=general is refused"
+        )
+    transcript_bytes = _safe_read(
+        transcript_path,
+        source_root,
+        max_bytes=MAX_TRANSCRIPT_BYTES,
+        label="transcript",
+    )
+    metadata = _load_sidecar(sidecar_path, source_root)
+    return NormalizedConversationProbe(
+        transcript_path=transcript_path.resolve(),
+        sidecar_path=sidecar_path.resolve(),
+        metadata=metadata,
+        source_version=_source_version(transcript_bytes, metadata),
+    )
+
+
+def load_normalized_conversation(
+    transcript_path: Path, source_root: Path, *, extract_mode: str
+) -> NormalizedConversation:
+    """Load and validate one normalized transcript/sidecar pair."""
+
+    transcript_path = Path(transcript_path)
+    source_root = Path(source_root)
+    sidecar_path = sidecar_path_for(transcript_path)
+    if extract_mode != "exchange":
+        raise NormalizedConversationError(
+            "normalized Hermes conversations require extract_mode=exchange; "
+            "extract_mode=general is refused"
+        )
+    transcript_bytes = _safe_read(
+        transcript_path,
+        source_root,
+        max_bytes=MAX_TRANSCRIPT_BYTES,
+        label="transcript",
+    )
+    try:
+        transcript = transcript_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise NormalizedConversationError("transcript must be valid UTF-8") from exc
+    sidecar = _load_sidecar(sidecar_path, source_root)
+    exchanges = _parse_exchanges(transcript)
+
+    exchange_from = min(
+        _parse_iso(item.authored_from, "exchange authored_from") for item in exchanges
+    )
+    exchange_to = max(_parse_iso(item.authored_to, "exchange authored_to") for item in exchanges)
+    if exchange_from < _parse_iso(sidecar.authored_from, "authored_from"):
+        raise NormalizedConversationError("exchange authored range precedes sidecar range")
+    if exchange_to > _parse_iso(sidecar.authored_to, "authored_to"):
+        raise NormalizedConversationError("exchange authored range exceeds sidecar range")
+
+    return NormalizedConversation(
+        transcript_path=transcript_path.resolve(),
+        sidecar_path=sidecar_path.resolve(),
+        transcript=transcript,
+        metadata=sidecar,
+        exchanges=exchanges,
+        source_version=_source_version(transcript_bytes, sidecar),
+    )
+
+
+def iter_normalized_conversation_chunks(
+    conversation: NormalizedConversation, *, chunk_size: int
+) -> Iterator[dict[str, Any]]:
+    """Yield bounded chunks without retaining copied transcript text."""
+
+    if not isinstance(chunk_size, int) or isinstance(chunk_size, bool) or chunk_size <= 0:
+        raise ValueError("chunk_size must be a positive integer")
+    chunk_index = 0
+    for exchange in conversation.exchanges:
+        for offset in range(exchange.start, exchange.stop, chunk_size):
+            yield {
+                "content": conversation.transcript[
+                    offset : min(offset + chunk_size, exchange.stop)
+                ],
+                "chunk_index": chunk_index,
+                "authored_from": exchange.authored_from,
+                "authored_to": exchange.authored_to,
+                "message_from": exchange.message_from,
+                "message_to": exchange.message_to,
+                "message_ids": exchange.message_ids,
+                "message_count": exchange.message_count,
+            }
+            chunk_index += 1
+
+
+def chunk_normalized_conversation(
+    conversation: NormalizedConversation, *, chunk_size: int
+) -> list[dict[str, Any]]:
+    """Return bounded chunks without changing normalized transcript bytes."""
+
+    return list(iter_normalized_conversation_chunks(conversation, chunk_size=chunk_size))
+
+
+def count_normalized_conversation_chunks(
+    conversation: NormalizedConversation, *, chunk_size: int
+) -> int:
+    """Count the chunks the miner will emit without copying their text."""
+
+    if not isinstance(chunk_size, int) or isinstance(chunk_size, bool) or chunk_size <= 0:
+        raise ValueError("chunk_size must be a positive integer")
+    return sum(
+        (exchange.stop - exchange.start + chunk_size - 1) // chunk_size
+        for exchange in conversation.exchanges
+    )
+
+
+def _validate_coverage_receipt(receipt: Any) -> dict[str, Any]:
+    if not isinstance(receipt, dict) or set(receipt) != _COVERAGE_FIELDS:
+        raise NormalizedConversationError("coverage receipt field mismatch")
+    if receipt.get("schema") != _COVERAGE_SCHEMA:
+        raise NormalizedConversationError("unsupported coverage receipt schema")
+    wing = receipt.get("wing")
+    if not isinstance(wing, str) or not re.fullmatch(r"wing_[a-z0-9]+", wing):
+        raise NormalizedConversationError("coverage wing must be a safe wing slug")
+    applied = _parse_iso(receipt.get("applied_snapshot_at"), "applied_snapshot_at")
+    authored_from = _parse_iso(receipt.get("authored_from"), "authored_from")
+    authored_to = _parse_iso(receipt.get("authored_to"), "authored_to")
+    if authored_from > authored_to or applied < authored_to:
+        raise NormalizedConversationError("coverage timestamp range is invalid")
+    sources = receipt.get("covered_sources")
+    if (
+        not isinstance(sources, str)
+        or not sources
+        or any(not _SLUG_RE.fullmatch(source) for source in sources.split(";"))
+        or len(set(sources.split(";"))) != len(sources.split(";"))
+    ):
+        raise NormalizedConversationError("covered_sources must be unique safe slugs")
+    for field in ("accepted_session_count", "quarantine_count"):
+        value = receipt.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise NormalizedConversationError(f"{field} must be a non-negative integer")
+    verified = receipt.get("verified_profile_receipt")
+    if not isinstance(verified, str) or not _FINGERPRINT_RE.fullmatch(verified):
+        raise NormalizedConversationError("verified_profile_receipt must be sha256:<hex>")
+    source_version = receipt.get("source_version")
+    if (
+        not isinstance(source_version, str)
+        or not source_version
+        or len(source_version) > 128
+        or any(char in source_version for char in ("/", "\\", "\x00"))
+    ):
+        raise NormalizedConversationError("source_version is invalid")
+    return dict(receipt)
+
+
+def _coverage_path(palace_path: Path) -> Path:
+    return Path(palace_path).expanduser().resolve() / _COVERAGE_FILENAME
+
+
+def read_applied_coverage(palace_path: Path) -> dict[str, dict[str, Any]]:
+    """Read the content-free applied coverage registry without changing it."""
+
+    path = _coverage_path(palace_path)
+    if not path.exists():
+        return {}
+    raw = _safe_read(
+        path,
+        path.parent,
+        max_bytes=256 * 1024,
+        label="coverage registry",
+    )
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise NormalizedConversationError("coverage registry is invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise NormalizedConversationError("coverage registry must be an object")
+    validated: dict[str, dict[str, Any]] = {}
+    for wing, receipt in payload.items():
+        checked = _validate_coverage_receipt(receipt)
+        if wing != checked["wing"]:
+            raise NormalizedConversationError("coverage registry wing key mismatch")
+        validated[wing] = checked
+    return validated
+
+
+def commit_applied_coverage(
+    palace_path: Path,
+    receipt: dict[str, Any],
+) -> dict[str, Any]:
+    """Atomically advance one wing after an operator verified its full apply."""
+
+    from .palace import mine_palace_lock
+
+    palace = Path(palace_path).expanduser().resolve()
+    if not palace.is_dir():
+        raise NormalizedConversationError("palace path must already exist")
+    checked = _validate_coverage_receipt(receipt)
+    with mine_palace_lock(str(palace)):
+        current = read_applied_coverage(palace)
+        previous = current.get(checked["wing"])
+        if previous == checked:
+            return checked
+        if previous is not None:
+            previous_snapshot = _parse_iso(
+                previous["applied_snapshot_at"], "previous applied_snapshot_at"
+            )
+            next_snapshot = _parse_iso(checked["applied_snapshot_at"], "applied_snapshot_at")
+            if next_snapshot < previous_snapshot:
+                raise NormalizedConversationError("coverage receipt must not move backward")
+            if next_snapshot == previous_snapshot:
+                raise NormalizedConversationError(
+                    "coverage receipt conflicts with the existing snapshot"
+                )
+            if _parse_iso(checked["authored_to"], "authored_to") < _parse_iso(
+                previous["authored_to"], "previous authored_to"
+            ):
+                raise NormalizedConversationError(
+                    "coverage authored watermark must not move backward"
+                )
+        current[checked["wing"]] = checked
+        encoded = (json.dumps(current, sort_keys=True, indent=2) + "\n").encode("utf-8")
+        destination = _coverage_path(palace)
+
+        fd, temporary_name = tempfile.mkstemp(
+            prefix=".normalized-conversation-coverage.",
+            suffix=".tmp",
+            dir=palace,
+        )
+        temporary = Path(temporary_name)
+        try:
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb", closefd=False) as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.close(fd)
+            fd = -1
+            os.replace(temporary, destination)
+            try:
+                directory_fd = os.open(palace, os.O_RDONLY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+            except OSError:
+                # Windows and some filesystems reject directory descriptors.
+                pass
+        finally:
+            if fd != -1:
+                os.close(fd)
+            temporary.unlink(missing_ok=True)
+    return checked

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -121,6 +121,26 @@ def test_make_convo_drawer_id_returns_expected_prefix():
     assert result.startswith("drawer_claude_diary_")
 
 
+def test_make_convo_drawer_id_separates_normalized_generation_recipe():
+    base = {
+        "wing": "amber",
+        "room": "communication",
+        "source_file": "/session.md",
+        "extract_mode": "exchange",
+        "chunk_index": 0,
+        "source_version": "sha256:" + ("1" * 64),
+        "source_chunk_size": 800,
+        "normalize_version": 2,
+        "id_recipe": "v3",
+    }
+
+    first = ids.make_convo_drawer_id(**base)
+    changed_size = ids.make_convo_drawer_id(**{**base, "source_chunk_size": 900})
+    changed_normalizer = ids.make_convo_drawer_id(**{**base, "normalize_version": 3})
+
+    assert len({first, changed_size, changed_normalizer}) == 3
+
+
 # ── make_convo_sentinel_id ────────────────────────────────────────────
 
 

--- a/tests/test_normalized_conversations.py
+++ b/tests/test_normalized_conversations.py
@@ -1,0 +1,919 @@
+"""Contract tests for canonical Hermes conversation exports."""
+
+import hashlib
+import importlib
+import json
+
+import pytest
+
+
+def _module():
+    return importlib.import_module("mempalace.normalized_conversations")
+
+
+def _write_pair(
+    tmp_path,
+    *,
+    transcript=None,
+    room="communication",
+    authored_from="2026-07-29T23:55:00Z",
+    authored_to="2026-07-30T00:05:00Z",
+):
+    transcript_path = tmp_path / "session.md"
+    transcript_text = transcript or (
+        '<!-- mempalace-exchange {"messages":['
+        '{"id":"41","role":"user","timestamp":"2026-07-29T23:55:00Z"},'
+        '{"id":"42","role":"assistant","timestamp":"2026-07-29T23:56:00Z"}]} -->\n'
+        "> teh exact user text must stay teh same\n"
+        "The assistant answer also stays byte-for-byte intact.\n"
+    )
+    transcript_path.write_text(transcript_text)
+    sidecar = {
+        "schema": "mempalace-normalized-conversation/v1",
+        "room": room,
+        "authored_from": authored_from,
+        "authored_to": authored_to,
+        "source_fingerprint": f"sha256:{hashlib.sha256(b'source rows').hexdigest()}",
+        "transformations": ("hermes-compaction-dedup;hermes-synthetic-filter;secret-redaction"),
+        "exporter_version": "1.0.0",
+        "hermes_profile": "amber",
+        "hermes_session_id": "session-123",
+        "hermes_source": "telegram",
+    }
+    sidecar_path = tmp_path / "session.md.meta.json"
+    sidecar_path.write_text(json.dumps(sidecar))
+    return transcript_path, sidecar_path, transcript_text, sidecar
+
+
+def test_one_exchange_preserves_exact_transformed_text_without_normalization(tmp_path):
+    normalized = _module()
+    transcript_path, _, transcript_text, _ = _write_pair(tmp_path)
+
+    contract = normalized.load_normalized_conversation(
+        transcript_path, tmp_path, extract_mode="exchange"
+    )
+    chunks = normalized.chunk_normalized_conversation(contract, chunk_size=800)
+
+    assert len(chunks) == 1
+    assert chunks[0]["content"] == transcript_text
+    assert "teh exact user text must stay teh same" in chunks[0]["content"]
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_exchange_chunks_reconstruct_exact_transcript_line_endings(tmp_path, newline):
+    normalized = _module()
+    transcript = newline.join(
+        [
+            '<!-- mempalace-exchange {"messages":['
+            '{"id":"41","role":"user","timestamp":"2026-07-29T23:55:00Z"},'
+            '{"id":"42","role":"assistant","timestamp":"2026-07-29T23:56:00Z"}]} -->',
+            "> exact user text",
+            "Assistant answer.",
+            "",
+            '<!-- mempalace-exchange {"messages":['
+            '{"id":"43","role":"user","timestamp":"2026-07-30T00:04:00Z"},'
+            '{"id":"44","role":"assistant","timestamp":"2026-07-30T00:05:00Z"}]} -->',
+            "> second user text",
+            "Second assistant answer.",
+            "",
+        ]
+    )
+    transcript_path, _, _, _ = _write_pair(tmp_path, transcript=transcript)
+    transcript_path.write_bytes(transcript.encode())
+
+    contract = normalized.load_normalized_conversation(
+        transcript_path, tmp_path, extract_mode="exchange"
+    )
+    chunks = normalized.chunk_normalized_conversation(contract, chunk_size=37)
+
+    assert "".join(chunk["content"] for chunk in chunks) == transcript
+
+
+def test_assistant_markdown_blockquote_remains_verbatim(tmp_path):
+    normalized = _module()
+    transcript = (
+        '<!-- mempalace-exchange {"messages":['
+        '{"id":"41","role":"user","timestamp":"2026-07-29T23:55:00Z"},'
+        '{"id":"42","role":"assistant","timestamp":"2026-07-29T23:56:00Z"}]} -->\n'
+        "> user asks about the quoted text\n"
+        "Assistant context:\n"
+        "> this is an assistant Markdown blockquote\n"
+        "Assistant conclusion.\n"
+    )
+    transcript_path, _, _, _ = _write_pair(tmp_path, transcript=transcript)
+
+    contract = normalized.load_normalized_conversation(
+        transcript_path, tmp_path, extract_mode="exchange"
+    )
+
+    assert (
+        "".join(
+            chunk["content"]
+            for chunk in normalized.chunk_normalized_conversation(contract, chunk_size=53)
+        )
+        == transcript
+    )
+
+
+def test_multi_day_exchange_bounds_are_preserved_per_chunk(tmp_path):
+    normalized = _module()
+    transcript = (
+        '<!-- mempalace-exchange {"messages":['
+        '{"id":"41","role":"user","timestamp":"2026-07-29T23:55:00Z"},'
+        '{"id":"42","role":"assistant","timestamp":"2026-07-29T23:56:00Z"}]} -->\n'
+        "> first question with enough content to keep\n"
+        "First answer with enough content to keep.\n"
+        '<!-- mempalace-exchange {"messages":['
+        '{"id":"43","role":"user","timestamp":"2026-07-30T00:04:00Z"},'
+        '{"id":"44","role":"assistant","timestamp":"2026-07-30T00:05:00Z"}]} -->\n'
+        "> second question with enough content to keep\n"
+        "Second answer with enough content to keep.\n"
+    )
+    transcript_path, _, _, _ = _write_pair(tmp_path, transcript=transcript)
+
+    contract = normalized.load_normalized_conversation(
+        transcript_path, tmp_path, extract_mode="exchange"
+    )
+    chunks = normalized.chunk_normalized_conversation(contract, chunk_size=800)
+
+    assert [chunk["authored_from"] for chunk in chunks] == [
+        "2026-07-29T23:55:00Z",
+        "2026-07-30T00:04:00Z",
+    ]
+    assert [chunk["authored_to"] for chunk in chunks] == [
+        "2026-07-29T23:56:00Z",
+        "2026-07-30T00:05:00Z",
+    ]
+    assert [chunk["message_from"] for chunk in chunks] == ["41", "43"]
+    assert [chunk["message_to"] for chunk in chunks] == ["42", "44"]
+
+
+def test_multi_assistant_exchange_has_ordered_unique_message_provenance(tmp_path):
+    normalized = _module()
+    transcript = (
+        '<!-- mempalace-exchange {"messages":['
+        '{"id":"51","role":"user","timestamp":"2026-07-29T23:55:00Z"},'
+        '{"id":"52","role":"assistant","timestamp":"2026-07-29T23:55:30Z"},'
+        '{"id":"53","role":"assistant","timestamp":"2026-07-29T23:56:00Z"}]} -->\n'
+        "> one user message with enough content\n"
+        "First assistant body.\n"
+        "Second assistant body.\n"
+    )
+    transcript_path, _, transcript_text, _ = _write_pair(tmp_path, transcript=transcript)
+
+    contract = normalized.load_normalized_conversation(
+        transcript_path, tmp_path, extract_mode="exchange"
+    )
+    chunks = normalized.chunk_normalized_conversation(contract, chunk_size=800)
+
+    assert len(chunks) == 1
+    assert chunks[0]["content"] == transcript_text
+    assert chunks[0]["message_from"] == "51"
+    assert chunks[0]["message_to"] == "53"
+    assert chunks[0]["message_count"] == 3
+
+
+@pytest.mark.parametrize(
+    "messages,match",
+    [
+        (
+            [
+                {"id": "1", "role": "assistant", "timestamp": "2026-07-29T23:55:00Z"},
+                {"id": "2", "role": "user", "timestamp": "2026-07-29T23:56:00Z"},
+            ],
+            "first message.*user",
+        ),
+        (
+            [
+                {"id": "1", "role": "user", "timestamp": "2026-07-29T23:55:00Z"},
+                {"id": "1", "role": "assistant", "timestamp": "2026-07-29T23:56:00Z"},
+            ],
+            "unique",
+        ),
+    ],
+)
+def test_malformed_exchange_provenance_fails_closed(tmp_path, messages, match):
+    normalized = _module()
+    transcript = (
+        f"<!-- mempalace-exchange {json.dumps({'messages': messages})} -->\n"
+        "> user message with enough content\n"
+        "Assistant answer with enough content.\n"
+    )
+    transcript_path, _, _, _ = _write_pair(tmp_path, transcript=transcript)
+
+    with pytest.raises(normalized.NormalizedConversationError, match=match):
+        normalized.load_normalized_conversation(transcript_path, tmp_path, extract_mode="exchange")
+
+
+def test_oversized_exchange_provenance_fails_closed(tmp_path):
+    normalized = _module()
+    messages = [
+        {
+            "id": f"message-{i}-" + ("x" * 128),
+            "role": "user" if i == 0 else "assistant",
+            "timestamp": f"2026-07-29T23:55:{i:02d}Z",
+        }
+        for i in range(120)
+    ]
+    transcript = (
+        f"<!-- mempalace-exchange {json.dumps({'messages': messages})} -->\n"
+        "> user message with enough content\n"
+        "Assistant answer with enough content.\n"
+    )
+    transcript_path, _, _, _ = _write_pair(tmp_path, transcript=transcript)
+
+    with pytest.raises(normalized.NormalizedConversationError, match="envelope.*too large"):
+        normalized.load_normalized_conversation(transcript_path, tmp_path, extract_mode="exchange")
+
+
+def test_sidecar_only_change_changes_composite_source_version(tmp_path):
+    normalized = _module()
+    transcript_path, sidecar_path, _, sidecar = _write_pair(tmp_path)
+    first = normalized.load_normalized_conversation(
+        transcript_path, tmp_path, extract_mode="exchange"
+    )
+
+    sidecar["room"] = "presence"
+    sidecar_path.write_text(json.dumps(sidecar))
+    second = normalized.load_normalized_conversation(
+        transcript_path, tmp_path, extract_mode="exchange"
+    )
+
+    assert first.source_version != second.source_version
+
+
+def test_general_mode_refuses_normalized_hermes_contract(tmp_path):
+    normalized = _module()
+    transcript_path, _, _, _ = _write_pair(tmp_path)
+
+    with pytest.raises(
+        normalized.NormalizedConversationError,
+        match="extract_mode=general",
+    ):
+        normalized.load_normalized_conversation(transcript_path, tmp_path, extract_mode="general")
+
+
+def test_exchange_bounds_use_min_and_max_when_timestamps_move_backward(tmp_path):
+    normalized = _module()
+    messages = [
+        {"id": "1", "role": "user", "timestamp": "2026-07-29T23:56:00Z"},
+        {"id": "2", "role": "assistant", "timestamp": "2026-07-29T23:55:00Z"},
+    ]
+    transcript = (
+        f"<!-- mempalace-exchange {json.dumps({'messages': messages})} -->\n"
+        "> user message with enough content\n"
+        "Assistant answer with enough content.\n"
+    )
+    transcript_path, _, _, _ = _write_pair(tmp_path, transcript=transcript)
+
+    contract = normalized.load_normalized_conversation(
+        transcript_path, tmp_path, extract_mode="exchange"
+    )
+    chunks = normalized.chunk_normalized_conversation(contract, chunk_size=800)
+
+    assert chunks[0]["authored_from"] == "2026-07-29T23:55:00Z"
+    assert chunks[0]["authored_to"] == "2026-07-29T23:56:00Z"
+    assert chunks[0]["message_from"] == "1"
+    assert chunks[0]["message_to"] == "2"
+
+
+def test_message_ids_must_be_unique_across_the_transcript(tmp_path):
+    normalized = _module()
+    transcript = (
+        '<!-- mempalace-exchange {"messages":['
+        '{"id":"1","role":"user","timestamp":"2026-07-29T23:55:00Z"},'
+        '{"id":"2","role":"assistant","timestamp":"2026-07-29T23:56:00Z"}]} -->\n'
+        "> first user message\n"
+        "First answer.\n"
+        '<!-- mempalace-exchange {"messages":['
+        '{"id":"1","role":"user","timestamp":"2026-07-30T00:04:00Z"},'
+        '{"id":"3","role":"assistant","timestamp":"2026-07-30T00:05:00Z"}]} -->\n'
+        "> second user message\n"
+        "Second answer.\n"
+    )
+    transcript_path, _, _, _ = _write_pair(tmp_path, transcript=transcript)
+
+    with pytest.raises(normalized.NormalizedConversationError, match="across the transcript"):
+        normalized.load_normalized_conversation(
+            transcript_path,
+            tmp_path,
+            extract_mode="exchange",
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda sidecar: sidecar.update(schema="unknown/v9"), "schema"),
+        (lambda sidecar: sidecar.update(room="../communication"), "room"),
+        (lambda sidecar: sidecar.update(room="decisions"), "room"),
+        (lambda sidecar: sidecar.update(extra={"nested": True}), "field"),
+    ],
+)
+def test_invalid_sidecar_contract_fails_closed(tmp_path, mutate, match):
+    normalized = _module()
+    transcript_path, sidecar_path, _, sidecar = _write_pair(tmp_path)
+    mutate(sidecar)
+    sidecar_path.write_text(json.dumps(sidecar))
+
+    with pytest.raises(normalized.NormalizedConversationError, match=match):
+        normalized.load_normalized_conversation(transcript_path, tmp_path, extract_mode="exchange")
+
+
+def test_symlink_sidecar_fails_closed(tmp_path):
+    normalized = _module()
+    transcript_path, sidecar_path, _, sidecar = _write_pair(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text(json.dumps(sidecar))
+    sidecar_path.unlink()
+    sidecar_path.symlink_to(target)
+
+    with pytest.raises(normalized.NormalizedConversationError, match="symlink"):
+        normalized.load_normalized_conversation(transcript_path, tmp_path, extract_mode="exchange")
+
+
+def test_conversation_scan_does_not_treat_sidecar_as_a_source(tmp_path):
+    from mempalace.convo_miner import scan_convos
+
+    transcript_path, _, _, _ = _write_pair(tmp_path)
+
+    assert scan_convos(str(tmp_path)) == [transcript_path]
+
+
+def test_miner_stamps_normalized_room_chronology_and_source_version(tmp_path):
+    import chromadb
+
+    from mempalace.convo_miner import mine_convos
+
+    source = tmp_path / "source"
+    source.mkdir()
+    transcript_path, _, _, _ = _write_pair(source)
+    palace = tmp_path / "palace"
+
+    mine_convos(str(source), str(palace), wing="wing_amber")
+
+    collection = chromadb.PersistentClient(path=str(palace)).get_collection("mempalace_drawers")
+    rows = collection.get(
+        where={"source_file": str(transcript_path.resolve())},
+        include=["documents", "metadatas"],
+    )
+    assert len(rows["ids"]) == 1
+    assert "teh exact user text must stay teh same" in rows["documents"][0]
+    metadata = rows["metadatas"][0]
+    assert metadata["wing"] == "wing_amber"
+    assert metadata["room"] == "communication"
+    assert metadata["authored_from"] == "2026-07-29T23:55:00Z"
+    assert metadata["authored_to"] == "2026-07-29T23:56:00Z"
+    assert metadata["message_from"] == "41"
+    assert metadata["message_to"] == "42"
+    assert metadata["source_version"].startswith("sha256:")
+    assert metadata["source_chunk_count"] == 1
+
+
+def test_sidecar_only_change_rebuilds_stable_source_path(tmp_path, capsys):
+    import chromadb
+
+    from mempalace.convo_miner import mine_convos
+
+    source = tmp_path / "source"
+    source.mkdir()
+    transcript_path, sidecar_path, _, sidecar = _write_pair(source)
+    palace = tmp_path / "palace"
+    mine_convos(str(source), str(palace), wing="wing_amber")
+    capsys.readouterr()
+
+    collection = chromadb.PersistentClient(path=str(palace)).get_collection("mempalace_drawers")
+    first = collection.get(
+        where={"source_file": str(transcript_path.resolve())},
+        include=["metadatas"],
+    )
+    first_version = first["metadatas"][0]["source_version"]
+    del collection
+
+    sidecar["room"] = "presence"
+    sidecar_path.write_text(json.dumps(sidecar))
+    mine_convos(str(source), str(palace), wing="wing_amber")
+    output = capsys.readouterr().out
+
+    collection = chromadb.PersistentClient(path=str(palace)).get_collection("mempalace_drawers")
+    second = collection.get(
+        where={"source_file": str(transcript_path.resolve())},
+        include=["metadatas"],
+    )
+    assert "Files skipped (already filed): 0" in output
+    assert {meta["room"] for meta in second["metadatas"]} == {"presence"}
+    assert {meta["source_version"] for meta in second["metadatas"]} != {first_version}
+
+
+def test_complete_normalized_source_skips_unchanged_pair(tmp_path, capsys):
+    from mempalace.convo_miner import mine_convos
+
+    source = tmp_path / "source"
+    source.mkdir()
+    _write_pair(source)
+    palace = tmp_path / "palace"
+
+    mine_convos(str(source), str(palace), wing="wing_amber")
+    capsys.readouterr()
+    mine_convos(str(source), str(palace), wing="wing_amber")
+    output = capsys.readouterr().out
+
+    assert "Files skipped (already filed): 1" in output
+
+
+def test_unchanged_pair_skips_exchange_materialization(tmp_path, monkeypatch):
+    import mempalace.convo_miner as convo_miner
+
+    source = tmp_path / "source"
+    source.mkdir()
+    _write_pair(source)
+    palace = tmp_path / "palace"
+    convo_miner.mine_convos(str(source), str(palace), wing="wing_amber")
+
+    def unexpected_materialization(*_args, **_kwargs):
+        raise AssertionError("unchanged source should not parse exchanges")
+
+    monkeypatch.setattr(
+        convo_miner,
+        "load_normalized_conversation",
+        unexpected_materialization,
+    )
+
+    convo_miner.mine_convos(str(source), str(palace), wing="wing_amber")
+
+
+def test_generation_recipe_change_rebuilds_without_reusing_drawer_ids(tmp_path, monkeypatch):
+    import chromadb
+
+    import mempalace.convo_miner as convo_miner
+
+    source = tmp_path / "source"
+    source.mkdir()
+    transcript_path, _, _, _ = _write_pair(source)
+    palace = tmp_path / "palace"
+    convo_miner.mine_convos(str(source), str(palace), wing="wing_amber")
+
+    collection = chromadb.PersistentClient(path=str(palace)).get_collection("mempalace_drawers")
+    before = collection.get(
+        where={"source_file": str(transcript_path.resolve())},
+        include=["metadatas"],
+    )
+    old_ids = set(before["ids"])
+    monkeypatch.setattr(
+        convo_miner,
+        "NORMALIZE_VERSION",
+        convo_miner.NORMALIZE_VERSION + 1,
+    )
+
+    convo_miner.mine_convos(str(source), str(palace), wing="wing_amber")
+    after = collection.get(
+        where={"source_file": str(transcript_path.resolve())},
+        include=["metadatas"],
+    )
+
+    assert old_ids.isdisjoint(after["ids"])
+    assert {metadata["normalize_version"] for metadata in after["metadatas"]} == {
+        convo_miner.NORMALIZE_VERSION
+    }
+
+
+def test_same_source_reconciles_independently_in_two_wings(tmp_path, capsys):
+    import chromadb
+
+    from mempalace.convo_miner import mine_convos, normalized_conversation_delta
+
+    source = tmp_path / "source"
+    source.mkdir()
+    transcript_path, _, _, _ = _write_pair(source)
+    palace = tmp_path / "palace"
+
+    mine_convos(str(source), str(palace), wing="wing_amber")
+    capsys.readouterr()
+    mine_convos(str(source), str(palace), wing="wing_daphne")
+    capsys.readouterr()
+
+    collection = chromadb.PersistentClient(path=str(palace)).get_collection("mempalace_drawers")
+    rows = collection.get(
+        where={"source_file": str(transcript_path.resolve())},
+        include=["metadatas"],
+    )
+    assert {metadata["wing"] for metadata in rows["metadatas"]} == {
+        "wing_amber",
+        "wing_daphne",
+    }
+    for wing in ("wing_amber", "wing_daphne"):
+        report = normalized_conversation_delta(str(source), str(palace), wing=wing)
+        assert report["unchanged"] == [str(transcript_path.resolve())]
+        assert report["new"] == []
+        assert report["changed"] == []
+
+
+def test_miner_general_mode_refuses_normalized_pair(tmp_path):
+    from mempalace.convo_miner import mine_convos
+
+    source = tmp_path / "source"
+    source.mkdir()
+    _write_pair(source)
+
+    with pytest.raises(
+        _module().NormalizedConversationError,
+        match="extract_mode=general",
+    ):
+        mine_convos(
+            str(source),
+            str(tmp_path / "palace"),
+            wing="wing_amber",
+            extract_mode="general",
+        )
+
+
+def test_normalized_rebuild_treats_purge_failure_as_fatal(tmp_path, monkeypatch):
+    import mempalace.convo_miner as convo_miner
+
+    source = tmp_path / "source"
+    source.mkdir()
+    _, sidecar_path, _, sidecar = _write_pair(source)
+    palace = tmp_path / "palace"
+    convo_miner.mine_convos(str(source), str(palace), wing="wing_amber")
+    sidecar["room"] = "presence"
+    sidecar_path.write_text(json.dumps(sidecar))
+
+    def fail_purge(*_args, **_kwargs):
+        raise RuntimeError("purge unavailable")
+
+    monkeypatch.setattr("mempalace.backends.chroma.ChromaCollection.delete", fail_purge)
+    with pytest.raises(RuntimeError, match="purge unavailable"):
+        convo_miner.mine_convos(str(source), str(palace), wing="wing_amber")
+
+
+def test_failed_target_stage_preserves_complete_generation_and_repairs(tmp_path, monkeypatch):
+    import chromadb
+
+    import mempalace.convo_miner as convo_miner
+    from mempalace.backends.chroma import ChromaCollection
+
+    source = tmp_path / "source"
+    source.mkdir()
+    transcript = (
+        '<!-- mempalace-exchange {"messages":['
+        '{"id":"41","role":"user","timestamp":"2026-07-29T23:55:00Z"},'
+        '{"id":"42","role":"assistant","timestamp":"2026-07-29T23:56:00Z"}]} -->\n'
+        "> preserve the complete generation while staging\n"
+        + ("Assistant evidence remains exact. " * 160)
+        + "\n"
+    )
+    transcript_path, sidecar_path, _, sidecar = _write_pair(source, transcript=transcript)
+    palace = tmp_path / "palace"
+    convo_miner.mine_convos(str(source), str(palace), wing="wing_amber")
+
+    collection = chromadb.PersistentClient(path=str(palace)).get_collection("mempalace_drawers")
+    before = collection.get(
+        where={
+            "$and": [
+                {"source_file": str(transcript_path.resolve())},
+                {"wing": "wing_amber"},
+            ]
+        },
+        include=["metadatas"],
+    )
+    old_version = before["metadatas"][0]["source_version"]
+    old_count = len(before["ids"])
+
+    sidecar["room"] = "presence"
+    sidecar_path.write_text(json.dumps(sidecar))
+    original_upsert = ChromaCollection.upsert
+    calls = 0
+
+    def fail_second_batch(self, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("target stage interrupted")
+        return original_upsert(self, **kwargs)
+
+    monkeypatch.setattr(convo_miner, "DRAWER_UPSERT_BATCH_SIZE", 1)
+    monkeypatch.setattr(ChromaCollection, "upsert", fail_second_batch)
+    with pytest.raises(RuntimeError, match="target stage interrupted"):
+        convo_miner.mine_convos(str(source), str(palace), wing="wing_amber")
+
+    interrupted = collection.get(
+        where={
+            "$and": [
+                {"source_file": str(transcript_path.resolve())},
+                {"wing": "wing_amber"},
+            ]
+        },
+        include=["metadatas"],
+    )
+    old_rows = [
+        metadata
+        for metadata in interrupted["metadatas"]
+        if metadata["source_version"] == old_version
+    ]
+    assert len(old_rows) == old_count
+    assert {metadata["source_chunk_count"] for metadata in old_rows} == {old_count}
+
+    monkeypatch.setattr(ChromaCollection, "upsert", original_upsert)
+    convo_miner.mine_convos(str(source), str(palace), wing="wing_amber")
+    repaired = collection.get(
+        where={
+            "$and": [
+                {"source_file": str(transcript_path.resolve())},
+                {"wing": "wing_amber"},
+            ]
+        },
+        include=["metadatas"],
+    )
+    assert {metadata["room"] for metadata in repaired["metadatas"]} == {"presence"}
+    assert {metadata["source_version"] for metadata in repaired["metadatas"]} != {old_version}
+    assert {metadata["source_chunk_count"] for metadata in repaired["metadatas"]} == {
+        len(repaired["ids"])
+    }
+
+
+def test_mixed_or_partial_normalized_source_repairs_on_retry(tmp_path, capsys):
+    import chromadb
+
+    from mempalace.convo_miner import mine_convos
+
+    source = tmp_path / "source"
+    source.mkdir()
+    transcript = (
+        '<!-- mempalace-exchange {"messages":['
+        '{"id":"41","role":"user","timestamp":"2026-07-29T23:55:00Z"},'
+        '{"id":"42","role":"assistant","timestamp":"2026-07-29T23:56:00Z"}]} -->\n'
+        "> keep the whole normalized exchange exact\n"
+        + ("Assistant evidence remains exact. " * 80)
+        + "\n"
+    )
+    transcript_path, _, _, _ = _write_pair(source, transcript=transcript)
+    palace = tmp_path / "palace"
+    mine_convos(str(source), str(palace), wing="wing_amber")
+    capsys.readouterr()
+
+    client = chromadb.PersistentClient(path=str(palace))
+    collection = client.get_collection("mempalace_drawers")
+    rows = collection.get(
+        where={"source_file": str(transcript_path.resolve())},
+        include=["documents", "metadatas"],
+    )
+    assert len(rows["ids"]) > 1
+    corrupt_metadata = dict(rows["metadatas"][0])
+    corrupt_metadata["source_version"] = "sha256:" + ("0" * 64)
+    collection.update(ids=[rows["ids"][0]], metadatas=[corrupt_metadata])
+    del collection, client
+
+    mine_convos(str(source), str(palace), wing="wing_amber")
+    output = capsys.readouterr().out
+    collection = chromadb.PersistentClient(path=str(palace)).get_collection("mempalace_drawers")
+    repaired = collection.get(
+        where={"source_file": str(transcript_path.resolve())},
+        include=["metadatas"],
+    )
+    versions = {meta["source_version"] for meta in repaired["metadatas"]}
+    expected_counts = {meta["source_chunk_count"] for meta in repaired["metadatas"]}
+
+    assert "Files skipped (already filed): 0" in output
+    assert len(versions) == 1
+    assert expected_counts == {len(repaired["ids"])}
+
+
+def test_delta_report_is_read_only_and_classifies_source_changes(tmp_path):
+    from mempalace.convo_miner import mine_convos, normalized_conversation_delta
+
+    source = tmp_path / "source"
+    source.mkdir()
+    first_dir = source / "first"
+    first_dir.mkdir()
+    first_path, first_sidecar_path, _, first_sidecar = _write_pair(first_dir)
+    removed_dir = source / "removed"
+    removed_dir.mkdir()
+    removed_path, _, _, _ = _write_pair(removed_dir)
+    palace = tmp_path / "palace"
+    mine_convos(str(source), str(palace), wing="wing_amber")
+
+    before = (palace / "chroma.sqlite3").stat().st_mtime_ns
+    first_sidecar["room"] = "presence"
+    first_sidecar_path.write_text(json.dumps(first_sidecar))
+    removed_path.unlink()
+    removed_path.with_name(removed_path.name + ".meta.json").unlink()
+    new_dir = source / "new"
+    new_dir.mkdir()
+    new_path, _, _, _ = _write_pair(new_dir)
+
+    report = normalized_conversation_delta(
+        str(source),
+        str(palace),
+        wing="wing_amber",
+    )
+
+    assert report["new"] == [str(new_path.resolve())]
+    assert report["changed"] == [str(first_path.resolve())]
+    assert report["unchanged"] == []
+    assert report["removed"] == [str(removed_path.resolve())]
+    assert report["replacement_drawers"] >= 1
+    assert isinstance(report["net_drawers"], int)
+    assert (palace / "chroma.sqlite3").stat().st_mtime_ns == before
+
+
+def _coverage_receipt(**overrides):
+    receipt = {
+        "schema": "mempalace-applied-coverage/v1",
+        "wing": "wing_amber",
+        "applied_snapshot_at": "2026-07-30T01:00:00Z",
+        "covered_sources": "cli;openclaw;telegram;whatsapp",
+        "authored_from": "2025-01-01T00:00:00Z",
+        "authored_to": "2026-07-30T00:05:00Z",
+        "accepted_session_count": 240,
+        "quarantine_count": 3,
+        "verified_profile_receipt": "sha256:" + ("1" * 64),
+        "source_version": "exporter-1.0.0",
+    }
+    receipt.update(overrides)
+    return receipt
+
+
+def test_coverage_registry_advances_atomically_and_is_private(tmp_path):
+    normalized = _module()
+    palace = tmp_path / "palace"
+    palace.mkdir()
+
+    committed = normalized.commit_applied_coverage(
+        palace,
+        _coverage_receipt(),
+    )
+    registry_path = palace / "normalized-conversation-coverage.json"
+
+    assert committed["wing"] == "wing_amber"
+    assert normalized.read_applied_coverage(palace)["wing_amber"] == committed
+    assert registry_path.stat().st_mode & 0o777 == 0o600
+    assert "telegram" in registry_path.read_text()
+    before = registry_path.stat().st_mtime_ns
+    assert normalized.commit_applied_coverage(palace, _coverage_receipt()) == committed
+    assert registry_path.stat().st_mtime_ns == before
+
+
+def test_coverage_registry_rejects_stale_and_conflicting_receipts(tmp_path):
+    normalized = _module()
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    current = _coverage_receipt(
+        applied_snapshot_at="2026-07-30T03:00:00Z",
+        authored_to="2026-07-30T02:00:00Z",
+    )
+    normalized.commit_applied_coverage(palace, current)
+    registry_path = palace / "normalized-conversation-coverage.json"
+    before = registry_path.read_bytes()
+
+    with pytest.raises(normalized.NormalizedConversationError, match="move backward"):
+        normalized.commit_applied_coverage(
+            palace,
+            _coverage_receipt(applied_snapshot_at="2026-07-30T02:30:00Z"),
+        )
+    with pytest.raises(normalized.NormalizedConversationError, match="conflicts"):
+        normalized.commit_applied_coverage(
+            palace,
+            _coverage_receipt(
+                applied_snapshot_at="2026-07-30T03:00:00Z",
+                accepted_session_count=241,
+            ),
+        )
+    with pytest.raises(normalized.NormalizedConversationError, match="watermark"):
+        normalized.commit_applied_coverage(
+            palace,
+            _coverage_receipt(
+                applied_snapshot_at="2026-07-30T04:00:00Z",
+                authored_to="2026-07-30T01:00:00Z",
+            ),
+        )
+
+    assert registry_path.read_bytes() == before
+    assert normalized.read_applied_coverage(palace)["wing_amber"] == current
+
+
+@pytest.mark.parametrize("forbidden", ["content", "messages", "excerpt"])
+def test_coverage_registry_rejects_content_fields(tmp_path, forbidden):
+    normalized = _module()
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    receipt = _coverage_receipt()
+    receipt[forbidden] = "private transcript text"
+
+    with pytest.raises(normalized.NormalizedConversationError, match="field mismatch"):
+        normalized.commit_applied_coverage(palace, receipt)
+
+    assert normalized.read_applied_coverage(palace) == {}
+
+
+def test_failed_coverage_replace_preserves_prior_watermark(tmp_path, monkeypatch):
+    normalized = _module()
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    normalized.commit_applied_coverage(palace, _coverage_receipt())
+    prior = normalized.read_applied_coverage(palace)
+
+    def fail_replace(*_args, **_kwargs):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(normalized.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="replace failed"):
+        normalized.commit_applied_coverage(
+            palace,
+            _coverage_receipt(
+                applied_snapshot_at="2026-07-30T02:00:00Z",
+                accepted_session_count=241,
+            ),
+        )
+
+    assert normalized.read_applied_coverage(palace) == prior
+
+
+def test_status_reads_coverage_without_advancing_it(tmp_path, monkeypatch):
+    import mempalace.mcp_server as mcp_server
+
+    normalized = _module()
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    normalized.commit_applied_coverage(palace, _coverage_receipt())
+    monkeypatch.setattr(
+        mcp_server,
+        "_config",
+        mcp_server.MempalaceConfig(palace_path=str(palace)),
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "_sqlite_taxonomy",
+        lambda: (0, {}),
+    )
+    monkeypatch.setattr(mcp_server, "_backend_db_exists", lambda: False)
+    monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", lambda: None)
+    monkeypatch.setattr(mcp_server, "_vector_disabled", False)
+
+    before = (palace / "normalized-conversation-coverage.json").read_bytes()
+    status = mcp_server.tool_status()
+
+    assert status["applied_coverage"]["wing_amber"]["accepted_session_count"] == 240
+    assert (palace / "normalized-conversation-coverage.json").read_bytes() == before
+
+
+def test_raw_mcp_registers_delta_and_operator_coverage_tools():
+    from mempalace import mcp_server
+
+    delta = mcp_server.TOOLS["mempalace_normalized_conversation_delta"]
+    commit = mcp_server.TOOLS["mempalace_commit_applied_coverage"]
+
+    assert delta["handler"] is mcp_server.tool_normalized_conversation_delta
+    assert delta["input_schema"]["required"] == ["source", "wing"]
+    assert delta["input_schema"]["additionalProperties"] is False
+    assert commit["handler"] is mcp_server.tool_commit_applied_coverage
+    assert commit["input_schema"]["required"] == ["receipt"]
+    assert commit["input_schema"]["additionalProperties"] is False
+    receipt_schema = commit["input_schema"]["properties"]["receipt"]
+    assert receipt_schema["additionalProperties"] is False
+    assert receipt_schema["properties"]["schema"]["const"] == ("mempalace-applied-coverage/v1")
+    assert receipt_schema["properties"]["verified_profile_receipt"]["pattern"].startswith(
+        "^sha256:"
+    )
+    assert "mempalace_commit_applied_coverage" in mcp_server._MUTATING_TOOLS
+
+
+def test_operator_coverage_tool_commits_verified_receipt(tmp_path, monkeypatch):
+    from mempalace import mcp_server
+
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    monkeypatch.setattr(
+        mcp_server,
+        "_config",
+        mcp_server.MempalaceConfig(palace_path=str(palace)),
+    )
+
+    result = mcp_server.tool_commit_applied_coverage(_coverage_receipt())
+
+    assert result["success"] is True
+    assert result["coverage"]["wing"] == "wing_amber"
+    assert (
+        mcp_server.tool_status()["applied_coverage"]["wing_amber"]["accepted_session_count"] == 240
+    )
+
+
+def test_operator_tools_return_stable_no_palace_error(monkeypatch):
+    from types import SimpleNamespace
+
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(
+        mcp_server,
+        "_config",
+        SimpleNamespace(palace_path=""),
+    )
+
+    for result in (
+        mcp_server.tool_normalized_conversation_delta("/tmp/source", "wing_amber"),
+        mcp_server.tool_commit_applied_coverage(_coverage_receipt()),
+    ):
+        assert result == {
+            "success": False,
+            "error": "no palace configured",
+            "error_class": "PalaceNotConfigured",
+        }

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Detailed parameter schemas for all 36 MCP tools.
+Detailed parameter schemas for all 38 MCP tools.
 
 ## Palace — Read Tools
 
@@ -144,6 +144,42 @@ Mine a directory into the palace — the MCP equivalent of `mempalace mine`. Wra
 | `extract` | string | No | Convos extraction strategy: `exchange` (default) or `general`; ignored by other modes |
 
 **Returns:** `{ success, mode, dry_run, output }` on success (`output` is the miner's human-readable summary; `output_truncated: true` is added when a very large summary is tail-trimmed), or `{ success: false, error, error_class? }` on failure.
+
+---
+
+### `mempalace_normalized_conversation_delta`
+
+Operator inspection for a directory using the normalized-conversation
+sidecar contract. It compares composite source versions and reports new,
+changed, unchanged, and removed sources through SQLite read-only mode. It
+does not alter the source directory, palace drawers, or applied watermark.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `source` | string | **Yes** | Normalized transcript staging directory |
+| `wing` | string | **Yes** | Exact destination wing |
+| `extract` | string | No | Must be `exchange` when present |
+
+**Returns:** `{ success, dry_run: true, report: { new, changed, unchanged, removed, new_drawers, replacement_drawers, changed_drawers, removed_drawers, net_drawers } }`
+
+---
+
+### `mempalace_commit_applied_coverage`
+
+Operator-only commit of a content-free wing coverage receipt. Call this only
+after every source in one profile has an accepted receipt and mixed-version
+verification has passed. The registry update is serialized by the palace lock
+and atomically replaces a private `0600` file. `mempalace_status` reads this
+watermark but never advances it.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `receipt` | object | **Yes** | Closed `mempalace-applied-coverage/v1` receipt with wing, verified snapshot and authored bounds, covered source slugs, accepted/quarantine counts, profile receipt digest, and source version |
+
+**Returns:** `{ success, coverage }` or `{ success: false, error, error_class }`.
+
+Keep this raw tool behind operator authentication. Do not expose it through an
+agent-facing policy adapter.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Operator export pipelines can now give MemPalace a canonical conversation
without losing exact text, message provenance, or authored chronology to
generic format inference. The contract is opt-in through an adjacent, closed
metadata sidecar; every existing source without that sidecar keeps the current
conversation-import behavior.

The replacement path is also crash-safe for normalized sources. A new
generation is written under IDs that include its content identity and ingest
recipe, verified for completeness inside the destination wing, and only then
allowed to retire the prior complete generation. Interrupted retries remove
only the incomplete target generation, so the last complete copy stays
readable.

| Decision | Reason |
|---|---|
| Closed sidecar plus provenance envelopes | The producer can prove identity and chronology without MemPalace guessing from Markdown. |
| Wing-local completeness and deletion | The same retained source may be mined into more than one private wing without one import skipping or deleting the other. |
| Stage, verify, then retire | Delete-first rebuilds can erase the only complete copy after a crash. |
| Separate delta and coverage operations | An operator can inspect reconciliation without writing, and status advances only after an explicitly verified apply. |

The coverage registry contains counts, source categories, time bounds, and
fingerprints only. It rejects transcript content and stale or conflicting
watermarks.

Related: #2115

## How to test

- `uv run pytest tests/ -q --ignore=tests/benchmarks`
  - 3,442 passed, 31 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- Focused contract coverage proves:
  - LF and CRLF transcripts reconstruct exactly, including trailing newlines.
  - Assistant Markdown blockquotes remain verbatim.
  - Amber and Daphne can mine the same source into independent wings.
  - A second-batch failure leaves the prior complete generation intact and
    repairs deterministically on retry.
  - Chunk-size, normalization-version, and ID-recipe changes get distinct
    generation IDs.
  - Coverage receipts reject content fields, stale snapshots, and conflicting
    watermarks.

## Post-Deploy Monitoring & Validation

- Search server logs for `normalized target generation is incomplete`,
  `normalized source replacement left stale drawer`, and coverage validation
  errors.
- On the first canary, compare the delta report before and after apply. Healthy
  output moves the reviewed sources from `new` or `changed` to `unchanged`,
  with no unexpected `removed` sources.
- Confirm one `source_version`, `source_chunk_size`, `normalize_version`, and
  `id_recipe` per committed source and wing.
- Confirm `mempalace_status` advances the wing watermark only after the
  operator commits the verified receipt.
- Stop and retain the prior release if a canary loses its prior complete
  generation, crosses wings, produces mixed recipes after retry, or advances
  coverage after a failed apply.
- Validation window: the first normalized-import canary and its immediate
  unchanged retry. Owner: the operator running that canary.

## New concepts

### Verified generation replacement

A verified generation replacement treats a rebuild as two durable states
instead of a delete followed by best-effort writes:

```mermaid
flowchart TB
  Old[Prior complete generation] --> Stage[Stage target generation]
  Stage --> Verify{Target recipe and count complete?}
  Verify -->|No| Keep[Keep prior generation and retry target]
  Verify -->|Yes| Retire[Retire prior generation]
  Retire --> Current[Target is the only complete generation]
```

This fits normalized transcripts because their content and ingest recipe give
each generation a deterministic identity. It avoids the obvious delete-first
approach, which can lose the only complete copy between bounded write batches.
Do not use this pattern when the storage backend already provides a real
transaction that atomically replaces the whole source.

## Checklist

- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
