### PR TITLE
feat(drawers): track last_modified timestamps

### DIFF
--- a/mempalace/backends/base.py
+++ b/mempalace/backends/base.py
@@ -359,6 +359,30 @@ class LexicalResult:
 # ---------------------------------------------------------------------------
 
 
+def initialize_last_modified_metadata(metadatas):
+    """Initialize last_modified from filed_at without mutating caller data."""
+    if metadatas is None:
+        return None
+
+    items = [metadatas] if isinstance(metadatas, dict) else list(metadatas)
+    result = []
+
+    for metadata in items:
+        if not isinstance(metadata, dict):
+            result.append(metadata)
+            continue
+
+        updated = dict(metadata)
+        filed_at = updated.get("filed_at")
+
+        if filed_at and not updated.get("last_modified"):
+            updated["last_modified"] = filed_at
+
+        result.append(updated)
+
+    return result
+
+
 class BaseCollection(ABC):
     """Per-collection read/write surface every backend must implement."""
 

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -34,6 +34,7 @@ from .base import (
     QueryResult,
     UnsupportedFilterError,
     _IncludeSpec,
+    initialize_last_modified_metadata,
 )
 
 logger = logging.getLogger(__name__)
@@ -1921,6 +1922,7 @@ class ChromaCollection(BaseCollection):
         misses a case (or skips for performance), reaching the chromadb
         client always goes through here first.
         """
+        metadatas = initialize_last_modified_metadata(metadatas)
         if metadatas is None:
             return None
         return [

--- a/mempalace/backends/embedding_wrapper.py
+++ b/mempalace/backends/embedding_wrapper.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from .base import BaseCollection
+from .base import BaseCollection, initialize_last_modified_metadata
 
 
 def _embed_texts(texts: list[str]) -> list[list[float]]:
@@ -91,7 +91,7 @@ class EmbeddingCollection(BaseCollection):
         documents = _as_list(documents)
         ids = _as_list(ids)
         if metadatas is not None:
-            metadatas = _as_list(metadatas)
+            metadatas = initialize_last_modified_metadata(_as_list(metadatas))
         if embeddings is None:
             embeddings = _embed_texts(documents)
         return self._inner.add(
@@ -105,7 +105,7 @@ class EmbeddingCollection(BaseCollection):
         documents = _as_list(documents)
         ids = _as_list(ids)
         if metadatas is not None:
-            metadatas = _as_list(metadatas)
+            metadatas = initialize_last_modified_metadata(_as_list(metadatas))
         if embeddings is None:
             embeddings = _embed_texts(documents)
         return self._inner.upsert(

--- a/mempalace/mcp_server/tools_write.py
+++ b/mempalace/mcp_server/tools_write.py
@@ -22,7 +22,9 @@ def _chunk_index(meta):
 
 
 def _response_safe_meta(meta):
-    safe_meta = _safe_meta(meta)
+    safe_meta = dict(_safe_meta(meta))
+    if not safe_meta.get("last_modified") and safe_meta.get("filed_at"):
+        safe_meta["last_modified"] = safe_meta["filed_at"]
     if safe_meta.get("source_file"):
         safe_meta["source_file"] = Path(safe_meta["source_file"]).name
     return safe_meta
@@ -398,6 +400,7 @@ def tool_add_drawer(
         "id_recipe": ID_RECIPE,
     }
 
+    base_meta["last_modified"] = base_meta["filed_at"]
     # Idempotency. Three cases to detect a prior committed write:
     # (a) Single-doc path: drawer_id row exists (the only id used).
     # (b) Chunked path: probe the LAST chunk id — its presence implies
@@ -1129,6 +1132,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
             if room.lower() != str(old_meta.get("room") or "").lower():
                 new_meta["room"] = room
 
+        new_meta["last_modified"] = datetime.now().isoformat()
         _wal_log(
             "update_drawer",
             {

--- a/tests/test_last_modified.py
+++ b/tests/test_last_modified.py
@@ -1,0 +1,257 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mempalace import mcp_server
+from mempalace.backends.base import (
+    initialize_last_modified_metadata,
+)
+from mempalace.backends.chroma import ChromaCollection
+from mempalace.backends.embedding_wrapper import (
+    EmbeddingCollection,
+)
+
+
+CREATED = "2020-01-01T00:00:00"
+MODIFIED = "2020-02-01T00:00:00"
+
+
+def test_initializer_copies_filed_at_preserves_explicit_and_does_not_mutate():
+    original = {
+        "wing": "test",
+        "filed_at": CREATED,
+    }
+    explicit = {
+        "wing": "test",
+        "filed_at": CREATED,
+        "last_modified": MODIFIED,
+    }
+    without_filed_at = {
+        "wing": "test",
+    }
+
+    result = initialize_last_modified_metadata(
+        [
+            original,
+            explicit,
+            without_filed_at,
+        ]
+    )
+
+    assert result == [
+        {
+            "wing": "test",
+            "filed_at": CREATED,
+            "last_modified": CREATED,
+        },
+        {
+            "wing": "test",
+            "filed_at": CREATED,
+            "last_modified": MODIFIED,
+        },
+        {
+            "wing": "test",
+        },
+    ]
+
+    assert "last_modified" not in original
+    assert explicit["last_modified"] == MODIFIED
+
+
+def test_initializer_accepts_one_metadata_dict():
+    result = initialize_last_modified_metadata(
+        {
+            "filed_at": CREATED,
+        }
+    )
+
+    assert result == [
+        {
+            "filed_at": CREATED,
+            "last_modified": CREATED,
+        }
+    ]
+
+
+class RawChromaCollection:
+    name = "drawers"
+    metadata = {
+        "hnsw:space": "cosine",
+    }
+
+    def __init__(self):
+        self.kwargs = None
+
+    def upsert(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_chroma_creation_initializes_last_modified():
+    raw = RawChromaCollection()
+    collection = ChromaCollection(raw)
+
+    collection.upsert(
+        ids=["drawer-1"],
+        documents=["document"],
+        embeddings=[[0.1, 0.2]],
+        metadatas=[
+            {
+                "wing": "test",
+                "filed_at": CREATED,
+            }
+        ],
+    )
+
+    assert raw.kwargs is not None
+    assert raw.kwargs["metadatas"] == [
+        {
+            "wing": "test",
+            "filed_at": CREATED,
+            "last_modified": CREATED,
+        }
+    ]
+
+
+class RawExplicitVectorCollection:
+    def __init__(self):
+        self.kwargs = None
+
+    def upsert(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_explicit_vector_creation_initializes_last_modified():
+    raw = RawExplicitVectorCollection()
+    collection = EmbeddingCollection(raw)
+
+    collection.upsert(
+        ids=["drawer-1"],
+        documents=["document"],
+        embeddings=[[0.1, 0.2]],
+        metadatas=[
+            {
+                "wing": "test",
+                "filed_at": CREATED,
+            }
+        ],
+    )
+
+    assert raw.kwargs is not None
+    assert raw.kwargs["metadatas"] == [
+        {
+            "wing": "test",
+            "filed_at": CREATED,
+            "last_modified": CREATED,
+        }
+    ]
+
+
+def test_response_metadata_falls_back_without_mutating_legacy_row():
+    stored = {
+        "wing": "test",
+        "filed_at": CREATED,
+        "source_file": "/tmp/example.md",
+    }
+
+    result = mcp_server._response_safe_meta(stored)
+
+    assert result["last_modified"] == CREATED
+    assert result["source_file"] == "example.md"
+    assert "last_modified" not in stored
+    assert stored["source_file"] == "/tmp/example.md"
+
+
+def test_add_drawer_stores_matching_creation_and_modification_time(
+    monkeypatch,
+):
+    collection = MagicMock()
+
+    collection.get.side_effect = [
+        {
+            "ids": [],
+        },
+        {
+            "ids": ["stored-drawer"],
+        },
+    ]
+
+    monkeypatch.setattr(
+        mcp_server,
+        "_get_collection",
+        lambda create=False: collection,
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "_wal_log",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "_config",
+        SimpleNamespace(
+            chunk_size=800,
+        ),
+    )
+
+    result = mcp_server.tool_add_drawer(
+        wing="test",
+        room="general",
+        content="A short drawer.",
+    )
+
+    assert result["success"] is True
+
+    metadata = collection.upsert.call_args.kwargs["metadatas"][0]
+
+    assert metadata["filed_at"]
+    assert metadata["last_modified"] == metadata["filed_at"]
+
+
+def test_update_drawer_stamps_last_modified_and_preserves_filed_at(
+    monkeypatch,
+):
+    collection = MagicMock()
+
+    collection.get.return_value = {
+        "ids": ["drawer-1"],
+        "documents": ["old content"],
+        "metadatas": [
+            {
+                "wing": "test",
+                "room": "general",
+                "filed_at": CREATED,
+                "last_modified": CREATED,
+            }
+        ],
+    }
+
+    monkeypatch.setattr(
+        mcp_server,
+        "_get_collection",
+        lambda create=False: collection,
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "_wal_log",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "_config",
+        SimpleNamespace(
+            chunk_size=800,
+        ),
+    )
+
+    result = mcp_server.tool_update_drawer(
+        "drawer-1",
+        content="new content",
+    )
+
+    assert result["success"] is True
+    collection.update.assert_called_once()
+
+    metadata = collection.update.call_args.kwargs["metadatas"][0]
+
+    assert metadata["filed_at"] == CREATED
+    assert datetime.fromisoformat(metadata["last_modified"]) > datetime.fromisoformat(CREATED)


### PR DESCRIPTION
## What does this PR do?

- initialize `last_modified` from `filed_at` when drawers are created
- preserve explicitly supplied `last_modified` values
- stamp a fresh `last_modified` value on every non-noop `update_drawer` operation
- preserve the original `filed_at` creation timestamp
- apply creation-time initialization to both Chroma and explicit-vector backends
- expose a read-time fallback for legacy drawers that only contain `filed_at`
- avoid mutating stored metadata while constructing MCP responses

## Metadata contract

New drawers use:

```text
filed_at      = creation timestamp
last_modified = creation timestamp
```

After `update_drawer` changes content or location metadata:

```text
filed_at      = original creation timestamp
last_modified = update timestamp
```

Existing drawers without `last_modified` remain valid. MCP drawer responses expose `filed_at` as the fallback `last_modified` value.

## Root cause

Drawer creation paths already wrote `filed_at`, but there was no common metadata invariant that initialized a modification timestamp.

`tool_update_drawer()` copied the existing metadata and rewrote content, wing, or room without recording when that modification happened.

As a result, clients could identify when a drawer was first filed but not when it was most recently changed.

## Implementation

A shared `initialize_last_modified_metadata()` helper now:

- accepts one metadata dictionary or a metadata sequence;
- copies dictionaries rather than mutating caller-owned values;
- initializes `last_modified` only when `filed_at` exists;
- preserves an explicitly supplied `last_modified`;
- leaves metadata without `filed_at` unchanged.

Creation-time initialization is applied at the two normal storage chokepoints:

- `ChromaCollection._sanitize_metadatas_for_chromadb()`;
- `EmbeddingCollection.add()` and `EmbeddingCollection.upsert()` for explicit-vector backends.

`tool_add_drawer()` also explicitly assigns the same value to `filed_at` and `last_modified`, ensuring that every physical chunk in an oversized logical drawer shares one creation timestamp.

`tool_update_drawer()` stamps a fresh ISO timestamp after input validation and before the single-row or chunked write.

`_response_safe_meta()` copies the metadata and supplies the legacy fallback without altering the stored dictionary.

## Compatibility

This is an additive metadata change.

- Existing drawer IDs are unchanged.
- Existing embeddings are unchanged.
- Existing `filed_at` values are unchanged.
- Existing rows do not require an immediate migration.
- Rows without `filed_at` remain unchanged rather than receiving a fabricated timestamp.
- Explicit `last_modified` values supplied by import or repair code are preserved.

## Tests

Regression coverage verifies that:

- creation initializes `last_modified` from `filed_at`;
- explicit modification timestamps are preserved;
- caller-owned metadata is not mutated;
- one metadata dictionary is normalized safely;
- Chroma writes receive the field;
- explicit-vector backend writes receive the field;
- legacy MCP responses fall back to `filed_at` without mutating stored metadata;
- `tool_add_drawer()` stores matching creation and modification timestamps;
- `tool_update_drawer()` advances `last_modified` while preserving `filed_at`.


Closes #1127


## How to test

- `python3 -m pytest tests/test_last_modified.py -q`
- `python3 -m pytest tests/test_last_modified.py tests/test_backends.py tests/test_embedding_wrapper.py tests/test_mcp_server.py -q`
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python -m pytest tests/ -v`

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
