### PR TITLE
feat(pgvector): push the lexical filter down to Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Shared-brain rules are `host:harness:project`, declared-idle, and MCP-shape aware.** `mempalace rules` takes `--host --harness --project` (stable lowercase tokens) and optional `--mcp full|light` (default `full`, matching the 45-tool server). The packaged snippet is the only coordination text: compose the identity from the current workspace, arm `logstream watch` only on listen / claim / delegate, write topics on named lanes without filtering the default inbox on them, claim with a lowest-HLC mutex, and use `kg_supersede` for single-valued fact changes. `--mcp light` swaps tool tokens onto the 3-tool triad; prose is identical. `logstream watch --agent` now defaults a sanitized `--state-file` (`:` → `_` under `~/.mempalace/watch/`) so Windows tuple identities do not need a private path overlay.
 
+### Performance
+
+- **pgvector lexical search no longer scrolls the whole table.** `lexical_search` pushed every document over the wire on every call, which made hybrid search unusable on a remote palace of ~141k drawers. Postgres now evaluates a substring filter that is a provable superset of the documents BM25 can score above zero, so only candidate rows cross the wire. Scoring, ranking and the `n_results` cut stay client-side and produce the same ids and the same scores as before. Collections gain a `token_count` column and a `pg_trgm` index; a palace created earlier picks both up on open and is backfilled once. `maintenance_state()` now reports `lexical_pushdown` so an operator can see which path a collection is on. (#2165)
+
 ### Bug Fixes
 
 - **The transcript-path fallback no longer gives every git worktree its own wing.** `_wing_from_transcript_path`'s primary path (reading `cwd` from the JSONL) already collapsed a `<project>/.claude/worktrees/<wt>` segment before deriving the wing; the fallback path, used whenever `cwd` is absent, had no equivalent strip, so the flattened `--claude-worktrees-<wt>` segment survived into the wing name. Applied the same collapse there. (#2388)

--- a/mempalace/backends/pgvector.py
+++ b/mempalace/backends/pgvector.py
@@ -94,6 +94,14 @@ _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
 # fold to "_", and the character set the result must then consist of.
 _SHARED_NAMESPACE_SEPARATOR_RE = re.compile(r"[\s\-./:_]+")
 _SHARED_NAMESPACE_RE = re.compile(r"^[a-z0-9_]*[a-z0-9][a-z0-9_]*$")
+
+# Text-search configuration for the pushed-down lexical arm. 'simple' does no
+# stemming and no stop-word removal, so it tokenizes any script the same way
+# ``_TOKEN_RE`` does — Arabic, CJK and English drawers all stay searchable in
+# one palace. A language config ('english') would stem and drop stop words for
+# English while silently degrading every other language, which breaks the
+# verbatim-recall promise for a mixed corpus.
+_FTS_CONFIG = "simple"
 # Operators that translate to a JSONB containment predicate and so can be
 # pushed down to SQL. Comparisons, $or and $contains stay on the local exact
 # path (Python filtering), mirroring the Qdrant backend's local fallback.
@@ -161,6 +169,36 @@ def _tokenize(text: str) -> list[str]:
     if not text:
         return []
     return _TOKEN_RE.findall(text.lower())
+
+
+def _escape_tsquery_token(token: str) -> str:
+    """Quote one token so ``to_tsquery`` reads it as a literal lexeme.
+
+    ``to_tsquery`` parses its argument as a *query expression*, so an unquoted
+    token carrying ``& | ! ( ) : *`` or ``<->`` would either inject operators or
+    abort the whole search with a syntax error. Wrapping the token in single
+    quotes reduces it to one lexeme; inside those quotes only ``'`` and ``\\``
+    keep any meaning, and both are neutralized by doubling them.
+
+    Tokens produced by :func:`_tokenize` are ``\\w``-only and never need this,
+    but the escape keeps the SQL correct for any future caller that feeds
+    ``lexical_rows`` raw user text.
+    """
+    escaped = token.replace("\\", "\\\\").replace("'", "''")
+    return f"'{escaped}'"
+
+
+def _tsquery_or(tokens: list[str]) -> str:
+    """Build an OR-semantics tsquery string from tokenizer output.
+
+    ``websearch_to_tsquery`` ANDs bare terms, which is far stricter than the
+    any-term scoring the BM25 path it replaces uses: a five-word question would
+    match nothing. Joining with ``|`` keeps the lexical arm a recall-oriented
+    candidate generator, which is what the hybrid re-ranker expects.
+
+    Empty tokens are dropped — an empty quoted lexeme is a tsquery syntax error.
+    """
+    return " | ".join(_escape_tsquery_token(token) for token in tokens if token)
 
 
 def _bm25_scores(query: str, documents: list[str], k1: float = 1.5, b: float = 0.75) -> list[float]:
@@ -538,6 +576,16 @@ def _hnsw_index_name(table: str) -> str:
     return _pg_identifier(f"{table}_hnsw_idx")
 
 
+def _fts_index_name(table: str) -> str:
+    """Deterministic, collision-safe full-text index name for ``table``.
+
+    Table-qualified so two collections sharing a schema cannot claim one index,
+    and routed through :func:`_pg_identifier` for the same reason
+    :func:`_hnsw_index_name` is.
+    """
+    return _pg_identifier(f"{table}_fts_idx")
+
+
 def _field_sql(field: str, expression: Any, params: list) -> str:
     """Translate one field predicate to a JSONB containment expression."""
     if isinstance(expression, dict):
@@ -823,6 +871,33 @@ class _PgVectorClient:
             f"embedding vector({int(dimension)}), "
             "updated_at timestamptz)"
         )
+        self.create_fts_index(table)
+
+    def create_fts_index(self, table: str) -> None:
+        """Create the GIN expression index backing :meth:`lexical_rows`.
+
+        Built here rather than behind ``run_maintenance`` because the table is
+        empty at creation time, so the build is instant and cannot block
+        writers — unlike the HNSW index, which is opt-in precisely because a
+        late build takes ACCESS EXCLUSIVE on a populated table. A palace created
+        before this index existed still searches correctly; Postgres just falls
+        back to a sequential scan, which is one server-side scan instead of the
+        whole table crossing the wire.
+
+        Failure is logged and swallowed for the same reason
+        :meth:`ensure_extension` swallows: the index is a performance asset, not
+        a correctness one, and a restricted role must still be able to open a
+        collection.
+        """
+        qi = _quote_identifier(table)
+        idx = _quote_identifier(_fts_index_name(table))
+        try:
+            self._execute(
+                f"CREATE INDEX IF NOT EXISTS {idx} ON {qi} "
+                f"USING gin (to_tsvector('{_FTS_CONFIG}', document))"
+            )
+        except BackendError:
+            logger.debug("pgvector FTS index creation skipped", exc_info=True)
 
     def upsert_rows(self, table: str, rows: list[dict]) -> None:
         if not rows:
@@ -886,6 +961,43 @@ class _PgVectorClient:
             self._row(record, with_embedding=with_embedding, with_distance=True)
             for record in rows or []
         ]
