### PR TITLE
fix(embedding): clamp/skip out-of-range embeddinggemma token ids (#2114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Opt-in clamp for out-of-range embeddinggemma token ids.** `mempalace mine --clamp-embedding-tokens` (or `embedding_clamp_token_ids` in `config.json` / `MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS`) clamps token ids past the model's `embed_tokens` row count (e.g. Gemma's `<image_soft_token>`) to the last valid row before `session.run()`, so the affected document gets a real embedding instead of falling through to the zero-vector, per-document skip fallback. Off by default; requires the optional `onnx` package (`pip install mempalace[clamp]`) to read the row count from the ONNX graph. (#2114)
+
 ---
 
 ## [3.6.0] — 2026-07-14

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -551,6 +551,9 @@ def cmd_mine(args):
     for raw in args.include_ignored or []:
         include_ignored.extend(part.strip() for part in raw.split(",") if part.strip())
 
+    if getattr(args, "clamp_embedding_tokens", False):
+        os.environ["MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS"] = "true"
+
     if getattr(args, "background", False) and not getattr(args, "daemon", False):
         print("mempalace: --background requires --daemon", file=sys.stderr)
         sys.exit(2)
@@ -568,6 +571,7 @@ def cmd_mine(args):
             "include_ignored": include_ignored,
             "max_chunks_per_file": getattr(args, "max_chunks_per_file", None),
             "redetect_origin": getattr(args, "redetect_origin", False),
+            "clamp_embedding_tokens": getattr(args, "clamp_embedding_tokens", False),
         }
         _submit_daemon_cli_job("mine", payload, args, background=getattr(args, "background", False))
         return
@@ -1872,6 +1876,17 @@ def main():
             f"summary counter. Default {_CLI_MAX_CHUNKS_PER_FILE_DEFAULT} "
             f"(or MEMPALACE_MAX_CHUNKS_PER_FILE). Set 0 to disable. Lower this on "
             f"Windows if you hit ONNX bad_alloc (#1455)."
