### PR TITLE
fix: crash in --llm-rerank output for model names without a dash

### DIFF
--- a/benchmarks/locomo_bench.py
+++ b/benchmarks/locomo_bench.py
@@ -665,7 +665,7 @@ def run_benchmark(
                 palace_cache = json.load(f)
             print(f"  Palace cache: {len(palace_cache)} room assignments loaded")
 
-    rerank_label = f" + LLM re-rank ({llm_model.split('-')[1]})" if llm_rerank_enabled else ""
+    rerank_label = f" + LLM re-rank ({llm_model})" if llm_rerank_enabled else ""
 
     print(f"\n{'=' * 60}")
     print("  MemPal × LoCoMo Benchmark")

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -3015,7 +3015,7 @@ def run_benchmark(
 
         if unique_sessions and api_key and not skip_precompute:
             print(
-                f"  Diary ingest: pre-computing {len(unique_sessions)} sessions with {llm_model.split('-')[1]}..."
+                f"  Diary ingest: pre-computing {len(unique_sessions)} sessions with {llm_model}..."
             )
             done = 0
             cache_path = Path(diary_cache_file) if diary_cache_file else None

--- a/benchmarks/longmemeval_bench.py
+++ b/benchmarks/longmemeval_bench.py
@@ -3051,9 +3051,8 @@ def run_benchmark(
     print(f"  Data:        {Path(data_file).name}")
     print(f"  Questions:   {len(data)}")
     print(f"  Granularity: {granularity}")
-    model_short = llm_model.split("-")[1] if "-" in llm_model else llm_model
-    rerank_label = f" + LLM re-rank ({model_short})" if llm_rerank_enabled else ""
-    diary_label = f" [diary ingest: {model_short}]" if mode == "diary" else ""
+    rerank_label = f" + LLM re-rank ({llm_model})" if llm_rerank_enabled else ""
+    diary_label = f" [diary ingest: {llm_model}]" if mode == "diary" else ""
     print(f"  Mode:        {mode}{diary_label}{rerank_label}")
     print(f"{'─' * 60}\n")
 


### PR DESCRIPTION
## What does this PR do?

`llm_model.split('-')[1]` raises `IndexError` for any model tag containing no dash. Three sites, two files, all of them building a display label:

| File | Line (pre-fix) | Effect |
|---|---|---|
| `benchmarks/locomo_bench.py` | 668 | crashes the whole benchmark at startup whenever `--llm-rerank` is on |
| `benchmarks/longmemeval_bench.py` | 3018 | same pattern on the diary pre-compute path |
| `benchmarks/longmemeval_bench.py` | 3054 | dash-guarded, so no crash, but same "guess a short name" logic |

Reproduce:

```bash
python benchmarks/locomo_bench.py locomo10.json --mode hybrid --llm-rerank \
  --llm-backend ollama --llm-model qwen3:8b
# IndexError: list index out of range
```

Any Ollama tag without a dash (`qwen3:8b`, `llama3:70b`) or OpenAI-compatible gateway route (`spark/fast`, provider-prefixed LiteLLM routes) triggers it, which is exactly the model population `--llm-backend ollama` exists to serve.

Every site only builds a string for `print()`, so the fix is to print the full model tag instead of guessing a short name from a dash split.

The third site is why this is two commits rather than one. The first commit patched the crashing line and missed the summary header 36 lines below it in the same `run_benchmark`. That line is dash-guarded so it never crashed, but after the first commit a single run printed two different spellings of one model: the diary pre-compute line showed `claude-sonnet-4-6` and the summary header showed `sonnet`; for `llama3.2-vision:11b` the header showed `vision:11b`. The second commit fixes it, and the two commits are kept separate because the miss is worth seeing.

What the old expression actually produced:

| tag | `tag.split('-')[1]` | now |
|---|---|---|
| `qwen3:8b` | `IndexError: list index out of range` | `qwen3:8b` |
| `llama3.2-vision:11b` | `vision:11b` | `llama3.2-vision:11b` |
| `claude-sonnet-4-6` | `sonnet` | `claude-sonnet-4-6` |

Scope check: `rerank_label`, `diary_label` and `model_short` reach only `print()` calls (`locomo_bench.py:676,956`, `longmemeval_bench.py:3057`). None of them enters `results_log`, a JSON field, or `out_file`, so printing a full tag containing `/` or `:` cannot introduce a path-construction bug. Every other `split('-')` in the repo (`convo_scanner.py:90`, `palace_graph.py:326`, `dialect.py:705,736,737,747`) operates on zettel or tunnel ids and project slugs, not model tags. `llm_model` cannot be `None` at any patched line: both argparse defaults are string literals (`locomo_bench.py:1042`, `longmemeval_bench.py:3318`).

No dash-split of a model tag remains anywhere under `benchmarks/`.

## How to test

**CI does not cover these files, and I would rather say so than let the suite count imply otherwise.** Verified on this branch:

```
$ pytest --collect-only benchmarks/ -q
no tests collected in 0.08s          # pyproject.toml:184  testpaths = ["tests"]

$ grep -rln 'locomo_bench\|longmemeval_bench' tests/
                                     # 0 files

$ ruff check .
All checks passed!                   # pyproject.toml:171  extend-exclude = ["benchmarks", "*.md"]
```

`.github/workflows/ci.yml:22,41,55` runs `pytest tests/ --ignore=tests/benchmarks`, which ignores a different directory and is irrelevant here. A syntax error in either file would pass CI. So the full-suite result below is evidence of no regression elsewhere, not evidence for this change.

Evidence that is actually about this change:

```
# the failing expression, on the tags that reach it
$ python -c "print('qwen3:8b'.split('-')[1])"
IndexError: list index out of range

# both files still import and parse (argparse --help forces module import)
$ python benchmarks/locomo_bench.py --help        # OK
$ python benchmarks/longmemeval_bench.py --help   # OK

# no dash-split of a model tag left
$ grep -rn "llm_model.split\|model_short" benchmarks/
                                                  # none

# lint, with the exclude bypassed by naming the paths explicitly
$ ruff format --check benchmarks/locomo_bench.py benchmarks/longmemeval_bench.py
2 files already formatted
$ ruff check benchmarks/locomo_bench.py benchmarks/longmemeval_bench.py
Found 6 errors     # identical count on develop: pre-existing, untouched by this diff
```

End-to-end: `locomo_bench` was run with `--llm-backend ollama --llm-model spark/fast` against an OpenAI-compatible endpoint. Before the change it crashed at startup; after it completes (1,986 questions) and the label reads `+ LLM re-rank (spark/fast)`.

Full suite, for the no-regression claim only: **3850 passed, 31 skipped**, exactly equal to pristine `origin/develop@e73e75b` in the same environment, as it must be for a diff that touches only `benchmarks/`. ruff 0.16.1 (the pinned version), Python 3.12.13.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`): 3850 passed, 31 skipped; identical to develop, since this diff touches only `benchmarks/`, which is outside `testpaths`
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`): clean on ruff 0.16.1; `benchmarks/` is inside `extend-exclude`, and the two changed files show the same 6 pre-existing errors as on develop when linted explicitly

---