### PR TITLE
perf(embedding): group documents by size before sub-batching (#2104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Performance
 
+- **EmbeddingGemma groups documents by size before sub-batching.** The tokenizer pads every row of a sub-batch to the longest sequence in it, so arrival order decided the bill: one long verbatim message dragged a whole sub-batch up to its own length. Measured over 43,157 `sweep` drawers from 160 Claude Code transcripts, padded token slots drop 39.7% and the quadratic attention term 45.0%. Vectors move by at most one float32 ULP (1.2e-07 absolute, cosine 0.99999992), which is reduction-order rounding and not a change of meaning. Applies to `embedding_model: embeddinggemma` only; the default MiniLM embedder pads to a fixed width and was never affected. (#2104)
 - **HNSW capacity probes are cached** and invalidated by palace file signature, so repeated MCP status/taxonomy paths no longer re-scan native segment files on every call. (#2051, #1471)
 - **`chunk_text` line numbering is O(N)** via incremental tallies, fixing multi-second hangs on large sources. (#2054, #2055)
 

--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -216,7 +216,9 @@ _EMBEDDINGGEMMA_MAX_LEN = 2048
 # matches the internal batch size of chromadb's ONNXMiniLM_L6_V2, whose
 # chunked _forward survives the same call sites. embeddinggemma's
 # sentence_embedding output is attention-masked, so sub-batch padding
-# does not change any row's vector.
+# does not change any row's vector. __call__ decides which documents share
+# a sub-batch by size rather than by arrival order (#2104), because the run
+# is priced on that padded length and not on the document count.
 _EMBEDDINGGEMMA_BATCH_SIZE = 32
 
 
@@ -356,6 +358,33 @@ class EmbeddinggemmaONNX:
             self._session = session
 
     def __call__(self, input: str | list[str] | None) -> list[list[float]]:  # noqa: A002 — ChromaDB EF protocol
+        """Embed ``input``, returning one vector per document in input order.
+
+        Documents are grouped by size before the sub-batch split. The
+        tokenizer pads every row of a sub-batch to the longest sequence in
+        it, and attention cost per layer is batch x heads x length^2, so one
+        long document drags a whole sub-batch up to its own length. Without
+        grouping the bill is set by arrival order: a verbatim transcript
+        whose long tool results sit between one-line replies pays the long
+        length for nearly every row (#2104).
+
+        An input that fits a single sub-batch is left in arrival order: every
+        row pads to the same width either way, so the keys would buy nothing
+        on the one-document search path.
+
+        Regrouping does not change what a row means. The model's
+        ``sentence_embedding`` output is attention-masked, so padding never
+        enters a row's values; what does move is float32 rounding, because a
+        different padded width changes the reduction order inside the GEMMs.
+        Measured against the same documents embedded in arrival order, that
+        residual peaks at one float32 ULP (1.2e-07 absolute, cosine
+        0.99999992).
+
+        The key is UTF-8 byte length rather than character count: this model
+        is multilingual, and bytes per token vary far less across scripts
+        than characters per token do. The sort is stable, so equal-size
+        documents keep arrival order and the split stays reproducible.
+        """
         if isinstance(input, str):
             # A bare string would be iterated character by character below,
             # silently producing one garbage vector per character.
@@ -367,14 +396,21 @@ class EmbeddinggemmaONNX:
             return []
         self._lazy_load()
         np = self._np
-        embeddings: list[list[float]] = []
-        # Tokenize and run per sub-batch, not over the whole input: padding
-        # is to the longest sequence in the sub-batch, and the ONNX runtime
-        # only ever holds batch_size rows of attention buffers at a time
-        # (#1770).
-        for start in range(0, len(input), self._batch_size):
-            chunk = input[start : start + self._batch_size]
-            texts = [_EMBEDDINGGEMMA_PREFIX + t for t in chunk]
+        # One sub-batch pads identically whatever the order, so the sort is
+        # only worth its keys once the input splits into several.
+        order: range | list[int] = range(len(input))
+        if len(input) > self._batch_size:
+            order = sorted(range(len(input)), key=lambda i: len(input[i].encode("utf-8")))
+        # Row i is filled by the sub-batch that carries document i. ``order``
+        # is a permutation of every index, so no placeholder survives; callers
+        # (ChromaDB included) zip the result against their ids positionally.
+        embeddings: list[list[float] | None] = [None] * len(input)
+        # Tokenize and run per sub-batch, not over the whole input: the ONNX
+        # runtime only ever holds batch_size rows of attention buffers at a
+        # time (#1770).
+        for start in range(0, len(order), self._batch_size):
+            idxs = order[start : start + self._batch_size]
+            texts = [_EMBEDDINGGEMMA_PREFIX + input[i] for i in idxs]
             encs = self._tokenizer.encode_batch(texts)
             input_ids = np.asarray([e.ids for e in encs], dtype=np.int64)
             input_ids = _sanitize_embeddinggemma_input_ids(
@@ -390,7 +426,16 @@ class EmbeddinggemmaONNX:
             # L2-normalize so cosine similarity == dot product (matches what the
             # MTEB methodology assumes; ChromaDB's distance is configured for it).
             norms = np.linalg.norm(sent_emb, axis=1, keepdims=True) + 1e-12
-            embeddings.extend((sent_emb / norms).tolist())
+            rows = (sent_emb / norms).tolist()
+            if len(rows) != len(idxs):
+                # zip would truncate silently and leave a None in the result,
+                # which only surfaces far downstream in the caller's array
+                # conversion. Fail on the sub-batch that came back short.
+                raise RuntimeError(
+                    f"embeddinggemma returned {len(rows)} rows for a {len(idxs)}-document sub-batch"
+                )
+            for row_index, row in zip(idxs, rows):
+                embeddings[row_index] = row
         return embeddings
 
     def embed_query(self, input: list[str]) -> list[list[float]]:  # noqa: A002 — ChromaDB EF protocol

--- a/tests/test_embeddinggemma.py
+++ b/tests/test_embeddinggemma.py
@@ -190,7 +190,9 @@ def test_call_chunks_large_batches(patched_lazy_load, monkeypatch):
     monkeypatch.setattr(_FakeTokenizer, "encode_batch", recording_encode_batch)
     ef = embedding.EmbeddinggemmaONNX()
     n = embedding._EMBEDDINGGEMMA_BATCH_SIZE * 2 + 6
-    docs = [f"doc {i}" for i in range(n)]
+    # Descending sizes, so size-sorted order is the reverse of arrival order
+    # and the assertion below cannot pass on both.
+    docs = [f"{'x' * (n - i)} doc {i}" for i in range(n)]
     out = ef(docs)
 
     assert batch_sizes == [
@@ -198,9 +200,11 @@ def test_call_chunks_large_batches(patched_lazy_load, monkeypatch):
         embedding._EMBEDDINGGEMMA_BATCH_SIZE,
         6,
     ], f"expected bounded sub-batches, got {batch_sizes}"
-    # Sub-batches must cover the input in order; combined with the per-chunk
-    # extend in __call__ this pins output row order to input order.
-    assert captured_texts == [embedding._EMBEDDINGGEMMA_PREFIX + d for d in docs]
+    # Sub-batches cover the input in size-sorted order; the scatter in
+    # __call__ puts every row back at its own input index afterwards.
+    ordered = sorted(docs, key=lambda d: len(d.encode("utf-8")))
+    assert ordered != docs, "fixture must not already be in size order"
+    assert captured_texts == [embedding._EMBEDDINGGEMMA_PREFIX + d for d in ordered]
     arr = np.asarray(out)
     assert arr.shape == (n, 384), f"chunked outputs must concatenate to (n, 384), got {arr.shape}"
     assert np.allclose(np.linalg.norm(arr, axis=1), 1.0, atol=1e-5)
@@ -249,6 +253,200 @@ def test_custom_batch_size_is_honored(patched_lazy_load, monkeypatch):
     out = ef([f"doc {i}" for i in range(24)])
     assert batch_sizes == [10, 10, 4]
     assert len(out) == 24
+
+
+# Bound before any test can monkeypatch the method, so the width helper
+# below measures with the real fake and never re-enters a recorder.
+_UNPATCHED_ENCODE_BATCH = _FakeTokenizer.encode_batch
+
+
+def _record_batches(monkeypatch, sink):
+    """Capture the texts handed to each encode_batch call, in order."""
+
+    def recording_encode_batch(self, texts):
+        sink.append(list(texts))
+        return _UNPATCHED_ENCODE_BATCH(self, texts)
+
+    monkeypatch.setattr(_FakeTokenizer, "encode_batch", recording_encode_batch)
+
+
+def _fake_padded_width(batches):
+    """Total padded token slots the fake tokenizer produces for `batches`.
+
+    Measured by encoding, not by re-deriving the fake's padding rule, so the
+    two cannot drift apart and quietly turn the assertion into a tautology.
+    """
+    tokenizer = _FakeTokenizer()
+    return sum(sum(len(e.ids) for e in _UNPATCHED_ENCODE_BATCH(tokenizer, b)) for b in batches)
+
+
+def test_call_groups_documents_by_size(patched_lazy_load, monkeypatch):
+    """Similar-size documents must share a sub-batch.
+
+    encode_batch pads every row to the longest sequence in the sub-batch and
+    attention cost per layer is batch x heads x length^2, so interleaving one
+    long document with short ones makes the short ones pay the long length
+    (#2104). Grouping by size is what keeps that bill proportional to the
+    text actually being embedded.
+    """
+    batches = []
+    _record_batches(monkeypatch, batches)
+    # One long document per sub-batch's worth of short ones: the pathological
+    # arrival order a verbatim transcript sweep produces.
+    long_doc = " ".join(["word"] * 200)
+    docs = [long_doc if i % _B == 0 else f"short {i}" for i in range(4 * _B)]
+
+    ef = embedding.EmbeddinggemmaONNX()
+    out = ef(docs)
+    assert len(out) == len(docs)
+
+    for texts in batches:
+        sizes = [len(t.encode("utf-8")) for t in texts]
+        assert sizes == sorted(sizes), f"sub-batch is not size-grouped: {sizes}"
+
+    prefixed = [embedding._EMBEDDINGGEMMA_PREFIX + d for d in docs]
+    arrival_order = [prefixed[s : s + _B] for s in range(0, len(prefixed), _B)]
+    assert _fake_padded_width(batches) < _fake_padded_width(arrival_order), (
+        "size grouping must lower the total padded width"
+    )
+
+
+def test_call_groups_by_utf8_size_not_character_count(patched_lazy_load, monkeypatch):
+    """The key is UTF-8 bytes, because this model is multilingual.
+
+    A CJK document is ~3 bytes per character and roughly a token per
+    character, so ordering by character count would file it next to Latin
+    documents several times cheaper to embed.
+    """
+    batches = []
+    _record_batches(monkeypatch, batches)
+    # Same character count, very different byte count (and token count).
+    docs = ["a" * 90] * _B + ["中" * 90] * _B
+    ef = embedding.EmbeddinggemmaONNX()
+    ef(list(reversed(docs)))
+
+    assert len(batches) == 2, f"expected two sub-batches, got {len(batches)}"
+    sizes = [[len(t.encode("utf-8")) for t in b] for b in batches]
+    assert max(sizes[0]) < min(sizes[1]), (
+        f"CJK documents must not share a sub-batch with Latin ones: {sizes}"
+    )
+
+
+def test_call_size_grouping_is_stable(patched_lazy_load, monkeypatch):
+    """Equal-size documents keep their arrival order.
+
+    An unstable sort would make the sub-batch split depend on nothing the
+    caller can see, so two identical inputs could take different code paths.
+    """
+    batches = []
+    _record_batches(monkeypatch, batches)
+    docs = [f"doc{i:03d}" for i in range(_B + 8)]  # identical size, distinct text
+    ef = embedding.EmbeddinggemmaONNX()
+    ef(docs)
+    captured = [t for b in batches for t in b]
+    assert captured == [embedding._EMBEDDINGGEMMA_PREFIX + d for d in docs]
+
+
+def test_call_keeps_arrival_order_within_a_single_sub_batch(patched_lazy_load, monkeypatch):
+    """An input that fits one sub-batch is not reordered.
+
+    Every row pads to the same width either way, so the sort would buy
+    nothing and only add keys to compute on the search hot path.
+    """
+    batches = []
+    _record_batches(monkeypatch, batches)
+    docs = [f"{'x' * (_B - i)} doc {i}" for i in range(_B)]  # descending size
+    ef = embedding.EmbeddinggemmaONNX()
+    ef(docs)
+    assert batches == [[embedding._EMBEDDINGGEMMA_PREFIX + d for d in docs]]
+
+
+class _MarkerTokenizer(_FakeTokenizer):
+    """Tokenizer whose first token id carries that document's own length.
+
+    ``_FakeTokenizer`` emits all-zero ids padded to one width, so a fake
+    session cannot tell its rows apart, which is exactly what an
+    order-restoration test has to observe.
+    """
+
+    def encode_batch(self, texts):
+        widths = [len(t) for t in texts]
+        padded = max(widths)
+
+        class _Enc:
+            def __init__(self, marker):
+                self.ids = [marker] + [0] * (padded - 1)
+                self.attention_mask = [1] * marker + [0] * (padded - marker)
+
+        return [_Enc(w) for w in widths]
+
+
+class _MarkerSession:
+    """Emit a vector whose first two dims encode the row's marker id.
+
+    Both dims scale by the same L2 norm, so ``row[0] / row[1]`` survives
+    normalization and identifies which document produced the row.
+    """
+
+    _WIDTH = 2 * embedding._EMBEDDINGGEMMA_DIM
+
+    def run(self, _output_names, feed):
+        ids = feed["input_ids"]
+        batch, length = ids.shape
+        sent = np.zeros((batch, self._WIDTH), dtype=np.float64)
+        sent[:, 0] = ids[:, 0]
+        sent[:, 1] = 1.0
+        return [np.zeros((batch, length, self._WIDTH), dtype=np.float64), sent]
+
+
+def _marker_ef(patched_lazy_load, session=None):
+    """An EF wired to the marker fakes, with the real lazy load short-circuited."""
+    # patched_lazy_load is taken so a future tightening of _lazy_load's
+    # early-return cannot turn these tests into a 300 MB model download.
+    ef = embedding.EmbeddinggemmaONNX()
+    ef._tokenizer = _MarkerTokenizer()
+    ef._session = session if session is not None else _MarkerSession()
+    ef._output_idx = 1
+    ef._np = np
+    return ef
+
+
+def test_call_returns_rows_at_their_input_index(patched_lazy_load):
+    """Row i of the result must be the embedding of document i.
+
+    Sub-batching by size reorders the work; ChromaDB zips the returned
+    vectors against the ids positionally, so grouping without the matching
+    scatter would file every drawer under another drawer's vector. That
+    half-applied state is what this pins: arrival order trivially satisfies
+    it, so it is the grouping tests that cover the other direction.
+    """
+    ef = _marker_ef(patched_lazy_load)
+    # Strictly descending sizes, so grouping reverses arrival order and an
+    # unscattered result would be visibly wrong.
+    docs = ["x" * n for n in range(200, 200 - 3 * _B, -1)]
+    out = ef(docs)
+
+    assert len(out) == len(docs)
+    assert all(row is not None for row in out), "every index must be filled"
+    markers = [round(row[0] / row[1]) for row in out]
+    assert markers == [len(embedding._EMBEDDINGGEMMA_PREFIX + d) for d in docs]
+
+
+def test_call_rejects_a_short_row_count_from_the_session(patched_lazy_load):
+    """A session returning fewer rows than documents must fail loudly.
+
+    Scattering by index would otherwise leave a None in the result and the
+    caller would only trip over it much later, converting to an array.
+    """
+
+    class _ShortSession(_MarkerSession):
+        def run(self, output_names, feed):
+            last_hidden, sent = super().run(output_names, feed)
+            return [last_hidden, sent[:-1]]
+
+    ef = _marker_ef(patched_lazy_load, session=_ShortSession())
+    with pytest.raises(RuntimeError, match="rows for a"):
+        ef(["x" * n for n in range(200, 200 - 2 * _B, -1)])
 
 
 def test_batch_size_below_one_is_rejected():


### PR DESCRIPTION
## What does this PR do?

Fixes #2104.

`EmbeddinggemmaONNX.__call__` split its input into sub-batches of 32 in arrival order. The tokenizer pads every row of a sub-batch to the longest sequence in that sub-batch (`enable_padding()` with no `length`, `mempalace/embedding.py:350`, capped by `enable_truncation(max_length=2048)`), and attention costs batch x heads x length^2 per layer, so one long document set the price for the other 31 in its slice.

`sweeper.sweep` stores one drawer per message verbatim, so multi-thousand-token tool results sit between one-line replies: the worst arrival order there is. This sorts by UTF-8 byte length before the split and scatters each row back to its input index.

ChromaDB's bundled MiniLM embedder pads to a fixed 256, so its cost never depended on batch composition. `embedding_model` defaults to `minilm` (`mempalace/config.py:764`), so only palaces configured for `embeddinggemma` are affected.

### Measured

Every Claude Code transcript over 80 KB on one machine, subagent sessions excluded: 160 files, 43,157 swept drawers, 24,388,031 real tokens, 5,337 of them at the 2,048 ceiling. Costed at the window `sweeper.sweep` really hands the embedder (64 documents per call) and the current sub-batch of 32:

| | padded token slots | per drawer | attention term |
|---|---|---|---|
| before | 86,830,353 | 2,012 | 175,787,335,499 |
| after | 52,396,272 | 1,214 | 96,686,289,276 |
| | **-39.7%** | | **-45.0%** |

Wall clock, one process and one model instance, 52 messages, `batch_size=8`:

```
baseline   1169.70 s
patched     490.83 s      x2.38
baseline   1286.23 s      (control run, so not warm-up)
max abs diff 1.192e-07
min cosine   0.999999917827
```

`sentence_embedding` is attention-masked, so padding never enters a row's values. The residual above is float32 rounding: a different padded width changes the reduction order inside the GEMMs, and `1.192e-07` is exactly one ULP at unit magnitude.

### Limits

- Not optimal on every input. When the count is not a multiple of 32 the tail can group worse than arrival order did. Of the 744 real embedder windows above, 10 regressed (1.3%), the worst of them by 17.7% on a 39-document window.
- The key is UTF-8 bytes rather than characters because bytes per token vary far less across scripts, and this embedder exists for the multilingual case.
- Peak memory is unchanged: the sub-batch holding the longest document pads to that document either way, and after grouping it lands in the last sub-batch, which may be short.
- This does not close the `sweep` vs `mine --mode convos` gap. `mine` normalizes first and `_format_tool_result` returns nothing for Read/Edit/Write results, so it embeds a fraction of the transcript in ~800-character chunks. Padding was the avoidable part.
- Both hypotheses in the issue read the code the other way round: `sweeper.sweep` already batches 64 drawers per `upsert` (`mempalace/sweeper.py:227-260`), and its pre-flight is one `collection.get(ids=batch_ids)` per batch, not per message.

Thanks @HectorBernstorff for the per-drawer timings and a two-command repro. The change follows neither fix sketched in the issue, but that measurement is what made the real cost findable.

## How to test

```bash
uv run pytest tests/test_embeddinggemma.py -v
uv run pytest tests/ -q --ignore=tests/benchmarks
uv run ruff check . && uv run ruff format --check .
```

Six added tests cover size grouping, the UTF-8 key against a character-count key, tie stability, the single-sub-batch short circuit, row-to-input-index restoration, and a session returning fewer rows than documents. Reverting `mempalace/embedding.py` alone, keeping the tests, fails four: three of the six added, plus `test_call_chunks_large_batches`, whose order assertion this PR rewrote.

End to end on a palace configured for `embeddinggemma`, `sweep` then `status` then `search` for a phrase from a long message returns that drawer.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
