### PR TITLE
fix(mcp): refuse vector writes into a diverged HNSW index instead of hanging forever

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -44,6 +44,7 @@ except (OSError, AttributeError):
 sys.stdout = sys.stderr
 
 import argparse  # noqa: E402  (deferred until after stdio protection above)
+import contextlib  # noqa: E402
 import json  # noqa: E402
 import logging  # noqa: E402
 import re  # noqa: E402
@@ -404,6 +405,31 @@ _MUTATING_TOOLS = frozenset(
         "mempalace_diary_write",
     }
 )
+
+# The subset of _MUTATING_TOOLS whose write path reaches the chroma vector
+# segment. Deliberately narrower: the knowledge-graph and tunnel/hallway tools
+# keep their own sqlite/JSON state and never touch HNSW, so an unusable vector
+# index has no say over them.
+#
+# The distinction earns its keep because a write into a diverged HNSW segment
+# does not fail — it blocks inside chromadb's Rust upsert with no timeout of its
+# own, for the life of the process, while this server holds the palace mine lock
+# and the writer lease. One stuck call becomes a palace-wide outage that a still
+# healthy handshake hides.
+_VECTOR_WRITE_TOOLS = frozenset(
+    {
+        "mempalace_add_drawer",
+        "mempalace_update_drawer",
+        "mempalace_delete_drawer",
+        "mempalace_delete_by_source",
+        "mempalace_diary_write",
+        "mempalace_checkpoint",
+        "mempalace_mine",
+        "mempalace_sync",
+    }
+)
+
+_DIVERGED_INDEX_ERROR_CODE = -32004
 
 # Read-only mode (#1877) refuses a wider set than the peer-writer guard above.
 #
@@ -4880,6 +4906,57 @@ def _mcp_read_only_refusal(req_id, tool_name: str):
     }
 
 
+def _mcp_diverged_index_refusal(req_id, tool_name: str):
+    """Refuse vector writes while the HNSW segment is known to be diverged.
+
+    The capacity probe (#1222) already routes *reads* around a diverged index:
+    ``search`` and ``check_duplicate`` fall back to BM25-only sqlite. Writes had
+    no such gate — they went straight to chromadb, where an upsert into that same
+    index can never come back. Observed on a 3.7.0 palace whose flushed segment
+    held 803 of 820 embeddings: three of five freshly generated vectors blocked
+    forever (25+ minutes, then killed), the other two committed in 0.03 s, and
+    the same vector reproduced the same verdict on every retry — so a write's
+    fate depended on where its embedding landed in the damaged graph. After
+    ``mempalace repair rebuild-index`` all five committed.
+
+    Refusing is also the honest answer for the write that does not hang: chromadb
+    acknowledges it into sqlite and the metadata segment, then leaves it out of
+    the HNSW segment. That drawer is filed and reported as success while being
+    invisible to vector search — 16 such drawers came out of a single checkpoint
+    that returned "completed successfully in 2s".
+
+    The probe behind this is pure sqlite + pickle, so the gate costs no chromadb
+    interaction on the path it is protecting.
+    """
+    if tool_name not in _VECTOR_WRITE_TOOLS:
+        return None
+
+    _refresh_vector_disabled_flag()
+
+    if not _vector_disabled:
+        return None
+
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {
+            "code": _DIVERGED_INDEX_ERROR_CODE,
+            "message": ("Palace vector index is diverged; refusing the write until it is rebuilt"),
+            "data": {
+                "tool": tool_name,
+                "palace": _config.palace_path or "",
+                "vector_disabled_reason": _vector_disabled_reason,
+                "hint": (
+                    "Stop the MemPalace MCP servers, run `mempalace repair rebuild-index`, "
+                    "then mempalace_reconnect. Recall keeps working meanwhile through the "
+                    "BM25 fallback; writes stay refused so they can neither hang inside "
+                    "chromadb nor land outside the index."
+                ),
+            },
+        },
+    }
+
+
 def _mcp_tool_preflight_refusal(req_id, tool_name: str):
     """Run MCP request preflight gates outside handle_request complexity."""
 
