### PR TITLE
fix(hooks): ingest only the active transcript

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1832,7 +1832,9 @@ def main():
 
     # mine
     p_mine = sub.add_parser("mine", help="Mine files into the palace")
-    p_mine.add_argument("dir", help="Directory to mine")
+    p_mine.add_argument(
+        "dir", help="Directory to mine, or one conversation file with --mode convos"
+    )
     p_mine.add_argument(
         "--backend",
         default=None,

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -418,9 +418,16 @@ def scan_convos(convo_dir: str) -> list:
     ``sys.stderr`` with a ``  SKIP: <relative-path> (symlink)`` line so the
     caller can tell why an apparent conversation directory yielded no files.
     """
-    convo_path = Path(convo_dir).expanduser().resolve()
+    # A direct conversation file is a valid source. For a file, feed only
+    # its basename through the existing directory validation loop.
+    requested_path = Path(convo_dir).expanduser()
+    single_file = requested_path.is_file()
+    convo_path = (requested_path.parent if single_file else requested_path).resolve()
+    scan_entries = (
+        [(str(convo_path), [], [requested_path.name])] if single_file else os.walk(convo_path)
+    )
     files = []
-    for root, dirs, filenames in os.walk(convo_path):
+    for root, dirs, filenames in scan_entries:
         dirs[:] = [d for d in dirs if d not in CONVO_SKIP_DIRS]
         for filename in filenames:
             if filename.endswith(".meta.json"):

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -1090,12 +1090,12 @@ def _ingest_transcript(transcript_path: str):
                 _submit_daemon_job(
                     "mine",
                     {
-                        "source": str(path.parent),
+                        "source": str(path),
                         "mode": "convos",
                         "wing": "sessions",
                         "agent": "mempalace",
                     },
-                    dedupe_key=_daemon_mine_dedupe_key(str(path.parent), "convos"),
+                    dedupe_key=_daemon_mine_dedupe_key(str(path), "convos"),
                     wait=False,
                 )
                 _log(f"Transcript ingest submitted to daemon: {path.name}")
@@ -1113,7 +1113,7 @@ def _ingest_transcript(transcript_path: str):
                 "-m",
                 "mempalace",
                 "mine",
-                str(path.parent),
+                str(path),
                 "--mode",
                 "convos",
                 "--wing",

--- a/tests/test_convo_miner.py
+++ b/tests/test_convo_miner.py
@@ -834,3 +834,41 @@ def test_register_file_sentinel_includes_source_mtime():
         assert abs(mined[str(tiny_file)] - os.path.getmtime(tiny_file)) < 0.001
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_mine_convos_dry_run_single_file_does_not_scan_siblings(
+    tmp_path,
+    capsys,
+):
+    selected = tmp_path / "selected.txt"
+    sibling = tmp_path / "sibling.txt"
+
+    selected.write_text(
+        "> Which transcript should be mined?\n"
+        "SELECTED_ONLY_MARKER belongs to the active transcript.\n\n"
+        "> Should sibling files be included?\n"
+        "No. Only the selected transcript should be scanned.\n",
+        encoding="utf-8",
+    )
+    sibling.write_text(
+        "> Should this sibling be mined?\n"
+        "SIBLING_SHOULD_NOT_BE_MINED by the single-file invocation.\n\n"
+        "> Is that important?\n"
+        "Yes. It keeps hook-triggered mining narrowly scoped.\n",
+        encoding="utf-8",
+    )
+
+    palace_path = tmp_path / "palace"
+
+    mine_convos(
+        str(selected),
+        str(palace_path),
+        wing="sessions",
+        dry_run=True,
+    )
+    output = capsys.readouterr().out
+
+    assert "Files:   1" in output
+    assert "[DRY RUN] selected.txt" in output
+    assert "sibling.txt" not in output
+    assert not palace_path.exists()

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -713,3 +713,21 @@ class TestExtractAuthoredAt:
         f = tmp_path / "session.jsonl"
         f.write_text('{"timestamp": 1}\n{"timestamp": false}\n')
         assert _extract_authored_at(f) is None
+
+
+def test_scan_convos_accepts_one_file_without_scanning_siblings(
+    tmp_path,
+):
+    selected = tmp_path / "selected.jsonl"
+    sibling = tmp_path / "sibling.jsonl"
+
+    selected.write_text(
+        '{"type": "user"}\n',
+        encoding="utf-8",
+    )
+    sibling.write_text(
+        '{"type": "user"}\n',
+        encoding="utf-8",
+    )
+
+    assert scan_convos(str(selected)) == [selected.resolve()]

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -1378,7 +1378,7 @@ def test_ingest_transcript_daemon_opt_in_submits_job(tmp_path):
     mock_popen.assert_not_called()
     mock_submit.assert_called_once()
     payload = mock_submit.call_args.args[1]
-    assert payload["source"] == str(tmp_path)
+    assert payload["source"] == str(transcript.resolve())
     assert payload["mode"] == "convos"
     assert payload["wing"] == "sessions"
 
@@ -1398,7 +1398,7 @@ def test_ingest_transcript_skips_when_target_running(tmp_path):
                     "-m",
                     "mempalace",
                     "mine",
-                    str(transcript.parent),
+                    str(transcript.resolve()),
                     "--mode",
                     "convos",
                     "--wing",
@@ -1763,7 +1763,7 @@ def test_precompact_with_timeout(tmp_path):
     assert result == {}
 
 
-def test_precompact_mines_transcript_dir(tmp_path, monkeypatch):
+def test_precompact_mines_only_active_transcript(tmp_path, monkeypatch):
     """Precompact ingests the active transcript via _ingest_transcript.
 
     With no MEMPAL_DIR, _mine_sync is a no-op; the transcript ingest is
@@ -1787,8 +1787,8 @@ def test_precompact_mines_transcript_dir(tmp_path, monkeypatch):
     mock_run.assert_not_called()
     mock_popen.assert_called_once()
     cmd = mock_popen.call_args[0][0]
-    # Mines the transcript's parent dir as convos, into wing "sessions".
-    assert str(tmp_path) in cmd
+    # Mines only the active transcript as convos, into wing "sessions".
+    assert str(transcript.resolve()) in cmd
     assert cmd[cmd.index("--mode") + 1] == "convos"
     assert cmd[cmd.index("--wing") + 1] == "sessions"
 


### PR DESCRIPTION
## What does this PR do?

- allow `mine --mode convos` to accept one supported conversation file
- feed a direct file through the existing extension, symlink, size, and regular-file validation
- change direct hook transcript ingest from the parent directory to the active transcript
- change daemon transcript ingest and its dedupe key to the active transcript
- scope the direct-spawn PID guard per transcript instead of per transcript directory
- preserve existing recursive directory behavior for manual mines and backfills
- document the single-file form in CLI help

## Root cause

`_ingest_transcript()` receives the exact transcript that triggered the Stop or PreCompact hook, but both hook write routes discarded that precision by passing:

```python
str(path.parent)
```

The daemon source, daemon dedupe key, and direct mine command therefore targeted every transcript in the same directory.

`scan_convos()` also only called `os.walk()` on its input. Passing the transcript itself was not a workaround because a file path produced zero discovered files.

Together, those behaviors meant every hook-triggered ingest scanned the complete sibling transcript set to update one active transcript.

## Implementation

`scan_convos()` now distinguishes between:

- a directory source, which continues through the existing recursive `os.walk()` behavior;
- a single-file source, which feeds only that basename through the same existing validation loop.

The single-file path therefore retains the existing protections for:

- supported conversation extensions;
- `.meta.json` exclusion;
- symlink exclusion;
- maximum file size;
- regular-file verification.

No separate or weaker file-validation path is introduced.

`_ingest_transcript()` now passes `str(path)` to:

- the daemon job payload;
- the daemon mine dedupe key;
- the direct `_spawn_mine()` command.

The destination wing remains `sessions`; this PR changes source scope only.

## Compatibility

Directory-based conversation mining remains unchanged:

```text
mempalace mine <directory> --mode convos
```

The following single-file form now works as well:

```text
mempalace mine <transcript.jsonl> --mode convos
```

This also gives users a direct CLI workaround independent of hooks.

PR #2070 changes transcript wing selection and may touch nearby lines in `_ingest_transcript()`, but it does not currently narrow the source from `path.parent` to `path`.

The two changes are logically independent, although a small rebase may be required depending on merge order.

## Tests

Regression coverage verifies that:

- `scan_convos()` given one transcript returns only that file even when a sibling transcript exists;
- a single-file `mine_convos(..., dry_run=True)` invocation reports exactly one file;
- the sibling transcript is absent from the dry-run output;
- the daemon job source is the resolved transcript path;
- the direct-spawn PID target is based on the resolved transcript path;
- PreCompact starts a conversation mine for the active transcript rather than its parent directory;
- existing directory-based scanning remains covered by the current scanner tests.

Closes #2102

## How to test

- `python3 -m pytest tests/test_convo_miner_unit.py -k "scan_convos_accepts_one_file_without_scanning_siblings" -q`
- `python3 -m pytest tests/test_convo_miner.py -k "dry_run_single_file_does_not_scan_siblings" -q`
- `python3 -m pytest tests/test_hooks_cli.py -k "ingest_transcript_daemon_opt_in_submits_job or ingest_transcript_skips_when_target_running or precompact_mines_only_active_transcript" -q`
- `python3 -m pytest tests/test_cli.py tests/test_hooks_cli.py tests/test_convo_miner.py tests/test_convo_miner_unit.py -q`
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python -m pytest tests/ -v`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
