### PR TITLE
feat(mine): route explicit source adapters through the RFC 002 registry

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -561,10 +561,14 @@ def _mine_args_forwardable(args, include_ignored) -> bool:
     """Only forward mines the ``mempalace_mine`` MCP tool can express.
 
     Flags the tool has no parameters for (kg-extract, gitignore handling,
-    chunking overrides, origin redetection, explicit backend) keep the
-    direct path — where a held writer lease still surfaces as the existing
-    MineAlreadyRunning error rather than being silently dropped.
+    chunking overrides, origin redetection, explicit backend, source-adapter
+    selection) keep the direct path — where a held writer lease still surfaces
+    as the existing MineAlreadyRunning error rather than being silently dropped.
     """
+    if getattr(args, "source", None):
+        # The tool carries no `source` parameter, so forwarding a --source mine
+        # would run the default --mode path under a different name.
+        return False
     if getattr(args, "kg_extract", False) or getattr(args, "redetect_origin", False):
         return False
     if args.no_gitignore or include_ignored:
@@ -678,6 +682,81 @@ def _forward_mine_to_hub(args, palace_path: str) -> bool:
     return True
 
 
+def _mine_via_source_adapter(args, palace_path):
+    """Route ``mine --source NAME`` through the RFC 002 source-adapter registry.
+
+    Opt-in seam: when an explicit ``--source`` names a registered adapter, mine
+    resolves it from ``mempalace.sources.registry``, runs its ``ingest()``, and
+    files each ``DrawerRecord`` through a ``PalaceContext``. When no ``--source``
+    is given, ``cmd_mine`` keeps its legacy ``--mode`` dispatch — the
+    filesystem/conversations miners have not moved onto the contract yet, so the
+    registry path stays opt-in and changes no existing behavior. This wires the
+    registry the spec reserves.
+    """
+    from .knowledge_graph import KnowledgeGraph
+    from .palace import MineAlreadyRunning, get_collection, mine_palace_lock
+    from .sources.base import DrawerRecord, SourceItemMetadata, SourceRef
+    from .sources.context import PalaceContext
+    from .sources.registry import get_adapter, resolve_adapter_for_source
+
+    name = resolve_adapter_for_source(explicit=args.source)
+    try:
+        adapter = get_adapter(name)
+    except KeyError as exc:
+        print(f"mempalace: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    # Routing precedence: an explicit --wing flows to the adapter through
+    # SourceRef.options and the adapter honors it. Secrets never travel here.
+    options = {}
+    if getattr(args, "wing", None):
+        options["wing"] = args.wing
+    ref = SourceRef(local_path=os.path.abspath(os.path.expanduser(args.dir)), options=options)
+
+    filed = 0
+    skipped = 0
+    try:
+        with mine_palace_lock(palace_path):
+            collection = get_collection(palace_path, create=True)
+            kg = KnowledgeGraph(db_path=os.path.join(palace_path, "knowledge_graph.sqlite3"))
+            ctx = PalaceContext(
+                drawer_collection=collection,
+                knowledge_graph=kg,
+                palace_path=palace_path,
+                config=MempalaceConfig(),
+                adapter_name=getattr(adapter, "name", name),
+                adapter_version=getattr(adapter, "adapter_version", ""),
+            )
+
+            skip_item = False
+            for result in adapter.ingest(source=ref, palace=ctx):
+                if isinstance(result, SourceItemMetadata):
+                    skip_item = False
+                    ctx._skip_requested = False
+                    existing = collection.get(where={"source_file": result.source_file}, limit=1)
+                    metas = (existing or {}).get("metadatas") or []
+                    if adapter.is_current(
+                        item=result, existing_metadata=metas[0] if metas else None
+                    ):
+                        ctx.skip_current_item()
+                        skip_item = True
+                elif isinstance(result, DrawerRecord):
+                    if skip_item or ctx._skip_requested:
+                        skipped += 1
+                        continue
+                    if not args.dry_run:
+                        ctx.upsert_drawer(result)
+                    filed += 1
+            adapter.close()
+    except MineAlreadyRunning as exc:
+        print(f"mempalace: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    verb = "Would file" if args.dry_run else "Drawers filed:"
+    tail = f"  (skipped {skipped} up-to-date)" if skipped else ""
+    print(f"  source={name}  {verb} {filed}{tail}")
+
+
 def cmd_mine(args):
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     include_ignored = []
@@ -686,6 +765,15 @@ def cmd_mine(args):
 
     if getattr(args, "background", False) and not getattr(args, "daemon", False):
         print("mempalace: --background requires --daemon", file=sys.stderr)
+        sys.exit(2)
+
+    # --mode carries no argparse default so it can sit in a mutually exclusive group with
+    # --source (see the parser). An unsupplied --mode means the projects path, as before.
+    if getattr(args, "mode", None) is None:
+        args.mode = "projects"
+
+    if getattr(args, "source", None) and getattr(args, "daemon", False):
+        print("mempalace: --source does not support --daemon yet", file=sys.stderr)
         sys.exit(2)
 
     if getattr(args, "daemon", False):
@@ -721,6 +809,12 @@ def cmd_mine(args):
             palace_dir=palace_path,
             llm_provider=None,
         )
+
+    # RFC 002 source-adapter seam: an explicit --source routes mine through the
+    # registry; absent it, the legacy --mode dispatch below runs unchanged.
+    if getattr(args, "source", None):
+        _mine_via_source_adapter(args, palace_path)
+        return
 
     from .palace import MineAlreadyRunning, MineValidationError
 
@@ -2301,14 +2395,30 @@ def main():
         default=None,
         help="Storage backend to use for this mine (default: config/env/detected/chroma)",
     )