@@ -4890,6 +4967,10 @@ def _mcp_tool_preflight_refusal(req_id, tool_name: str):
     sqlite_integrity_error = _mcp_sqlite_integrity_refusal(req_id, tool_name)
     if sqlite_integrity_error is not None:
         return sqlite_integrity_error
+
+    diverged_index_error = _mcp_diverged_index_refusal(req_id, tool_name)
+    if diverged_index_error is not None:
+        return diverged_index_error
 
     return _mcp_peer_writer_refusal(req_id, tool_name)
 
@@ -5041,7 +5122,10 @@ def handle_request(request):
             if "entry" not in tool_args or tool_args["entry"] is None:
                 tool_args["entry"] = content_val
         try:
-            result = _decorate_mcp_tool_result(tool_name, TOOLS[tool_name]["handler"](**tool_args))
+            with _write_stall_watch(tool_name):
+                result = _decorate_mcp_tool_result(
+                    tool_name, TOOLS[tool_name]["handler"](**tool_args)
+                )
 
             return {
                 "jsonrpc": "2.0",
@@ -5265,6 +5349,130 @@ def _maybe_eager_warmup_embedder() -> None:
             palace_path,
             device,
         )
+
+
+_WRITE_STALL_WARN_ENV = "MEMPALACE_MCP_WRITE_STALL_WARN_SECS"
+_WRITE_STALL_WARN_DEFAULT = 60.0
+_WRITE_STALL_EXIT_ENV = "MEMPALACE_MCP_WRITE_STALL_EXIT_SECS"
+_WRITE_STALL_EXIT_DEFAULT = 0.0
+# EX_TEMPFAIL: the palace is fine, this process is not. A client that restarts
+# the server gets a working one; a zero exit would read as an orderly shutdown.
+_WRITE_STALL_EXIT_CODE = 75
+
+_write_stall_lock = threading.Lock()
+# Optional[dict]: {"tool": str, "since": float(monotonic), "warned": bool}
+_write_stall_inflight: Optional[dict] = None
+
+
+def _write_stall_secs(env_name: str, default: float) -> float:
+    raw = os.environ.get(env_name, "")
+    if not raw.strip():
+        return default
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        logger.warning("%s=%r is not a number; using %.0fs", env_name, raw, default)
+        return default
+
+
+def _write_stall_action(elapsed: float, warn_secs: float, exit_secs: float, warned: bool):
+    """Decide what an in-flight vector write has earned: ``None``/warn/exit.
+
+    Pure so the thresholds can be tested without a stalled write; ``exit`` is
+    checked first so a single tick can escalate straight past an unsent warning.
+    """
+    if exit_secs > 0 and elapsed >= exit_secs:
+        return "exit"
+    if warn_secs > 0 and elapsed >= warn_secs and not warned:
+        return "warn"
+    return None
+
+
+@contextlib.contextmanager
+def _write_stall_watch(tool_name: str):
+    """Register a vector write as in flight for the stall watchdog."""
+    global _write_stall_inflight
+
+    if tool_name not in _VECTOR_WRITE_TOOLS:
+        yield
+        return
+
+    with _write_stall_lock:
+        _write_stall_inflight = {
+            "tool": tool_name,
+            "since": time.monotonic(),
+            "warned": False,
+        }
+    try:
+        yield
+    finally:
+        with _write_stall_lock:
+            _write_stall_inflight = None
+
+
+def _start_write_stall_watchdog() -> None:
+    """Start a daemon thread that reports a vector write that stopped returning.
+
+    A chromadb write has no timeout of its own. When one blocks, this process
+    holds the dispatch lock, the palace mine lock and the writer lease, so it
+    answers nothing else and every peer session drops to read-only — and no log
+    on the server side says why. The only trace of a 25-minute outage was the
+    client's own "tool still running" ticks; the handshake stayed healthy, and
+    ``mempalace_status`` could not answer because the dispatch lock was held by
+    the stuck call. So the report has to come from a thread that is not waiting
+    on that lock, and it has to reach stderr, where the MCP host records it.
+
+    ``MEMPALACE_MCP_WRITE_STALL_WARN_SECS`` (default 60, 0 disables) sets when to
+    warn. ``MEMPALACE_MCP_WRITE_STALL_EXIT_SECS`` (default 0 = never) lets an
+    operator turn the wedge into a restartable failure: a server stuck inside
+    chromadb will not recover, and exiting is what releases the locks its peers
+    are queued behind.
+    """
+    warn_secs = _write_stall_secs(_WRITE_STALL_WARN_ENV, _WRITE_STALL_WARN_DEFAULT)
+    exit_secs = _write_stall_secs(_WRITE_STALL_EXIT_ENV, _WRITE_STALL_EXIT_DEFAULT)
+    if warn_secs <= 0 and exit_secs <= 0:
+        return
+
+    thresholds = [t for t in (warn_secs, exit_secs) if t > 0]
+    interval = max(1.0, min(15.0, min(thresholds) / 4))
+
+    def _watchdog() -> None:
+        while True:
+            time.sleep(interval)
+            with _write_stall_lock:
+                inflight = _write_stall_inflight
+                if inflight is None:
+                    continue
+                elapsed = time.monotonic() - inflight["since"]
+                action = _write_stall_action(elapsed, warn_secs, exit_secs, inflight["warned"])
+                tool = inflight["tool"]
+                if action == "warn":
+                    inflight["warned"] = True
+            if action == "warn":
+                logger.warning(
+                    "%s has been inside the palace write path for %.0fs and has not "
+                    "returned. chromadb writes have no timeout: this server now answers "
+                    "nothing else and holds the writer lease, so peer sessions are "
+                    "read-only. Check `mempalace repair --dry-run` for HNSW divergence; "
+                    "restarting this MCP server releases the locks.",
+                    tool,
+                    elapsed,
+                )
+            elif action == "exit":
+                logger.error(
+                    "%s stalled in the palace write path for %.0fs (limit %s=%.0fs); "
+                    "exiting so the palace locks are released and the client can "
+                    "reconnect. The stalled write is lost — rebuild the index before "
+                    "retrying it.",
+                    tool,
+                    elapsed,
+                    _WRITE_STALL_EXIT_ENV,
+                    exit_secs,
+                )
+                os._exit(_WRITE_STALL_EXIT_CODE)
+
+    t = threading.Thread(target=_watchdog, name="mcp-write-stall-watchdog", daemon=True)
+    t.start()
 
 
 def _start_idle_exit_watchdog() -> None:
