### PR TITLE
docs: clarify hook write routing release scope

### DIFF
--- a/docs/hook-write-routing.md
+++ b/docs/hook-write-routing.md
@@ -1,5 +1,11 @@
 # Hook write routing
 
+> [!IMPORTANT]
+> This page documents unreleased hook write-routing behavior on `develop`.
+> MemPalace v3.6.0 does not consume `write_routing.hooks`; see the
+> [v3.6.0 write-routing policy](https://github.com/MemPalace/mempalace/blob/v3.6.0/docs/write-routing-policy.md#backward-compatibility)
+> for behavior available in that release.
+
 Hook-triggered writes use the shared write-routing policy introduced for the
 Tier 3 rollout tracked in #1963.
 


### PR DESCRIPTION
## Summary

- mark the hook write-routing guide as unreleased `develop` behavior
- state that MemPalace v3.6.0 does not consume `write_routing.hooks`
- link released users to the immutable v3.6.0 routing guidance

## Root cause

`docs/hook-write-routing.md` was added after v3.6.0, but both the released package and `develop` still report version 3.6.0. Because the default-branch document had no release boundary, users could reasonably treat unreleased configuration as available in the installed package.

## User impact

Readers can now distinguish default-branch behavior from released behavior before copying a configuration that is inert on v3.6.0 and may become fail-closed after a later upgrade.

## Validation

- confirmed v3.6.0 is the latest published release
- confirmed the pinned v3.6.0 document and `#backward-compatibility` anchor exist
- confirmed the rendered GitHub link returns HTTP 200
- confirmed the existing hook-routing content is unchanged below the notice
- `git diff --check`
- GitNexus change detection: low risk, no affected execution flows

Fixes #2105