-    p_mine.add_argument(
+    # --mode and --source select the ingest path and cannot both apply. argparse counts an
+    # option as "seen" for exclusivity only when its value differs from its default, so a
+    # default of "projects" here would let `--source X --mode projects` through while
+    # `--source X --mode convos` errored. default=None makes both spellings fail alike;
+    # cmd_mine restores "projects" when --mode goes unsupplied.
+    mine_path = p_mine.add_mutually_exclusive_group()
+    mine_path.add_argument(
         "--mode",
         choices=["projects", "convos", "extract"],
-        default="projects",
+        default=None,
         help=(
             "Ingest mode: 'projects' for code/docs (default), 'convos' for chat "
             "exports, 'extract' for office documents (PDF/DOCX/RTF/etc., requires "
             "mempalace[extract])"
+        ),
+    )
+    mine_path.add_argument(
+        "--source",
+        default=None,
+        metavar="NAME",
+        help=(
+            "RFC 002 source adapter to mine through (e.g. a third-party "
+            "mempalace-source-<name> package). Explicit selection only — no "
+            "auto-detect. Omit to use the legacy --mode dispatch."
         ),
     )
     p_mine.add_argument("--wing", default=None, help="Wing name (default: directory name)")

--- a/tests/test_hub_forward.py
+++ b/tests/test_hub_forward.py
@@ -34,6 +34,7 @@ def _mine_args(source_dir, **overrides):
         backend=None,
         global_backend=None,
         mode="convos",
+        source=None,
         wing=None,
         no_gitignore=False,
         include_ignored=None,
@@ -281,6 +282,7 @@ class TestForwardability:
             (dict(no_gitignore=True), []),
             (dict(max_chunks_per_file=10), []),
             (dict(backend="qdrant"), []),
+            (dict(source="ndjson"), []),
             (dict(), ["*.log"]),
         ],
     )

