### PR TITLE
fix(pgvector): retry statement once when the connection died under the client

### DIFF
--- a/mempalace/backends/pgvector.py
+++ b/mempalace/backends/pgvector.py
@@ -533,23 +533,56 @@ class _PgVectorClient:
 
     def _execute(self, sql: str, params=None, *, fetch: bool = False, many: bool = False):
         with self._lock:
-            conn = self._connect()
-            try:
-                with conn.cursor() as cur:
-                    if many:
-                        cur.executemany(sql, params or [])
-                        rows = None
-                    else:
-                        cur.execute(sql, params or [])
-                        rows = cur.fetchall() if fetch else None
-                conn.commit()
-            except Exception as exc:  # noqa: BLE001 - normalize to BackendError
+            for attempt in (0, 1):
+                conn = self._connect()
                 try:
-                    conn.rollback()
-                except Exception:  # pragma: no cover - rollback best effort
-                    pass
-                raise BackendError(f"pgvector query failed: {exc}") from exc
-        return rows
+                    with conn.cursor() as cur:
+                        if many:
+                            cur.executemany(sql, params or [])
+                            rows = None
+                        else:
+                            cur.execute(sql, params or [])
+                            rows = cur.fetchall() if fetch else None
+                    conn.commit()
+                    return rows
+                except Exception as exc:  # noqa: BLE001 - normalize to BackendError
+                    try:
+                        conn.rollback()
+                    except Exception:  # pragma: no cover - rollback best effort
+                        pass
+                    # A long-lived idle connection can die under the process
+                    # (Postgres restart, NAT/idle-flow reap): the dead socket
+                    # is only discovered at the next statement. That is a
+                    # connection failure, not a query failure — discard the
+                    # connection and retry the statement once on a fresh one
+                    # instead of surfacing a spurious BackendError.
+                    if attempt == 0 and self._connection_dead(conn, exc):
+                        try:
+                            conn.close()
+                        except Exception:  # pragma: no cover - close best effort
+                            pass
+                        self._conn = None
+                        continue
+                    raise BackendError(f"pgvector query failed: {exc}") from exc
+
+    @staticmethod
+    def _connection_dead(conn, exc: Exception) -> bool:
+        """True when a query failure means the connection itself is gone."""
+        if getattr(conn, "closed", False) or getattr(conn, "broken", False):
+            return True
+        try:
+            import psycopg
+        except ImportError:  # pragma: no cover - _connect already required it
+            return False
+        conn_errors = tuple(
+            err
+            for err in (
+                getattr(psycopg, "OperationalError", None),
+                getattr(psycopg, "InterfaceError", None),
+            )
+            if isinstance(err, type)
+        )
+        return bool(conn_errors) and isinstance(exc, conn_errors)
 
     def ping(self) -> None:
         self._execute("SELECT 1", fetch=True)

--- a/tests/test_pgvector_backend.py
+++ b/tests/test_pgvector_backend.py
@@ -1060,3 +1060,142 @@ def test_strip_lone_surrogates_reuses_config_util():
     cleaned = strip_lone_surrogates(raw)
     assert chr(0xD800) not in cleaned
     assert json.loads(cleaned) == {"k": f"v{chr(0xFFFD)}w"}
