### PR TITLE
fix(search): return distinct passages after closet enrichment

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -1198,6 +1198,238 @@ def _candidate_pool_size(n_results: int, date_window_active: bool) -> int:
     return max(min(n_results * 15, 500), n_results)
 
 
+_CLOSET_RESULT_POOL_MULTIPLIER = 4
+_MAX_HYDRATION_CHARS = 10000
+
+
+def _candidate_pool_limits(
+    candidate_strategy: str,
+    n_results: int,
+    date_window_active: bool = False,
+) -> tuple[int, int]:
+    """Return vector-query and pre-enrichment candidate limits.
+
+    Date-window searches retain the wider current-develop pool because the
+    timestamp constraint is applied after retrieval. The normal vector path
+    also remains at least four times wide through closet enrichment. Union
+    mode keeps only the requested top vector candidates before lexical merge.
+    """
+    base_query_limit = _candidate_pool_size(
+        n_results,
+        date_window_active,
+    )
+
+    if candidate_strategy == "union":
+        return base_query_limit, n_results
+
+    widened = max(
+        base_query_limit,
+        n_results * _CLOSET_RESULT_POOL_MULTIPLIER,
+    )
+    return widened, widened
+
+
+def _enrich_closet_hits(
+    hits: list,
+    drawers_col,
+    query: str,
+    stop_words: frozenset = frozenset(),
+) -> list:
+    """Hydrate closet-boosted hits and memoise each source/group fetch."""
+    query_terms = set(
+        _tokenize(
+            query,
+            stop_words,
+        )
+    )
+    source_cache: dict = {}
+
+    for hit in hits:
+        if hit.get("matched_via") == "drawer":
+            continue
+
+        full_source = hit.get("_source_file_full") or ""
+
+        if not full_source:
+            continue
+
+        parent_drawer_id = hit.get("_parent_drawer_id") or None
+        cache_key = (
+            full_source,
+            parent_drawer_id,
+        )
+
+        if cache_key not in source_cache:
+            try:
+                source_drawers = drawers_col.get(
+                    where=(
+                        _scoped_source_filter(
+                            full_source,
+                            parent_drawer_id,
+                        )
+                    ),
+                    include=[
+                        "documents",
+                        "metadatas",
+                    ],
+                )
+            except Exception:
+                logger.debug(
+                    "Neighbor fetch failed for %s",
+                    full_source,
+                    exc_info=True,
+                )
+                source_cache[cache_key] = None
+            else:
+                source_cache[cache_key] = (
+                    list(
+                        getattr(
+                            source_drawers,
+                            "documents",
+                            None,
+                        )
+                        or []
+                    ),
+                    list(
+                        getattr(
+                            source_drawers,
+                            "metadatas",
+                            None,
+                        )
+                        or []
+                    ),
+                )
+
+        cached = source_cache[cache_key]
+
+        if cached is None:
+            continue
+
+        docs, metadatas = cached
+
+        if len(docs) <= 1:
+            continue
+
+        indexed = []
+
+        for index, (
+            document,
+            metadata,
+        ) in enumerate(
+            zip(
+                docs,
+                metadatas,
+            )
+        ):
+            chunk_index = (
+                metadata.get(
+                    "chunk_index",
+                    index,
+                )
+                if isinstance(
+                    metadata,
+                    dict,
+                )
+                else index
+            )
+
+            if not isinstance(
+                chunk_index,
+                int,
+            ):
+                chunk_index = index
+
+            indexed.append(
+                (
+                    chunk_index,
+                    document or "",
+                )
+            )
+
+        indexed.sort(key=lambda pair: pair[0])
+        ordered_docs = [document for _, document in indexed]
+
+        best_index = 0
+        best_score = -1
+
+        for index, document in enumerate(ordered_docs):
+            lowered = document.lower()
+            score = sum(1 for term in query_terms if term in lowered)
+
+            if score > best_score:
+                best_score = score
+                best_index = index
+
+        start = max(
+            0,
+            best_index - 1,
+        )
+        end = min(
+            len(ordered_docs),
+            best_index + 2,
+        )
+        expanded = "\n\n".join(ordered_docs[start:end])
+
+        if len(expanded) > _MAX_HYDRATION_CHARS:
+            expanded = expanded[:_MAX_HYDRATION_CHARS] + (
+                f"\n\n[...truncated. "
+                f"{len(ordered_docs)} total drawers. "
+                "Use mempalace_get_drawer "
+                "for full content.]"
+            )
+
+        hit["text"] = expanded
+        hit["drawer_index"] = best_index
+        hit["total_drawers"] = len(ordered_docs)
+
+    return hits
+
+
+def _dedupe_rendered_hits(
+    hits: list,
+) -> list:
+    """Drop repeated closet-rendered passages while preserving rank order.
+
+    Plain drawer hits retain their historical behavior, including legitimate
+    exact repeats at different source positions. A duplicate is removed only
+    when either occurrence came through closet enrichment.
+    """
+    unique = []
+    first_by_key: dict = {}
+
+    for hit in hits:
+        source = hit.get("_source_file_full") or hit.get("source_path") or hit.get("source_file")
+        text = hit.get("text")
+
+        if not source or not isinstance(
+            text,
+            str,
+        ):
+            unique.append(hit)
+            continue
+
+        key = (
+            source,
+            text,
+        )
+        previous = first_by_key.get(key)
+
+        if previous is None:
+            first_by_key[key] = hit
+            unique.append(hit)
+            continue
+
+        previous_is_closet = previous.get("matched_via") == "drawer+closet"
+        current_is_closet = hit.get("matched_via") == "drawer+closet"
+
+        if previous_is_closet or current_is_closet:
+            continue
+
+        unique.append(hit)
+
+    return unique
+
+
 # Strategy dispatch — keeps search_memories' branch count under the
 # project's complexity ceiling (C901 max-complexity=25). New strategies
 # register here.
