### PR TITLE
feat(dream): non-destructive memory consolidation verb

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1052,6 +1052,52 @@ def cmd_hallways(args):
         print(f"    {label}")
 
 
+def cmd_dream(args):
+    """Consolidate the palace on a non-destructive copy (a 'dream')."""
+    from .dream import dream
+
+    palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
+    report = dream(
+        palace_path,
+        wing=args.wing,
+        threshold=args.threshold,
+        candidate_path=os.path.expanduser(args.candidate) if args.candidate else None,
+        retire_conflicts=args.retire_conflicts,
+    )
+
+    bar = "=" * 55
+    print(f"\n{bar}")
+    print("  MemPalace Dream — consolidation candidate ready")
+    print(bar)
+    print(f"  Wing:    {report['wing'] or '(whole palace)'}")
+    print(
+        f"  Drawers: {report['drawers_before']:,} → {report['drawers_after']:,} "
+        f"(-{report['drawers_merged']:,} merged)"
+    )
+    if args.retire_conflicts:
+        print(
+            f"  KG contradictions: {len(report['kg_conflicts'])} flagged, "
+            f"{report['kg_facts_retired']} retired"
+        )
+    else:
+        print(
+            f"  KG contradictions: {len(report['kg_conflicts'])} flagged "
+            "(review-only; --retire-conflicts to retire)"
+        )
+    for c in report["kg_conflicts"][:10]:
+        objs = ", ".join(name for name, _ in c["objects"])
+        print(f"    ? {c['subject']} {c['predicate']} → {{{objs}}}")
+    print("-" * 55)
+    print(f"  Candidate: {report['candidate']}")
+    print("  Review, then adopt or discard:")
+    print(
+        f"    adopt:   mv {report['palace']} {report['palace']}.pre-dream "
+        f"&& mv {report['candidate']} {report['palace']}"
+    )
+    print(f"    discard: rm -rf {report['candidate']}")
+    print(f"{bar}\n")
+
+
 def cmd_status(args):
     from .miner import status
 
@@ -1975,6 +2021,28 @@ def main():
     )
 
     # search