+
+    def lexical_rows(
+        self,
+        table: str,
+        *,
+        tokens: list[str],
+        limit: int,
+        where: Optional[dict],
+    ) -> list[dict]:
+        """Rank rows by Postgres full-text relevance, top ``limit`` only.
+
+        ``where`` must already be pushdown-safe (see
+        :func:`_requires_local_filter`); the caller keeps anything broader on
+        the local path. Returns ``id``/``document``/``metadata``/``score``
+        dicts, ``score`` being ``ts_rank_cd`` — not BM25, which the hybrid
+        re-ranker recomputes in memory over the merged candidate pool anyway.
+        """
+        qi = _quote_identifier(table)
+        params: list = [_tsquery_or(tokens)]
+        where_sql = _where_to_sql(where, params) if where else "TRUE"
+        params.append(int(limit))
+        # SQL text order — tsquery %s in FROM, then WHERE params, then LIMIT %s
+        # — already matches positional binding order in ``params``.
+        sql = (
+            "SELECT id, document, metadata, "
+            f"ts_rank_cd(to_tsvector('{_FTS_CONFIG}', document), q) AS score "
+            f"FROM {qi}, to_tsquery('{_FTS_CONFIG}', %s) AS q "
+            f"WHERE to_tsvector('{_FTS_CONFIG}', document) @@ q AND ({where_sql}) "
+            "ORDER BY score DESC LIMIT %s"
+        )
+        rows = self._execute(sql, params, fetch=True)
+        out = []
+        for record in rows or []:
+            row = self._row(record, with_embedding=False, with_distance=False)
+            row["score"] = float(record[3]) if record[3] is not None else 0.0
+            out.append(row)
+        return out
 
     def scroll_rows(
         self,
@@ -1619,8 +1731,72 @@ class PgVectorCollection(BaseCollection):
             return {}
         return self._client.facet_counts(self._table, field=field, where=where, limit=limit)
 
-    def lexical_search(self, *, query: str, n_results: int = 10, where: Optional[dict] = None):
+    def lexical_search(
+        self, *, query: str, n_results: int = 10, where: Optional[dict] = None
+    ) -> LexicalResult:
+        """Rank drawers lexically, pushing the scan into Postgres when possible.
+
+        The local path below scrolls every row — documents included — to the
+        client and scores BM25 in Python, which costs O(table size) bytes over
+        the wire per query. On a remote palace of ~141k drawers that is minutes
+        per query and makes hybrid search unusable, so the default path hands
+        the work to Postgres full-text search instead.
+
+        Postgres is used only when ``where`` translates fully to SQL; anything
+        broader (``$or``, comparisons, ``$contains``) falls back to the exact
+        local path, as does a server-side failure, so the pushdown can never
+        change or drop results.
+        """
         _validate_where(where)
+        if not _requires_local_filter(where):
+            result = self._lexical_search_fts(query=query, n_results=n_results, where=where)
+            if result is not None:
+                return result
+        return self._lexical_search_local(query=query, n_results=n_results, where=where)
+
+    def _lexical_search_fts(
+        self, *, query: str, n_results: int, where: Optional[dict]
+    ) -> Optional[LexicalResult]:
+        """Postgres FTS arm of :meth:`lexical_search`; ``None`` means fall back."""
+        # Ordered exactly as the local path orders its checks: a closed
+        # collection raises before an empty query short-circuits.
+        self._ensure_open()
+        tokens = _tokenize(query)
+        if not tokens:
+            # No lexeme can match, and an empty tsquery is a syntax error.
+            return LexicalResult(hits=[])
+        if not self._table_exists():
+            if self._marker_exists():
+                raise CollectionNotInitializedError(self._collection_name)
+            return LexicalResult(hits=[])
+        try:
+            rows = self._client.lexical_rows(
+                self._table, tokens=tokens, limit=n_results, where=where
+            )
+        except BackendError:
+            # Fail open to the exact (slow) local path rather than silently
+            # dropping the lexical arm of a hybrid search.
+            logger.debug("pgvector FTS lexical search failed; falling back", exc_info=True)
+            return None
+        hits = [
+            LexicalHit(
+                id=row["id"],
+                document=row["document"],
+                metadata=row["metadata"],
+                score=row["score"],
+            )
+            for row in rows
+            # ``metadata @> ...`` is broader than the exact _matches_where
+            # contract for array/object values, so the filter is re-applied
+            # here exactly as the local path applies it.
+            if row["score"] > 0 and _matches_where(row["metadata"], where)
+        ]
+        return LexicalResult(hits=hits)
+
+    def _lexical_search_local(
+        self, *, query: str, n_results: int, where: Optional[dict]
+    ) -> LexicalResult:
+        """Exact client-side BM25 over a full scroll — the fallback path."""
         pushdown = None if _requires_local_filter(where) else where
         rows = self._scroll(where=pushdown, with_embedding=False)
         rows = [row for row in rows if _matches_where(row["metadata"], where)]

--- a/mempalace/backends/pgvector.py
+++ b/mempalace/backends/pgvector.py
@@ -95,13 +95,13 @@ _TOKEN_RE = re.compile(r"\w{2,}", re.UNICODE)
 _SHARED_NAMESPACE_SEPARATOR_RE = re.compile(r"[\s\-./:_]+")
 _SHARED_NAMESPACE_RE = re.compile(r"^[a-z0-9_]*[a-z0-9][a-z0-9_]*$")
 
-# Text-search configuration for the pushed-down lexical arm. 'simple' does no
-# stemming and no stop-word removal, so it tokenizes any script the same way
-# ``_TOKEN_RE`` does — Arabic, CJK and English drawers all stay searchable in
-# one palace. A language config ('english') would stem and drop stop words for
-# English while silently degrading every other language, which breaks the
-# verbatim-recall promise for a mixed corpus.
-_FTS_CONFIG = "simple"
+# Column holding ``len(_tokenize(document))`` for each row. BM25 needs the mean
+# document length over the *whole* corpus, not just over the rows a query
+# matched; keeping the count beside the row lets one cheap aggregate supply it
+# without the documents themselves crossing the wire. Written by Python (not a
+# generated column) so the stored value is by construction the same number
+# ``_bm25_scores`` computes — no second tokenizer to drift against.
+_TOKEN_COUNT_COLUMN = "token_count"
 # Operators that translate to a JSONB containment predicate and so can be
 # pushed down to SQL. Comparisons, $or and $contains stay on the local exact
 # path (Python filtering), mirroring the Qdrant backend's local fallback.
@@ -171,37 +171,54 @@ def _tokenize(text: str) -> list[str]:
     return _TOKEN_RE.findall(text.lower())
 
 
-def _escape_tsquery_token(token: str) -> str:
-    """Quote one token so ``to_tsquery`` reads it as a literal lexeme.
+def _token_count(document: str) -> int:
+    """The BM25 document length of ``document``, as stored in ``token_count``."""
+    return len(_tokenize(document))
 
-    ``to_tsquery`` parses its argument as a *query expression*, so an unquoted
-    token carrying ``& | ! ( ) : *`` or ``<->`` would either inject operators or
-    abort the whole search with a syntax error. Wrapping the token in single
-    quotes reduces it to one lexeme; inside those quotes only ``'`` and ``\\``
-    keep any meaning, and both are neutralized by doubling them.
 
-    Tokens produced by :func:`_tokenize` are ``\\w``-only and never need this,
-    but the escape keeps the SQL correct for any future caller that feeds
-    ``lexical_rows`` raw user text.
+def _like_pattern(token: str) -> str:
+    """Build the ``ILIKE`` pattern that tests whether ``token`` occurs in a document.
+
+    Every token :func:`_tokenize` produces is, by construction, a literal
+    substring of ``text.lower()`` — the regex only ever returns spans it matched
+    in that string. So ``document ILIKE '%<token>%'`` is true for *every*
+    document :func:`_bm25_scores` can score above zero, which is exactly the
+    superset property the pushdown needs to stay lossless.
+
+    ``%`` and ``_`` are LIKE wildcards and ``\\`` is the escape character; a
+    ``\\w`` token can only ever contain ``_``, but all three are escaped so the
+    pattern stays a literal-substring test for any future caller passing raw
+    text.
     """
-    escaped = token.replace("\\", "\\\\").replace("'", "''")
-    return f"'{escaped}'"
+    escaped = token.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+    return f"%{escaped}%"
 
 
-def _tsquery_or(tokens: list[str]) -> str:
-    """Build an OR-semantics tsquery string from tokenizer output.
+def _bm25_scores(
+    query: str,
+    documents: list[str],
+    k1: float = 1.5,
+    b: float = 0.75,
+    *,
+    corpus_size: Optional[int] = None,
+    corpus_avgdl: Optional[float] = None,
+) -> list[float]:
+    """Score ``documents`` against ``query`` with Okapi BM25.
 
-    ``websearch_to_tsquery`` ANDs bare terms, which is far stricter than the
-    any-term scoring the BM25 path it replaces uses: a five-word question would
-    match nothing. Joining with ``|`` keeps the lexical arm a recall-oriented
-    candidate generator, which is what the hybrid re-ranker expects.
+    ``corpus_size`` and ``corpus_avgdl`` describe the collection the documents
+    were drawn from. They matter when ``documents`` is a *filtered* candidate
+    pool rather than the whole collection: BM25's IDF term is a function of the
+    collection size and its length normalization is a function of the mean
+    document length, so scoring a pool with pool-derived statistics produces
+    different numbers — and therefore a different top-N — than scoring the whole
+    collection would. Supplying the collection-wide values makes the two
+    identical. Both default to the statistics of ``documents`` itself, which is
+    correct when the caller really did pass the whole collection.
 
-    Empty tokens are dropped — an empty quoted lexeme is a tsquery syntax error.
+    Document frequency needs no such treatment: a document containing a query
+    term always survives a filter built from those same terms, so counting
+    within the pool already yields the collection-wide count.
     """
-    return " | ".join(_escape_tsquery_token(token) for token in tokens if token)
-
-
-def _bm25_scores(query: str, documents: list[str], k1: float = 1.5, b: float = 0.75) -> list[float]:
     query_terms = set(_tokenize(query))
     n_docs = len(documents)
     if not query_terms or n_docs == 0:
@@ -211,7 +228,9 @@ def _bm25_scores(query: str, documents: list[str], k1: float = 1.5, b: float = 0
     doc_lens = [len(toks) for toks in tokenized]
     if not any(doc_lens):
         return [0.0] * n_docs
-    avgdl = sum(doc_lens) / n_docs or 1.0
+    avgdl = corpus_avgdl if corpus_avgdl else (sum(doc_lens) / n_docs or 1.0)
+    if corpus_size:
+        n_docs = corpus_size
 
     df = {term: 0 for term in query_terms}
     for toks in tokenized:
@@ -364,6 +383,31 @@ def _requires_local_filter(where: Optional[dict], where_document: Optional[dict]
                 stack.append(value)
             elif isinstance(value, list):
                 stack.extend(item for item in value if isinstance(item, dict))
+    return False
+
+
+def _has_null_operand(where: Optional[dict]) -> bool:
+    """True when ``where`` compares against JSON null anywhere.
+
+    ``metadata @> '{"k": null}'`` demands the key be *present* holding null,
+    while :func:`_matches_where` reads ``meta.get(key)`` and so also accepts the
+    key being absent — the containment predicate is strictly narrower, and no
+    amount of post-filtering can put back a row SQL never returned. The lexical
+    pushdown declines these filters rather than inherit the difference, because
+    it derives the BM25 corpus statistics from the SQL scope and needs that
+    scope to be the one the local path would have scored.
+    """
+    if not where:
+        return False
+    stack: list = [where]
+    while stack:
+        node = stack.pop()
+        if node is None:
+            return True
+        if isinstance(node, dict):
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
     return False
 
 
@@ -576,14 +620,14 @@ def _hnsw_index_name(table: str) -> str:
     return _pg_identifier(f"{table}_hnsw_idx")
 
 
-def _fts_index_name(table: str) -> str:
-    """Deterministic, collision-safe full-text index name for ``table``.
+def _trgm_index_name(table: str) -> str:
+    """Deterministic, collision-safe trigram index name for ``table``.
 
     Table-qualified so two collections sharing a schema cannot claim one index,
     and routed through :func:`_pg_identifier` for the same reason
     :func:`_hnsw_index_name` is.
     """
-    return _pg_identifier(f"{table}_fts_idx")
+    return _pg_identifier(f"{table}_trgm_idx")
 
 
 def _field_sql(field: str, expression: Any, params: list) -> str:
@@ -702,6 +746,10 @@ class _PgVectorClient:
         self._conn = None
         self._closed = False
         self._lock = threading.RLock()
+        # table -> whether it carries the token_count column. Guarded by the
+        # same lock every _execute takes, so concurrent collections sharing one
+        # client cannot see a half-written entry.
+        self._token_count_columns: dict[str, bool] = {}
 
     def _connect(self):
         try:
@@ -869,69 +917,155 @@ class _PgVectorClient:
             "document text NOT NULL DEFAULT '', "
             "metadata jsonb NOT NULL DEFAULT '{}'::jsonb, "
             f"embedding vector({int(dimension)}), "
-            "updated_at timestamptz)"
+            f"updated_at timestamptz, "
+            f"{_quote_identifier(_TOKEN_COUNT_COLUMN)} integer)"
         )
-        self.create_fts_index(table)
+        self.ensure_lexical_assets(table)
 
-    def create_fts_index(self, table: str) -> None:
-        """Create the GIN expression index backing :meth:`lexical_rows`.
+    def ensure_lexical_assets(self, table: str) -> None:
+        """Add the column and index the pushed-down lexical path wants.
 
-        Built here rather than behind ``run_maintenance`` because the table is
-        empty at creation time, so the build is instant and cannot block
-        writers — unlike the HNSW index, which is opt-in precisely because a
-        late build takes ACCESS EXCLUSIVE on a populated table. A palace created
-        before this index existed still searches correctly; Postgres just falls
-        back to a sequential scan, which is one server-side scan instead of the
-        whole table crossing the wire.
+        Both are best-effort. ``token_count`` is what makes the pushdown exact,
+        so a table without it simply stays on the local path — a correctness
+        floor, not a crash. The trigram index only makes the substring predicate
+        fast; without it Postgres sequentially scans, which is still one
+        server-side scan instead of the whole table crossing the wire.
 
-        Failure is logged and swallowed for the same reason
-        :meth:`ensure_extension` swallows: the index is a performance asset, not
-        a correctness one, and a restricted role must still be able to open a
+        Failures are logged and swallowed for the same reason
+        :meth:`ensure_extension` swallows: a restricted role that may not run
+        ``CREATE EXTENSION`` or ``ALTER TABLE`` must still be able to open a
         collection.
+
+        Deliberately *not* a ``to_tsvector`` expression index. Postgres caps a
+        tsvector at 1 MB, and that cap is enforced at write time by an
+        expression index, so indexing one would turn a large drawer from a slow
+        write into a failed write. A trigram index has no such cap.
         """
         qi = _quote_identifier(table)
-        idx = _quote_identifier(_fts_index_name(table))
+        col = _quote_identifier(_TOKEN_COUNT_COLUMN)
         try:
+            self._execute(f"ALTER TABLE {qi} ADD COLUMN IF NOT EXISTS {col} integer")
+        except BackendError:
+            logger.debug("pgvector token_count column not available", exc_info=True)
+        self._token_count_columns.pop(table, None)
+        try:
+            self._execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
             self._execute(
-                f"CREATE INDEX IF NOT EXISTS {idx} ON {qi} "
-                f"USING gin (to_tsvector('{_FTS_CONFIG}', document))"
+                f"CREATE INDEX IF NOT EXISTS {_quote_identifier(_trgm_index_name(table))} "
+                f"ON {qi} USING gin (document gin_trgm_ops)"
             )
         except BackendError:
-            logger.debug("pgvector FTS index creation skipped", exc_info=True)
+            logger.debug("pgvector trigram index creation skipped", exc_info=True)
+        self.backfill_token_counts(table)
+
+    def has_token_count(self, table: str) -> bool:
+        """Whether ``table`` carries the ``token_count`` column, memoized.
+
+        A palace created before this column existed keeps working; the lexical
+        path just sees ``False`` and stays local.
+        """
+        cached = self._token_count_columns.get(table)
+        if cached is not None:
+            return cached
+        try:
+            rows = self._execute(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = current_schema() "
+                "AND table_name = %s AND column_name = %s",
+                [table, _TOKEN_COUNT_COLUMN],
+                fetch=True,
+            )
+            present = bool(rows)
+        except BackendError:
+            logger.debug("pgvector token_count probe failed", exc_info=True)
+            present = False
+        self._token_count_columns[table] = present
+        return present
+
+    def backfill_token_counts(self, table: str, batch: int = 2000) -> int:
+        """Fill ``token_count`` for rows written before the column existed.
+
+        Counted in Python, by the same :func:`_tokenize` BM25 uses, rather than
+        by a Postgres regex that only *approximately* agrees with it — a
+        backfilled length that is off by one silently changes every future
+        ranking for that collection.
+
+        The one-time cost is a single pass of the documents over the wire, which
+        is what *every* lexical query used to cost. Returns the number of rows
+        filled; best-effort, so a role without UPDATE just leaves the collection
+        on the local path.
+        """
+        if not self.has_token_count(table):
+            return 0
+        qi = _quote_identifier(table)
+        col = _quote_identifier(_TOKEN_COUNT_COLUMN)
+        filled = 0
+        try:
+            while True:
+                rows = self._execute(
+                    f"SELECT id, document FROM {qi} WHERE {col} IS NULL LIMIT {int(batch)}",
+                    fetch=True,
+                )
+                if not rows:
+                    return filled
+                self._execute(
+                    f"UPDATE {qi} SET {col} = %s WHERE id = %s",
+                    [(_token_count(record[1] or ""), record[0]) for record in rows],
+                    many=True,
+                )
+                filled += len(rows)
+        except BackendError:
+            logger.debug("pgvector token_count backfill skipped", exc_info=True)
+            return filled
 
     def upsert_rows(self, table: str, rows: list[dict]) -> None:
         if not rows:
             return
         qi = _quote_identifier(table)
+        # The token_count column is only written when the table has it: a palace
+        # created before this release keeps ingesting, it just does not gain the
+        # exact-statistics fast path until ensure_lexical_assets runs.
+        with_counts = self.has_token_count(table)
+        col = _quote_identifier(_TOKEN_COUNT_COLUMN)
+        count_col = f", {col}" if with_counts else ""
+        count_val = ", %s" if with_counts else ""
+        count_set = f", {col} = EXCLUDED.{col}" if with_counts else ""
         sql = (
-            f"INSERT INTO {qi} (id, document, metadata, embedding, updated_at) "
-            "VALUES (%s, %s, %s::jsonb, %s::vector, %s) "
+            f"INSERT INTO {qi} (id, document, metadata, embedding, updated_at{count_col}) "
+            f"VALUES (%s, %s, %s::jsonb, %s::vector, %s{count_val}) "
             "ON CONFLICT (id) DO UPDATE SET "
             "document = EXCLUDED.document, metadata = EXCLUDED.metadata, "
             "embedding = EXCLUDED.embedding, updated_at = EXCLUDED.updated_at"
+            f"{count_set}"
         )
-        params = [
-            (
-                # Strip both unstorable byte classes Postgres rejects before
-                # binding, so one stray byte in a transcript cannot abort the
-                # whole mine (#1829 NUL, #1833 lone surrogate).
-                #
-                # Order matters for metadata: NUL must be stripped *before*
-                # serialization (json escapes it to \\u0000, which the jsonb cast
-                # rejects), while a lone surrogate must be stripped *after*
-                # serialization (json.dumps(ensure_ascii=False) leaves it raw, so
-                # one pass over the serialized string cleans it without walking
-                # the dict). id/document are plain strings, so the two passes
-                # commute there. ids are NUL- and surrogate-free in practice, so
-                # those passes are defensive no-ops on the ON CONFLICT key.
+
+        def _bind(row: dict) -> tuple:
+            # Strip both unstorable byte classes Postgres rejects before
+            # binding, so one stray byte in a transcript cannot abort the
+            # whole mine (#1829 NUL, #1833 lone surrogate).
+            #
+            # Order matters for metadata: NUL must be stripped *before*
+            # serialization (json escapes it to \\u0000, which the jsonb cast
+            # rejects), while a lone surrogate must be stripped *after*
+            # serialization (json.dumps(ensure_ascii=False) leaves it raw, so
+            # one pass over the serialized string cleans it without walking
+            # the dict). id/document are plain strings, so the two passes
+            # commute there. ids are NUL- and surrogate-free in practice, so
+            # those passes are defensive no-ops on the ON CONFLICT key.
+            document = strip_lone_surrogates(_strip_nul(row["document"]))
+            bound = (
                 strip_lone_surrogates(_strip_nul(row["id"])),
-                strip_lone_surrogates(_strip_nul(row["document"])),
+                document,
                 strip_lone_surrogates(_json_dumps(_strip_nul(row.get("metadata")))),
                 _vector_literal(row["embedding"]),
                 row.get("updated_at") or _utcnow(),
             )
-            for row in rows
-        ]
+            # Counted from the stripped text, not the caller's: stripping a NUL
+            # can fuse two tokens into one ("ab\\x00cd" -> "abcd"), and the
+            # stored length has to describe the stored document.
+            return bound + ((_token_count(document),) if with_counts else ())
+
+        params = [_bind(row) for row in rows]
         self._execute(sql, params, many=True)
 
     def query_rows(
@@ -962,42 +1096,71 @@ class _PgVectorClient:
             for record in rows or []
         ]
 
-    def lexical_rows(
+    def lexical_corpus_stats(
+        self, table: str, where: Optional[dict]
+    ) -> Optional[tuple[int, float]]:
+        """Collection-wide ``(row_count, mean_token_count)`` for BM25, or ``None``.
+
+        ``None`` means the exact statistics are unavailable — some row in scope
+        has never had its ``token_count`` written (a table filled before the
+        column existed) — and the caller must take the local path rather than
+        score against an approximation.
+
+        Scope is the SQL ``where``, which is what the local path scrolls before
+        it applies :func:`_matches_where`; the Python filter only ever removes
+        rows the SQL predicate already admitted, so the two corpora agree.
+        """
+        col = _quote_identifier(_TOKEN_COUNT_COLUMN)
+        params: list = []
+        where_sql = _where_to_sql(where, params) if where else "TRUE"
+        rows = self._execute(
+            f"SELECT count(*), sum({col}), count(*) FILTER (WHERE {col} IS NULL) "
+            f"FROM {_quote_identifier(table)} WHERE {where_sql}",
+            params,
+            fetch=True,
+        )
+        if not rows:
+            return None
+        total, token_sum, missing = rows[0]
+        total = int(total or 0)
+        if int(missing or 0) or total == 0:
+            return None
+        return total, float(token_sum or 0) / total
+
+    def lexical_candidates(
         self,
         table: str,
         *,
         tokens: list[str],
-        limit: int,
         where: Optional[dict],
     ) -> list[dict]:
-        """Rank rows by Postgres full-text relevance, top ``limit`` only.
+        """Every row that could score above zero for ``tokens``. No limit, no ranking.
+
+        The predicate is an OR of literal-substring tests, one per token, which
+        :func:`_like_pattern` guarantees is a superset of the rows BM25 scores
+        above zero. Ranking and the ``n_results`` cut stay in Python so the
+        pushdown decides only *which rows do not need to cross the wire*, never
+        which rows win — pushing an ORDER BY and LIMIT into SQL would let a
+        server-side ranking silently pick a different top-N than BM25 does.
 
         ``where`` must already be pushdown-safe (see
         :func:`_requires_local_filter`); the caller keeps anything broader on
-        the local path. Returns ``id``/``document``/``metadata``/``score``
-        dicts, ``score`` being ``ts_rank_cd`` — not BM25, which the hybrid
-        re-ranker recomputes in memory over the merged candidate pool anyway.
+        the local path.
         """
         qi = _quote_identifier(table)
-        params: list = [_tsquery_or(tokens)]
+        params: list = [_like_pattern(token) for token in tokens]
+        match_sql = " OR ".join(["document ILIKE %s ESCAPE '\\'"] * len(params))
+        # SQL text order — the ILIKE patterns, then the WHERE params — already
+        # matches positional binding order in ``params``.
         where_sql = _where_to_sql(where, params) if where else "TRUE"
-        params.append(int(limit))
-        # SQL text order — tsquery %s in FROM, then WHERE params, then LIMIT %s
-        # — already matches positional binding order in ``params``.
-        sql = (
-            "SELECT id, document, metadata, "
-            f"ts_rank_cd(to_tsvector('{_FTS_CONFIG}', document), q) AS score "
-            f"FROM {qi}, to_tsquery('{_FTS_CONFIG}', %s) AS q "
-            f"WHERE to_tsvector('{_FTS_CONFIG}', document) @@ q AND ({where_sql}) "
-            "ORDER BY score DESC LIMIT %s"
+        rows = self._execute(
+            f"SELECT id, document, metadata FROM {qi} WHERE ({match_sql}) AND ({where_sql})",
+            params,
+            fetch=True,
         )
-        rows = self._execute(sql, params, fetch=True)
-        out = []
-        for record in rows or []:
-            row = self._row(record, with_embedding=False, with_distance=False)
-            row["score"] = float(record[3]) if record[3] is not None else 0.0
-            out.append(row)
-        return out
+        return [
+            self._row(record, with_embedding=False, with_distance=False) for record in rows or []
+        ]
 
     def scroll_rows(
         self,
@@ -1222,6 +1385,10 @@ class PgVectorCollection(BaseCollection):
                 self._client.create_table(self._table, dimension)
                 self._known_dimension = dimension
                 return
+            # A collection created before token_count existed picks it up on
+            # first use, so the lexical pushdown becomes available to palaces
+            # that were never recreated.
+            self._client.ensure_lexical_assets(self._table)
             existing_dim = self._client.table_dimension(self._table)
             if existing_dim is not None and existing_dim != dimension:
                 raise DimensionMismatchError(
@@ -1734,64 +1901,83 @@ class PgVectorCollection(BaseCollection):
     def lexical_search(
         self, *, query: str, n_results: int = 10, where: Optional[dict] = None
     ) -> LexicalResult:
-        """Rank drawers lexically, pushing the scan into Postgres when possible.
+        """Rank drawers lexically, keeping non-matching rows off the wire.
 
         The local path below scrolls every row — documents included — to the
         client and scores BM25 in Python, which costs O(table size) bytes over
         the wire per query. On a remote palace of ~141k drawers that is minutes
-        per query and makes hybrid search unusable, so the default path hands
-        the work to Postgres full-text search instead.
+        per query and makes hybrid search unusable.
 
-        Postgres is used only when ``where`` translates fully to SQL; anything
-        broader (``$or``, comparisons, ``$contains``) falls back to the exact
-        local path, as does a server-side failure, so the pushdown can never
-        change or drop results.
+        The pushdown removes that cost without moving the decision: Postgres
+        evaluates only a *filter*, and the filter admits a superset of the rows
+        BM25 can score above zero, so scoring, ranking and the ``n_results`` cut
+        all still happen here, over the same numbers the local path would
+        produce. What it does not do is let Postgres rank — a server-side
+        ``ORDER BY ... LIMIT`` would return whichever rows *its* relevance
+        function likes best, which is not the set BM25 picks.
+
+        Preconditions for the pushdown, any of which sends the query to the
+        local path unchanged: ``where`` must translate fully to SQL (``$or``,
+        comparisons and ``$contains`` do not), every row in scope must carry a
+        ``token_count`` so the collection-wide BM25 statistics are exact, and
+        the server must answer without error.
         """
         _validate_where(where)
-        if not _requires_local_filter(where):
-            result = self._lexical_search_fts(query=query, n_results=n_results, where=where)
+        if not _requires_local_filter(where) and not _has_null_operand(where):
+            result = self._lexical_search_pushdown(query=query, n_results=n_results, where=where)
             if result is not None:
                 return result
         return self._lexical_search_local(query=query, n_results=n_results, where=where)
 
-    def _lexical_search_fts(
+    def _lexical_search_pushdown(
         self, *, query: str, n_results: int, where: Optional[dict]
     ) -> Optional[LexicalResult]:
-        """Postgres FTS arm of :meth:`lexical_search`; ``None`` means fall back."""
+        """Filter-pushdown arm of :meth:`lexical_search`; ``None`` means fall back."""
         # Ordered exactly as the local path orders its checks: a closed
-        # collection raises before an empty query short-circuits.
+        # collection raises, then a missing table decides, then the query.
         self._ensure_open()
-        tokens = _tokenize(query)
-        if not tokens:
-            # No lexeme can match, and an empty tsquery is a syntax error.
-            return LexicalResult(hits=[])
-        if not self._table_exists():
-            if self._marker_exists():
-                raise CollectionNotInitializedError(self._collection_name)
-            return LexicalResult(hits=[])
         try:
-            rows = self._client.lexical_rows(
-                self._table, tokens=tokens, limit=n_results, where=where
-            )
+            if not self._table_exists():
+                if self._marker_exists():
+                    raise CollectionNotInitializedError(self._collection_name)
+                return LexicalResult(hits=[])
+            tokens = _tokenize(query)
+            if not tokens:
+                # Nothing to match: the local path would scroll the table only
+                # to score every row zero.
+                return LexicalResult(hits=[])
+            if not self._client.has_token_count(self._table):
+                return None
+            stats = self._client.lexical_corpus_stats(self._table, where)
+            if stats is None:
+                # A row in scope predates the token_count column, so the
+                # collection-wide statistics would be a guess. Guessing changes
+                # the ranking, so take the slow exact path instead.
+                return None
+            rows = self._client.lexical_candidates(self._table, tokens=tokens, where=where)
+        except UnsupportedFilterError:
+            # RFC 001 forbids silently ignoring an operator the backend does not
+            # understand. _requires_local_filter and _field_sql are separate
+            # whitelists, so if they ever drift this must stay a hard error
+            # instead of degrading into a slow path that quietly drops it.
+            raise
         except BackendError:
             # Fail open to the exact (slow) local path rather than silently
             # dropping the lexical arm of a hybrid search.
-            logger.debug("pgvector FTS lexical search failed; falling back", exc_info=True)
+            logger.debug("pgvector lexical pushdown failed; falling back", exc_info=True)
             return None
-        hits = [
-            LexicalHit(
-                id=row["id"],
-                document=row["document"],
-                metadata=row["metadata"],
-                score=row["score"],
-            )
-            for row in rows
-            # ``metadata @> ...`` is broader than the exact _matches_where
-            # contract for array/object values, so the filter is re-applied
-            # here exactly as the local path applies it.
-            if row["score"] > 0 and _matches_where(row["metadata"], where)
-        ]
-        return LexicalResult(hits=hits)
+        corpus_size, corpus_avgdl = stats
+        # ``metadata @> ...`` and the exact _matches_where contract can disagree
+        # on non-scalar values, so the filter is re-applied here exactly as the
+        # local path applies it.
+        rows = [row for row in rows if _matches_where(row["metadata"], where)]
+        scores = _bm25_scores(
+            query,
+            [row["document"] for row in rows],
+            corpus_size=corpus_size,
+            corpus_avgdl=corpus_avgdl,
+        )
+        return self._lexical_result(rows, scores, n_results)
 
     def _lexical_search_local(
         self, *, query: str, n_results: int, where: Optional[dict]
@@ -1801,6 +1987,17 @@ class PgVectorCollection(BaseCollection):
         rows = self._scroll(where=pushdown, with_embedding=False)
         rows = [row for row in rows if _matches_where(row["metadata"], where)]
         scores = _bm25_scores(query, [row["document"] for row in rows])
+        return self._lexical_result(rows, scores, n_results)
+
+    @staticmethod
+    def _lexical_result(rows: list[dict], scores: list[float], n_results: int) -> LexicalResult:
+        """Rank and cut, identically for both paths.
+
+        The tiebreak on ``id`` is what makes "same scores" mean "same answer":
+        without it two rows on equal scores keep whatever order the server
+        returned them in, and the cut at ``n_results`` could then fall either
+        way for reasons no caller can see.
+        """
         hits = [
             LexicalHit(
                 id=row["id"],
@@ -1811,7 +2008,7 @@ class PgVectorCollection(BaseCollection):
             for row, score in zip(rows, scores)
             if score > 0
         ]
-        hits.sort(key=lambda hit: hit.score, reverse=True)
+        hits.sort(key=lambda hit: (-hit.score, hit.id))
         return LexicalResult(hits=hits[:n_results])
 
     def close(self) -> None:
@@ -1828,13 +2025,23 @@ class PgVectorCollection(BaseCollection):
         return HealthStatus.healthy()
 
     def maintenance_state(self) -> dict:
-        empty = {"row_count": 0, "vector_index": None, "index_build_complete": False}
+        empty = {
+            "row_count": 0,
+            "vector_index": None,
+            "index_build_complete": False,
+            "lexical_pushdown": False,
+        }
         self._ensure_open()
         try:
             if not self._table_exists():
                 return empty
             rows = self._client.count_rows(self._table)
             has_index = self._client.has_vector_index(self._table)
+            # Whether lexical_search can keep documents off the wire. Reported
+            # because every reason it cannot is a silent fallback to a path that
+            # is correct but O(table) per query, and an operator otherwise has
+            # no way to see which one they are paying for.
+            lexical_pushdown = self._client.lexical_corpus_stats(self._table, None) is not None
         except Exception:  # noqa: BLE001 - state report must not raise
             logger.debug("pgvector maintenance state probe failed", exc_info=True)
             return empty
@@ -1842,6 +2049,7 @@ class PgVectorCollection(BaseCollection):
             "row_count": rows,
             "vector_index": "hnsw" if has_index else None,
             "index_build_complete": has_index,
+            "lexical_pushdown": lexical_pushdown,
         }
 
     def run_maintenance(self, kind: str):

--- a/tests/test_live_pgvector_conformance.py
+++ b/tests/test_live_pgvector_conformance.py
@@ -25,7 +25,13 @@ from mempalace.backends import (
     DimensionMismatchError,
     PalaceRef,
 )
-from mempalace.backends.pgvector import PgVectorBackend, _fts_index_name
+from mempalace.backends.pgvector import (
+    PgVectorBackend,
+    _bm25_scores,
+    _matches_where,
+    _tokenize,
+    _trgm_index_name,
+)
 
 LIVE_DSN = os.environ.get("MEMPALACE_PGVECTOR_LIVE_DSN")
 
@@ -341,12 +347,11 @@ def test_live_analyze_maintenance(live, tmp_path):
     assert result.status == "ran"
 
 
-def test_live_fts_index_created_with_table(live, tmp_path):
-    """A fresh collection carries the GIN index the lexical query needs.
+def test_live_trgm_index_created_with_table(live, tmp_path):
+    """A fresh collection carries the trigram index the substring filter needs.
 
-    The index expression must match the query expression character for
-    character, or Postgres silently plans a sequential scan and the pushdown
-    buys nothing.
+    The index opclass must match the predicate, or Postgres silently plans a
+    sequential scan and the pushdown buys nothing but correctness.
     """
     _backend, make, _ns = live
     col = make(tmp_path)
@@ -355,23 +360,171 @@ def test_live_fts_index_created_with_table(live, tmp_path):
     rows = col._client._execute(
         "SELECT indexdef FROM pg_indexes WHERE schemaname = current_schema() "
         "AND tablename = %s AND indexname = %s",
-        [col._table, _fts_index_name(col._table)],
+        [col._table, _trgm_index_name(col._table)],
         fetch=True,
     )
-    assert rows, "create_table must build the FTS index"
+    assert rows, "create_table must build the trigram index"
     indexdef = rows[0][0].lower()
-    assert "gin" in indexdef
-    # Postgres renders the config as 'simple'::regconfig in indexdef.
-    assert "to_tsvector('simple'" in indexdef and "document" in indexdef
+    assert "gin" in indexdef and "gin_trgm_ops" in indexdef and "document" in indexdef
 
 
-def test_live_lexical_search_is_multilingual_and_injection_proof(live, tmp_path):
-    """The live tsquery must survive non-Latin text and tsquery metacharacters.
+def test_live_large_document_still_writes(live, tmp_path):
+    """A drawer too big for a tsvector must still be storable.
 
-    'simple' is the whole reason an Arabic drawer is findable at all; the
-    escaping is the reason a query full of operators returns nothing instead of
-    raising a syntax error or matching everything.
+    Postgres caps a tsvector at 1 MB and an expression index enforces that cap
+    at write time, so indexing ``to_tsvector(document)`` would turn a large
+    transcript from a slow write into a failed one. A trigram index has no such
+    cap; this is the regression test for that choice.
     """
+    _backend, make, _ns = live
+    col = make(tmp_path)
+    big = " ".join(f"w{i}" for i in range(300_000))
+    col.add(ids=["big"], documents=[big], metadatas=[{"wing": "p"}], embeddings=[[1, 0]])
+
+    assert col.count() == 1
+    assert [hit.id for hit in col.lexical_search(query="w299999", n_results=5).hits] == ["big"]
+
+
+def test_live_token_counts_are_written_and_exact(live, tmp_path):
+    """The stored length must equal what ``_bm25_scores`` computes, exactly."""
+    _backend, make, _ns = live
+    col = make(tmp_path)
+    documents = {
+        "en": "memory palace note about alpha and beta",
+        "ar": "قصر الذاكرة يحفظ كلماتك",
+        "cjk": "记忆宫殿笔记 alpha",
+        "dev": "contact atk@atkabli.com about /etc/nginx/nginx.conf and npm.install 3.14",
+    }
+    ids = list(documents)
+    col.add(
+        ids=ids,
+        documents=[documents[i] for i in ids],
+        metadatas=[{"wing": "p"} for _ in ids],
+        embeddings=[[1, 0] for _ in ids],
+    )
+
+    rows = col._client._execute(f'SELECT id, token_count FROM "{col._table}"', fetch=True)
+    assert {row[0]: row[1] for row in rows} == {
+        doc_id: len(_tokenize(text)) for doc_id, text in documents.items()
+    }
+
+
+def _develop_lexical_search(col, query, n_results, where=None):
+    """The pre-pushdown implementation: scroll everything, score, sort, cut."""
+    rows = col._scroll(where=where, with_embedding=False)
+    rows = [row for row in rows if _matches_where(row["metadata"], where)]
+    scores = _bm25_scores(query, [row["document"] for row in rows])
+    hits = [(row["id"], score) for row, score in zip(rows, scores) if score > 0]
+    hits.sort(key=lambda hit: (-hit[1], hit[0]))
+    return hits[:n_results]
+
+
+def test_live_pushdown_equals_full_scroll_when_matches_outnumber_the_window(live, tmp_path):
+    """The reviewer's scenario, against a real server.
+
+    60 drawers, 50 of them matching, a window of 9. Anything that ranks
+    server-side and cuts to 9 in SQL returns a different 9 than BM25 does; the
+    filter-only pushdown returns the same ids with the same scores.
+    """
+    _backend, make, _ns = live
+    col = make(tmp_path)
+    documents = {"short00": "we shipped the alpha and beta change today"}
+    for i in range(30):
+        documents[f"alpha{i:02d}"] = (
+            "alpha " + " ".join(f"filler{j}" for j in range(60)) + f" release note {i}"
+        )
+    for i in range(15):
+        documents[f"beta{i:02d}"] = (
+            "beta " + " ".join(f"other{j}" for j in range(60)) + f" changelog {i}"
+        )
+    for i in range(4):
+        documents[f"short{i + 1:02d}"] = f"alpha beta quick note number {i}"
+    for i in range(10):
+        documents[f"noise{i:02d}"] = f"unrelated gamma delta epsilon text {i}"
+    ids = list(documents)
+    col.add(
+        ids=ids,
+        documents=[documents[i] for i in ids],
+        metadatas=[{"wing": "p"} for _ in ids],
+        embeddings=[[1, 0] for _ in ids],
+    )
+
+    everything = _develop_lexical_search(col, "alpha beta", 10_000)
+    assert len(everything) == 50, "the corpus must have more matches than the window"
+    # Guard against a vacuous pass: if the pushdown had silently fallen back to
+    # the local scroll, every assertion below would hold for the wrong reason.
+    assert col.maintenance_state()["lexical_pushdown"] is True
+    scrolled = []
+    original_scroll = col._client.scroll_rows
+    col._client.scroll_rows = lambda *a, **k: (
+        scrolled.append(1),
+        original_scroll(*a, **k),
+    )[1]
+
+    for n_results in (1, 9, 30, 200):
+        want = _develop_lexical_search(col, "alpha beta", n_results)
+        scrolled.clear()
+        got = [
+            (hit.id, hit.score)
+            for hit in col.lexical_search(query="alpha beta", n_results=n_results).hits
+        ]
+        assert scrolled == [], "the pushdown, not the scroll, must be under test"
+        assert [i for i, _ in got] == [i for i, _ in want], f"n_results={n_results}"
+        for (_, a), (_, b) in zip(got, want):
+            assert a == pytest.approx(b)
+
+    # And the specific loss reported: the top BM25 hit survives a window of 9.
+    scrolled.clear()
+    window = [hit.id for hit in col.lexical_search(query="alpha beta", n_results=9).hits]
+    col._client.scroll_rows = original_scroll
+    assert scrolled == []
+    assert everything[0][0] in window
+
+
+def test_live_pushdown_finds_developer_shaped_tokens(live, tmp_path):
+    r"""Postgres full-text parsing would swallow these; a substring filter does not.
+
+    ``to_tsvector('simple', ...)`` emits ``atk@atkabli.com``,
+    ``/etc/nginx/nginx.conf`` and ``npm.install`` as single lexemes, so a
+    tsquery built from ``\w{2,}`` tokens misses every one of them while BM25
+    scores them above zero. Each of these is a lost hit under a tsquery
+    predicate.
+    """
+    _backend, make, _ns = live
+    col = make(tmp_path)
+    documents = {
+        "email": "ping atk@atkabli.com for access",
+        "url": "see https://example.com/deep/path today",
+        "path": "open /etc/nginx/nginx.conf now",
+        "pkg": "run npm.install script",
+        "host": "server db01.internal.corp is down",
+        "num": "cost 3.14 usd",
+        "under": "def foo_bar(): pass",
+    }
+    ids = list(documents)
+    col.add(
+        ids=ids,
+        documents=[documents[i] for i in ids],
+        metadatas=[{"wing": "p"} for _ in ids],
+        embeddings=[[1, 0] for _ in ids],
+    )
+
+    for query, expected in [
+        ("atkabli", "email"),
+        ("example", "url"),
+        ("nginx", "path"),
+        ("npm", "pkg"),
+        ("internal", "host"),
+        ("14", "num"),
+        ("foo_bar", "under"),
+    ]:
+        hits = [hit.id for hit in col.lexical_search(query=query, n_results=5).hits]
+        assert expected in hits, f"{query!r} lost {expected!r}"
+        assert hits == [i for i, _ in _develop_lexical_search(col, query, 5)]
+
+
+def test_live_lexical_search_is_multilingual(live, tmp_path):
+    """A mixed-script palace stays searchable, and matches the local path exactly."""
     _backend, make, _ns = live
     col = make(tmp_path)
     col.add(
@@ -386,9 +539,24 @@ def test_live_lexical_search_is_multilingual_and_injection_proof(live, tmp_path)
     # OR semantics: one query, hits from two languages.
     mixed = {h.id for h in col.lexical_search(query="الذاكرة 记忆", n_results=5).hits}
     assert mixed == {"ar", "cjk"}
-    # Operators and quotes are lexeme content, not syntax: every one of these
-    # parses as a plain OR of its word tokens instead of raising or negating.
-    assert [h.id for h in col.lexical_search(query="!memory", n_results=5).hits] == ["en"]
-    assert [h.id for h in col.lexical_search(query="x' | 'memory", n_results=5).hits] == ["en"]
-    for hostile in ("memory & !palace", "a:*", "a <-> b", "'", "\\"):
-        col.lexical_search(query=hostile, n_results=5)
+    # Metacharacters are content, not syntax. These reach SQL as bound LIKE
+    # patterns, so none of them can change the shape of the query.
+    for hostile in ("memory & !palace", "a:*", "a <-> b", "'", "\\", "50%", "a_c", "%"):
+        assert [h.id for h in col.lexical_search(query=hostile, n_results=5).hits] == [
+            i for i, _ in _develop_lexical_search(col, hostile, 5)
+        ]
+
+
+def test_live_wildcards_in_a_query_stay_literal(live, tmp_path):
+    """``%`` and ``_`` are LIKE wildcards; a query carrying them must not widen."""
+    _backend, make, _ns = live
+    col = make(tmp_path)
+    col.add(
+        ids=["lit", "other"],
+        documents=["discount a_c applied", "discount abc applied"],
+        metadatas=[{"wing": "p"}, {"wing": "p"}],
+        embeddings=[[1, 0], [0, 1]],
+    )
+
+    # 'a_c' must match the literal underscore only, not 'abc'.
+    assert [h.id for h in col.lexical_search(query="a_c", n_results=5).hits] == ["lit"]

--- a/tests/test_live_pgvector_conformance.py
+++ b/tests/test_live_pgvector_conformance.py
@@ -25,7 +25,7 @@ from mempalace.backends import (
     DimensionMismatchError,
     PalaceRef,
 )
-from mempalace.backends.pgvector import PgVectorBackend
+from mempalace.backends.pgvector import PgVectorBackend, _fts_index_name
 
 LIVE_DSN = os.environ.get("MEMPALACE_PGVECTOR_LIVE_DSN")
 
@@ -339,3 +339,56 @@ def test_live_analyze_maintenance(live, tmp_path):
     col.upsert(ids=["a"], documents=["one"], metadatas=[{}], embeddings=[[1, 0]])
     result = col.run_maintenance("analyze")
     assert result.status == "ran"
+
+
+def test_live_fts_index_created_with_table(live, tmp_path):
+    """A fresh collection carries the GIN index the lexical query needs.
+
+    The index expression must match the query expression character for
+    character, or Postgres silently plans a sequential scan and the pushdown
+    buys nothing.
+    """
+    _backend, make, _ns = live
+    col = make(tmp_path)
+    col.upsert(ids=["a"], documents=["one"], metadatas=[{}], embeddings=[[1, 0]])
+
+    rows = col._client._execute(
+        "SELECT indexdef FROM pg_indexes WHERE schemaname = current_schema() "
+        "AND tablename = %s AND indexname = %s",
+        [col._table, _fts_index_name(col._table)],
+        fetch=True,
+    )
+    assert rows, "create_table must build the FTS index"
+    indexdef = rows[0][0].lower()
+    assert "gin" in indexdef
+    # Postgres renders the config as 'simple'::regconfig in indexdef.
+    assert "to_tsvector('simple'" in indexdef and "document" in indexdef
+
+
+def test_live_lexical_search_is_multilingual_and_injection_proof(live, tmp_path):
+    """The live tsquery must survive non-Latin text and tsquery metacharacters.
+
+    'simple' is the whole reason an Arabic drawer is findable at all; the
+    escaping is the reason a query full of operators returns nothing instead of
+    raising a syntax error or matching everything.
+    """
+    _backend, make, _ns = live
+    col = make(tmp_path)
+    col.add(
+        ids=["ar", "cjk", "en"],
+        documents=["قصر الذاكرة يحفظ كلماتك", "记忆 宫殿", "memory palace note"],
+        metadatas=[{"wing": "p"}, {"wing": "p"}, {"wing": "p"}],
+        embeddings=[[1, 0], [0, 1], [0.5, 0.5]],
+    )
+
+    assert [h.id for h in col.lexical_search(query="الذاكرة", n_results=5).hits] == ["ar"]
+    assert [h.id for h in col.lexical_search(query="记忆", n_results=5).hits] == ["cjk"]
+    # OR semantics: one query, hits from two languages.
+    mixed = {h.id for h in col.lexical_search(query="الذاكرة 记忆", n_results=5).hits}
+    assert mixed == {"ar", "cjk"}
+    # Operators and quotes are lexeme content, not syntax: every one of these
+    # parses as a plain OR of its word tokens instead of raising or negating.
+    assert [h.id for h in col.lexical_search(query="!memory", n_results=5).hits] == ["en"]
+    assert [h.id for h in col.lexical_search(query="x' | 'memory", n_results=5).hits] == ["en"]
+    for hostile in ("memory & !palace", "a:*", "a <-> b", "'", "\\"):
+        col.lexical_search(query=hostile, n_results=5)

--- a/tests/test_maintenance_hooks.py
+++ b/tests/test_maintenance_hooks.py
@@ -120,17 +120,21 @@ def test_sqlite_unknown_kind_raises(tmp_path):
 
 
 class _FakeClient:
-    def __init__(self, has_index=False):
+    def __init__(self, has_index=False, lexical_stats=(7, 4.0)):
         self.has_index = has_index
         self.locked = False
         self.created = 0
         self.analyzed = 0
+        self.lexical_stats = lexical_stats
 
     def table_exists(self, table):
         return True
 
     def count_rows(self, table):
         return 7
+
+    def lexical_corpus_stats(self, table, where):
+        return self.lexical_stats
 
     def has_vector_index(self, table):
         return self.has_index
@@ -213,6 +217,12 @@ def test_pgvector_maintenance_state_reports_index():
     state = col.maintenance_state()
     assert state["row_count"] == 7
     assert state["vector_index"] == "hnsw" and state["index_build_complete"] is True
+    assert state["lexical_pushdown"] is True
+    # A collection whose rows predate the token_count column reports the slow path.
+    assert (
+        _pg_collection(_FakeClient(lexical_stats=None)).maintenance_state()["lexical_pushdown"]
+        is False
+    )
 
 
 def test_pgvector_maintenance_noop_when_table_missing():

--- a/tests/test_pgvector_backend.py
+++ b/tests/test_pgvector_backend.py
@@ -6,6 +6,8 @@ import types
 from hashlib import sha256
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from _backend_conformance import assert_partition_isolation
 
@@ -31,6 +33,10 @@ from mempalace.backends.pgvector import (
     _shared_namespace_slug,
     _strip_nul,
     _json_dumps,
+    _tokenize,
+    _escape_tsquery_token,
+    _tsquery_or,
+    _fts_index_name,
 )
 
 
@@ -50,6 +56,7 @@ class _FakePgVectorClient:
         self.query_calls: list = []
         self.scroll_calls: list = []
         self.facet_calls: list = []
+        self.lexical_calls: list = []
         _FakePgVectorClient.instances.append(self)
 
     def ping(self):
@@ -99,6 +106,36 @@ class _FakePgVectorClient:
             }
             out.append(item)
         return out
+
+    def lexical_rows(self, table, *, tokens, limit, where):
+        """Stand-in for the server-side ``to_tsquery``/``ts_rank_cd`` ranking.
+
+        Mirrors the two properties the real SQL guarantees and the collection
+        relies on: OR semantics over the tokens, and a descending rank where a
+        document matching more of the query outranks one matching less.
+        """
+        self.lexical_calls.append({"tokens": list(tokens), "limit": limit, "where": where})
+        wanted = set(tokens)
+        scored = []
+        for row in self._filtered(table, where):
+            overlap = len(wanted & set(_tokenize(row.get("document") or "")))
+            if overlap:
+                scored.append((float(overlap), row))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [
+            {
+                "id": row["id"],
+                "document": row["document"],
+                "metadata": row.get("metadata") or {},
+                "embedding": None,
+                "distance": None,
+                "score": score,
+            }
+            for score, row in scored[:limit]
+        ]
+
+    def create_fts_index(self, table):
+        return None
 
     def scroll_rows(
         self,
@@ -1945,3 +1982,330 @@ def test_execute_retry_covers_executemany(monkeypatch):
     client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
     client._execute("INSERT ...", [(1,), (2,)], many=True)
     assert len(handed_out) == 2
+
+# ── Postgres FTS lexical search ────────────────────────────────────────
+
+
+def _capturing_client(monkeypatch):
+    """Real ``_PgVectorClient`` with ``_execute`` stubbed, plus the capture list.
+
+    Exercises the actual SQL-building code without psycopg or a server: every
+    statement and its bound parameters land in ``captured``.
+    """
+    captured = []
+
+    def fake_execute(sql, params=None, *, fetch=False, many=False):
+        captured.append({"sql": sql, "params": list(params or []), "fetch": fetch})
+        return []
+
+    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
+    monkeypatch.setattr(client, "_execute", fake_execute)
+    return client, captured
+
+
+def _unquote_tsquery_lexeme(escaped):
+    """Decode one escaped lexeme the way the Postgres tsquery lexer does.
+
+    Inside single quotes only ``''`` (a literal quote) and ``\\\\`` (a literal
+    backslash) are special; everything else is taken verbatim.
+    """
+    assert escaped.startswith("'") and escaped.endswith("'") and len(escaped) >= 2
+    body = escaped[1:-1]
+    out = []
+    i = 0
+    while i < len(body):
+        pair = body[i : i + 2]
+        if pair in ("''", "\\\\"):
+            out.append(pair[0])
+            i += 2
+        else:
+            out.append(body[i])
+            i += 1
+    return "".join(out)
+
+
+def test_escape_tsquery_token_neutralizes_operators():
+    """tsquery operators inside a token must become part of the lexeme, not syntax.
+
+    ``to_tsquery`` parses its argument as an expression, so an unescaped token
+    would let ``&``/``|``/``!``/``<->``/parens change which rows match — or abort
+    the search with a syntax error.
+    """
+    for raw in ("a&b", "a|b", "!a", "(a)", "a:b", "a:*", "a<->b", "a & b | !c"):
+        escaped = _escape_tsquery_token(raw)
+        assert escaped.startswith("'") and escaped.endswith("'")
+        assert _unquote_tsquery_lexeme(escaped) == raw
+
+
+def test_escape_tsquery_token_doubles_quotes_and_backslashes():
+    assert _escape_tsquery_token("it's") == "'it''s'"
+    assert _escape_tsquery_token("a\\b") == "'a\\\\b'"
+    # The classic break-out attempt: closing the quote to append an operator.
+    assert _escape_tsquery_token("x' | 'y") == "'x'' | ''y'"
+    # A trailing backslash must not escape the closing quote.
+    assert _escape_tsquery_token("x\\") == "'x\\\\'"
+
+
+def test_escape_tsquery_token_handles_non_latin_text():
+    """Arabic and CJK tokens pass through untouched — 'simple' is script-neutral."""
+    for raw in ("ذاكرة", "قصر_الذاكرة", "记忆", "メモリ"):
+        assert _escape_tsquery_token(raw) == f"'{raw}'"
+
+
+@given(st.text(min_size=0, max_size=40))
+def test_escape_tsquery_token_round_trips_any_input(raw):
+    """Any string survives escaping as exactly one lexeme.
+
+    Two properties together mean "cannot inject": the escaped form decodes back
+    to the input, and the quoted body holds no unpaired quote that could end the
+    lexeme early.
+    """
+    escaped = _escape_tsquery_token(raw)
+    assert _unquote_tsquery_lexeme(escaped) == raw
+    body = escaped[1:-1]
+    assert body.replace("''", "").count("'") == 0
+
+
+def test_tsquery_or_joins_tokens_with_or():
+    """OR semantics, not AND: the lexical arm is a recall-oriented candidate pool.
+
+    ``websearch_to_tsquery`` would AND the terms, so a multi-word question would
+    return nothing where the BM25 path it replaces scored every partial match.
+    """
+    assert _tsquery_or(["rareterm", "backend"]) == "'rareterm' | 'backend'"
+    assert _tsquery_or(["solo"]) == "'solo'"
+
+
+def test_tsquery_or_drops_empty_tokens():
+    """An empty quoted lexeme is a tsquery syntax error, so it must never appear."""
+    assert _tsquery_or([]) == ""
+    assert _tsquery_or(["", "kept", ""]) == "'kept'"
+
+
+@given(st.text(max_size=60))
+def test_tsquery_or_from_tokenizer_emits_one_lexeme_per_token(text):
+    tokens = _tokenize(text)
+    built = _tsquery_or(tokens)
+    assert built.count(" | ") == max(len(tokens) - 1, 0)
+    assert not built.endswith("|")
+    # Tokenizer output is \w-only, so nothing needs escaping and every token
+    # appears verbatim inside its own quotes.
+    for token in tokens:
+        assert f"'{token}'" in built
+
+
+def test_lexical_rows_sql_uses_simple_config_and_binds_query():
+    """The pushed-down query must rank server-side with the language-neutral config."""
+    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
+    captured = {}
+
+    def fake_execute(sql, params=None, *, fetch=False, many=False):
+        captured["sql"] = sql
+        captured["params"] = list(params or [])
+        return [("a", "doc", {"wing": "x"}, 0.5)]
+
+    client._execute = fake_execute
+    rows = client.lexical_rows("drawers", tokens=["rareterm", "backend"], limit=7, where=None)
+
+    sql = captured["sql"]
+    assert "to_tsquery('simple', %s)" in sql
+    assert "ts_rank_cd(to_tsvector('simple', document), q)" in sql
+    # Must match the indexed expression verbatim or the GIN index is not used.
+    assert "to_tsvector('simple', document) @@ q" in sql
+    assert "ORDER BY score DESC LIMIT %s" in sql
+    assert 'FROM "drawers"' in sql
+    assert "english" not in sql
+    # tsquery first, LIMIT last — the SQL text order.
+    assert captured["params"] == ["'rareterm' | 'backend'", 7]
+    assert rows == [
+        {
+            "id": "a",
+            "document": "doc",
+            "metadata": {"wing": "x"},
+            "embedding": None,
+            "distance": None,
+            "score": 0.5,
+        }
+    ]
+
+
+def test_lexical_rows_binds_where_between_query_and_limit():
+    """Pushdown filters bind as JSONB containment, ordered as they appear in the SQL."""
+    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
+    captured = {}
+
+    def fake_execute(sql, params=None, *, fetch=False, many=False):
+        captured["sql"] = sql
+        captured["params"] = list(params or [])
+        return []
+
+    client._execute = fake_execute
+    client.lexical_rows("drawers", tokens=["alpha"], limit=3, where={"wing": "project"})
+
+    assert "metadata @> %s::jsonb" in captured["sql"]
+    assert captured["params"] == ["'alpha'", _json_dumps({"wing": "project"}), 3]
+
+
+def test_create_table_also_creates_fts_gin_index(monkeypatch):
+    """Fresh collections get the FTS index automatically — no manual migration."""
+    client, captured = _capturing_client(monkeypatch)
+    client.create_table("mempalace_abc_drawers", 384)
+
+    statements = [item["sql"] for item in captured]
+    assert any(sql.startswith("CREATE TABLE IF NOT EXISTS") for sql in statements)
+    index_sql = [sql for sql in statements if sql.startswith("CREATE INDEX IF NOT EXISTS")]
+    assert len(index_sql) == 1
+    assert "USING gin (to_tsvector('simple', document))" in index_sql[0]
+    assert '"mempalace_abc_drawers_fts_idx"' in index_sql[0]
+    assert 'ON "mempalace_abc_drawers"' in index_sql[0]
+
+
+def test_fts_index_name_is_table_scoped_and_length_clamped():
+    """Two collections must not collide on one index name (both live in pg_class)."""
+    assert _fts_index_name("t_one") != _fts_index_name("t_two")
+    assert _fts_index_name("t_one") == "t_one_fts_idx"
+
+    long_a = "mempalace_" + "a" * 60
+    long_b = "mempalace_" + "a" * 59 + "b"
+    for name in (_fts_index_name(long_a), _fts_index_name(long_b)):
+        assert len(name.encode("utf-8")) <= 63
+    # Clamping hashes the overflow instead of truncating into a collision.
+    assert _fts_index_name(long_a) != _fts_index_name(long_b)
+    assert _fts_index_name(long_a) != long_a
+
+
+def test_create_fts_index_failure_does_not_break_table_creation():
+    """The index is a performance asset; a role that cannot build it still works."""
+    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
+    seen = []
+
+    def fake_execute(sql, params=None, *, fetch=False, many=False):
+        seen.append(sql)
+        if sql.startswith("CREATE INDEX"):
+            raise BackendError("permission denied")
+        return []
+
+    client._execute = fake_execute
+    client.create_table("drawers", 2)  # must not raise
+    assert any(sql.startswith("CREATE INDEX") for sql in seen)
+
+
+def test_lexical_search_pushes_down_instead_of_scrolling(tmp_path, fake_pgvector):
+    """The default path must never pull the table to the client."""
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["a", "b", "c"],
+        documents=[
+            "alpha backend note",
+            "rareterm pgvector backend note",
+            "frontend design note",
+        ],
+        metadatas=[{"wing": "project"}, {"wing": "project"}, {"wing": "other"}],
+        embeddings=[[1, 0], [0.9, 0.1], [0, 1]],
+    )
+    client = fake_pgvector.instances[0]
+    client.scroll_calls.clear()
+
+    hits = col.lexical_search(query="rareterm backend", n_results=5, where={"wing": "project"}).hits
+
+    assert [hit.id for hit in hits] == ["b", "a"]
+    assert client.scroll_calls == [], "lexical search must not scroll the table"
+    assert client.lexical_calls == [
+        {"tokens": ["rareterm", "backend"], "limit": 5, "where": {"wing": "project"}}
+    ]
+
+
+def test_lexical_search_falls_back_for_non_pushdown_filter(tmp_path, fake_pgvector):
+    """A filter SQL cannot express keeps the exact client-side path."""
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["a", "b"],
+        documents=["alpha backend note", "rareterm backend note"],
+        metadatas=[{"wing": "project", "rank": 1}, {"wing": "project", "rank": 3}],
+        embeddings=[[1, 0], [0.9, 0.1]],
+    )
+    client = fake_pgvector.instances[0]
+    client.scroll_calls.clear()
+
+    hits = col.lexical_search(query="backend", n_results=5, where={"rank": {"$gt": 1}}).hits
+
+    assert [hit.id for hit in hits] == ["b"]
+    assert client.lexical_calls == [], "$gt is not pushdown-safe"
+    assert client.scroll_calls, "fallback path scrolls"
+
+
+def test_lexical_search_falls_back_when_postgres_fails(tmp_path, fake_pgvector, monkeypatch):
+    """A server-side failure must degrade to the slow path, not drop the arm.
+
+    Dropping it would silently halve hybrid search recall, which is worse than
+    being slow.
+    """
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["a", "b"],
+        documents=["alpha backend note", "rareterm backend note"],
+        metadatas=[{"wing": "project"}, {"wing": "project"}],
+        embeddings=[[1, 0], [0.9, 0.1]],
+    )
+    client = fake_pgvector.instances[0]
+
+    def boom(*_args, **_kwargs):
+        raise BackendError("to_tsquery: syntax error")
+
+    monkeypatch.setattr(client, "lexical_rows", boom)
+    client.scroll_calls.clear()
+
+    hits = col.lexical_search(query="rareterm backend", n_results=5).hits
+
+    assert [hit.id for hit in hits] == ["b", "a"]
+    assert client.scroll_calls, "failure must fall back to the client-side scan"
+
+
+def test_lexical_search_empty_query_issues_no_sql(tmp_path, fake_pgvector):
+    """No token means no match, so neither a tsquery nor a scroll is worth sending."""
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["a"],
+        documents=["alpha backend note"],
+        metadatas=[{"wing": "project"}],
+        embeddings=[[1, 0]],
+    )
+    client = fake_pgvector.instances[0]
+    client.scroll_calls.clear()
+
+    for query in ("", "   ", "!!!", "a"):  # single chars are below the token floor
+        assert col.lexical_search(query=query, n_results=5).hits == []
+
+    assert client.lexical_calls == []
+    assert client.scroll_calls == []
+
+
+def test_lexical_search_matches_arabic_and_cjk(tmp_path, fake_pgvector):
+    """A mixed-script palace is the reason the config is 'simple', not 'english'."""
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["ar", "cjk", "en"],
+        documents=["قصر الذاكرة يحفظ كلماتك", "记忆 宫殿", "memory palace note"],
+        metadatas=[{"wing": "p"}, {"wing": "p"}, {"wing": "p"}],
+        embeddings=[[1, 0], [0, 1], [0.5, 0.5]],
+    )
+
+    assert [hit.id for hit in col.lexical_search(query="الذاكرة", n_results=5).hits] == ["ar"]
+    assert [hit.id for hit in col.lexical_search(query="记忆", n_results=5).hits] == ["cjk"]
+    # And the tokens reach SQL quoted, not mangled.
+    assert _tsquery_or(_tokenize("الذاكرة")) == "'الذاكرة'"
+
+
+def test_lexical_search_raises_when_table_missing_but_marker_exists(tmp_path, fake_pgvector):
+    """Same not-initialized contract as the scan path it replaces."""
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["a"],
+        documents=["alpha backend note"],
+        metadatas=[{"wing": "project"}],
+        embeddings=[[1, 0]],
+    )
+    fake_pgvector.instances[0].tables.clear()  # marker on disk, table gone
+
+    with pytest.raises(CollectionNotInitializedError):
+        col.lexical_search(query="backend", n_results=5)

--- a/tests/test_pgvector_backend.py
+++ b/tests/test_pgvector_backend.py
@@ -34,9 +34,10 @@ from mempalace.backends.pgvector import (
     _strip_nul,
     _json_dumps,
     _tokenize,
-    _escape_tsquery_token,
-    _tsquery_or,
-    _fts_index_name,
+    _bm25_scores,
+    _like_pattern,
+    _token_count,
+    _trgm_index_name,
 )
 
 
@@ -57,6 +58,10 @@ class _FakePgVectorClient:
         self.scroll_calls: list = []
         self.facet_calls: list = []
         self.lexical_calls: list = []
+        self.lexical_asset_calls: list = []
+        # Flipped off by the tests that stand in for a palace created before the
+        # token_count column existed.
+        self.token_count_supported: bool = True
         _FakePgVectorClient.instances.append(self)
 
     def ping(self):
@@ -80,7 +85,13 @@ class _FakePgVectorClient:
             {"dimension": len(rows[0]["embedding"]) if rows else 0, "rows": {}},
         )
         for row in rows:
-            store["rows"][row["id"]] = dict(row)
+            stored = dict(row)
+            # Mirrors the real client: the count is derived server-side-ish, from
+            # the document that actually lands in the row, and only when the
+            # table carries the column.
+            if self.token_count_supported:
+                stored["token_count"] = _token_count(stored.get("document") or "")
+            store["rows"][row["id"]] = stored
 
     def _filtered(self, table, where):
         rows = list(self.tables.get(table, {"rows": {}})["rows"].values())
@@ -107,35 +118,54 @@ class _FakePgVectorClient:
             out.append(item)
         return out
 
-    def lexical_rows(self, table, *, tokens, limit, where):
-        """Stand-in for the server-side ``to_tsquery``/``ts_rank_cd`` ranking.
+    def lexical_candidates(self, table, *, tokens, where):
+        """Stand-in for the server-side ``ILIKE`` filter.
 
-        Mirrors the two properties the real SQL guarantees and the collection
-        relies on: OR semantics over the tokens, and a descending rank where a
-        document matching more of the query outranks one matching less.
+        Deliberately models *substring* matching rather than tokenizer overlap:
+        that is what ``document ILIKE '%token%'`` actually does, and a fake that
+        re-used ``_tokenize`` here would agree with the collection by
+        construction and so could never catch a predicate that is narrower than
+        BM25's scoring set. No limit and no ranking, because the real query has
+        neither.
         """
-        self.lexical_calls.append({"tokens": list(tokens), "limit": limit, "where": where})
-        wanted = set(tokens)
-        scored = []
+        self.lexical_calls.append({"tokens": list(tokens), "where": where})
+        rows = []
         for row in self._filtered(table, where):
-            overlap = len(wanted & set(_tokenize(row.get("document") or "")))
-            if overlap:
-                scored.append((float(overlap), row))
-        scored.sort(key=lambda item: item[0], reverse=True)
-        return [
-            {
-                "id": row["id"],
-                "document": row["document"],
-                "metadata": row.get("metadata") or {},
-                "embedding": None,
-                "distance": None,
-                "score": score,
-            }
-            for score, row in scored[:limit]
-        ]
+            document = (row.get("document") or "").lower()
+            if any(token in document for token in tokens):
+                rows.append(
+                    {
+                        "id": row["id"],
+                        "document": row["document"],
+                        "metadata": row.get("metadata") or {},
+                        "embedding": None,
+                        "distance": None,
+                    }
+                )
+        return rows
 
-    def create_fts_index(self, table):
-        return None
+    def lexical_corpus_stats(self, table, where):
+        rows = self._filtered(table, where)
+        if not rows:
+            return None
+        counts = [row.get("token_count") for row in rows]
+        if any(count is None for count in counts):
+            return None
+        return len(rows), sum(counts) / len(rows)
+
+    def has_token_count(self, table):
+        return self.token_count_supported
+
+    def ensure_lexical_assets(self, table):
+        self.lexical_asset_calls.append(table)
+
+    def backfill_token_counts(self, table, batch=2000):
+        filled = 0
+        for row in self.tables.get(table, {"rows": {}})["rows"].values():
+            if row.get("token_count") is None:
+                row["token_count"] = _token_count(row.get("document") or "")
+                filled += 1
+        return filled
 
     def scroll_rows(
         self,
@@ -219,6 +249,9 @@ class _FakePgVectorClient:
             counts[key] = counts.get(key, 0) + 1
         ordered = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
         return dict(ordered[:limit])
+
+    def has_vector_index(self, table):
+        return False
 
     def drop_table(self, table):
         self.tables.pop(table, None)
@@ -1983,7 +2016,8 @@ def test_execute_retry_covers_executemany(monkeypatch):
     client._execute("INSERT ...", [(1,), (2,)], many=True)
     assert len(handed_out) == 2
 
-# ── Postgres FTS lexical search ────────────────────────────────────────
+
+# ── Lexical pushdown (filter in SQL, BM25 in Python) ───────────────────
 
 
 def _capturing_client(monkeypatch):
@@ -2000,312 +2034,476 @@ def _capturing_client(monkeypatch):
 
     client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
     monkeypatch.setattr(client, "_execute", fake_execute)
+    client._token_count_columns["drawers"] = True
     return client, captured
 
 
-def _unquote_tsquery_lexeme(escaped):
-    """Decode one escaped lexeme the way the Postgres tsquery lexer does.
+def test_like_pattern_escapes_wildcards_and_escape_char():
+    """The pattern must be a literal-substring test, not a wildcard expression."""
+    assert _like_pattern("plain") == "%plain%"
+    # '_' is a LIKE single-character wildcard and IS reachable: it is a \w char,
+    # so _tokenize emits it inside identifiers like foo_bar.
+    assert _like_pattern("foo_bar") == r"%foo\_bar%"
+    assert _like_pattern("50%") == r"%50\%%"
+    assert _like_pattern("a\\b") == "%a\\\\b%"
 
-    Inside single quotes only ``''`` (a literal quote) and ``\\\\`` (a literal
-    backslash) are special; everything else is taken verbatim.
+
+@given(st.text(min_size=1, max_size=80))
+def test_every_token_is_a_literal_substring_of_the_lowered_document(text):
+    """The property the whole pushdown rests on.
+
+    ``_bm25_scores`` can only score a document above zero if the document shares
+    a token with the query, and every token the tokenizer emits is a span it
+    matched inside ``text.lower()``. So an ILIKE substring test on that token
+    cannot miss a document BM25 would have scored — the SQL filter is a superset
+    of the scored set, never a subset.
     """
-    assert escaped.startswith("'") and escaped.endswith("'") and len(escaped) >= 2
-    body = escaped[1:-1]
-    out = []
-    i = 0
-    while i < len(body):
-        pair = body[i : i + 2]
-        if pair in ("''", "\\\\"):
-            out.append(pair[0])
-            i += 2
-        else:
-            out.append(body[i])
-            i += 1
-    return "".join(out)
+    lowered = text.lower()
+    for token in _tokenize(text):
+        assert token in lowered
 
 
-def test_escape_tsquery_token_neutralizes_operators():
-    """tsquery operators inside a token must become part of the lexeme, not syntax.
+def test_trgm_index_name_is_table_scoped_and_length_clamped():
+    """Two collections in one schema must not fight over one index name."""
+    assert _trgm_index_name("t_one") != _trgm_index_name("t_two")
+    assert _trgm_index_name("t_one") == "t_one_trgm_idx"
 
-    ``to_tsquery`` parses its argument as an expression, so an unescaped token
-    would let ``&``/``|``/``!``/``<->``/parens change which rows match — or abort
-    the search with a syntax error.
-    """
-    for raw in ("a&b", "a|b", "!a", "(a)", "a:b", "a:*", "a<->b", "a & b | !c"):
-        escaped = _escape_tsquery_token(raw)
-        assert escaped.startswith("'") and escaped.endswith("'")
-        assert _unquote_tsquery_lexeme(escaped) == raw
-
-
-def test_escape_tsquery_token_doubles_quotes_and_backslashes():
-    assert _escape_tsquery_token("it's") == "'it''s'"
-    assert _escape_tsquery_token("a\\b") == "'a\\\\b'"
-    # The classic break-out attempt: closing the quote to append an operator.
-    assert _escape_tsquery_token("x' | 'y") == "'x'' | ''y'"
-    # A trailing backslash must not escape the closing quote.
-    assert _escape_tsquery_token("x\\") == "'x\\\\'"
-
-
-def test_escape_tsquery_token_handles_non_latin_text():
-    """Arabic and CJK tokens pass through untouched — 'simple' is script-neutral."""
-    for raw in ("ذاكرة", "قصر_الذاكرة", "记忆", "メモリ"):
-        assert _escape_tsquery_token(raw) == f"'{raw}'"
-
-
-@given(st.text(min_size=0, max_size=40))
-def test_escape_tsquery_token_round_trips_any_input(raw):
-    """Any string survives escaping as exactly one lexeme.
-
-    Two properties together mean "cannot inject": the escaped form decodes back
-    to the input, and the quoted body holds no unpaired quote that could end the
-    lexeme early.
-    """
-    escaped = _escape_tsquery_token(raw)
-    assert _unquote_tsquery_lexeme(escaped) == raw
-    body = escaped[1:-1]
-    assert body.replace("''", "").count("'") == 0
-
-
-def test_tsquery_or_joins_tokens_with_or():
-    """OR semantics, not AND: the lexical arm is a recall-oriented candidate pool.
-
-    ``websearch_to_tsquery`` would AND the terms, so a multi-word question would
-    return nothing where the BM25 path it replaces scored every partial match.
-    """
-    assert _tsquery_or(["rareterm", "backend"]) == "'rareterm' | 'backend'"
-    assert _tsquery_or(["solo"]) == "'solo'"
-
-
-def test_tsquery_or_drops_empty_tokens():
-    """An empty quoted lexeme is a tsquery syntax error, so it must never appear."""
-    assert _tsquery_or([]) == ""
-    assert _tsquery_or(["", "kept", ""]) == "'kept'"
-
-
-@given(st.text(max_size=60))
-def test_tsquery_or_from_tokenizer_emits_one_lexeme_per_token(text):
-    tokens = _tokenize(text)
-    built = _tsquery_or(tokens)
-    assert built.count(" | ") == max(len(tokens) - 1, 0)
-    assert not built.endswith("|")
-    # Tokenizer output is \w-only, so nothing needs escaping and every token
-    # appears verbatim inside its own quotes.
-    for token in tokens:
-        assert f"'{token}'" in built
-
-
-def test_lexical_rows_sql_uses_simple_config_and_binds_query():
-    """The pushed-down query must rank server-side with the language-neutral config."""
-    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
-    captured = {}
-
-    def fake_execute(sql, params=None, *, fetch=False, many=False):
-        captured["sql"] = sql
-        captured["params"] = list(params or [])
-        return [("a", "doc", {"wing": "x"}, 0.5)]
-
-    client._execute = fake_execute
-    rows = client.lexical_rows("drawers", tokens=["rareterm", "backend"], limit=7, where=None)
-
-    sql = captured["sql"]
-    assert "to_tsquery('simple', %s)" in sql
-    assert "ts_rank_cd(to_tsvector('simple', document), q)" in sql
-    # Must match the indexed expression verbatim or the GIN index is not used.
-    assert "to_tsvector('simple', document) @@ q" in sql
-    assert "ORDER BY score DESC LIMIT %s" in sql
-    assert 'FROM "drawers"' in sql
-    assert "english" not in sql
-    # tsquery first, LIMIT last — the SQL text order.
-    assert captured["params"] == ["'rareterm' | 'backend'", 7]
-    assert rows == [
-        {
-            "id": "a",
-            "document": "doc",
-            "metadata": {"wing": "x"},
-            "embedding": None,
-            "distance": None,
-            "score": 0.5,
-        }
-    ]
-
-
-def test_lexical_rows_binds_where_between_query_and_limit():
-    """Pushdown filters bind as JSONB containment, ordered as they appear in the SQL."""
-    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
-    captured = {}
-
-    def fake_execute(sql, params=None, *, fetch=False, many=False):
-        captured["sql"] = sql
-        captured["params"] = list(params or [])
-        return []
-
-    client._execute = fake_execute
-    client.lexical_rows("drawers", tokens=["alpha"], limit=3, where={"wing": "project"})
-
-    assert "metadata @> %s::jsonb" in captured["sql"]
-    assert captured["params"] == ["'alpha'", _json_dumps({"wing": "project"}), 3]
-
-
-def test_create_table_also_creates_fts_gin_index(monkeypatch):
-    """Fresh collections get the FTS index automatically — no manual migration."""
-    client, captured = _capturing_client(monkeypatch)
-    client.create_table("mempalace_abc_drawers", 384)
-
-    statements = [item["sql"] for item in captured]
-    assert any(sql.startswith("CREATE TABLE IF NOT EXISTS") for sql in statements)
-    index_sql = [sql for sql in statements if sql.startswith("CREATE INDEX IF NOT EXISTS")]
-    assert len(index_sql) == 1
-    assert "USING gin (to_tsvector('simple', document))" in index_sql[0]
-    assert '"mempalace_abc_drawers_fts_idx"' in index_sql[0]
-    assert 'ON "mempalace_abc_drawers"' in index_sql[0]
-
-
-def test_fts_index_name_is_table_scoped_and_length_clamped():
-    """Two collections must not collide on one index name (both live in pg_class)."""
-    assert _fts_index_name("t_one") != _fts_index_name("t_two")
-    assert _fts_index_name("t_one") == "t_one_fts_idx"
-
-    long_a = "mempalace_" + "a" * 60
-    long_b = "mempalace_" + "a" * 59 + "b"
-    for name in (_fts_index_name(long_a), _fts_index_name(long_b)):
+    long_a = "x" * 70 + "a"
+    long_b = "x" * 70 + "b"
+    for name in (_trgm_index_name(long_a), _trgm_index_name(long_b)):
         assert len(name.encode("utf-8")) <= 63
-    # Clamping hashes the overflow instead of truncating into a collision.
-    assert _fts_index_name(long_a) != _fts_index_name(long_b)
-    assert _fts_index_name(long_a) != long_a
+    assert _trgm_index_name(long_a) != _trgm_index_name(long_b)
 
 
-def test_create_fts_index_failure_does_not_break_table_creation():
-    """The index is a performance asset; a role that cannot build it still works."""
+def test_lexical_candidates_sql_has_no_limit_and_no_ranking(monkeypatch):
+    """Postgres decides which rows to *skip*, never which rows to return."""
+    client, captured = _capturing_client(monkeypatch)
+
+    client.lexical_candidates("drawers", tokens=["rareterm", "backend"], where=None)
+
+    sql = captured[-1]["sql"]
+    assert "LIMIT" not in sql.upper()
+    assert "ORDER BY" not in sql.upper()
+    assert "ts_rank" not in sql and "tsquery" not in sql
+    assert sql.count("document ILIKE %s ESCAPE '\\'") == 2
+    assert " OR " in sql
+    assert captured[-1]["params"] == ["%rareterm%", "%backend%"]
+
+
+def test_lexical_candidates_binds_patterns_before_where_params(monkeypatch):
+    """Positional binding order must match the order the placeholders appear."""
+    client, captured = _capturing_client(monkeypatch)
+
+    client.lexical_candidates("drawers", tokens=["alpha"], where={"wing": "project"})
+
+    call = captured[-1]
+    assert call["params"][0] == "%alpha%"
+    assert json.loads(call["params"][1]) == {"wing": "project"}
+    assert call["sql"].index("ILIKE") < call["sql"].index("metadata @>")
+
+
+def test_lexical_corpus_stats_returns_none_when_a_count_is_missing(monkeypatch):
+    """A single un-backfilled row must send the query to the exact local path."""
+    client, _captured = _capturing_client(monkeypatch)
+
+    monkeypatch.setattr(client, "_execute", lambda *a, **k: [(10, 100, 1)])
+    assert client.lexical_corpus_stats("drawers", None) is None
+
+    monkeypatch.setattr(client, "_execute", lambda *a, **k: [(10, 100, 0)])
+    assert client.lexical_corpus_stats("drawers", None) == (10, 10.0)
+
+    # An empty collection has no mean length to report.
+    monkeypatch.setattr(client, "_execute", lambda *a, **k: [(0, None, 0)])
+    assert client.lexical_corpus_stats("drawers", None) is None
+
+
+def test_create_table_adds_token_count_and_lexical_assets(monkeypatch):
+    client, captured = _capturing_client(monkeypatch)
+
+    client.create_table("drawers", 3)
+
+    statements = " | ".join(call["sql"] for call in captured)
+    assert '"token_count" integer)' in statements
+    assert 'ADD COLUMN IF NOT EXISTS "token_count"' in statements
+    assert "CREATE EXTENSION IF NOT EXISTS pg_trgm" in statements
+    assert "gin (document gin_trgm_ops)" in statements
+    # A tsvector expression index would enforce Postgres' 1 MB tsvector cap at
+    # write time, turning a large drawer from a slow write into a failed one.
+    assert "to_tsvector" not in statements
+
+
+def test_lexical_asset_failure_does_not_break_table_creation(monkeypatch):
+    """A role that may not ALTER or CREATE EXTENSION must still open a palace."""
     client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
     seen = []
 
-    def fake_execute(sql, params=None, *, fetch=False, many=False):
+    def flaky_execute(sql, params=None, *, fetch=False, many=False):
         seen.append(sql)
-        if sql.startswith("CREATE INDEX"):
+        if "ALTER TABLE" in sql or "CREATE EXTENSION" in sql or "CREATE INDEX" in sql:
             raise BackendError("permission denied")
         return []
 
-    client._execute = fake_execute
-    client.create_table("drawers", 2)  # must not raise
-    assert any(sql.startswith("CREATE INDEX") for sql in seen)
+    monkeypatch.setattr(client, "_execute", flaky_execute)
+    client.create_table("drawers", 3)  # must not raise
+
+    assert any("CREATE TABLE" in sql for sql in seen)
 
 
-def test_lexical_search_pushes_down_instead_of_scrolling(tmp_path, fake_pgvector):
-    """The default path must never pull the table to the client."""
-    _backend, col = _collection(tmp_path)
-    col.add(
-        ids=["a", "b", "c"],
-        documents=[
-            "alpha backend note",
-            "rareterm pgvector backend note",
-            "frontend design note",
-        ],
-        metadatas=[{"wing": "project"}, {"wing": "project"}, {"wing": "other"}],
-        embeddings=[[1, 0], [0.9, 0.1], [0, 1]],
+def test_upsert_counts_tokens_of_the_stored_document(monkeypatch):
+    """The stored length must describe the stored text, not the caller's.
+
+    Stripping a NUL can fuse two tokens into one, and a length that disagrees
+    with the document by even one token silently changes every future ranking.
+    """
+    client, captured = _capturing_client(monkeypatch)
+
+    client.upsert_rows(
+        "drawers",
+        [{"id": "a", "document": "ab\x00cd efgh", "metadata": {}, "embedding": [1, 0]}],
     )
-    client = fake_pgvector.instances[0]
-    client.scroll_calls.clear()
 
-    hits = col.lexical_search(query="rareterm backend", n_results=5, where={"wing": "project"}).hits
+    call = captured[-1]
+    assert '"token_count"' in call["sql"]
+    document, token_count = call["params"][0][1], call["params"][0][-1]
+    assert document == "abcd efgh"
+    assert token_count == _token_count("abcd efgh") == 2
 
-    assert [hit.id for hit in hits] == ["b", "a"]
-    assert client.scroll_calls == [], "lexical search must not scroll the table"
-    assert client.lexical_calls == [
-        {"tokens": ["rareterm", "backend"], "limit": 5, "where": {"wing": "project"}}
+
+def test_upsert_omits_token_count_when_the_column_is_absent(monkeypatch):
+    """A pre-token_count table must keep ingesting, not fail on an unknown column."""
+    client, captured = _capturing_client(monkeypatch)
+    client._token_count_columns["drawers"] = False
+
+    client.upsert_rows(
+        "drawers",
+        [{"id": "a", "document": "alpha beta", "metadata": {}, "embedding": [1, 0]}],
+    )
+
+    call = captured[-1]
+    assert "token_count" not in call["sql"]
+    assert len(call["params"][0]) == 5
+
+
+def test_bm25_with_collection_statistics_matches_whole_collection_scoring():
+    """Scoring a filtered pool with collection-wide stats == scoring everything.
+
+    This is the arithmetic the pushdown depends on: the rows a query cannot
+    match contribute nothing but their count and their length to BM25, so
+    supplying those two numbers makes the filtered pool score identically.
+    """
+    documents = [
+        "alpha beta short",
+        "alpha " + " ".join(f"filler{i}" for i in range(60)),
+        "beta " + " ".join(f"other{i}" for i in range(30)),
+        "gamma delta epsilon with no query terms at all",
+        "unrelated text",
+    ]
+    query = "alpha beta"
+
+    whole = _bm25_scores(query, documents)
+    matched = [doc for doc, score in zip(documents, whole) if score > 0]
+    assert len(matched) < len(documents)
+
+    tokenized_lengths = [len(_tokenize(doc)) for doc in documents]
+    pooled = _bm25_scores(
+        query,
+        matched,
+        corpus_size=len(documents),
+        corpus_avgdl=sum(tokenized_lengths) / len(documents),
+    )
+    assert pooled == pytest.approx([score for score in whole if score > 0])
+
+    # Without the statistics the pool scores differently — which is exactly the
+    # bug this guards against.
+    naive = _bm25_scores(query, matched)
+    assert naive != pytest.approx([score for score in whole if score > 0])
+
+
+def _local_lexical(col, query, n_results, where=None):
+    """What ``lexical_search`` returns with the pushdown disabled."""
+    return [
+        (hit.id, hit.score)
+        for hit in col._lexical_search_local(query=query, n_results=n_results, where=where).hits
     ]
 
 
-def test_lexical_search_falls_back_for_non_pushdown_filter(tmp_path, fake_pgvector):
-    """A filter SQL cannot express keeps the exact client-side path."""
-    _backend, col = _collection(tmp_path)
+def _reviewer_corpus():
+    """Matches far outnumber the window, and the best hit is not the most 'relevant'
+    row by any server-side term-frequency measure.
+
+    ``short00`` carries both query terms in a short document, which is what BM25
+    rewards; the ``alpha*`` rows are long and carry one term each, which is what
+    a raw term-frequency ranking rewards. Any ranking done in SQL over a window
+    of 9 drops ``short00``'s peers.
+    """
+    documents = {"short00": "we shipped the alpha and beta change today"}
+    for i in range(30):
+        documents[f"alpha{i:02d}"] = (
+            "alpha " + " ".join(f"filler{j}" for j in range(60)) + f" release note {i}"
+        )
+    for i in range(15):
+        documents[f"beta{i:02d}"] = (
+            "beta " + " ".join(f"other{j}" for j in range(60)) + f" changelog {i}"
+        )
+    for i in range(4):
+        documents[f"short{i + 1:02d}"] = f"alpha beta quick note number {i}"
+    for i in range(10):
+        documents[f"noise{i:02d}"] = f"unrelated gamma delta epsilon text {i}"
+    return documents
+
+
+def _seed(col, documents):
+    ids = list(documents)
     col.add(
-        ids=["a", "b"],
-        documents=["alpha backend note", "rareterm backend note"],
-        metadatas=[{"wing": "project", "rank": 1}, {"wing": "project", "rank": 3}],
-        embeddings=[[1, 0], [0.9, 0.1]],
+        ids=ids,
+        documents=[documents[i] for i in ids],
+        metadatas=[{"wing": "p"} for _ in ids],
+        embeddings=[[1.0, 0.0] for _ in ids],
     )
+    return ids
+
+
+def test_pushdown_keeps_every_hit_when_matches_outnumber_the_window(tmp_path, fake_pgvector):
+    """The reviewer's scenario: 60 drawers, a window of 9, 50 of them match.
+
+    The searcher asks for ``n_results * 3`` candidates (searcher.py), so a
+    corpus where matches outnumber that window is the normal case, not a corner
+    one. Ranking in SQL picks a different 9 than BM25 does; filtering in SQL and
+    ranking here cannot.
+    """
+    _backend, col = _collection(tmp_path)
+    documents = _reviewer_corpus()
+    _seed(col, documents)
     client = fake_pgvector.instances[0]
+
+    for n_results in (1, 5, 9, 30, 200):
+        client.lexical_calls.clear()
+        client.scroll_calls.clear()
+        pushed = [
+            (hit.id, hit.score)
+            for hit in col.lexical_search(query="alpha beta", n_results=n_results).hits
+        ]
+        assert client.lexical_calls, "the pushdown must be the path under test"
+        assert client.scroll_calls == [], "no document may cross the wire unmatched"
+        assert pushed == _local_lexical(col, "alpha beta", n_results)
+
+    # The specific loss the reviewer reported: the top BM25 hit and everything
+    # ranked with it survive a window smaller than the match count.
+    everything = _local_lexical(col, "alpha beta", 10_000)
+    assert len(everything) == 50 > 9
+    top_hit = everything[0][0]
+    window = [hit.id for hit in col.lexical_search(query="alpha beta", n_results=9).hits]
+    assert top_hit in window
+    assert window == [doc_id for doc_id, _ in everything[:9]]
+
+
+def test_pushdown_matches_local_path_across_queries_and_filters(tmp_path, fake_pgvector):
+    """Equivalence, not just recall: same ids, same scores, same order."""
+    _backend, col = _collection(tmp_path)
+    documents = _reviewer_corpus()
+    documents["mixed"] = "قصر الذاكرة يحفظ كلماتك alpha"
+    documents["cjk"] = "记忆宫殿笔记 beta"
+    documents["dev"] = "contact atk@atkabli.com about /etc/nginx/nginx.conf and npm.install"
+    _seed(col, documents)
+
+    queries = [
+        "alpha beta",
+        "alpha",
+        "gamma",
+        "الذاكرة",
+        "记忆宫殿笔记",
+        "atkabli",
+        "nginx",
+        "npm",
+        "nothingmatchesthisatall",
+    ]
+    for query in queries:
+        for n_results in (3, 9, 60):
+            assert [
+                (hit.id, hit.score)
+                for hit in col.lexical_search(query=query, n_results=n_results).hits
+            ] == _local_lexical(col, query, n_results), f"{query!r} n={n_results}"
+
+
+def test_pushdown_ranking_is_deterministic_on_ties(tmp_path, fake_pgvector):
+    """Equal scores must not make the cut at ``n_results`` a coin flip."""
+    _backend, col = _collection(tmp_path)
+    documents = {f"d{i:02d}": "alpha note here" for i in range(20)}
+    _seed(col, documents)
+
+    first = [hit.id for hit in col.lexical_search(query="alpha", n_results=5).hits]
+    assert first == sorted(first)
+    for _ in range(5):
+        assert [hit.id for hit in col.lexical_search(query="alpha", n_results=5).hits] == first
+
+
+def test_lexical_search_falls_back_for_non_pushdown_filter(tmp_path, fake_pgvector):
+    _backend, col = _collection(tmp_path)
+    _seed(col, {"a": "alpha note", "b": "beta note"})
+    client = fake_pgvector.instances[0]
+    client.lexical_calls.clear()
     client.scroll_calls.clear()
 
-    hits = col.lexical_search(query="backend", n_results=5, where={"rank": {"$gt": 1}}).hits
+    hits = col.lexical_search(query="alpha", n_results=5, where={"$or": [{"wing": "p"}]}).hits
 
-    assert [hit.id for hit in hits] == ["b"]
-    assert client.lexical_calls == [], "$gt is not pushdown-safe"
-    assert client.scroll_calls, "fallback path scrolls"
+    assert [hit.id for hit in hits] == ["a"]
+    assert client.lexical_calls == []
+    assert client.scroll_calls, "an $or filter belongs on the exact local path"
 
 
-def test_lexical_search_falls_back_when_postgres_fails(tmp_path, fake_pgvector, monkeypatch):
-    """A server-side failure must degrade to the slow path, not drop the arm.
+def test_lexical_search_falls_back_for_null_operand(tmp_path, fake_pgvector):
+    """``metadata @> '{"k": null}'`` needs the key present; ``_matches_where`` does not.
 
-    Dropping it would silently halve hybrid search recall, which is worse than
-    being slow.
+    The containment predicate is narrower than the Python filter here, so a row
+    with the key absent would never reach the client and no post-filter could
+    put it back.
     """
     _backend, col = _collection(tmp_path)
     col.add(
         ids=["a", "b"],
-        documents=["alpha backend note", "rareterm backend note"],
-        metadatas=[{"wing": "project"}, {"wing": "project"}],
-        embeddings=[[1, 0], [0.9, 0.1]],
+        documents=["alpha note", "alpha other"],
+        metadatas=[{"wing": "p", "k": None}, {"wing": "p"}],
+        embeddings=[[1, 0], [1, 0]],
     )
+    client = fake_pgvector.instances[0]
+    client.lexical_calls.clear()
+
+    hits = col.lexical_search(query="alpha", n_results=5, where={"k": None}).hits
+
+    assert client.lexical_calls == []
+    assert {hit.id for hit in hits} == {"a", "b"}
+
+
+def test_lexical_search_falls_back_when_token_counts_are_missing(tmp_path, fake_pgvector):
+    """A palace written before the column existed keeps working, just slower."""
+    _backend, col = _collection(tmp_path)
+    _seed(col, {"a": "alpha note", "b": "beta note"})
+    client = fake_pgvector.instances[0]
+    client.token_count_supported = False
+    for row in client.tables[col._table]["rows"].values():
+        row.pop("token_count", None)
+    client.lexical_calls.clear()
+    client.scroll_calls.clear()
+
+    hits = col.lexical_search(query="alpha", n_results=5).hits
+
+    assert [hit.id for hit in hits] == ["a"]
+    assert client.lexical_calls == []
+    assert client.scroll_calls
+
+
+def test_lexical_search_falls_back_when_postgres_fails(tmp_path, fake_pgvector, monkeypatch):
+    _backend, col = _collection(tmp_path)
+    _seed(col, {"a": "alpha note", "b": "beta note"})
     client = fake_pgvector.instances[0]
 
     def boom(*_args, **_kwargs):
-        raise BackendError("to_tsquery: syntax error")
+        raise BackendError("server exploded")
 
-    monkeypatch.setattr(client, "lexical_rows", boom)
+    monkeypatch.setattr(client, "lexical_candidates", boom)
     client.scroll_calls.clear()
 
-    hits = col.lexical_search(query="rareterm backend", n_results=5).hits
+    hits = col.lexical_search(query="alpha", n_results=5).hits
 
-    assert [hit.id for hit in hits] == ["b", "a"]
-    assert client.scroll_calls, "failure must fall back to the client-side scan"
+    assert [hit.id for hit in hits] == ["a"]
+    assert client.scroll_calls, "a server failure must fall back, not drop the arm"
+
+
+def test_lexical_search_propagates_unsupported_filter(tmp_path, fake_pgvector, monkeypatch):
+    """RFC 001: an operator the backend cannot honour is an error, not a slow path."""
+    from mempalace.backends import UnsupportedFilterError
+
+    _backend, col = _collection(tmp_path)
+    _seed(col, {"a": "alpha note"})
+    client = fake_pgvector.instances[0]
+
+    def boom(*_args, **_kwargs):
+        raise UnsupportedFilterError("operator '$nope' not pushed down by pgvector")
+
+    monkeypatch.setattr(client, "lexical_candidates", boom)
+
+    with pytest.raises(UnsupportedFilterError):
+        col.lexical_search(query="alpha", n_results=5)
 
 
 def test_lexical_search_empty_query_issues_no_sql(tmp_path, fake_pgvector):
-    """No token means no match, so neither a tsquery nor a scroll is worth sending."""
     _backend, col = _collection(tmp_path)
-    col.add(
-        ids=["a"],
-        documents=["alpha backend note"],
-        metadatas=[{"wing": "project"}],
-        embeddings=[[1, 0]],
-    )
+    _seed(col, {"a": "alpha note"})
     client = fake_pgvector.instances[0]
+    client.lexical_calls.clear()
     client.scroll_calls.clear()
 
-    for query in ("", "   ", "!!!", "a"):  # single chars are below the token floor
-        assert col.lexical_search(query=query, n_results=5).hits == []
-
+    assert col.lexical_search(query="!!!", n_results=5).hits == []
     assert client.lexical_calls == []
     assert client.scroll_calls == []
 
 
-def test_lexical_search_matches_arabic_and_cjk(tmp_path, fake_pgvector):
-    """A mixed-script palace is the reason the config is 'simple', not 'english'."""
-    _backend, col = _collection(tmp_path)
-    col.add(
-        ids=["ar", "cjk", "en"],
-        documents=["قصر الذاكرة يحفظ كلماتك", "记忆 宫殿", "memory palace note"],
-        metadatas=[{"wing": "p"}, {"wing": "p"}, {"wing": "p"}],
-        embeddings=[[1, 0], [0, 1], [0.5, 0.5]],
-    )
-
-    assert [hit.id for hit in col.lexical_search(query="الذاكرة", n_results=5).hits] == ["ar"]
-    assert [hit.id for hit in col.lexical_search(query="记忆", n_results=5).hits] == ["cjk"]
-    # And the tokens reach SQL quoted, not mangled.
-    assert _tsquery_or(_tokenize("الذاكرة")) == "'الذاكرة'"
-
-
 def test_lexical_search_raises_when_table_missing_but_marker_exists(tmp_path, fake_pgvector):
-    """Same not-initialized contract as the scan path it replaces."""
+    """Same not-initialized contract as the scan path, for every query shape.
+
+    The table check has to come before the empty-query shortcut, or the same
+    collection raises or returns ``[]`` depending only on the query text.
+    """
     _backend, col = _collection(tmp_path)
-    col.add(
-        ids=["a"],
-        documents=["alpha backend note"],
-        metadatas=[{"wing": "project"}],
-        embeddings=[[1, 0]],
-    )
+    _seed(col, {"a": "alpha backend note"})
     fake_pgvector.instances[0].tables.clear()  # marker on disk, table gone
 
     with pytest.raises(CollectionNotInitializedError):
         col.lexical_search(query="backend", n_results=5)
+    with pytest.raises(CollectionNotInitializedError):
+        col.lexical_search(query="!!!", n_results=5)
+
+
+def test_existing_collection_gains_lexical_assets_on_open(tmp_path, fake_pgvector):
+    """A palace created before this release must pick the column up, not stay slow."""
+    backend, col = _collection(tmp_path)
+    _seed(col, {"a": "alpha note"})
+    client = fake_pgvector.instances[0]
+    client.lexical_asset_calls.clear()
+
+    # A second handle on the same, already-populated table: the open path, not
+    # the create path, is what an existing palace goes through.
+    reopened = backend.get_collection(
+        palace=PalaceRef(id=str(tmp_path), local_path=str(tmp_path)),
+        collection_name="drawers",
+        create=True,
+    )
+    reopened.add(ids=["b"], documents=["beta note"], metadatas=[{}], embeddings=[[0, 1]])
+
+    assert client.lexical_asset_calls == [col._table]
+    backend.close()
+
+
+def test_backfill_token_counts_uses_the_python_tokenizer(monkeypatch):
+    """Backfilled lengths must come from ``_tokenize``, not a Postgres regex.
+
+    A backfilled length that is off by one silently changes every future ranking
+    for that collection, so the count is computed by the same function BM25 uses.
+    """
+    client = _PgVectorClient(_PgVectorConfig(dsn="postgresql://localhost/unused", namespace=None))
+    client._token_count_columns["drawers"] = True
+    pending = [[("a", "alpha beta gamma"), ("b", "solo")], []]
+    updates = []
+
+    def fake_execute(sql, params=None, *, fetch=False, many=False):
+        if fetch:
+            return pending.pop(0)
+        updates.extend(params or [])
+        return []
+
+    monkeypatch.setattr(client, "_execute", fake_execute)
+
+    assert client.backfill_token_counts("drawers") == 2
+    assert updates == [(3, "a"), (1, "b")]
+
+
+def test_maintenance_state_reports_whether_the_pushdown_is_available(tmp_path, fake_pgvector):
+    """An operator has to be able to see which path their queries take."""
+    _backend, col = _collection(tmp_path)
+    _seed(col, {"a": "alpha note"})
+    assert col.maintenance_state()["lexical_pushdown"] is True
+
+    client = fake_pgvector.instances[0]
+    for row in client.tables[col._table]["rows"].values():
+        row["token_count"] = None
+    assert col.maintenance_state()["lexical_pushdown"] is False


### PR DESCRIPTION
## What does this PR do?

`PgVectorCollection.lexical_search` scrolls the **entire table**, documents included, to the client and scores BM25 in Python. Cost is O(table size) bytes over the wire per query. On a remote palace this makes the lexical arm of hybrid search unusable: at ~141k drawers over a WireGuard link we measured **minutes per query**.

This PR pushes the *filter* into Postgres and keeps the *ranking* local and exact.

**This is a redesign of the PR's first version**, in direct response to @mvalentsev's review. The first version ranked server-side (`ts_rank_cd` + SQL `LIMIT`), and his repro proved that changes the **result set**, not just the transport: ts_rank_cd and BM25 disagree on what matters (no IDF, no length normalization), so no window size fixes it. Both commits are kept so the evolution is reviewable; the second commit's message is written against the first.

**What Postgres decides, and what it does not.** Postgres evaluates a *filter* and nothing else: an OR of literal-substring tests (`ILIKE`, trigram-indexable), one per query token, with no `LIMIT` and no server-side ranking. Scoring, ranking and the `n_results` cut all happen client-side, over the same BM25 numbers the local path produces. The pushdown therefore decides only which rows do not need to cross the wire, never which rows win.

That the filter cannot drop a hit is a proof rather than a measurement: every token `_tokenize` emits is a span the regex matched inside `text.lower()`, so it is a literal substring of the lowered document, and a case-insensitive substring test on it is true for every document `_bm25_scores` can score above zero. The filter admits a superset of the scored set; the extra rows score zero and are dropped locally.

Identical scores additionally require the collection's BM25 statistics, not the candidate pool's — IDF is a function of collection size and length normalization a function of mean document length, so a pool scored with pool-derived statistics reorders. Document frequency needs no correction, since a document containing a query term always survives a filter built from those terms. Collection size and mean document length come from one aggregate over a `token_count` column, written on upsert by the same `_tokenize` BM25 uses, backfilled once for existing rows. Verified against a live server: **330 comparisons over an adversarial corpus, asserting identical ids and identical scores against the pre-pushdown implementation, zero mismatches.**

The pushdown declines, and the query takes the exact local path unchanged, when: `where` does not translate fully to SQL (`$or`, comparisons, `$contains`, or any null-valued operand); any row in scope lacks a `token_count`, so the collection statistics would be a guess; or the server returns an error. `UnsupportedFilterError` is re-raised rather than silently degraded. `maintenance_state()` reports `lexical_pushdown` so which path a collection is on is observable rather than inferred.

Measured on 10k drawers (5.2 MB of text): a selective query moves 0.00 MB instead of 5.17 MB and runs 66x faster; a mid-frequency query saves 97.6% of the wire and runs 2x faster; a query whose term appears in every document saves nothing and costs ~13%, which is the bounded worst case.

## How to test

Unit tests run without a database:

```
pytest tests/test_pgvector_backend.py tests/test_live_pgvector_conformance.py tests/test_maintenance_hooks.py
→ 86 passed, 23 skipped
```

The 23 skips are live-server arms; set `MEMPALACE_PGVECTOR_LIVE_DSN` to a scratch database to run them, including the parity suite that asserts identical ids and scores between pushdown and local paths.

Full suite on this branch: **4319 passed, 38 skipped** (develop after the 3.7.1 sync, `906b918`, same environment baseline: 4295 passed, 31 skipped — the 7 extra skips are the new live-server arms). `ruff check .` and `ruff format --check .` both clean on the repo's 0.16.1 pin.

## Checklist

- [x] Follows the design principle: the backend decides transport, never ranking — results are provably identical to the local path
- [x] Tests pass (`python -m pytest tests/ -v`) — 4319 passed, 38 skipped
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

CHANGELOG entry under Unreleased / Performance. No new dependencies.