--- a/tests/test_mine_source_registry.py
+++ b/tests/test_mine_source_registry.py
@@ -1,0 +1,122 @@
+"""RFC 002 source-adapter CLI seam: ``mine --source NAME`` routes through the
+registry and files adapter-authored ``DrawerRecord``s via ``PalaceContext``.
+
+This covers the seam wired into ``cmd_mine`` — the registry/ingest-loop path is
+opt-in and leaves the legacy ``--mode`` dispatch untouched.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from argparse import Namespace
+from typing import Iterator
+
+import pytest
+
+from mempalace.sources.base import (
+    AdapterSchema,
+    BaseSourceAdapter,
+    DrawerRecord,
+    FieldSpec,
+    IngestResult,
+    SourceItemMetadata,
+    SourceRef,
+)
+from mempalace.sources.registry import register, reset_adapters, unregister
+
+
+class _FakeAdapter(BaseSourceAdapter):
+    name = "fake-test"
+    adapter_version = "0.1.0"
+    capabilities = frozenset({"byte_preserving"})
+    supported_modes = frozenset({"whole_record"})
+    declared_transformations = frozenset()
+    default_privacy_class = "internal"
+
+    def ingest(self, *, source: SourceRef, palace) -> Iterator[IngestResult]:
+        yield SourceItemMetadata(source_file="fake://item/1", version="v1")
+        yield DrawerRecord(
+            content="the operator said the verb leads",
+            source_file="fake://item/1",
+            metadata={"wing": "wing_test", "room": "general", "lar_demo": "1"},
+        )
+
+    def describe_schema(self) -> AdapterSchema:
+        return AdapterSchema(
+            version="1.0",
+            fields={"lar_demo": FieldSpec(type="string", required=False, description="demo field")},
+        )
+
+
+@pytest.fixture
+def _fake_adapter():
+    register("fake-test", _FakeAdapter)
+    yield
+    reset_adapters()
+    unregister("fake-test")
+
+
+def test_mine_source_files_pre_annotated_record(tmp_dir, palace_path, _fake_adapter):
+    from mempalace.cli import _mine_via_source_adapter
+    from mempalace.palace import get_collection
+
+    args = Namespace(source="fake-test", dir=tmp_dir, wing=None, dry_run=False)
+    _mine_via_source_adapter(args, palace_path)
+
+    col = get_collection(palace_path, create=True)
+    got = col.get(where={"source_file": "fake://item/1"})
+    assert got["documents"] == ["the operator said the verb leads"]
+    meta = got["metadatas"][0]
+    assert meta["lar_demo"] == "1"  # adapter-authored metadata lands verbatim
+    assert meta["adapter_name"] == "fake-test"  # stamped by PalaceContext, not by the adapter
+    assert meta["adapter_version"] == "0.1.0"
+
+
+def test_mine_source_dry_run_files_nothing(tmp_dir, palace_path, _fake_adapter):
+    from mempalace.cli import _mine_via_source_adapter
+    from mempalace.palace import get_collection
+
+    args = Namespace(source="fake-test", dir=tmp_dir, wing=None, dry_run=True)
+    _mine_via_source_adapter(args, palace_path)
+
+    col = get_collection(palace_path, create=True)
+    assert col.get(where={"source_file": "fake://item/1"})["ids"] == []
+
+
+def test_mine_source_unknown_adapter_exits(tmp_dir, palace_path):
+    from mempalace.cli import _mine_via_source_adapter
+
+    args = Namespace(source="does-not-exist", dir=tmp_dir, wing=None, dry_run=False)
+    with pytest.raises(SystemExit):
+        _mine_via_source_adapter(args, palace_path)
+
+
+def _run_mine(*argv: str):
+    """Invoke the real CLI so the assertions read the parser users actually meet."""
+    return subprocess.run(
+        [sys.executable, "-m", "mempalace.cli", "mine", *argv],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_mine_source_and_explicit_mode_are_mutually_exclusive():
+    """`--source` and an explicitly supplied `--mode` cannot both apply.
+
+    All three spellings must fail alike. argparse counts an option as "seen" for exclusivity
+    only when its value differs from its default, so a `--mode` default of "projects" would
+    admit `--mode projects` here while rejecting `--mode convos`; the parser carries no
+    default, so the three behave the same.
+    """
+    for mode in ("projects", "convos", "extract"):
+        out = _run_mine("/tmp/does-not-matter", "--source", "fake-test", "--mode", mode)
+        assert out.returncode == 2, f"--mode {mode} alongside --source should fail the parser"
+        assert "not allowed with" in out.stderr
+
+
+def test_mine_help_documents_source_as_the_extension_path():
+    out = _run_mine("--help")
+    assert out.returncode == 0
+    assert "--source" in out.stdout and "RFC 002" in out.stdout


### PR DESCRIPTION
Closes #2062.

`mempalace mine --source <adapter-name>` resolves the adapter through `resolve_adapter_for_source()`, constructs the existing `PalaceContext`, and runs the adapter ingestion path. Adapter-authored metadata lands verbatim; `PalaceContext` stamps `adapter_name` and `adapter_version`. Omitting `--source` leaves the legacy `--mode` dispatch untouched, so `mempalace mine <dir>` and `--mode projects|convos|extract` behave exactly as before.

**The exclusivity criterion.** `--mode` and `--source` select the ingest path and cannot both apply, so they sit in a mutually exclusive group with `--mode` carrying no argparse default. argparse counts an option as "seen" for exclusivity only when its value differs from its default, which makes the default load-bearing here:

```
--mode default="projects":  --source nd --mode convos    → error
                            --source nd --mode projects  → accepted
--mode default=None:        both spellings               → error
```

`cmd_mine` restores `"projects"` when `--mode` goes unsupplied, so the parser holds the group and the dispatch site holds the default. If you would rather keep the default in argparse and accept the `--mode projects` spelling passing, say so and I will drop that part.

Tests cover registry resolution, `PalaceContext` construction, verbatim adapter metadata, unknown-adapter failure, dry-run filing nothing, exclusivity across all three mode spellings, and `--help` documenting `--source` as the RFC 002 extension path.

Suite: 3607 passed, 31 skipped. The five `test_init` leaked-`PYTHONPATH` results reproduce identically on an untouched `develop` checkout, so this branch leaves them where it found them.
