### PR TITLE
fix(convo_miner): stop sweeper drawers being purged (#2089)

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -514,12 +514,28 @@ def _file_chunks_locked(
         # (file_already_mined() returned False for pre-v2 drawers) and on a
         # changed/grown transcript (mtime differs) — clean them out so the
         # source doesn't end up with mixed old/new drawers.
+        #
+        # A failed purge must abort this file's mine attempt rather than
+        # fall through to upsert: proceeding on top of an unpurged (or
+        # partially purged) set produces duplicate/stale drawers under
+        # mixed schema versions, with no operator-visible signal beyond a
+        # debug log (#105 — convo_miner's own instance of the same swallow
+        # already fixed for miner.py at #23). Returning here leaves the old
+        # drawers' stored mtime untouched, so the next mine still sees a
+        # mismatch and retries.
         try:
             delete_ids = _source_file_delete_ids(collection, source_file, extract_mode)
             if delete_ids:
                 collection.delete(ids=delete_ids)
-        except Exception:
+        except Exception as exc:
+            print(
+                f"  ! [skip] stale-drawer purge failed for {source_file!r} "
+                f"({exc!r}); leaving existing drawers untouched, will retry "
+                f"on the next mine",
+                file=sys.stderr,
+            )
             logger.debug("Stale-drawer purge failed for %s", source_file, exc_info=True)
+            return 0, room_counts_delta, True
 
         # Batch chunks into bounded upserts so large transcripts keep most of
         # the embedding speedup without one huge Chroma/SQLite request. Keep

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -1214,10 +1214,26 @@ mine_global_lock = mine_palace_lock
 
 
 def _metadata_matches_extract_mode(meta: dict, extract_mode: Optional[str]) -> bool:
+    """Scope a drawer to a convo-miner extraction mode.
+
+    A missing ``extract_mode`` is treated as a legacy exchange-mode row
+    ONLY when the drawer is otherwise convo_miner's own (no ``ingest_mode``
+    at all -- pre-``ingest_mode``-schema convo drawers -- or the convo
+    miner's own ``"convos"`` tag). A drawer from a different producer that
+    never set ``extract_mode`` because it was never meant to carry one --
+    e.g. the sweeper's ``ingest_mode="sweep"`` rows -- must not match: the
+    legacy-compat rule otherwise scoops every sweeper drawer for a shared
+    transcript into convo_miner's default "exchange" purge/idempotency
+    scope and silently deletes them on the very next re-mine (#104).
+    """
     if extract_mode is None:
         return True
     stored_mode = meta.get("extract_mode")
-    return stored_mode == extract_mode or (extract_mode == "exchange" and stored_mode is None)
+    if stored_mode == extract_mode:
+        return True
+    if stored_mode is not None:
+        return False
+    return extract_mode == "exchange" and meta.get("ingest_mode") in (None, "convos")
 
 
 def file_already_mined(

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -10,6 +10,7 @@ from mempalace.convo_miner import (
     _emit_bounded,
     _extract_authored_at,
     _file_chunks_locked,
+    _source_file_delete_ids,
     chunk_exchanges,
     detect_convo_room,
     scan_convos,
@@ -582,6 +583,75 @@ class TestFileChunksLocked:
         assert "MemoryStack" in entities
         assert "rag/foo.py" in entities
         assert "do_thing_now" in entities
+
+    def test_aborts_when_stale_drawer_purge_fails(self, monkeypatch):
+        """#105: a failed purge must abort the mine attempt, not silently
+        proceed to upsert on top of it — the same swallow already fixed
+        for miner.py's process_file at #23, own instance here."""
+        import mempalace.convo_miner as convo_miner
+
+        class FailingPurgeCol:
+            def __init__(self):
+                self.upsert_called = False
+
+            def get(self, *args, **kwargs):
+                raise RuntimeError("simulated transient backend error")
+
+            def delete(self, *args, **kwargs):
+                pass
+
+            def upsert(self, documents, ids, metadatas):
+                self.upsert_called = True
+
+        chunks = [{"content": f"chunk {i} " * 20, "chunk_index": i} for i in range(3)]
+        col = FailingPurgeCol()
+        monkeypatch.setattr(
+            convo_miner, "file_already_mined", lambda collection, source_file, **kwargs: False
+        )
+        monkeypatch.setattr(convo_miner, "mine_lock", lambda source_file: contextlib.nullcontext())
+        monkeypatch.setattr(convo_miner, "_detect_hall_cached", lambda content: "conversations")
+
+        drawers, room_counts, skipped = _file_chunks_locked(
+            col, "chat.txt", chunks, "wing", "general", "agent", "exchange"
+        )
+
+        assert col.upsert_called is False, (
+            "_file_chunks_locked inserted new chunks even though the "
+            "stale-drawer purge raised — old and new rows can now coexist "
+            "as duplicates/orphans"
+        )
+        assert drawers == 0
+        assert skipped is True
+
+
+class TestSourceFileDeleteIds:
+    """#104: the sweeper writes drawers with no extract_mode at all
+    (ingest_mode="sweep"). convo_miner's default exchange-mode purge
+    must not scoop those up — they were never meant to carry
+    extract_mode, unlike a genuine legacy pre-schema convo_miner row."""
+
+    def test_excludes_sweeper_rows_from_exchange_mode_purge(self):
+        class FakeCol:
+            def get(self, where=None, limit=None, offset=0, include=None):
+                if offset > 0:
+                    return {"ids": [], "metadatas": []}
+                return {
+                    "ids": ["sweep_1", "exchange_1", "legacy_1"],
+                    "metadatas": [
+                        {"ingest_mode": "sweep", "session_id": "s1", "role": "user"},
+                        {"ingest_mode": "convos", "extract_mode": "exchange"},
+                        {"source_file": "chat.txt"},  # pre-ingest_mode legacy row
+                    ],
+                }
+
+        delete_ids = _source_file_delete_ids(FakeCol(), "chat.txt", "exchange")
+
+        assert "sweep_1" not in delete_ids, (
+            "sweeper's drawer was scooped into convo_miner's default "
+            "exchange-mode purge and would be deleted on the next re-mine"
+        )
+        assert "exchange_1" in delete_ids
+        assert "legacy_1" in delete_ids
 
 
 class TestExtractAuthoredAt:

--- a/tests/test_palace.py
+++ b/tests/test_palace.py
@@ -5,7 +5,7 @@ import chromadb
 from _chroma_palace_helper import make_minimal_chroma_sqlite
 
 from mempalace.backends import CollectionNotInitializedError, PalaceNotFoundError
-from mempalace.palace import _open_collection_or_explain, get_collection
+from mempalace.palace import _metadata_matches_extract_mode, _open_collection_or_explain, get_collection
 
 
 def _capture():
@@ -26,6 +26,45 @@ def test_open_collection_or_explain_state_a_missing_dir(tmp_path):
     assert any("mempalace init" in line for line in lines)
     # Helper must not create the directory.
     assert not missing.exists()
+
+
+class TestMetadataMatchesExtractMode:
+    """#104: a missing extract_mode must only be treated as a legacy
+    exchange-mode row when the drawer is otherwise convo_miner's own —
+    never for a drawer positively identified as another producer's
+    (e.g. the sweeper's ingest_mode="sweep"), which never set
+    extract_mode because it was never meant to carry one."""
+
+    def test_no_extract_mode_requested_matches_everything(self):
+        assert _metadata_matches_extract_mode({"ingest_mode": "sweep"}, None) is True
+
+    def test_exact_match(self):
+        assert _metadata_matches_extract_mode({"extract_mode": "general"}, "general") is True
+
+    def test_mismatched_explicit_extract_mode_never_matches(self):
+        assert _metadata_matches_extract_mode({"extract_mode": "general"}, "exchange") is False
+
+    def test_legacy_convo_row_with_no_ingest_mode_matches_exchange(self):
+        """Pre-ingest_mode-schema convo_miner drawers: no extract_mode,
+        no ingest_mode at all — the original legacy-compat case."""
+        assert _metadata_matches_extract_mode({"source_file": "chat.txt"}, "exchange") is True
+
+    def test_convo_miners_own_ingest_mode_matches_exchange(self):
+        assert _metadata_matches_extract_mode({"ingest_mode": "convos"}, "exchange") is True
+
+    def test_sweeper_row_never_matches_exchange(self):
+        """The actual #104 bug: a sweeper drawer has no extract_mode but
+        DOES carry ingest_mode="sweep" — it must not be swept into
+        convo_miner's default "exchange" purge/idempotency scope."""
+        sweeper_meta = {
+            "ingest_mode": "sweep",
+            "session_id": "s1",
+            "role": "assistant",
+        }
+        assert _metadata_matches_extract_mode(sweeper_meta, "exchange") is False
+
+    def test_sweeper_row_never_matches_general(self):
+        assert _metadata_matches_extract_mode({"ingest_mode": "sweep"}, "general") is False
 
 
 def test_open_collection_or_explain_state_b_no_db(tmp_path):

--- a/tests/test_palace.py
+++ b/tests/test_palace.py
@@ -5,7 +5,11 @@ import chromadb
 from _chroma_palace_helper import make_minimal_chroma_sqlite
 
 from mempalace.backends import CollectionNotInitializedError, PalaceNotFoundError
-from mempalace.palace import _metadata_matches_extract_mode, _open_collection_or_explain, get_collection
+from mempalace.palace import (
+    _metadata_matches_extract_mode,
+    _open_collection_or_explain,
+    get_collection,
+)
 
 
 def _capture():


### PR DESCRIPTION
## Summary

Conflict-resolved merge of #2089 onto current `develop`.

- Prevents sweeper drawers from matching convo_miner extract_mode purge/idempotency scope
- Aborts when purge fails instead of continuing into a half-state
- Resolves `tests/test_palace.py` import conflict with single-writer tests from #2079 (keeps both test suites)

Closes #2089.

## Test plan

- [x] `uv run pytest tests/test_palace.py tests/test_convo_miner_unit.py`