### PR TITLE
feat(search): optional time-decay re-ranking with durable exemption (#337)

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -174,6 +174,29 @@ class MempalaceConfig:
         return self._file_config.get("hall_keywords", DEFAULT_HALL_KEYWORDS)
 
     @property
+    def decay_enabled(self):
+        """Whether time-decay re-ranking is applied to search (default off)."""
+        return self._file_config.get("decay", {}).get("enabled", False)
+
+    @property
+    def decay_half_life_days(self):
+        """Ebbinghaus half-life in days for recency re-ranking."""
+        return self._file_config.get("decay", {}).get("half_life_days", 60)
+
+    @property
+    def decay_durable_rooms(self):
+        """Rooms exempt from decay (empty by default — room names are
+        auto-assigned by the miner, so exempt by wing or type= instead)."""
+        return self._file_config.get("decay", {}).get("durable_rooms", [])
+
+    @property
+    def decay_durable_wings(self):
+        """Curated wings exempt from decay (canonical notes shouldn't sink)."""
+        return self._file_config.get("decay", {}).get(
+            "durable_wings", ["memory", "identity"]
+        )
+
+    @property
     def hook_silent_save(self):
         """Whether the stop hook saves directly (True) or blocks for MCP calls (False)."""
         return self._file_config.get("hooks", {}).get("silent_save", True)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -351,6 +351,7 @@ def tool_search(
     dist = (1.0 - min_similarity) if min_similarity is not None else max_distance
     # Mitigate system prompt contamination (Issue #333)
     sanitized = sanitize_query(query)
+    decay_hl = _config.decay_half_life_days if _config.decay_enabled else 0.0
     result = search_memories(
         sanitized["clean_query"],
         palace_path=_config.palace_path,
@@ -358,6 +359,9 @@ def tool_search(
         room=room,
         n_results=limit,
         max_distance=dist,
+        decay_half_life_days=decay_hl,
+        durable_rooms=_config.decay_durable_rooms,
+        durable_wings=_config.decay_durable_wings,
     )
     # Attach sanitizer metadata for transparency
     if sanitized["was_sanitized"]:

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -7,6 +7,8 @@ Returns verbatim text — the actual words, never summaries.
 """
 
 import logging
+import math
+from datetime import datetime, timezone
 from pathlib import Path
 
 from .palace import get_collection
@@ -16,6 +18,35 @@ logger = logging.getLogger("mempalace_mcp")
 
 class SearchError(Exception):
     """Raised when search cannot proceed (e.g. no palace found)."""
+
+
+def _parse_filed_at(meta: dict):
+    """UTC-aware datetime from a drawer's timestamp metadata, or None."""
+    raw = meta.get("filed_at") or meta.get("date") or meta.get("source_mtime")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+def _is_durable(meta: dict, durable_rooms, durable_wings) -> bool:
+    """Durable drawers are exempt from decay so canonical old notes don't sink."""
+    if str(meta.get("type", "")).lower() in ("wisdom", "durable"):
+        return True
+    return meta.get("room") in durable_rooms or meta.get("wing") in durable_wings
+
+
+def _decay_multiplier(filed_at, now, half_life_days: float) -> float:
+    """exp(-ln2 * age_days / half_life); 1.0 when age is unknown or non-positive."""
+    if filed_at is None or half_life_days <= 0:
+        return 1.0
+    age_days = (now - filed_at).total_seconds() / 86400.0
+    if age_days <= 0:
+        return 1.0
+    return math.exp(-math.log(2) * age_days / half_life_days)
 
 
 def build_where_filter(wing: str = None, room: str = None) -> dict:
@@ -100,6 +131,10 @@ def search_memories(
     room: str = None,
     n_results: int = 5,
     max_distance: float = 0.0,
+    decay_half_life_days: float = 0.0,
+    durable_rooms=(),
+    durable_wings=(),
+    overfetch: int = 6,
 ) -> dict:
     """Programmatic search — returns a dict instead of printing.
 
@@ -115,6 +150,13 @@ def search_memories(
             cosine distance (hnsw:space=cosine) — 0 = identical, 2 = opposite.
             Results with distance > this value are filtered out. A value of
             0.0 disables filtering. Typical useful range: 0.3–1.0.
+        decay_half_life_days: Ebbinghaus half-life for recency re-ranking. 0
+            disables decay (behaviour is byte-identical to before). When > 0,
+            over-fetch, multiply each similarity by a half-life factor over the
+            drawer's filed_at age, re-rank, then truncate to n_results.
+        durable_rooms/durable_wings: rooms/wings exempt from decay (canonical
+            notes shouldn't sink); drawers with type in {wisdom,durable} are also exempt.
+        overfetch: candidate multiplier when decaying (fetch n_results*overfetch, capped).
     """
     try:
         col = get_collection(palace_path, create=False)
@@ -126,11 +168,13 @@ def search_memories(
         }
 
     where = build_where_filter(wing, room)
+    decay_on = decay_half_life_days and decay_half_life_days > 0
+    fetch_n = min(n_results * overfetch, 200) if decay_on else n_results
 
     try:
         kwargs = {
             "query_texts": [query],
-            "n_results": n_results,
+            "n_results": fetch_n,
             "include": ["documents", "metadatas", "distances"],
         }
         if where:
@@ -144,21 +188,33 @@ def search_memories(
     metas = results["metadatas"][0]
     dists = results["distances"][0]
 
+    now = datetime.now(timezone.utc)
     hits = []
     for doc, meta, dist in zip(docs, metas, dists):
         # Filter on raw distance before rounding to avoid precision loss
         if max_distance > 0.0 and dist > max_distance:
             continue
-        hits.append(
-            {
-                "text": doc,
-                "wing": meta.get("wing", "unknown"),
-                "room": meta.get("room", "unknown"),
-                "source_file": Path(meta.get("source_file", "?")).name,
-                "similarity": round(max(0.0, 1 - dist), 3),
-                "distance": round(dist, 4),
-            }
-        )
+        similarity = round(max(0.0, 1 - dist), 3)
+        hit = {
+            "text": doc,
+            "wing": meta.get("wing", "unknown"),
+            "room": meta.get("room", "unknown"),
+            "source_file": Path(meta.get("source_file", "?")).name,
+            "similarity": similarity,
+            "distance": round(dist, 4),
+        }
+        if decay_on:
+            durable = _is_durable(meta, durable_rooms, durable_wings)
+            filed = _parse_filed_at(meta)
+            mult = 1.0 if durable else _decay_multiplier(filed, now, decay_half_life_days)
+            hit["age_days"] = round((now - filed).total_seconds() / 86400.0, 1) if filed else None
+            hit["durable"] = durable
+            hit["decayed_score"] = round(similarity * mult, 4)
+        hits.append(hit)
+
+    if decay_on:
+        hits.sort(key=lambda h: h["decayed_score"], reverse=True)
+        hits = hits[:n_results]
 
     return {
         "query": query,


### PR DESCRIPTION
## What

Implements optional **time-decay re-ranking** for search — roadmap item #337 ("recent memories surface before older ones").

When enabled, `search_memories` multiplies each hit's similarity by an Ebbinghaus half-life factor `0.5 ^ (age_days / half_life)` (age from the drawer's `filed_at`), re-ranks, and truncates. A slightly weaker-matching recent memory can now outrank a stale stronger match.

## Off by default

`decay.enabled` defaults to **false** — behavior is byte-identical unless turned on. All logic lives at the single retrieval choke point (`search_memories`), so the MCP `search` tool inherits it.

## Config (`~/.mempalace/config.json`)

```json
"decay": {
  "enabled": true,
  "half_life_days": 60,
  "durable_wings": ["memory", "identity"],
  "durable_rooms": []
}
```

## Durable exemption

Drawers in `durable_wings` / `durable_rooms`, or tagged `type: "durable"` / `"wisdom"`, skip decay (freshness forced to 1.0) so canonical notes don't sink. Exempting by **wing** is recommended over **room**, since room names are auto-assigned by the miner (a bulk import auto-labeled `architecture` should not be treated as canonical).

## Caveats

- Decay re-ranks within an over-fetched candidate window (`n_results × 6`, capped) — it reorders near-matches, it does not rescue an item far outside the similarity top-N.
- ChromaDB can't decay server-side, so this is a client-side over-fetch + re-rank. No reindex; no schema change; missing `filed_at` → no decay (back-compat).

## Testing

Validated before/after on a ~8k-drawer palace: recent tickets lift, stale bulk content sinks, curated `memory/*` notes stay put. Decay math + exemption covered by a self-check.

Files: `mempalace/searcher.py`, `mempalace/config.py`, `mempalace/mcp_server.py` (~90 lines).