+
+
+def _install_fake_psycopg(monkeypatch, connect):
+    fake_psycopg = types.ModuleType("psycopg")
+
+    class OperationalError(Exception):
+        pass
+
+    class InterfaceError(Exception):
+        pass
+
+    fake_psycopg.OperationalError = OperationalError
+    fake_psycopg.InterfaceError = InterfaceError
+    fake_psycopg.connect = connect
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+    return fake_psycopg
+
+
+def test_client_retries_statement_once_on_dead_connection(monkeypatch):
+    """A statement that fails because the connection died under the process
+    (Postgres restart, idle-flow reap) must be retried once on a fresh
+    connection instead of surfacing a BackendError.
+
+    The first fake connection raises ``OperationalError`` on execute — the
+    shape psycopg produces when it discovers a dead socket. The client must
+    discard it, reconnect, and run the statement on the replacement.
+    """
+    created = []
+
+    class _DeadOnExecuteCursor:
+        def __init__(self, error):
+            self._error = error
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def execute(self, sql, params=None):
+            if self._error is not None:
+                raise self._error
+
+        def executemany(self, sql, params=None):
+            return None
+
+        def fetchall(self):
+            return [(1,)]
+
+    class _FakeConn:
+        def __init__(self, error=None):
+            self.closed = False
+            self._error = error
+
+        def cursor(self):
+            return _DeadOnExecuteCursor(self._error)
+
+        def commit(self):
+            return None
+
+        def rollback(self):
+            if self._error is not None:
+                raise self._error
+
+        def close(self):
+            self.closed = True
+
+    def connect(dsn):
+        error = None
+        if not created:
+            error = sys.modules["psycopg"].OperationalError(
+                "server closed the connection unexpectedly"
+            )
+        conn = _FakeConn(error)
+        created.append(conn)
+        return conn
+
+    _install_fake_psycopg(monkeypatch, connect)
+
+    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
+    client.ping()
+
+    assert len(created) == 2
+    assert created[0].closed
+    assert client._conn is created[1]
+    client.close()
+
+
+def test_client_does_not_retry_query_errors(monkeypatch):
+    """A failure with the connection still healthy is a query error — it must
+    surface as BackendError immediately, with no reconnect."""
+    created = []
+
+    class _FailingCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def execute(self, sql, params=None):
+            raise ValueError("bad statement")
+
+        def executemany(self, sql, params=None):
+            return None
+
+        def fetchall(self):
+            return [(1,)]
+
+    class _FakeConn:
+        def __init__(self):
+            self.closed = False
+
+        def cursor(self):
+            return _FailingCursor()
+
+        def commit(self):
+            return None
+
+        def rollback(self):
+            return None
+
+        def close(self):
+            self.closed = True
+
+    def connect(dsn):
+        conn = _FakeConn()
+        created.append(conn)
+        return conn
+
+    _install_fake_psycopg(monkeypatch, connect)
+
+    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
+    with pytest.raises(BackendError):
+        client.ping()
+
+    assert len(created) == 1
+    assert client._conn is created[0]
+    client.close()


### PR DESCRIPTION
## Problem

The pgvector backend holds one long-lived psycopg connection per process. When that connection dies under the process — Postgres container restart, overnight idle-flow reap on macOS (`tcp_keepalives_idle=0` server-side, 2h system keepidle) — the dead socket is only discovered at the next statement. `_PgVectorClient._execute` treated that as a query failure and raised `BackendError`, so a Claude Code MCP session sitting on a stale socket returned `MCP error -32000: Internal tool error` for every tool call until the user manually reconnected.

Observed in the wild: next-morning MCP sessions showed the connection dead (`lsof` reported the client's `:5432` socket as `CLOSED` while the process was alive); every mempalace tool call failed until a manual reconnect.

## Fix

In `_execute`, distinguish connection death from query failure:

- connection-level failure = `conn.closed` / `conn.broken` / `psycopg.OperationalError` / `psycopg.InterfaceError` (new `_connection_dead` helper, tolerant of the fake psycopg modules used in tests)
- on the first such failure, close and discard the connection, reconnect, and retry the statement **once**
- query-level errors still raise `BackendError` immediately, no retry

The retry stays under the existing `self._lock`, so the single-shared-connection invariant is unchanged.

## Verification

- Two new unit tests in `tests/test_pgvector_backend.py`: dead-connection retry succeeds on a fresh connection (old connection closed, client swaps to the replacement); plain query errors do not reconnect and surface immediately.
- Full `tests/test_pgvector_backend.py` suite: 39 passed, 1 skipped.
- Live check against a real Postgres: `pg_terminate_backend()` on the client's own backend pid, then the next `_execute` returned normally on a replacement connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrnpT3PNyNGo6wddR2AaZs