@@ -1292,14 +1524,20 @@ def _finalize_candidate_hits(
             ),
         )
 
-    hits = _hybrid_rank(
-        hits, query, metric=_metric_for_collection(drawers_col), stop_words=stop_words
-    )[:n_results]
-    for h in hits:
-        h.pop("_sort_key", None)
-        h.pop("_source_file_full", None)
-        h.pop("_chunk_index", None)
-        h.pop("_parent_drawer_id", None)
+    ranked = _hybrid_rank(
+        hits,
+        query,
+        metric=_metric_for_collection(drawers_col),
+        stop_words=stop_words,
+    )
+    hits = _dedupe_rendered_hits(ranked)[:n_results]
+
+    for hit in hits:
+        hit.pop("_sort_key", None)
+        hit.pop("_source_file_full", None)
+        hit.pop("_chunk_index", None)
+        hit.pop("_parent_drawer_id", None)
+
     return hits, None
 
 
@@ -1646,7 +1884,7 @@ def search_memories(
         candidate_strategy: How candidates for the hybrid re-rank are gathered.
 
             * ``"vector"`` (default) — preserves historical behavior: top
-              ``n_results * 3`` rows from the vector index are the rerank pool.
+              ``n_results * 4`` rows from the vector index are the rerank pool.
               Cheap; works well when query and target docs agree in the
               embedding space.
             * ``"union"`` — also pull top ``n_results * 3`` lexical candidates
@@ -1706,7 +1944,11 @@ def search_memories(
     # This avoids the "weak-closets regression" where narrative content
     # produces low-signal closets (regex extraction matches few topics)
     # and closet-first routing hides drawers that direct search would find.
-    pool_size = _candidate_pool_size(n_results, date_window_active)
+    pool_size, pre_enrichment_limit = _candidate_pool_limits(
+        candidate_strategy,
+        n_results,
+        date_window_active,
+    )
     try:
         dkwargs = {
             "query_texts": [query],
@@ -1816,65 +2058,16 @@ def search_memories(
         scored.append(entry)
 
     scored.sort(key=lambda h: h["_sort_key"])
-    hits = scored[:n_results]
+    hits = scored[:pre_enrichment_limit]
 
-    # Drawer-grep enrichment: for closet-boosted hits whose source has
-    # multiple drawers, return the keyword-best chunk + its immediate
-    # neighbors instead of just the drawer vector search landed on. The
-    # closet said "this source is relevant"; vector may have picked the
-    # wrong chunk within it; grep picks the right one.
-    MAX_HYDRATION_CHARS = 10000
-    for h in hits:
-        if h["matched_via"] == "drawer":
-            continue
-        full_source = h.get("_source_file_full") or ""
-        if not full_source:
-            continue
-        # Narrow by ``parent_drawer_id`` when present so unrelated
-        # chunked drawers sharing ``source_file`` do not stitch (#1580).
-        try:
-            source_drawers = drawers_col.get(
-                where=_scoped_source_filter(full_source, h.get("_parent_drawer_id")),
-                include=["documents", "metadatas"],
-            )
-        except Exception:
-            logger.debug("Neighbor fetch failed for %s", full_source, exc_info=True)
-            continue
-        docs = source_drawers.documents
-        metas_ = source_drawers.metadatas
-        if len(docs) <= 1:
-            continue
-
-        # Sort by chunk_index so best_idx + neighbors are positional.
-        indexed = []
-        for idx, (d, m) in enumerate(zip(docs, metas_)):
-            ci = m.get("chunk_index", idx) if isinstance(m, dict) else idx
-            if not isinstance(ci, int):
-                ci = idx
-            indexed.append((ci, d))
-        indexed.sort(key=lambda p: p[0])
-        ordered_docs = [d for _, d in indexed]
-
-        query_terms = set(_tokenize(query, stop_words))
-        best_idx, best_score = 0, -1
-        for idx, d in enumerate(ordered_docs):
-            d_lower = d.lower()
-            s = sum(1 for t in query_terms if t in d_lower)
-            if s > best_score:
-                best_score, best_idx = s, idx
-
-        start = max(0, best_idx - 1)
-        end = min(len(ordered_docs), best_idx + 2)
-        expanded = "\n\n".join(ordered_docs[start:end])
-        if len(expanded) > MAX_HYDRATION_CHARS:
-            expanded = (
-                expanded[:MAX_HYDRATION_CHARS]
-                + f"\n\n[...truncated. {len(ordered_docs)} total drawers. "
-                "Use mempalace_get_drawer for full content.]"
-            )
-        h["text"] = expanded
-        h["drawer_index"] = best_idx
-        h["total_drawers"] = len(ordered_docs)
+    # Drawer-grep enrichment: retain the wider pool until repeated
+    # closet-rendered passages can be replaced by distinct candidates.
+    _enrich_closet_hits(
+        hits,
+        drawers_col,
+        query,
+        stop_words=stop_words,
+    )
 
     # Candidate strategy hook: optionally widen the rerank pool's *source*
     # before ranking. Default ("vector") is a no-op; "union" merges top-K

--- a/tests/test_search_distinct_closet_results.py
+++ b/tests/test_search_distinct_closet_results.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from mempalace.miner import process_file
+from mempalace.palace import (
+    get_closets_collection,
+    get_collection,
+)
+from mempalace.searcher import (
+    _candidate_pool_limits,
+    _dedupe_rendered_hits,
+    _enrich_closet_hits,
+    search_memories,
+)
+
+
+def test_rendered_dedup_preserves_first_ranked_closet_hit_and_plain_repeats():
+    hits = [
+        {
+            "drawer_id": "closet-first",
+            "source_file": "same.md",
+            "source_path": "/one/same.md",
+            "text": "same rendered passage",
+            "matched_via": "drawer+closet",
+        },
+        {
+            "drawer_id": "closet-later",
+            "source_file": "same.md",
+            "source_path": "/one/same.md",
+            "text": "same rendered passage",
+            "matched_via": "drawer+closet",
+        },
+        {
+            "drawer_id": "other-path",
+            "source_file": "same.md",
+            "source_path": "/two/same.md",
+            "text": "same rendered passage",
+            "matched_via": "drawer+closet",
+        },
+        {
+            "drawer_id": "plain-repeat-1",
+            "source_file": "repeat.md",
+            "source_path": "/one/repeat.md",
+            "text": ("legitimate repeated source text"),
+            "matched_via": "drawer",
+        },
+        {
+            "drawer_id": "plain-repeat-2",
+            "source_file": "repeat.md",
+            "source_path": "/one/repeat.md",
+            "text": ("legitimate repeated source text"),
+            "matched_via": "drawer",
+        },
+    ]
+
+    result = _dedupe_rendered_hits(hits)
+
+    assert [hit["drawer_id"] for hit in result] == [
+        "closet-first",
+        "other-path",
+        "plain-repeat-1",
+        "plain-repeat-2",
+    ]
+
+
+def test_closet_enrichment_memoises_by_source_and_parent_group():
+    drawers_col = MagicMock()
+
+    def get_group(
+        *,
+        where,
+        include,
+    ):
+        assert include == [
+            "documents",
+            "metadatas",
+        ]
+
+        parent = where["$and"][1]["parent_drawer_id"]
+
+        return SimpleNamespace(
+            documents=[
+                (f"{parent} token best chunk"),
+                (f"{parent} neighboring context"),
+            ],
+            metadatas=[
+                {
+                    "chunk_index": 0,
+                },
+                {
+                    "chunk_index": 1,
+                },
+            ],
+        )
+
+    drawers_col.get.side_effect = get_group
+
+    hits = [
+        {
+            "drawer_id": "a-0",
+            "text": "raw a0",
+            "matched_via": ("drawer+closet"),
+            "_source_file_full": ("/shared/log.md"),
+            "_parent_drawer_id": ("parent-a"),
+        },
+        {
+            "drawer_id": "a-1",
+            "text": "raw a1",
+            "matched_via": ("drawer+closet"),
+            "_source_file_full": ("/shared/log.md"),
+            "_parent_drawer_id": ("parent-a"),
+        },
+        {
+            "drawer_id": "b-0",
+            "text": "raw b0",
+            "matched_via": ("drawer+closet"),
+            "_source_file_full": ("/shared/log.md"),
+            "_parent_drawer_id": ("parent-b"),
+        },
+    ]
+
+    _enrich_closet_hits(
+        hits,
+        drawers_col,
+        "token",
+    )
+
+    assert drawers_col.get.call_count == 2
+    assert hits[0]["text"] == hits[1]["text"]
+    assert "parent-a" in hits[0]["text"]
+    assert "parent-b" in hits[2]["text"]
+    assert hits[0]["text"] != hits[2]["text"]
+
+
+def test_search_promotes_distinct_results_from_wider_pool_and_fetches_source_once():
+    repeated_source = "/project/large.md"
+    query = "quasar authentication token rotation"
+
+    repeated_documents = [(f"raw repeated-source drawer {index}") for index in range(5)]
+    fallback_documents = [(f"independent fallback passage {index}") for index in range(4)]
+    documents = repeated_documents + fallback_documents
+
+    repeated_metadatas = [
+        {
+            "source_file": (repeated_source),
+            "wing": "code",
+            "room": "docs",
+            "chunk_index": index,
+            "filed_at": (f"2026-08-04T00:00:0{index}"),
+        }
+        for index in range(5)
+    ]
+    fallback_metadatas = [
+        {
+            "source_file": (f"/project/fallback-{index}.md"),
+            "wing": "code",
+            "room": "docs",
+            "chunk_index": 0,
+            "filed_at": (f"2026-08-04T00:01:0{index}"),
+        }
+        for index in range(4)
+    ]
+
+    drawers_col = MagicMock()
+    drawers_col.distance_metric = "cosine"
+    drawers_col.query.return_value = {
+        "ids": [
+            [
+                *[f"same-{index}" for index in range(5)],
+                *[f"fallback-{index}" for index in range(4)],
+            ]
+        ],
+        "documents": [documents],
+        "metadatas": [(repeated_metadatas + fallback_metadatas)],
+        "distances": [
+            [
+                0.05,
+                0.06,
+                0.07,
+                0.08,
+                0.09,
+                0.45,
+                0.46,
+                0.47,
+                0.48,
+            ]
+        ],
+    }
+    drawers_col.get.return_value = SimpleNamespace(
+        documents=[
+            ("context before the target"),
+            ("quasar authentication token rotation exact target"),
+            ("context after the target"),
+        ],
+        metadatas=[
+            {
+                "chunk_index": 0,
+            },
+            {
+                "chunk_index": 1,
+            },
+            {
+                "chunk_index": 2,
+            },
+        ],
+    )
+
+    closets_col = MagicMock()
+    closets_col.query.return_value = {
+        "ids": [
+            [
+                "closet-1",
+            ]
+        ],
+        "documents": [
+            [
+                query,
+            ]
+        ],
+        "metadatas": [
+            [
+                {
+                    "source_file": (repeated_source),
+                }
+            ]
+        ],
+        "distances": [
+            [
+                0.1,
+            ]
+        ],
+    }
+
+    with patch(
+        "mempalace.searcher.get_collection",
+        return_value=drawers_col,
+    ):
+        with patch(
+            "mempalace.searcher.get_closets_collection",
+            return_value=closets_col,
+        ):
+            result = search_memories(
+                query,
+                "/fake/palace",
+                n_results=5,
+            )
+
+    hits = result["results"]
+    rendered_keys = {
+        (
+            hit["source_path"],
+            hit["text"],
+        )
+        for hit in hits
+    }
+
+    assert len(hits) == 5
+    assert len(rendered_keys) == 5
+    assert hits[0]["drawer_id"] == "same-0"
+    assert drawers_col.query.call_args.kwargs["n_results"] == 20
+    assert drawers_col.get.call_count == 1
+    assert sum(hit["source_path"] == repeated_source for hit in hits) == 1
+
+
+def test_process_file_preserves_legitimate_exact_repeats_at_different_positions(
+    tmp_path,
+):
+    repeated = (
+        "REPEATED LEGAL NOTICE: "
+        + ("This clause must appear in both the introduction and the appendix. " * 2)
+    ).strip()
+
+    unique = (
+        "UNIQUE MIDDLE SECTION: "
+        + ("This paragraph explains a different implementation detail for the reader. " * 2)
+    ).strip()
+
+    source = tmp_path / "legitimate-repeat.md"
+    source.write_text(
+        (repeated + "\n\n" + unique + "\n\n" + repeated),
+        encoding="utf-8",
+    )
+
+    (
+        drawer_count,
+        room,
+        skip_reason,
+    ) = process_file(
+        source,
+        project_path=tmp_path,
+        collection=None,
+        wing="test",
+        rooms=[
+            {
+                "name": "general",
+                "description": ("General"),
+                "keywords": [],
+            }
+        ],
+        agent="test",
+        dry_run=True,
+        chunk_size=220,
+        chunk_overlap=0,
+        min_chunk_size=1,
+    )
+
+    assert drawer_count == 3
+    assert room == "general"
+    assert skip_reason is None
+
+
+def test_real_chromadb_source_scoped_search_returns_no_duplicate_rendered_passages(
+    palace_path,
+):
+    source = "/project/drift-reminder.py"
+    query = "quasar authentication token rotation"
+
+    documents = [
+        (
+            f"SECTION_{index:02d} "
+            f"unique marker {index:02d}. "
+            + (query if index == 3 else (f"independent topic {index:02d}"))
+            + (f". Distinct diagnostic prose for chunk {index:02d}.")
+        )
+        for index in range(8)
+    ]
+
+    drawers = get_collection(palace_path)
+    drawers.upsert(
+        ids=[f"drawer_{index}" for index in range(8)],
+        documents=documents,
+        metadatas=[
+            {
+                "wing": "code",
+                "room": "docs",
+                "source_file": source,
+                "chunk_index": index,
+                "filed_at": (f"2026-08-04T12:00:0{index}"),
+            }
+            for index in range(8)
+        ],
+    )
+
+    closets = get_closets_collection(palace_path)
+    closets.upsert(
+        ids=[
+            "closet_drift_reminder",
+        ],
+        documents=[(f"{query} {query}|;|→drawer_3")],
+        metadatas=[
+            {
+                "wing": "code",
+                "room": "docs",
+                "source_file": source,
+            }
+        ],
+    )
+
+    raw = drawers.get(
+        where={
+            "source_file": source,
+        },
+        include=[
+            "documents",
+            "metadatas",
+        ],
+    )
+
+    assert len(raw.ids) == 8
+    assert len(set(raw.ids)) == 8
+    assert len(set(raw.documents)) == 8
+
+    result = search_memories(
+        query,
+        palace_path,
+        wing="code",
+        room="docs",
+        source_file=source,
+        n_results=5,
+    )
+
+    assert "error" not in result, result
+
+    hits = result["results"]
+
+    assert hits
+    assert any(hit["matched_via"] == "drawer+closet" for hit in hits)
+    assert len(hits) == len(
+        {
+            (
+                hit["source_path"],
+                hit["text"],
+            )
+            for hit in hits
+        }
+    )
+
+
+def test_candidate_pool_limits_widen_only_default_vector_strategy():
+    assert _candidate_pool_limits(
+        "vector",
+        5,
+    ) == (
+        20,
+        20,
+    )
+
+    assert _candidate_pool_limits(
+        "union",
+        5,
+    ) == (
+        15,
+        5,
+    )


### PR DESCRIPTION
## What does this PR do?

- remove the speculative miner-side content deduplication
- keep a wider vector candidate pool until closet enrichment completes
- memoise drawer retrieval by full source path and parent drawer group
- preserve the existing closet hydration and final hybrid ranking
- remove repeated rendered passages after final ranking
- retain the first-ranked occurrence
- fill the requested result set from remaining distinct candidates
- preserve plain drawer repeats and all stored source content

## Root cause

The original report in #2052 was measured through `search_memories()` and showed different drawer IDs and timestamps carrying the same passage.

A two-version real-path investigation traced the same corpus through MemPalace v3.6.0 and current `develop`.

For both versions:

- `chunk_text()` produced distinct chunks;
- the drawer upsert payload was distinct;
- the raw Chroma collection was distinct;
- direct SQLite extraction was distinct;
- direct vector-query results were distinct;
- repeated text first appeared in the final `search_memories()` response.

The duplication is introduced during closet enrichment.

Every closet-boosted hit from one source independently selects the same query-best source chunk and neighbours. The hit keeps its original ID, timestamp, distance, and ranking metadata, but its displayed `text` is replaced with the same expanded passage.

The old implementation had already cut the pool to `n_results`, leaving no unused candidates to promote after those repeated rendered passages were removed.

This is the cause described independently in #2083.

## Why the miner patch was removed

The previous revision deleted any later chunk whose complete text matched an earlier chunk.

That assumption was not supported by the real-path investigation.

It was also unsafe: the real chunker can legitimately emit the same legal notice, code block, or paragraph from two different source positions. Content-only deduplication removed the later valid occurrence.

This revision does not modify mining, stored documents, drawer IDs, or source-position metadata.

## Implementation

The vector path now retains up to:

`n_results * 4`

candidates through closet enrichment.

Drawer retrieval for enrichment is memoised by:

`(full_source_path, parent_drawer_id)`

The parent component preserves the existing #1580 isolation between unrelated logical drawers that share one `source_file`.

After the existing final hybrid rank, results are deduplicated by:

`(full_source_path, rendered_text)`

A duplicate is removed only when either occurrence came through closet enrichment.

Plain drawer results retain their historical behavior, including legitimate exact repeats at different source positions.

The first-ranked occurrence is preserved, and the result list is cut to `n_results` only after rendered-result deduplication.

## Result-count semantics

`n_results` remains a maximum.

When the wider pool contains enough distinct candidates, duplicate enriched hits are replaced by lower-ranked distinct results.

When no additional distinct passage exists, the response may contain fewer than `n_results` entries rather than padding the response with repeated copies.

## Investigation evidence

The comparison covered:

- MemPalace v3.6.0, the version reported in #2052;
- current `develop`;
- Markdown;
- CRLF C#;
- BOM-prefixed Markdown;
- long-line boundary cases;
- an intentional exact-repeat control;
- two unchanged mining passes;
- raw Chroma and direct SQLite inspection.

Across the audited corpus, the miner and raw storage stayed unique. The same source-level passage was duplicated only after closet enrichment.

## Candidate-pool compatibility

For the default `candidate_strategy="vector"` path, the vector pool remains four times wider through closet enrichment and rendered-result deduplication.

The opt-in `candidate_strategy="union"` path preserves its historical candidate contract:

- query `n_results * 3` vector candidates;
- retain the requested top `n_results` vector candidates;
- merge backend lexical candidates;
- perform the final hybrid rank.

This prevents the closet-diversity change from altering lexical-candidate provenance or the existing `matched_via="bm25_backend"` behavior.

## Tests

Regression coverage verifies that:

- the first-ranked closet-rendered occurrence is preserved;
- repeated closet-rendered passages are removed;
- plain drawer repeats remain untouched;
- identical basenames under different full paths do not collide;
- one source/group fetch is reused for repeated hits;
- different parent drawer groups remain isolated;
- the vector query requests a four-times wider pool;
- distinct lower-ranked candidates refill the requested result count;
- `process_file()` preserves legitimate exact repeats from different source positions;
- a real Chroma collection contains unique raw IDs and documents;
- a real source-scoped closet search returns no duplicate rendered passages.

Closes #2052

Closes #2083

## How to test

- `python3 -m pytest tests/test_search_distinct_closet_results.py -q`
- `python3 -m pytest tests/test_search_distinct_closet_results.py tests/test_searcher.py tests/test_closets.py tests/test_hybrid_search.py tests/test_hybrid_candidate_union.py tests/test_search_drawer_id.py tests/test_miner.py -q`
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python -m pytest tests/ -v`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
