### PR TITLE
fix(sweep): collapse repeated message UUIDs before upsert

### DIFF
--- a/mempalace/sweeper.py
+++ b/mempalace/sweeper.py
@@ -230,28 +230,48 @@ def sweep(jsonl_path: str, palace_path: str, source_label: Optional[str] = None)
         nonlocal drawers_added, drawers_already_present
         if not batch_ids:
             return
-        # Pre-flight: which IDs in this batch are already present?
-        # Upsert is idempotent on data but counts as "added" would lie;
-        # this pre-query makes the metric honest (Copilot PR 998 review).
+        # Collapse repeated deterministic IDs before backend calls.
+        # Rewritten transcripts can contain the same message UUID more than
+        # once, and Chroma rejects duplicate IDs in one get or upsert request.
+        # Reassigning a dict key preserves its first position but replaces its
+        # value, so the final occurrence supplies the document and metadata.
+        deduped: dict[str, tuple[str, dict]] = {}
+        for drawer_id, document, metadata in zip(
+            batch_ids,
+            batch_docs,
+            batch_metas,
+        ):
+            deduped[drawer_id] = (document, metadata)
+
+        unique_ids = list(deduped)
+        unique_docs = [deduped[drawer_id][0] for drawer_id in unique_ids]
+        unique_metas = [deduped[drawer_id][1] for drawer_id in unique_ids]
+
+        # Pre-flight: which unique IDs are already present?
         try:
-            existing = collection.get(ids=list(batch_ids), include=[])
-            # Chroma returns a dict; typed backends return GetResult — the
-            # compat shim makes ``.get("ids")`` work on both.
+            existing = collection.get(
+                ids=unique_ids,
+                include=[],
+            )
+            # Chroma returns a dict; typed backends return GetResult - the
+            # compatibility shim makes .get("ids") work on both.
             present = set(existing.get("ids") or [])
         except Exception as exc:
             logger.warning(
                 "sweeper: existence pre-check failed (%s); "
-                "counting all batch rows as new (metric may over-count on reruns).",
+                "counting all unique batch rows as new "
+                "(metric may over-count on reruns).",
                 exc,
             )
             present = set()
-        new_count = sum(1 for rid in batch_ids if rid not in present)
-        already_count = len(batch_ids) - new_count
+
+        new_count = sum(1 for drawer_id in unique_ids if drawer_id not in present)
+        already_count = len(unique_ids) - new_count
 
         collection.upsert(
-            ids=batch_ids,
-            documents=batch_docs,
-            metadatas=batch_metas,
+            ids=unique_ids,
+            documents=unique_docs,
+            metadatas=unique_metas,
         )
         drawers_added += new_count
         drawers_already_present += already_count

--- a/tests/test_sweeper.py
+++ b/tests/test_sweeper.py
@@ -316,3 +316,104 @@ class TestSweeperDrawerMetadata:
                 "user",
                 "assistant",
             ), f"Drawer missing or wrong role metadata: {m}"