+    p_dream = sub.add_parser(
+        "dream",
+        help="Consolidate memory on a non-destructive copy (dedup drawers + flag KG contradictions)",
+    )
+    p_dream.add_argument("--wing", default=None, help="Limit consolidation to one wing")
+    p_dream.add_argument(
+        "--threshold",
+        type=float,
+        default=None,
+        help="Near-duplicate similarity threshold for drawer merge (default: dedup default)",
+    )
+    p_dream.add_argument(
+        "--candidate",
+        default=None,
+        help="Where to write the candidate palace (default: <palace>.dream-<wing>-<timestamp>)",
+    )
+    p_dream.add_argument(
+        "--retire-conflicts",
+        action="store_true",
+        help="Also invalidate the older side of each KG contradiction (candidate only)",
+    )
+
     p_search = sub.add_parser("search", help="Find anything, exact words")
     p_search.add_argument("query", help="What to search for")
     p_search.add_argument(
@@ -2314,6 +2382,7 @@ def main():
         "split": cmd_split,
         "search": cmd_search,
         "sweep": cmd_sweep,
+        "dream": cmd_dream,
         "sync": cmd_sync,
         "mcp": cmd_mcp,
         "serve": cmd_serve,

--- a/mempalace/dream.py
+++ b/mempalace/dream.py
@@ -36,6 +36,35 @@ def _drawer_count(palace_path: str) -> int:
     return ChromaBackend().get_collection(palace_path, COLLECTION_NAME).count()
 
 
+def _cow_copytree(src: str, dst: str) -> None:
+    """Clone the palace copy-on-write when the filesystem supports it, else fall
+    back to a deep copy.
+
+    A dream only removes a handful of drawers from the candidate, so on a
+    copy-on-write filesystem the clone shares blocks with the original and costs
+    almost no extra time or disk regardless of palace size — only the blocks
+    dedup rewrites diverge, and they diverge on the candidate, never the source.
+    Uses APFS ``clonefile`` via ``cp -c`` on macOS and reflink via
+    ``cp --reflink=auto`` on Linux (both silently degrade to a normal copy when
+    the volume can't clone); ``shutil.copytree`` is the portable last resort.
+    """
+    import platform
+    import subprocess
+
+    if platform.system() == "Darwin":
+        cmd = ["cp", "-cR", src, dst]
+    else:
+        cmd = ["cp", "-a", "--reflink=auto", src, dst]
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        # cp missing, unsupported flag, or clone refused -> portable deep copy.
+        if os.path.exists(dst):
+            shutil.rmtree(dst, ignore_errors=True)
+        shutil.copytree(src, dst)
+
+
 def detect_kg_conflicts(kg_db_path: str) -> list[dict]:
     """Active (subject, predicate) pairs that point at more than one object.
 
@@ -117,7 +146,9 @@ def dream(
         raise FileExistsError(f"candidate path already exists: {candidate_path}")
 
     # Non-destructive: consolidate the copy, leave the original untouched.
-    shutil.copytree(palace_path, candidate_path)
+    # Copy-on-write where the filesystem allows, so the candidate is cheap even
+    # for a large palace (see _cow_copytree).
+    _cow_copytree(palace_path, candidate_path)
 
     before = _drawer_count(candidate_path)
     dedup_palace(palace_path=candidate_path, threshold=threshold, dry_run=False, wing=wing)

--- a/mempalace/dream.py
+++ b/mempalace/dream.py
@@ -1,0 +1,140 @@
+"""Dream: non-destructive memory consolidation.
+
+A *dream* reorganizes an accumulated palace the way sleep consolidates memory.
+It works entirely on a COPY of the palace: it merges near-identical drawers via
+the existing deduplicator, flags knowledge-graph contradictions, and (opt-in)
+retires the older side of each contradiction. The original palace is never
+touched — the caller reviews the candidate, then adopts or discards it.
+
+This mirrors the immutable-input / review-then-adopt contract of managed-agent
+"dreams" while honoring MemPalace's own rule: incremental only, never destroy.
+
+Run a dream when no session is actively writing the palace (e.g. on a schedule),
+so the filesystem copy is consistent.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+from datetime import datetime
+
+from .backends.chroma import ChromaBackend
+from .dedup import DEFAULT_THRESHOLD, dedup_palace
+from .knowledge_graph import KnowledgeGraph
+
+COLLECTION_NAME = "mempalace_drawers"
+
+
+def _kg_path(palace_path: str) -> str:
+    """The knowledge graph lives inside the palace directory."""
+    return os.path.join(palace_path, "knowledge_graph.sqlite3")
+
+
+def _drawer_count(palace_path: str) -> int:
+    return ChromaBackend().get_collection(palace_path, COLLECTION_NAME).count()
+
+
+def detect_kg_conflicts(kg_db_path: str) -> list[dict]:
+    """Active (subject, predicate) pairs that point at more than one object.
+
+    These are *candidate* contradictions. With no functional-vs-multivalued
+    predicate model, some are genuine supersessions ("lives_in") and some are
+    legitimately multi-valued ("knows"), so we surface them for review rather
+    than guess. Each entry: {subject, predicate, objects: [(name, valid_from)]}.
+    """
+    if not os.path.exists(kg_db_path):
+        return []
+    conn = sqlite3.connect(kg_db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            """
+            SELECT es.name AS subject, t.predicate AS predicate,
+                   eo.name AS object, t.valid_from AS valid_from
+            FROM triples t
+            JOIN entities es ON es.id = t.subject
+            JOIN entities eo ON eo.id = t.object
+            WHERE t.valid_to IS NULL
+            ORDER BY es.name, t.predicate, t.valid_from
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    grouped: dict[tuple[str, str], list[tuple[str, str]]] = {}
+    for r in rows:
+        grouped.setdefault((r["subject"], r["predicate"]), []).append(
+            (r["object"], r["valid_from"])
+        )
+    conflicts = []
+    for (subject, predicate), objs in grouped.items():
+        if len({o for o, _ in objs}) > 1:
+            conflicts.append({"subject": subject, "predicate": predicate, "objects": objs})
+    return conflicts
+
+
+def _retire_older_conflicts(kg_db_path: str, conflicts: list[dict]) -> int:
+    """Opt-in. Keep the newest-``valid_from`` object per conflict, invalidate the
+    rest. Operates on the candidate KG only. Returns the count of facts retired.
+    A ``None`` valid_from sorts oldest so a dated fact always supersedes it.
+    """
+    kg = KnowledgeGraph(db_path=kg_db_path)
+    retired = 0
+    for c in conflicts:
+        objs = sorted(c["objects"], key=lambda o: (o[1] is not None, o[1] or ""))
+        keeper_name, keeper_from = objs[-1]
+        for obj_name, _ in objs[:-1]:
+            if obj_name == keeper_name:
+                continue
+            kg.invalidate(c["subject"], c["predicate"], obj_name, ended=keeper_from)
+            retired += 1
+    return retired
+
+
+def dream(
+    palace_path: str,
+    wing: str | None = None,
+    threshold: float | None = None,
+    candidate_path: str | None = None,
+    retire_conflicts: bool = False,
+) -> dict:
+    """Consolidate a COPY of the palace. Returns a report dict; never mutates the
+    input palace.
+    """
+    if threshold is None:
+        threshold = DEFAULT_THRESHOLD
+    palace_path = os.path.abspath(os.path.expanduser(palace_path))
+    if not os.path.isdir(palace_path):
+        raise FileNotFoundError(f"palace not found: {palace_path}")
+
+    if candidate_path is None:
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        candidate_path = f"{palace_path.rstrip('/')}.dream-{wing or 'palace'}-{stamp}"
+    candidate_path = os.path.abspath(os.path.expanduser(candidate_path))
+    if os.path.exists(candidate_path):
+        raise FileExistsError(f"candidate path already exists: {candidate_path}")
+
+    # Non-destructive: consolidate the copy, leave the original untouched.
+    shutil.copytree(palace_path, candidate_path)
+
+    before = _drawer_count(candidate_path)
+    dedup_palace(palace_path=candidate_path, threshold=threshold, dry_run=False, wing=wing)
+    after = _drawer_count(candidate_path)
+
+    conflicts = detect_kg_conflicts(_kg_path(candidate_path))
+    retired = (
+        _retire_older_conflicts(_kg_path(candidate_path), conflicts) if retire_conflicts else 0
+    )
+
+    return {
+        "palace": palace_path,
+        "candidate": candidate_path,
+        "wing": wing,
+        "drawers_before": before,
+        "drawers_after": after,
+        "drawers_merged": before - after,
+        "kg_conflicts": conflicts,
+        "kg_facts_retired": retired,
+    }

--- a/tests/test_dream.py
+++ b/tests/test_dream.py
@@ -1,0 +1,98 @@
+"""Tests for mempalace.dream — non-destructive consolidation.
+
+Focus on the dream *orchestration* contract (drawer dedup is covered by
+test_dedup): the input palace is never mutated, KG contradictions are detected,
+and opt-in retirement resolves them on the candidate only.
+"""
+
+import os
+
+import chromadb
+
+from mempalace.dream import detect_kg_conflicts, dream
+from mempalace.knowledge_graph import KnowledgeGraph
+
+KG_FILE = "knowledge_graph.sqlite3"
+
+
+def _seed_palace(palace_path):
+    """A tiny real palace: a few drawers plus a KG holding one genuine
+    contradiction (Roy lives_in Denver→Austin) and one legitimately
+    single-valued fact (Roy knows Alice) that must NOT be flagged.
+    """
+    client = chromadb.PersistentClient(path=palace_path)
+    col = client.get_or_create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
+    col.add(
+        ids=["d1", "d2", "d3"],
+        documents=["alpha beta gamma", "alpha beta gamma", "wholly distinct content"],
+        metadatas=[
+            {"wing": "wing_x", "source_file": "a.txt"},
+            {"wing": "wing_x", "source_file": "a.txt"},
+            {"wing": "wing_x", "source_file": "b.txt"},
+        ],
+    )
+    client.close()
+
+    kg = KnowledgeGraph(db_path=os.path.join(palace_path, KG_FILE))
+    kg.add_triple("Roy", "lives_in", "Denver", valid_from="2020-01-01")
+    kg.add_triple("Roy", "lives_in", "Austin", valid_from="2025-01-01")
+    kg.add_triple("Roy", "knows", "Alice", valid_from="2019-01-01")
+    kg.close()
+
+
+def _drawer_count(palace_path):
+    client = chromadb.PersistentClient(path=palace_path)
+    n = client.get_or_create_collection("mempalace_drawers").count()
+    client.close()
+    return n
+
+
+def _conflict_keys(kg_db_path):
+    return {(c["subject"], c["predicate"]) for c in detect_kg_conflicts(kg_db_path)}
+
+
+def test_dream_is_nondestructive(palace_path):
+    _seed_palace(palace_path)
+    before = _drawer_count(palace_path)
+
+    report = dream(palace_path, wing="wing_x")
+
+    assert os.path.isdir(report["candidate"])
+    assert report["candidate"] != report["palace"]
+    assert report["palace"] == os.path.abspath(palace_path)
+    # original drawer count and KG conflicts are untouched
+    assert _drawer_count(palace_path) == before
+    assert ("Roy", "lives_in") in _conflict_keys(os.path.join(palace_path, KG_FILE))
+
+
+def test_dream_detects_kg_contradiction(palace_path):
+    _seed_palace(palace_path)
+    report = dream(palace_path, wing="wing_x")
+    keys = {(c["subject"], c["predicate"]) for c in report["kg_conflicts"]}
+    assert ("Roy", "lives_in") in keys  # divergent objects -> flagged
+    assert ("Roy", "knows") not in keys  # single object -> not flagged
+
+
+def test_dream_retire_conflicts_only_on_candidate(palace_path):
+    _seed_palace(palace_path)
+    report = dream(palace_path, wing="wing_x", retire_conflicts=True)
+
+    assert report["kg_facts_retired"] >= 1
+    # candidate contradiction resolved...
+    assert ("Roy", "lives_in") not in _conflict_keys(os.path.join(report["candidate"], KG_FILE))
+    # ...but the original palace still holds it (never mutated)
+    assert ("Roy", "lives_in") in _conflict_keys(os.path.join(palace_path, KG_FILE))
+
+
+def test_dream_default_review_only_keeps_conflicts(palace_path):
+    _seed_palace(palace_path)
+    report = dream(palace_path, wing="wing_x")  # retire_conflicts defaults False
+    assert report["kg_facts_retired"] == 0
+    assert ("Roy", "lives_in") in _conflict_keys(os.path.join(report["candidate"], KG_FILE))
+
+
+def test_dream_missing_palace_raises(tmp_dir):
+    import pytest
+
+    with pytest.raises(FileNotFoundError):
+        dream(os.path.join(tmp_dir, "nope"))

--- a/tests/test_dream.py
+++ b/tests/test_dream.py
@@ -96,3 +96,25 @@ def test_dream_missing_palace_raises(tmp_dir):
 
     with pytest.raises(FileNotFoundError):
         dream(os.path.join(tmp_dir, "nope"))
+
+
+def test_cow_copytree_is_independent_on_write(tmp_dir):
+    """The candidate must be independent of the source: whether the clone is
+    copy-on-write or a deep copy, writing the clone must not change the source.
+    This is what makes the dream non-destructive regardless of copy mechanism.
+    """
+    from mempalace.dream import _cow_copytree
+
+    src = os.path.join(tmp_dir, "src")
+    os.makedirs(os.path.join(src, "sub"))
+    with open(os.path.join(src, "sub", "f.txt"), "w") as f:
+        f.write("original")
+
+    dst = os.path.join(tmp_dir, "dst")
+    _cow_copytree(src, dst)
+    assert open(os.path.join(dst, "sub", "f.txt")).read() == "original"
+
+    with open(os.path.join(dst, "sub", "f.txt"), "w") as f:
+        f.write("changed")
+    assert open(os.path.join(src, "sub", "f.txt")).read() == "original"
+    assert open(os.path.join(dst, "sub", "f.txt")).read() == "changed"


### PR DESCRIPTION
## Summary

This adds `mempalace dream`, a memory-consolidation pass. Over many sessions a palace accumulates near-duplicate drawers and contradictory knowledge-graph facts because writes are local and incremental. A dream reorganizes that accumulation the way sleep consolidates memory, and it does so **non-destructively**: it works on a copy of the palace and produces a reviewable candidate, so the input palace is never mutated. This honors the project's incremental-only, never-destroy principle while giving the same review-then-adopt shape as managed-agent "dreams."

## What it does

Given a palace (optionally scoped to one wing), `dream`:

- copies the palace to a candidate directory;
- merges near-identical drawers on the candidate via the existing deduplicator (`dedup_palace`, wing-scopeable);
- flags knowledge-graph contradictions — active `(subject, predicate)` pairs that point at more than one object. Because there is no functional-vs-multivalued predicate model, some of these are genuine supersessions (`lives_in`) and some are legitimately multi-valued (`knows`), so they are surfaced for review by default rather than auto-retired. This keeps legitimately multi-valued facts from being silently lost;
- with `--retire-conflicts`, invalidates the older side of each contradiction on the candidate only (keeping the newest `valid_from`);
- prints a diff report plus the exact adopt and discard commands.

The original palace and its knowledge graph are never touched, so the candidate can be reviewed and then adopted or discarded.

## CLI

```
mempalace --palace <path> dream [--wing W] [--threshold T] [--candidate DIR] [--retire-conflicts]
```

`--palace` is the existing global option. `--wing` limits consolidation to one wing; `--retire-conflicts` opts into retiring the older side of each contradiction; `--candidate` overrides the default candidate location (`<palace>.dream-<wing>-<timestamp>`).

## Implementation

- New module `mempalace/dream.py` with `dream()`, `detect_kg_conflicts()`, and the opt-in `_retire_older_conflicts()`. It reuses `dedup.dedup_palace` and `KnowledgeGraph.invalidate`; it adds no new consolidation logic and no external-API dependency.
- `mempalace/cli.py` gains the `cmd_dream` handler, a `dream` subparser, and the dispatch entry.
- `tests/test_dream.py` covers non-destructiveness (original drawer count and KG contradictions unchanged), contradiction detection (divergent objects flagged, single-valued facts not), opt-in retirement (resolved on the candidate only, original still holds the contradiction), the review-only default, and the missing-palace error path.

## Testing

- `ruff check .` and `ruff format --check .` both clean.
- Full suite: 3611 passed, coverage 81% (the one unrelated `test_mcp_server` failure is a pre-existing full-suite ordering flake that passes in isolation; that CI job runs with `--reruns 2`).
- The verb was also exercised end to end from the CLI against a throwaway seeded palace: the candidate is produced, the contradiction is reported, and the original palace is left intact.