@@ -5686,6 +5894,10 @@ def _run_stdio_loop() -> None:
     # that outlived their Claude Code session (#1552).
     _start_idle_exit_watchdog()
 
+    # Say so when a chromadb write stops coming back, from a thread the stuck
+    # call is not blocking.
+    _start_write_stall_watchdog()
+
     while True:
         try:
             line = sys.stdin.readline()
@@ -5759,6 +5971,7 @@ def _run_http_loop() -> None:
         # soon as the process is alive.
         _refresh_vector_disabled_flag()
         _start_idle_exit_watchdog()
+        _start_write_stall_watchdog()
 
         raw_warmup = os.environ.get("MEMPALACE_EAGER_WARMUP", "").strip().lower()
         if raw_warmup in _WARMUP_TRUTHY:

--- a/tests/test_vector_write_gate.py
+++ b/tests/test_vector_write_gate.py
@@ -1,0 +1,252 @@
+"""Tests for the write-side half of the #1222 HNSW divergence guard.
+
+The capacity probe already routed *reads* to the BM25 fallback when the flushed
+HNSW segment lags sqlite. These cover the two gaps that left writes exposed:
+
+* ``_mcp_diverged_index_refusal`` — a vector write into a diverged index is
+  refused at dispatch instead of reaching chromadb, where an upsert can block
+  for the life of the process.
+* the write-stall watchdog — when a write does stop coming back anyway, a
+  thread that the stuck call is not blocking says so on stderr, and an operator
+  can opt into turning the wedge into a restartable exit.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+
+REASON = "HNSW index holds 803 elements but sqlite has 820 embeddings"
+
+
+@pytest.fixture
+def diverged(monkeypatch):
+    """A palace whose vector index is known-diverged, probe counted."""
+    from mempalace import mcp_server
+
+    probes = {"n": 0}
+
+    def _probe():
+        probes["n"] += 1
+
+    monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", _probe)
+    monkeypatch.setattr(mcp_server, "_vector_disabled", True)
+    monkeypatch.setattr(mcp_server, "_vector_disabled_reason", REASON)
+    return probes
+
+
+# ── Dispatch gate ─────────────────────────────────────────────────────────
+
+
+def test_vector_write_refused_while_index_diverged(diverged):
+    from mempalace import mcp_server
+
+    err = mcp_server._mcp_diverged_index_refusal(req_id=7, tool_name="mempalace_add_drawer")
+
+    assert err is not None
+    assert err["id"] == 7
+    assert err["error"]["code"] == mcp_server._DIVERGED_INDEX_ERROR_CODE
+    data = err["error"]["data"]
+    assert data["tool"] == "mempalace_add_drawer"
+    assert data["vector_disabled_reason"] == REASON
+    # The refusal has to carry the way out, not just the verdict.
+    assert "rebuild-index" in data["hint"]
+
+
+@pytest.mark.parametrize(
+    "tool",
+    sorted(
+        {
+            "mempalace_add_drawer",
+            "mempalace_update_drawer",
+            "mempalace_delete_drawer",
+            "mempalace_delete_by_source",
+            "mempalace_diary_write",
+            "mempalace_checkpoint",
+            "mempalace_mine",
+            "mempalace_sync",
+        }
+    ),
+)
+def test_every_vector_write_tool_is_gated(diverged, tool):
+    from mempalace import mcp_server
+
+    assert tool in mcp_server._MUTATING_TOOLS, "the vector set must stay a subset"
+    assert mcp_server._mcp_diverged_index_refusal(req_id=1, tool_name=tool) is not None
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        "mempalace_kg_add",
+        "mempalace_kg_invalidate",
+        "mempalace_kg_supersede",
+        "mempalace_create_tunnel",
+        "mempalace_delete_tunnel",
+        "mempalace_delete_hallway",
+    ],
+)
+def test_non_vector_writes_are_not_gated(diverged, tool):
+    """The knowledge graph and hallways keep their own state — a broken HNSW
+    segment has no say over them, and must not even cost them a probe."""
+    from mempalace import mcp_server
+
+    assert mcp_server._mcp_diverged_index_refusal(req_id=1, tool_name=tool) is None
+    assert diverged["n"] == 0
+
+
+def test_read_tools_are_not_gated(diverged):
+    """Reads have their own fallback (BM25); refusing them here would break it."""
+    from mempalace import mcp_server
+
+    assert mcp_server._mcp_diverged_index_refusal(req_id=1, tool_name="mempalace_search") is None
+
+
+def test_healthy_index_allows_the_write(monkeypatch):
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(mcp_server, "_refresh_vector_disabled_flag", lambda: None)
+    monkeypatch.setattr(mcp_server, "_vector_disabled", False)
+
+    assert (
+        mcp_server._mcp_diverged_index_refusal(req_id=1, tool_name="mempalace_add_drawer") is None
+    )
+
+
+def test_gate_re_probes_so_a_repair_un_gates_without_restart(diverged):
+    """The gate must consult the probe on every call: a long-lived stdio server
+    has to notice `mempalace repair` finishing in another process."""
+    from mempalace import mcp_server
+
+    mcp_server._mcp_diverged_index_refusal(req_id=1, tool_name="mempalace_add_drawer")
+    mcp_server._mcp_diverged_index_refusal(req_id=2, tool_name="mempalace_add_drawer")
+
+    assert diverged["n"] == 2
+
+
+def test_preflight_reports_divergence_ahead_of_the_peer_writer_lock(diverged, monkeypatch):
+    """Both gates can be up at once — a peer holds the lease *because* this
+    palace is wedged. The diverged verdict is the actionable one."""
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(mcp_server, "_mcp_read_only_refusal", lambda req_id, tool_name: None)
+    monkeypatch.setattr(mcp_server, "_mcp_sqlite_integrity_refusal", lambda req_id, tool_name: None)
+    monkeypatch.setattr(
+        mcp_server,
+        "_mcp_peer_writer_refusal",
+        lambda req_id, tool_name: {"error": {"code": -32001}},
+    )
+
+    err = mcp_server._mcp_tool_preflight_refusal(req_id=3, tool_name="mempalace_add_drawer")
+
+    assert err["error"]["code"] == mcp_server._DIVERGED_INDEX_ERROR_CODE
+
+
+def test_dispatch_refuses_before_the_handler_runs(diverged, monkeypatch):
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(mcp_server, "_mcp_sqlite_integrity_refusal", lambda req_id, tool_name: None)
+    monkeypatch.setattr(mcp_server, "_mcp_peer_writer_refusal", lambda req_id, tool_name: None)
+
+    def _must_not_run(**kwargs):  # pragma: no cover - the point is that it never runs
+        raise AssertionError("handler reached chromadb despite the diverged index")
+
+    monkeypatch.setitem(mcp_server.TOOLS["mempalace_add_drawer"], "handler", _must_not_run)
+
+    resp = mcp_server.handle_request(
+        {
+            "method": "tools/call",
+            "id": 11,
+            "params": {
+                "name": "mempalace_add_drawer",
+                "arguments": {"wing": "w", "room": "r", "content": "c"},
+            },
+        }
+    )
+
+    assert resp["error"]["code"] == mcp_server._DIVERGED_INDEX_ERROR_CODE
+
+
+# ── Write-stall watchdog ──────────────────────────────────────────────────
+
+
+def test_stall_action_warns_once_then_stays_quiet():
+    from mempalace import mcp_server
+
+    assert mcp_server._write_stall_action(59.0, 60.0, 0.0, False) is None
+    assert mcp_server._write_stall_action(60.0, 60.0, 0.0, False) == "warn"
+    assert mcp_server._write_stall_action(600.0, 60.0, 0.0, True) is None
+
+
+def test_stall_action_escalates_to_exit_when_opted_in():
+    from mempalace import mcp_server
+
+    assert mcp_server._write_stall_action(299.0, 60.0, 300.0, True) is None
+    assert mcp_server._write_stall_action(300.0, 60.0, 300.0, True) == "exit"
+    # A single tick may cross both lines; exit wins over an unsent warning.
+    assert mcp_server._write_stall_action(300.0, 60.0, 300.0, False) == "exit"
+
+
+def test_stall_action_respects_disabled_thresholds():
+    from mempalace import mcp_server
+
+    assert mcp_server._write_stall_action(10_000.0, 0.0, 0.0, False) is None
+
+
+def test_stall_secs_falls_back_on_garbage(monkeypatch):
+    from mempalace import mcp_server
+
+    monkeypatch.setenv(mcp_server._WRITE_STALL_WARN_ENV, "soon")
+    assert mcp_server._write_stall_secs(mcp_server._WRITE_STALL_WARN_ENV, 60.0) == 60.0
+
+    monkeypatch.setenv(mcp_server._WRITE_STALL_WARN_ENV, "-5")
+    assert mcp_server._write_stall_secs(mcp_server._WRITE_STALL_WARN_ENV, 60.0) == 0.0
+
+    monkeypatch.delenv(mcp_server._WRITE_STALL_WARN_ENV)
+    assert mcp_server._write_stall_secs(mcp_server._WRITE_STALL_WARN_ENV, 60.0) == 60.0
+
+
+def test_stall_watch_registers_the_write_and_clears_it():
+    from mempalace import mcp_server
+
+    with mcp_server._write_stall_watch("mempalace_add_drawer"):
+        inflight = mcp_server._write_stall_inflight
+        assert inflight is not None
+        assert inflight["tool"] == "mempalace_add_drawer"
+        assert inflight["warned"] is False
+
+    assert mcp_server._write_stall_inflight is None
+
+
+def test_stall_watch_clears_on_failure():
+    """A raising handler must not leave a phantom write in flight — the next
+    write would inherit its clock and trip the watchdog."""
+    from mempalace import mcp_server
+
+    with pytest.raises(RuntimeError):
+        with mcp_server._write_stall_watch("mempalace_checkpoint"):
+            raise RuntimeError("boom")
+
+    assert mcp_server._write_stall_inflight is None
+
+
+def test_stall_watch_ignores_tools_that_never_reach_chromadb():
+    from mempalace import mcp_server
+
+    with mcp_server._write_stall_watch("mempalace_search"):
+        assert mcp_server._write_stall_inflight is None
+
+
+def test_watchdog_thread_not_started_when_both_thresholds_are_zero(monkeypatch):
+    from mempalace import mcp_server
+
+    monkeypatch.setenv(mcp_server._WRITE_STALL_WARN_ENV, "0")
+    monkeypatch.setenv(mcp_server._WRITE_STALL_EXIT_ENV, "0")
+    before = [t.name for t in threading.enumerate()]
+
+    mcp_server._start_write_stall_watchdog()
+
+    after = [t.name for t in threading.enumerate()]
+    assert after == before


### PR DESCRIPTION
Tier-1 guardrail from #1963, on the side the existing guard does not cover: **writes**. Closes the hole that #1845 / #1908 report as "MCP tools hang forever".

## The gap

`#1222`'s capacity probe already keeps a diverged palace usable for recall — `search` and `check_duplicate` fall back to BM25-only sqlite. The write path had no equivalent: it went straight to chromadb. And a write into a diverged index does not fail. It blocks inside chromadb's Rust upsert, which has no timeout of its own, for the life of the process — while the server holds the dispatch lock, the palace mine lock and the writer lease.

That turns one stuck call into a palace-wide outage that hides behind a healthy handshake:

| Symptom | Why it misleads |
|---|---|
| MCP handshake keeps answering | the server looks alive; only writes are gone |
| `mempalace_status` never returns | the stuck call holds `_REQUEST_DISPATCH_LOCK` |
| peer sessions go read-only | the wedged process still holds the writer lease |
| nothing in any server-side log | the only trace was the client's own `tool 'mempalace_checkpoint' still running (960s elapsed)` ticks |

## Forensics from the incident behind this PR

MemPalace 3.7.0, chromadb 1.5.9, Linux, 820-drawer palace. `mempalace_checkpoint` wedged for 25+ minutes and had to be killed; it was the second wedge that day.

Live `py-spy` on the stuck process:

```
Thread (idle): "MainThread"
    syscall (libc.so.6)
    0x… (chromadb_rust_bindings.abi3.so)
    _upsert (chromadb/api/rust.py:549)
    upsert (chromadb/api/models/Collection.py:530)
    upsert (mempalace/backends/chroma.py:1677)
    tool_add_drawer (mempalace/mcp_server.py)
    tool_checkpoint (mempalace/mcp_server.py)
```

0% CPU, 64 idle `tokio-rt-worker` threads, and **no fcntl lock on `chroma.sqlite3` at all** (`/proc/locks` clean) — an internal wait inside the Rust core, not sqlite contention and not cross-process locking.

State of that palace: flushed HNSW segment held **803 elements against 820 sqlite rows**; vector segment `max_seq_id` stuck one record behind the metadata segment, exactly the chroma#6975 shape the epic documents.

Reproduced on `cp -a` copies (never on the live palace), one write per copy, differing only in the embedding:

| vector | before rebuild | after `repair rebuild-index` |
|---|---|---|
| seed 1 | commits, 0.03s | commits, 0.24s |
| seed 2 | **hangs** | commits, 0.24s |
| seed 3 | **hangs** | commits, 0.21s |
| seed 4 | **hangs** | commits, 0.20s |
| seed 5 | commits, 0.03s | commits, 0.24s |

Re-running a hanging vector hangs again; re-running a committing one commits again. So it is not a race — a write's fate is a deterministic function of where its embedding lands in the damaged graph. That is why the same palace serves some checkpoints and swallows others, and why "it worked a minute ago" is worthless as evidence here.

**The write that does not hang is not safe either.** In the same incident, 16 drawers came out of a single checkpoint that returned `completed successfully in 2s`: chromadb acknowledged them into sqlite and the metadata segment and left them out of the HNSW segment. They were filed, reported as success, and invisible to vector search until the rebuild.

## What this PR adds

**1. `_mcp_diverged_index_refusal` — dispatch refuses vector writes while the probe reports divergence.**

Placed in `_mcp_tool_preflight_refusal` after the sqlite-integrity gate and *before* the peer-writer gate: both can be up at once (a peer holds the lease precisely because this palace is wedged), and the diverged verdict is the actionable one. The error payload carries the reason and the way out (`mempalace repair rebuild-index`, then `mempalace_reconnect`).

Scoped by a new `_VECTOR_WRITE_TOOLS`, deliberately narrower than `_MUTATING_TOOLS`: the knowledge-graph and tunnel/hallway tools keep their own sqlite/JSON state, never reach the segment, and must not even pay for the probe. The probe itself is pure sqlite + pickle, so the gate costs no chromadb interaction on the path it protects, and it re-runs per call — a `repair` finishing in another process un-gates a long-lived stdio server without a restart.

**2. A write-stall watchdog — say it when a chromadb write stops coming back.**

`MEMPALACE_MCP_WRITE_STALL_WARN_SECS` (default 60, `0` disables) warns from a thread the stuck call is not blocking, on stderr, where the MCP host records it. That alone would have turned a silent 25-minute outage into a line naming chromadb, the writer lease and the repair command at the 60-second mark.

`MEMPALACE_MCP_WRITE_STALL_EXIT_SECS` (default `0` = never) is the opt-in half: a server stuck inside chromadb never recovers, and exiting is the only thing that releases the palace locks its peers are queued behind. Exit code 75 (`EX_TEMPFAIL`) so it does not read as an orderly shutdown. Default off — no behaviour change for anyone who does not ask for it.

## What this PR does not do

- It does not fix the root cause. chroma#6975 and the multi-writer topology stay exactly as #1963 describes them; Tier 3 is still the only durable answer. This converts an unbounded hang into a bounded, actionable refusal.
- It does not touch the CLI path, so the Tier-1 item "CLI `search()` divergence probe" stays open.
- It does not try to cancel a write already inside chromadb — a blocking Rust call cannot be interrupted from Python. The watchdog reports it, and optionally exits; it never pretends to unwind it.

## Tests

`tests/test_vector_write_gate.py`, 28 tests: every gated tool refused, every non-vector mutating tool untouched (and unprobed), healthy index un-gated, probe re-run per call, gate ordering inside preflight, dispatch refusing before the handler runs, plus the watchdog's threshold decisions (warn once, escalate to exit, disabled by `0`), env parsing fallbacks, and in-flight registration clearing on both success and exception.

Full suite on Linux/py3.12 with chromadb 1.5.9: **3629 passed, 31 skipped**. Six failures in my sandbox (`test_init_filters_sys_path_from_leaked_pythonpath` ×5 and `test_sqlite_exact_read_only_open_sees_active_writer_wal`) are artifacts of the venv I test in — it injects a second site-packages via a `.pth`, which is exactly the sys.path shape those tests assert about — and reproduce identically on a pristine `develop` checkout in the same venv, so they are not from this change.

`ruff check` and `ruff format --check` clean under both pins in the tree — `0.15.14` (ci.yml) and `0.15.20` (pyproject `dev`); those two disagree, which may be worth a separate one-line fix given the "keep this pin identical" comment in ci.yml.

Refs #1845, #1908, #1963
