### PR TITLE
fix(cli): record embedder identity on closets too

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1063,38 +1063,51 @@ def cmd_palace_set_embedder(args):
     """Record (or force-override) a palace's embedder identity (RFC 001).
 
     Resolves the ``unknown`` state for a legacy palace, or records a specific
-    model with ``--model``. It records identity on the palace only; it does not
-    change the configured model — when the two differ it prints how to align
+    model with ``--model``. Both the drawers and the closets collection are
+    recorded — a palace whose closets keep an unknown identity never gets the
+    fail-fast model-swap check that ``_enforce_embedder_identity`` provides.
+    It records identity on the palace only; it does not change the configured
+    model — when the two differ it prints how to align
     ``MEMPALACE_EMBEDDING_MODEL``. ``--force`` overwrites an existing,
     differently-named identity.
     """
     from .backends.base import EmbedderIdentityMismatchError
     from .palace import set_palace_embedder_identity
+    from .repair import RECOVERABLE_COLLECTIONS
 
     config = MempalaceConfig()
     palace_path = os.path.abspath(
         os.path.expanduser(args.palace) if args.palace else config.palace_path
     )
     model = getattr(args, "model", None)
-    try:
-        old, new = set_palace_embedder_identity(
-            palace_path,
-            model=model,
-            force=getattr(args, "force", False),
-            backend=_backend_arg(args),
-        )
-    except EmbedderIdentityMismatchError as exc:
-        print(f"  ✗ {exc}")
-        raise SystemExit(2) from exc
-    if old is None:
-        print(f"  ✓ recorded embedder identity: {new.model_name} (dim={new.dimension})")
-    elif old.model_name == new.model_name:
-        print(f"  ✓ embedder identity unchanged: {new.model_name} (dim={new.dimension})")
-    else:
-        print(
-            f"  ✓ embedder identity changed: {old.model_name} → {new.model_name} "
-            f"(dim={new.dimension})"
-        )
+    new = None
+    for collection_name in RECOVERABLE_COLLECTIONS:
+        try:
+            old, new = set_palace_embedder_identity(
+                palace_path,
+                model=model,
+                force=getattr(args, "force", False),
+                backend=_backend_arg(args),
+                collection_name=collection_name,
+            )
+        except EmbedderIdentityMismatchError as exc:
+            print(f"  ✗ {collection_name}: {exc}")
+            raise SystemExit(2) from exc
+        if old is None:
+            print(
+                f"  ✓ recorded embedder identity on {collection_name}: "
+                f"{new.model_name} (dim={new.dimension})"
+            )
+        elif old.model_name == new.model_name:
+            print(
+                f"  ✓ embedder identity unchanged on {collection_name}: "
+                f"{new.model_name} (dim={new.dimension})"
+            )
+        else:
+            print(
+                f"  ✓ embedder identity changed on {collection_name}: "
+                f"{old.model_name} → {new.model_name} (dim={new.dimension})"
+            )
     # set-embedder records the palace's identity; it does not change the
     # configured model. If they differ, the next normal open would mismatch —
     # tell the user how to align them.

--- a/tests/test_embedder_identity.py
+++ b/tests/test_embedder_identity.py
@@ -450,3 +450,40 @@ def test_qdrant_enforcement_model_swap_raises(tmp_path, monkeypatch, clear_ident
     monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "embeddinggemma")
     with pytest.raises(EmbedderIdentityMismatchError):
         P._enforce_embedder_identity(col, str(tmp_path), "mempalace_drawers", create=False)
+
+
+# ---------------------------------------------------------------------------
+# CLI set-embedder covers every collection
+# ---------------------------------------------------------------------------
+
+
+def test_cli_set_embedder_records_closets_too(tmp_path, monkeypatch, clear_identity_cache):
+    """``palace set-embedder`` must cover closets, not just drawers.
+
+    Recording only drawers leaves closets in the ``unknown`` state, so the
+    fail-fast model-swap check never engages for closet vectors and a later
+    swap degrades closet search silently.
+    """
+    from types import SimpleNamespace
+
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_MODEL", "minilm")
+    from mempalace import cli
+    from mempalace import palace as P
+
+    for name in ("mempalace_drawers", "mempalace_closets"):
+        col = P.get_collection(
+            str(tmp_path), collection_name=name, create=True, _skip_identity_check=True
+        )
+        col.add(documents=["x"], ids=["a"], metadatas=[{}], embeddings=[[0.1, 0.2, 0.3, 0.4]])
+    P._VALIDATED_IDENTITY.clear()
+
+    cli.cmd_palace_set_embedder(
+        SimpleNamespace(palace=str(tmp_path), model="minilm", force=False, backend=None)
+    )
+
+    P._VALIDATED_IDENTITY.clear()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        for name in ("mempalace_drawers", "mempalace_closets"):
+            P.get_collection(str(tmp_path), collection_name=name, create=False)


### PR DESCRIPTION
## What does this PR do?

- record the embedder identity on both collections in `RECOVERABLE_COLLECTIONS` instead of only the default drawers collection
- name the collection in every success/failure line so a partial run is readable
- add a regression test asserting neither collection warns after `set-embedder`

`set_palace_embedder_identity()` already takes `collection_name`, but `cmd_palace_set_embedder` never passes it, so it always lands on `mempalace_drawers`. Closets stay in the `unknown` state.

That is more than a stray warning. `_enforce_embedder_identity` exists so "a model swap fails fast — before any query silently returns degraded results". With no recorded identity on closets, that check never engages there: after a model swap drawers raise `EmbedderIdentityMismatchError` while closet vectors keep being compared against embeddings from a different model.

Hit this on a qdrant palace (86k drawers / 70k closets) that predates the identity sidecar. `palace set-embedder --model embeddinggemma` reported success, and every subsequent search still warned on `mempalace_closets`.

## How to test

```
mempalace palace set-embedder --model <your model>
```

Before: one `✓ recorded embedder identity` line, and opening the palace still warns on `mempalace_closets`.
After: one line per collection, no warning from either.

```
pytest tests/test_embedder_identity.py -v
```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