+        ),
+    )
+    p_mine.add_argument(
+        "--clamp-embedding-tokens",
+        action="store_true",
+        help=(
+            "With embedding_model=embeddinggemma, clamp token ids past the model's "
+            "embed_tokens row count (e.g. Gemma's <image_soft_token>) to the last "
+            "valid row instead of skipping the document. Default: off (or "
+            "MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS). Requires the optional 'onnx' "
+            "package (mempalace[clamp]); a no-op without it."
         ),
     )
 

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -794,6 +794,31 @@ class MempalaceConfig:
             return max(1, (os.cpu_count() or 2) // 2)
         return val if val > 0 else 0
 
+    @property
+    def embedding_clamp_token_ids(self) -> bool:
+        """Whether to clamp out-of-range token ids before ``session.run()`` (#2114).
+
+        Only affects the ``embeddinggemma`` ONNX embedder. Off by default: a
+        document that tokenizes to an id past the model's ``embed_tokens`` row
+        count (e.g. Gemma's ``<image_soft_token>`` in the text-only ONNX
+        export) already falls back to a per-document retry-and-skip so one
+        poisoned document can't abort the whole mine. Turning this on instead
+        clamps the id to the last valid row before the forward pass, so the
+        affected document gets a (lossy) embedding instead of a zero vector.
+
+        Requires the optional ``onnx`` package to read the embedding matrix's
+        row count from the ONNX graph (``pip install mempalace[clamp]``);
+        without it, this setting is a no-op and the retry-and-skip fallback
+        remains in effect.
+
+        Read from env ``MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS`` first, then
+        ``embedding_clamp_token_ids`` in ``config.json``, then ``False``.
+        """
+        env_val = os.environ.get("MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS")
+        if env_val is not None:
+            return env_val.strip().lower() not in ("", "false", "0", "no")
+        return bool(self._file_config.get("embedding_clamp_token_ids", False))
+
     def set_embedding_model(self, model: str) -> None:
         """Persist the embedding-model choice to ``config.json``.
 

--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -142,6 +142,17 @@ def _resolve_intra_op_threads() -> int:
         return 0
 
 
+def _resolve_clamp_token_ids() -> bool:
+    """Read the configured embed_tokens clamping setting (default off)."""
+    try:
+        from .config import MempalaceConfig
+
+        return MempalaceConfig().embedding_clamp_token_ids
+    except Exception:
+        logger.debug("embedding_clamp_token_ids resolution failed; defaulting off", exc_info=True)
+        return False
+
+
 def _build_ef_class():
     """Subclass ``ONNXMiniLM_L6_V2`` with name ``"default"``.
 
@@ -220,6 +231,56 @@ _EMBEDDINGGEMMA_MAX_LEN = 2048
 _EMBEDDINGGEMMA_BATCH_SIZE = 32
 
 
+def _resolve_embed_tokens_row_count(model_path: str) -> Optional[int]:
+    """Return the row count (vocab size) of the model's token-embedding matrix.
+
+    Finds the ``Gather`` node that reads directly from a graph input (the
+    ``input_ids`` embedding lookup) and returns the row count of whichever
+    initializer feeds its data operand, resolving through one quantize/
+    dequantize hop if present (the quantized export Gathers from
+    ``*.weight_quantized`` rather than ``*.weight`` directly). Parses graph
+    metadata only — ``load_external_data=False`` skips the multi-hundred-MB
+    weight blobs, so this is cheap even though the model itself is large.
+
+    Requires the optional ``onnx`` package (``pip install mempalace[clamp]``).
+    Returns ``None`` if it isn't installed or the graph doesn't match the
+    expected shape — callers must treat that as "row count unknown" and
+    skip clamping rather than fail.
+    """
+    try:
+        import onnx
+    except ImportError:
+        return None
+    try:
+        graph = onnx.load(model_path, load_external_data=False).graph
+        input_names = {i.name for i in graph.input}
+        gather = next(
+            (
+                n
+                for n in graph.node
+                if n.op_type == "Gather" and len(n.input) > 1 and n.input[1] in input_names
+            ),
+            None,
+        )
+        if gather is None:
+            return None
+        name_to_init = {init.name: init for init in graph.initializer}
+        init = name_to_init.get(gather.input[0])
+        if init is None:
+            # Quantized export: the Gather's data operand is produced by a
+            # DequantizeLinear (or similar) node, not an initializer directly.
+            # Its first initializer input is the actual weight matrix.
+            producer = next((n for n in graph.node if gather.input[0] in n.output), None)
+            if producer is not None:
+                init = next((name_to_init[i] for i in producer.input if i in name_to_init), None)
+        if init is None or len(init.dims) == 0:
+            return None
+        return int(init.dims[0])
+    except Exception:
+        logger.debug("embed_tokens row-count resolution failed", exc_info=True)
+        return None
+
+
 class EmbeddinggemmaONNX:
     """ChromaDB-compatible EF using embeddinggemma-300m ONNX (q8, MRL→384d).
 
@@ -246,6 +307,7 @@ class EmbeddinggemmaONNX:
         preferred_providers=None,
         batch_size: int = _EMBEDDINGGEMMA_BATCH_SIZE,
         intra_op_num_threads: int = 0,
+        clamp_token_ids: bool = False,
     ):
         if batch_size < 1:
             raise ValueError(f"batch_size must be >= 1, got {batch_size}")
@@ -254,10 +316,16 @@ class EmbeddinggemmaONNX:
         )
         self._batch_size = batch_size
         self._intra_op_num_threads = intra_op_num_threads
+        # Opt-in: clamp out-of-range token ids before session.run() instead
+        # of relying solely on the per-document retry-and-skip in __call__.
+        self._clamp_token_ids = clamp_token_ids
         self._session = None
         self._tokenizer = None
         self._np = None
         self._output_idx = None
+        # Resolved lazily alongside the session; None means clamping is
+        # skipped (not requested, or the row count couldn't be resolved).
+        self._embed_rows: Optional[int] = None
         # Instances are shared across threads via _EF_CACHE; serialize the
         # one-time model load so concurrent cold calls cannot build (and
         # transiently hold) two full model sessions.
@@ -313,6 +381,15 @@ class EmbeddinggemmaONNX:
             self._output_idx = output_idx
             self._tokenizer = tokenizer
             self._np = np
+            if self._clamp_token_ids:
+                rows = _resolve_embed_tokens_row_count(model_path)
+                if rows is None:
+                    logger.warning(
+                        "clamp_token_ids requested but embed_tokens row count could not "
+                        "be resolved (is the 'onnx' package installed? see "
+                        "mempalace[clamp]) — falling back to per-document skip on error."
+                    )
+                self._embed_rows = rows
             # Session is assigned last: the unlocked fast path above treats a
             # non-None session as "fully loaded", so every other attribute
             # must already be in place when it becomes visible.
@@ -328,6 +405,12 @@ class EmbeddinggemmaONNX:
         encs = self._tokenizer.encode_batch(texts)
         input_ids = np.asarray([e.ids for e in encs], dtype=np.int64)
         attention_mask = np.asarray([e.attention_mask for e in encs], dtype=np.int64)
+        if self._embed_rows is not None:
+            # Land any id past the last embed_tokens row (e.g. Gemma's
+            # <image_soft_token>) on the last valid row instead of letting
+            # Gather raise. Lossy, but keeps the rest of the sub-batch out
+            # of the per-document retry path below.
+            np.clip(input_ids, 0, self._embed_rows - 1, out=input_ids)
         outputs = self._session.run(
             None, {"input_ids": input_ids, "attention_mask": attention_mask}
         )
@@ -404,7 +487,8 @@ def get_embedding_function(device: Optional[str] = None, model: Optional[str] = 
             model = cfg.embedding_model
 
     providers, effective = _resolve_providers(device)
-    cache_key = (model, tuple(providers))
+    clamp_token_ids = _resolve_clamp_token_ids()
+    cache_key = (model, tuple(providers), clamp_token_ids)
     cached = _EF_CACHE.get(cache_key)  # lock-free fast path; dict.get is GIL-atomic
     if cached is not None:
         return cached
@@ -415,7 +499,11 @@ def get_embedding_function(device: Optional[str] = None, model: Optional[str] = 
 
         threads = _resolve_intra_op_threads()
         if model == "embeddinggemma":
-            ef = EmbeddinggemmaONNX(preferred_providers=providers, intra_op_num_threads=threads)
+            ef = EmbeddinggemmaONNX(
+                preferred_providers=providers,
+                intra_op_num_threads=threads,
+                clamp_token_ids=clamp_token_ids,
+            )
         else:
             # Default: minilm (or anything we don't recognize — back-compat win).
             ef_cls = _build_ef_class()

--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -318,6 +318,25 @@ class EmbeddinggemmaONNX:
             # must already be in place when it becomes visible.
             self._session = session
 
+    def _run_batch(self, texts: list[str]) -> list[list[float]]:
+        """Tokenize + ``session.run`` one sub-batch, truncated and L2-normalized.
+
+        Split out of ``__call__`` so it can be retried at batch size 1 (see
+        the per-document fallback there) without duplicating the tensor prep.
+        """
+        np = self._np
+        encs = self._tokenizer.encode_batch(texts)
+        input_ids = np.asarray([e.ids for e in encs], dtype=np.int64)
+        attention_mask = np.asarray([e.attention_mask for e in encs], dtype=np.int64)
+        outputs = self._session.run(
+            None, {"input_ids": input_ids, "attention_mask": attention_mask}
+        )
+        sent_emb = outputs[self._output_idx][:, :_EMBEDDINGGEMMA_DIM]
+        # L2-normalize so cosine similarity == dot product (matches what the
+        # MTEB methodology assumes; ChromaDB's distance is configured for it).
+        norms = np.linalg.norm(sent_emb, axis=1, keepdims=True) + 1e-12
+        return (sent_emb / norms).tolist()
+
     def __call__(self, input: str | list[str] | None) -> list[list[float]]:  # noqa: A002 — ChromaDB EF protocol
         if isinstance(input, str):
             # A bare string would be iterated character by character below,
@@ -329,7 +348,6 @@ class EmbeddinggemmaONNX:
             # sequence is not rejected by ambiguous-truth-value semantics.
             return []
         self._lazy_load()
-        np = self._np
         embeddings: list[list[float]] = []
         # Tokenize and run per sub-batch, not over the whole input: padding
         # is to the longest sequence in the sub-batch, and the ONNX runtime
@@ -338,17 +356,25 @@ class EmbeddinggemmaONNX:
         for start in range(0, len(input), self._batch_size):
             chunk = input[start : start + self._batch_size]
             texts = [_EMBEDDINGGEMMA_PREFIX + t for t in chunk]
-            encs = self._tokenizer.encode_batch(texts)
-            input_ids = np.asarray([e.ids for e in encs], dtype=np.int64)
-            attention_mask = np.asarray([e.attention_mask for e in encs], dtype=np.int64)
-            outputs = self._session.run(
-                None, {"input_ids": input_ids, "attention_mask": attention_mask}
-            )
-            sent_emb = outputs[self._output_idx][:, :_EMBEDDINGGEMMA_DIM]
-            # L2-normalize so cosine similarity == dot product (matches what the
-            # MTEB methodology assumes; ChromaDB's distance is configured for it).
-            norms = np.linalg.norm(sent_emb, axis=1, keepdims=True) + 1e-12
-            embeddings.extend((sent_emb / norms).tolist())
+            try:
+                embeddings.extend(self._run_batch(texts))
+            except Exception:
+                # Token ids past embed_tokens row count, e.g. gemma
+                # <image_soft_token>, makes session.run() raise for the whole
+                # sub-batch (see #2114). Therefore, retry one document at a
+                # time and drop only the offender, so we can still mine the
+                # rest of the batch. Note: ollama (llama-ollama-compat.cpp)
+                # truncates tokenizer arrays for the same class of bugs.
+                for text in texts:
+                    try:
+                        embeddings.extend(self._run_batch([text]))
+                    except Exception:
+                        logger.warning(
+                            "Skipping one document, embedding failed: %.80r",
+                            text,
+                            exc_info=True,
+                        )
+                        embeddings.append([0.0] * _EMBEDDINGGEMMA_DIM)
         return embeddings
 
     def embed_query(self, input: list[str]) -> list[list[float]]:  # noqa: A002 — ChromaDB EF protocol

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -19,11 +19,12 @@ from .config import MempalaceConfig
 _EXPLICIT_BACKEND_ENV = "MEMPALACE_BACKEND_EXPLICIT"
 _PALACE_PATH_ENV = "MEMPALACE_PALACE_PATH"
 _BACKEND_ENV = "MEMPALACE_BACKEND"
+_CLAMP_TOKEN_IDS_ENV = "MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS"
 # Env vars a job may mutate via _apply_backend / palace_path injection. They are
 # snapshotted per job and restored afterward so a job that switches the backend
 # (e.g. qdrant) cannot poison every later job in the same daemon process —
 # including mcp_tool jobs, which read MempalaceConfig (and thus the leaked env).
-_PER_JOB_ENV = (_PALACE_PATH_ENV, _BACKEND_ENV, _EXPLICIT_BACKEND_ENV)
+_PER_JOB_ENV = (_PALACE_PATH_ENV, _BACKEND_ENV, _EXPLICIT_BACKEND_ENV, _CLAMP_TOKEN_IDS_ENV)
 
 
 READ_TOOLS = frozenset(
@@ -147,6 +148,8 @@ def run_mine(payload: dict[str, Any]) -> dict[str, Any]:
     )
     os.environ["MEMPALACE_PALACE_PATH"] = palace_path
     _apply_backend(payload.get("backend"))
+    if payload.get("clamp_embedding_tokens"):
+        os.environ[_CLAMP_TOKEN_IDS_ENV] = "true"
 
     source = payload.get("source") or payload.get("dir")
     mode = payload.get("mode") or "projects"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ pgvector = ["psycopg[binary]>=3.1"]
 gpu = ["onnxruntime-gpu>=1.16"]
 dml = ["onnxruntime-directml>=1.16"]
 coreml = ["onnxruntime>=1.16"]
+# Optional: lets --clamp-embedding-tokens read the embeddinggemma ONNX
+# graph's embed_tokens row count. Not required for normal embeddinggemma use.
+clamp = ["onnx>=1.14"]
 # Multilingual extra kept as a no-op alias for back-compat with
 # `pip install mempalace[multilingual]` — these deps now ship in core.
 multilingual = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,6 +185,38 @@ def test_embedding_threads_invalid_falls_back_to_auto(tmp_path, monkeypatch):
     assert cfg.embedding_threads == 2
 
 
+def test_embedding_clamp_token_ids_default_off(tmp_path, monkeypatch):
+    monkeypatch.delenv("MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS", raising=False)
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.embedding_clamp_token_ids is False
+
+
+def test_embedding_clamp_token_ids_from_config(tmp_path, monkeypatch):
+    monkeypatch.delenv("MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS", raising=False)
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump({"embedding_clamp_token_ids": True}, f)
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.embedding_clamp_token_ids is True
+
+
+def test_embedding_clamp_token_ids_env_overrides_config(tmp_path, monkeypatch):
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump({"embedding_clamp_token_ids": True}, f)
+    monkeypatch.setenv("MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS", "false")
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    assert cfg.embedding_clamp_token_ids is False
+
+
+def test_embedding_clamp_token_ids_env_truthy_values(tmp_path, monkeypatch):
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+    for value in ("true", "1", "yes", "TRUE"):
+        monkeypatch.setenv("MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS", value)
+        assert cfg.embedding_clamp_token_ids is True, f"expected True for {value!r}"
+    for value in ("false", "0", "no", ""):
+        monkeypatch.setenv("MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS", value)
+        assert cfg.embedding_clamp_token_ids is False, f"expected False for {value!r}"
+
+
 def test_sqlite_read_uri_opens_path_with_spaces(tmp_path):
     """sqlite_read_uri must open a read-only DB whose path contains spaces,
     which a bare f"file:{path}?mode=ro" mis-parses (especially on Windows)."""

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -121,7 +121,7 @@ def test_get_embedding_function_threads_cap_passed_to_embeddinggemma(monkeypatch
     captured = {}
 
     class DummyGemma:
-        def __init__(self, preferred_providers=None, intra_op_num_threads=0):
+        def __init__(self, preferred_providers=None, intra_op_num_threads=0, clamp_token_ids=False):
             captured["threads"] = intra_op_num_threads
 
     monkeypatch.setattr(embedding, "EmbeddinggemmaONNX", DummyGemma)
@@ -182,6 +182,55 @@ def test_minilm_ef_model_override_falls_back_when_uncapped(monkeypatch):
     # Upstream leaves intra_op at ORT's default (0 = unset), confirming we
     # deferred to it rather than applying our cap.
     assert captured["sess_options"].intra_op_num_threads == 0
+
+
+def test_get_embedding_function_clamp_token_ids_passed_to_embeddinggemma(monkeypatch):
+    """The resolved config setting (#2114) must reach the EF constructor."""
+    captured = {}
+
+    class DummyGemma:
+        def __init__(self, preferred_providers=None, intra_op_num_threads=0, clamp_token_ids=False):
+            captured["clamp_token_ids"] = clamp_token_ids
+
+    monkeypatch.setattr(embedding, "EmbeddinggemmaONNX", DummyGemma)
+    monkeypatch.setattr(
+        embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
+    )
+    monkeypatch.setattr(embedding, "_resolve_clamp_token_ids", lambda: True)
+
+    embedding.get_embedding_function("cpu", "embeddinggemma")
+
+    assert captured["clamp_token_ids"] is True
+
+
+def test_cache_key_separates_clamp_token_ids_setting(monkeypatch):
+    """A cached EF built with clamp off must not be served once clamp turns on.
+
+    Without ``clamp_token_ids`` in the cache key, a config change mid-process
+    (e.g. between two mine runs in the same daemon) would silently keep
+    serving the stale EF instance.
+    """
+    build_count = {"n": 0}
+
+    class DummyGemma:
+        def __init__(self, preferred_providers=None, intra_op_num_threads=0, clamp_token_ids=False):
+            build_count["n"] += 1
+            self.clamp_token_ids = clamp_token_ids
+
+    monkeypatch.setattr(embedding, "EmbeddinggemmaONNX", DummyGemma)
+    monkeypatch.setattr(
+        embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
+    )
+
+    monkeypatch.setattr(embedding, "_resolve_clamp_token_ids", lambda: False)
+    off = embedding.get_embedding_function("cpu", "embeddinggemma")
+
+    monkeypatch.setattr(embedding, "_resolve_clamp_token_ids", lambda: True)
+    on = embedding.get_embedding_function("cpu", "embeddinggemma")
+
+    assert build_count["n"] == 2, "clamp on/off must not share a cache entry"
+    assert off.clamp_token_ids is False
+    assert on.clamp_token_ids is True
 
 
 def test_describe_device_uses_resolved_effective_device(monkeypatch):

--- a/tests/test_embeddinggemma.py
+++ b/tests/test_embeddinggemma.py
@@ -118,6 +118,106 @@ def patched_lazy_load(monkeypatch):
     return calls
 
 
+def _write_synthetic_embed_graph(tmp_path, quantized: bool):
+    """Build a tiny ONNX file shaped like embeddinggemma's embed_tokens lookup.
+
+    ``quantized=False`` mirrors the fp32 export (Gather reads the weight
+    initializer directly). ``quantized=True`` mirrors the q8 export used by
+    mempalace (Gather reads a DequantizeLinear output, one hop away from the
+    real weight initializer) — see #2114.
+    """
+    onnx = pytest.importorskip("onnx")
+    from onnx import TensorProto, helper
+
+    input_ids = helper.make_tensor_value_info("input_ids", TensorProto.INT64, ["batch", "seq"])
+    attention_mask = helper.make_tensor_value_info(
+        "attention_mask", TensorProto.INT64, ["batch", "seq"]
+    )
+
+    if quantized:
+        weight_q = helper.make_tensor(
+            "model.embed_tokens.weight_quantized", TensorProto.INT8, [500, 8], [0] * 4000
+        )
+        scale = helper.make_tensor("model.embed_tokens.weight_scale", TensorProto.FLOAT, [1], [1.0])
+        zero_point = helper.make_tensor(
+            "model.embed_tokens.weight_zero_point", TensorProto.INT8, [1], [0]
+        )
+        dequant = helper.make_node(
+            "DequantizeLinear",
+            [
+                "model.embed_tokens.weight_quantized",
+                "model.embed_tokens.weight_scale",
+                "model.embed_tokens.weight_zero_point",
+            ],
+            ["model.embed_tokens.weight_dequantized_tensor"],
+            name="/model/embed_tokens/DequantizeLinear",
+        )
+        gather = helper.make_node(
+            "Gather",
+            ["model.embed_tokens.weight_dequantized_tensor", "input_ids"],
+            ["embedded"],
+            name="/model/embed_tokens/Gather",
+        )
+        nodes = [dequant, gather]
+        initializers = [weight_q, scale, zero_point]
+    else:
+        weight = helper.make_tensor(
+            "model.embed_tokens.weight", TensorProto.FLOAT, [1000, 8], [0.0] * 8000
+        )
+        gather = helper.make_node(
+            "Gather",
+            ["model.embed_tokens.weight", "input_ids"],
+            ["embedded"],
+            name="/model/embed_tokens/Gather",
+        )
+        nodes = [gather]
+        initializers = [weight]
+
+    output = helper.make_tensor_value_info("embedded", TensorProto.FLOAT, ["batch", "seq", 8])
+    graph = helper.make_graph(
+        nodes, "g", [input_ids, attention_mask], [output], initializer=initializers
+    )
+    model = helper.make_model(graph, producer_name="mempalace-test")
+    path = str(tmp_path / "synthetic.onnx")
+    onnx.save_model(model, path)
+    return path
+
+
+def test_resolve_embed_tokens_row_count_direct_initializer(tmp_path):
+    """fp32-style export: Gather reads the weight initializer directly."""
+    path = _write_synthetic_embed_graph(tmp_path, quantized=False)
+    assert embedding._resolve_embed_tokens_row_count(path) == 1000
+
+
+def test_resolve_embed_tokens_row_count_dequantize_hop(tmp_path):
+    """q8-style export (mempalace's actual model): one DequantizeLinear hop
+    between the Gather and the real weight initializer (#2114)."""
+    path = _write_synthetic_embed_graph(tmp_path, quantized=True)
+    assert embedding._resolve_embed_tokens_row_count(path) == 500
+
+
+def test_resolve_embed_tokens_row_count_none_without_onnx_package(monkeypatch):
+    """The optional 'onnx' package (mempalace[clamp]) may not be installed —
+    resolution must degrade to None, not raise."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "onnx":
+            raise ImportError("no onnx")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert embedding._resolve_embed_tokens_row_count("/nonexistent.onnx") is None
+
+
+def test_resolve_embed_tokens_row_count_none_for_bad_path():
+    """A missing/unparseable file must degrade to None, not raise."""
+    pytest.importorskip("onnx")
+    assert embedding._resolve_embed_tokens_row_count("/nonexistent/path.onnx") is None
+
+
 def test_name_is_stable():
     """ChromaDB persists this on the collection — changing it breaks reads."""
     assert embedding.EmbeddinggemmaONNX.name() == "embeddinggemma_300m"
@@ -307,6 +407,117 @@ def test_bad_document_is_skipped_not_fatal(patched_lazy_load, monkeypatch):
     assert np.allclose(arr[1], 0.0)
     assert np.allclose(np.linalg.norm(arr[0]), 1.0, atol=1e-5)
     assert np.allclose(np.linalg.norm(arr[2]), 1.0, atol=1e-5)
+
+
+def test_clamp_token_ids_off_by_default():
+    """The opt-in flag (#2114) must default to False on the constructor."""
+    ef = embedding.EmbeddinggemmaONNX()
+    assert ef._clamp_token_ids is False
+    assert ef._embed_rows is None
+
+
+def test_clamp_disabled_still_uses_retry_and_skip(patched_lazy_load, monkeypatch):
+    """With clamp_token_ids=False (default), an out-of-range id must still
+    hit the pre-existing per-document retry-and-skip fallback, unchanged."""
+    fake_session_cls = _make_fake_session()
+
+    class _PoisonedSession(fake_session_cls):
+        def run(self, output_names, feed):
+            ids = feed["input_ids"]
+            if (ids >= 500).any():
+                raise RuntimeError("INVALID_ARGUMENT: Gather index out of bounds")
+            return super().run(output_names, feed)
+
+    import onnxruntime
+
+    monkeypatch.setattr(onnxruntime, "InferenceSession", lambda *a, **kw: _PoisonedSession())
+
+    class _OutOfRangeTokenizer(_FakeTokenizer):
+        def encode_batch(self, texts):
+            class _Enc:
+                def __init__(self, tid, n):
+                    self.ids = [tid] * n
+                    self.attention_mask = [1] * n
+
+            max_len = max(len(t.split()) for t in texts)
+            return [_Enc(999 if "poison" in t else 0, max_len) for t in texts]
+
+    import tokenizers
+
+    monkeypatch.setattr(
+        tokenizers.Tokenizer, "from_file", staticmethod(lambda _p: _OutOfRangeTokenizer())
+    )
+
+    ef = embedding.EmbeddinggemmaONNX(clamp_token_ids=False)
+    out = ef(["poison doc", "good doc"])
+
+    arr = np.asarray(out)
+    assert np.allclose(arr[0], 0.0), "unclamped poisoned doc must fall back to zero-vector"
+    assert np.allclose(np.linalg.norm(arr[1]), 1.0, atol=1e-5)
+
+
+def test_clamp_enabled_avoids_retry_and_returns_real_embedding(patched_lazy_load, monkeypatch):
+    """With clamp_token_ids=True and a resolvable row count (#2114), an
+    out-of-range id must be clamped before session.run() — the poisoned
+    document gets a real embedding, and the batched run never raises (so
+    the per-document retry path is never triggered)."""
+    monkeypatch.setattr(embedding, "_resolve_embed_tokens_row_count", lambda path: 500)
+
+    fake_session_cls = _make_fake_session()
+    run_calls = []
+
+    class _StrictSession(fake_session_cls):
+        def run(self, output_names, feed):
+            ids = feed["input_ids"]
+            run_calls.append(ids.copy())
+            if (ids >= 500).any() or (ids < 0).any():
+                raise RuntimeError("INVALID_ARGUMENT: Gather index out of bounds")
+            return super().run(output_names, feed)
+
+    import onnxruntime
+
+    monkeypatch.setattr(onnxruntime, "InferenceSession", lambda *a, **kw: _StrictSession())
+
+    class _OutOfRangeTokenizer(_FakeTokenizer):
+        def encode_batch(self, texts):
+            class _Enc:
+                def __init__(self, tid, n):
+                    self.ids = [tid] * n
+                    self.attention_mask = [1] * n
+
+            max_len = max(len(t.split()) for t in texts)
+            # 999 mirrors <image_soft_token>'s id landing past embed_tokens'
+            # 500-row bound in this synthetic setup.
+            return [_Enc(999 if "poison" in t else 0, max_len) for t in texts]
+
+    import tokenizers
+
+    monkeypatch.setattr(
+        tokenizers.Tokenizer, "from_file", staticmethod(lambda _p: _OutOfRangeTokenizer())
+    )
+
+    ef = embedding.EmbeddinggemmaONNX(clamp_token_ids=True)
+    out = ef(["poison doc", "good doc"])
+
+    assert len(run_calls) == 1, "clamping must avoid the per-document retry pass entirely"
+    assert (run_calls[0] < 500).all(), "ids must be clamped below the row count before run()"
+
+    arr = np.asarray(out)
+    assert np.allclose(np.linalg.norm(arr[0]), 1.0, atol=1e-5), (
+        "clamped poisoned doc must get a real embedding, not the zero-vector fallback"
+    )
+    assert np.allclose(np.linalg.norm(arr[1]), 1.0, atol=1e-5)
+
+
+def test_clamp_enabled_but_row_count_unresolvable_warns_and_skips(patched_lazy_load, monkeypatch):
+    """If embed_tokens row count can't be resolved (no 'onnx' package, or an
+    unexpected graph shape), clamping must be skipped — not raise — leaving
+    the retry-and-skip fallback as the only safety net."""
+    monkeypatch.setattr(embedding, "_resolve_embed_tokens_row_count", lambda path: None)
+
+    ef = embedding.EmbeddinggemmaONNX(clamp_token_ids=True)
+    ef._lazy_load()
+    assert ef._embed_rows is None
 
 
 def test_call_empty_input_returns_empty(patched_lazy_load):

--- a/tests/test_embeddinggemma.py
+++ b/tests/test_embeddinggemma.py
@@ -253,6 +253,62 @@ def test_batch_size_below_one_is_rejected():
         embedding.EmbeddinggemmaONNX(batch_size=-3)
 
 
+def test_bad_document_is_skipped_not_fatal(patched_lazy_load, monkeypatch):
+    """One document that blows up session.run() must not abort the batch.
+
+    __call__ must retry document-by-document and skip only the offending
+    one — every other document in the batch still gets a real vector.
+    """
+    calls = {"run": 0}
+    fake_session_cls = _make_fake_session()
+
+    class _PoisonedSession(fake_session_cls):
+        def run(self, output_names, feed):
+            calls["run"] += 1
+            batch = feed["input_ids"].shape[0]
+            if batch > 1:
+                # Batched calls always contains poisoned docs. Fail it,
+                # forcing the per-document retry path.
+                raise RuntimeError("INVALID_ARGUMENT: Gather index out of bounds")
+            # Single-document retry: poisoned doc (id 0 in this fixtures
+            # tokenizer) still fails; everything else succeeds.
+            if feed["input_ids"][0][0] == 999:
+                raise RuntimeError("INVALID_ARGUMENT: Gather index out of bounds")
+            return super().run(output_names, feed)
+
+    import onnxruntime
+
+    monkeypatch.setattr(onnxruntime, "InferenceSession", lambda *a, **kw: _PoisonedSession())
+
+    class _PoisonAwareTokenizer(_FakeTokenizer):
+        def encode_batch(self, texts):
+            class _Enc:
+                def __init__(self, tid, n):
+                    self.ids = [tid] * n
+                    self.attention_mask = [1] * n
+
+            max_len = max(len(t.split()) for t in texts)
+            return [_Enc(999 if "poison" in t else 0, max_len) for t in texts]
+
+    import tokenizers
+
+    monkeypatch.setattr(
+        tokenizers.Tokenizer, "from_file", staticmethod(lambda _p: _PoisonAwareTokenizer())
+    )
+
+    ef = embedding.EmbeddinggemmaONNX()
+    out = ef(["good one", "poison doc", "good two"])
+
+    assert len(out) == 3
+    arr = np.asarray(out)
+    assert arr.shape == (3, 384)
+    # The poisoned row is the zero-vector fallback. Good rows are still
+    # unit-normalized real embeddings.
+    assert np.allclose(arr[1], 0.0)
+    assert np.allclose(np.linalg.norm(arr[0]), 1.0, atol=1e-5)
+    assert np.allclose(np.linalg.norm(arr[2]), 1.0, atol=1e-5)
+
+
 def test_call_empty_input_returns_empty(patched_lazy_load):
     """Zero docs must yield zero embeddings without loading the model."""
     ef = embedding.EmbeddinggemmaONNX()

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -52,6 +52,7 @@ mempalace mine <dir> --wing myapp
 | `--extract` | `exchange` | `exchange` or `general` (for convos mode) |
 | `--no-gitignore` | — | Don't respect .gitignore |
 | `--include-ignored` | — | Always scan these paths even if ignored |
+| `--clamp-embedding-tokens` | off | Clamp out-of-range embeddinggemma token ids instead of skipping the document (requires `mempalace[clamp]`) |
 
 ## `mempalace search`
 


### PR DESCRIPTION
## Summary

Fixes #2114 — `EmbeddinggemmaONNX.__call__` passed token ids straight into
`session.run()` with no bounds check. Any mined text containing a special
token past the model's `embed_tokens` row count (e.g. Gemma's
`<image_soft_token>`, id 262144 on the text-only ONNX export whose matrix
has 262144 rows) aborted the whole mine.

Two commits:

1. **`fix(embedding): skip poisoned documents instead of aborting mine`** —
   retry a failed sub-batch one document at a time and drop only the
   offender (filed as a zero vector), so one bad document no longer takes
   down the run.
2. **`feat(embedding): opt-in clamp for out-of-range embeddinggemma token ids`** — (optional)
   the requested clamp/filter behavior, gated behind
   `--clamp-embedding-tokens` / `MEMPALACE_EMBEDDING_CLAMP_TOKEN_IDS` /
   `embedding_clamp_token_ids` in `config.json`, off by default. When
   enabled and the optional `onnx` package (`mempalace[clamp]`) is
   installed, out-of-range ids are clamped to the last valid row before
   `session.run()` so the affected document gets a real (if lossy)
   embedding instead of the zero-vector fallback.

## Testing

- `tests/test_embeddinggemma.py`: graph-parsing against synthetic ONNX
  models (direct-initializer and quantize/dequantize-hop layouts), missing
  `onnx` package fallback, clamp on/off behavior against a mocked poisoned
  session.
- `tests/test_embedding.py`: cache-key separation, threading through
  `get_embedding_function`.
- `tests/test_config.py`: new `embedding_clamp_token_ids` config property.
- Verified end-to-end against the real cached `embeddinggemma-300m-ONNX`
  model: reproduced the exact `<image_soft_token>` crash from the issue
  and confirmed the clamp path fixes it.

`ruff check` / `ruff format --check` clean. `pytest` scoped to the touched
modules (`test_embeddinggemma.py`, `test_embedding.py`, `test_config.py`,
`test_cli.py`) passes.