+
+
+class TestSweeperDuplicateMessageIds:
+    def test_sweep_collapses_repeated_uuid_last_record_wins(
+        self,
+        tmp_path,
+    ):
+        from mempalace.palace import get_collection
+        from mempalace.sweeper import _drawer_id_for_message, sweep
+
+        session_id = "00000000-0000-0000-0000-00000000aaaa"
+        repeated_uuid = "11111111-1111-1111-1111-111111111111"
+        assistant_uuid = "22222222-2222-2222-2222-222222222222"
+
+        records = [
+            {
+                "type": "user",
+                "uuid": repeated_uuid,
+                "sessionId": session_id,
+                "timestamp": "2020-01-01T00:00:01.000Z",
+                "message": {
+                    "role": "user",
+                    "content": "first copy",
+                },
+            },
+            {
+                "type": "user",
+                "uuid": repeated_uuid,
+                "sessionId": session_id,
+                "timestamp": "2020-01-01T00:00:02.000Z",
+                "message": {
+                    "role": "user",
+                    "content": "second copy, same uuid",
+                },
+            },
+            {
+                "type": "assistant",
+                "uuid": assistant_uuid,
+                "sessionId": session_id,
+                "timestamp": "2020-01-01T00:00:03.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": "ok",
+                },
+            },
+        ]
+
+        jsonl_path = tmp_path / "session.jsonl"
+        jsonl_path.write_text(
+            "".join(json.dumps(record) + "\n" for record in records),
+            encoding="utf-8",
+        )
+        palace_path = str(tmp_path / "palace")
+
+        result = sweep(
+            str(jsonl_path),
+            palace_path,
+        )
+
+        assert result["drawers_added"] == 2
+        assert result["drawers_already_present"] == 0
+        assert result["drawers_upserted"] == 2
+        assert result["drawers_skipped"] == 0
+
+        collection = get_collection(
+            palace_path,
+            create=False,
+        )
+        repeated_id = _drawer_id_for_message(
+            session_id,
+            repeated_uuid,
+        )
+        assistant_id = _drawer_id_for_message(
+            session_id,
+            assistant_uuid,
+        )
+
+        rows = collection.get(
+            ids=[repeated_id, assistant_id],
+            include=["documents", "metadatas"],
+        )
+
+        by_id = {
+            drawer_id: (document, metadata)
+            for drawer_id, document, metadata in zip(
+                rows["ids"],
+                rows["documents"],
+                rows["metadatas"],
+            )
+        }
+
+        assert set(by_id) == {
+            repeated_id,
+            assistant_id,
+        }
+
+        repeated_document, repeated_metadata = by_id[repeated_id]
+
+        assert repeated_document == "USER: second copy, same uuid"
+        assert repeated_metadata["timestamp"] == "2020-01-01T00:00:02.000Z"
+        assert by_id[assistant_id][0] == "ASSISTANT: ok"


### PR DESCRIPTION
## What does this PR do?

- collapse repeated deterministic drawer IDs before the sweeper's backend calls
- send only unique IDs to both the existence check and upsert
- use explicit last-record-wins behavior for repeated message UUIDs
- calculate added, already-present, and upserted counters from the unique rows actually processed
- preserve unrelated messages from the same transcript batch

## Root cause

`sweep()` stages one row for every transcript message, while drawer IDs are deterministic from `session_id + message_uuid`.

When a transcript contains the same UUID more than once, the batch contains duplicate IDs.

ChromaDB rejects duplicate IDs in both:

- `collection.get(ids=...)`
- `collection.upsert(ids=...)`

The existence-check failure was caught and converted into an inaccurate metric, but the later upsert failure aborted the complete file. As a result, unrelated valid messages in the same batch were also lost.

## Implementation

`_flush()` now collapses the staged rows into a dictionary keyed by deterministic drawer ID before either backend call.

For repeated IDs:

- the key retains its original insertion position
- the final occurrence supplies the document and metadata
- only one row for that ID is sent to the backend

This provides last-record-wins behavior consistent with the existing deterministic-ID and upsert semantics.

The returned counters are calculated from the unique rows actually sent to the backend.

## Tests

Adds the reported three-record reproduction:

- two user records share one UUID
- the second user record contains updated content and timestamp
- one assistant record has a distinct UUID

The regression verifies that:

- the sweep completes successfully
- two unique drawers are written
- the repeated UUID stores the final record
- the final record's timestamp is preserved
- the unrelated assistant message is preserved
- returned counters describe the two unique writes

Closes #2112

## How to test

- `python3 -m pytest tests/test_sweeper.py -k "collapses_repeated_uuid_last_record_wins" -q`
- `python3 -m pytest tests/test_sweeper.py -q`
- `python3 -m pytest tests/test_sweeper.py tests/test_cli.py -q`
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python -m pytest tests/ -v`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
