### PR TITLE
feat: config-dir lever, ndjson source adapter, stored metadata on hits

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -561,10 +561,14 @@ def _mine_args_forwardable(args, include_ignored) -> bool:
     """Only forward mines the ``mempalace_mine`` MCP tool can express.
 
     Flags the tool has no parameters for (kg-extract, gitignore handling,
-    chunking overrides, origin redetection, explicit backend) keep the
-    direct path — where a held writer lease still surfaces as the existing
-    MineAlreadyRunning error rather than being silently dropped.
+    chunking overrides, origin redetection, explicit backend, source-adapter
+    selection) keep the direct path — where a held writer lease still surfaces
+    as the existing MineAlreadyRunning error rather than being silently dropped.
     """
+    if getattr(args, "source", None):
+        # The tool carries no `source` parameter, so forwarding a --source mine
+        # would run the default --mode path under a different name.
+        return False
     if getattr(args, "kg_extract", False) or getattr(args, "redetect_origin", False):
         return False
     if args.no_gitignore or include_ignored:
@@ -678,6 +682,81 @@ def _forward_mine_to_hub(args, palace_path: str) -> bool:
     return True
 
 
+def _mine_via_source_adapter(args, palace_path):
+    """Route ``mine --source NAME`` through the RFC 002 source-adapter registry.
+
+    Opt-in seam: when an explicit ``--source`` names a registered adapter, mine
+    resolves it from ``mempalace.sources.registry``, runs its ``ingest()``, and
+    files each ``DrawerRecord`` through a ``PalaceContext``. When no ``--source``
+    is given, ``cmd_mine`` keeps its legacy ``--mode`` dispatch — the
+    filesystem/conversations miners have not moved onto the contract yet, so the
+    registry path stays opt-in and changes no existing behavior. This wires the
+    registry the spec reserves.
+    """
+    from .knowledge_graph import KnowledgeGraph
+    from .palace import MineAlreadyRunning, get_collection, mine_palace_lock
+    from .sources.base import DrawerRecord, SourceItemMetadata, SourceRef
+    from .sources.context import PalaceContext
+    from .sources.registry import get_adapter, resolve_adapter_for_source
+
+    name = resolve_adapter_for_source(explicit=args.source)
+    try:
+        adapter = get_adapter(name)
+    except KeyError as exc:
+        print(f"mempalace: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    # Routing precedence: an explicit --wing flows to the adapter through
+    # SourceRef.options and the adapter honors it. Secrets never travel here.
+    options = {}
+    if getattr(args, "wing", None):
+        options["wing"] = args.wing
+    ref = SourceRef(local_path=os.path.abspath(os.path.expanduser(args.dir)), options=options)
+
+    filed = 0
+    skipped = 0
+    try:
+        with mine_palace_lock(palace_path):
+            collection = get_collection(palace_path, create=True)
+            kg = KnowledgeGraph(db_path=os.path.join(palace_path, "knowledge_graph.sqlite3"))
+            ctx = PalaceContext(
+                drawer_collection=collection,
+                knowledge_graph=kg,
+                palace_path=palace_path,
+                config=MempalaceConfig(),
+                adapter_name=getattr(adapter, "name", name),
+                adapter_version=getattr(adapter, "adapter_version", ""),
+            )
+
+            skip_item = False
+            for result in adapter.ingest(source=ref, palace=ctx):
+                if isinstance(result, SourceItemMetadata):
+                    skip_item = False
+                    ctx._skip_requested = False
+                    existing = collection.get(where={"source_file": result.source_file}, limit=1)
+                    metas = (existing or {}).get("metadatas") or []
+                    if adapter.is_current(
+                        item=result, existing_metadata=metas[0] if metas else None
+                    ):
+                        ctx.skip_current_item()
+                        skip_item = True
+                elif isinstance(result, DrawerRecord):
+                    if skip_item or ctx._skip_requested:
+                        skipped += 1
+                        continue
+                    if not args.dry_run:
+                        ctx.upsert_drawer(result)
+                    filed += 1
+            adapter.close()
+    except MineAlreadyRunning as exc:
+        print(f"mempalace: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    verb = "Would file" if args.dry_run else "Drawers filed:"
+    tail = f"  (skipped {skipped} up-to-date)" if skipped else ""
+    print(f"  source={name}  {verb} {filed}{tail}")
+
+
 def cmd_mine(args):
     palace_path = os.path.expanduser(args.palace) if args.palace else MempalaceConfig().palace_path
     include_ignored = []
@@ -686,6 +765,15 @@ def cmd_mine(args):
 
     if getattr(args, "background", False) and not getattr(args, "daemon", False):
         print("mempalace: --background requires --daemon", file=sys.stderr)
+        sys.exit(2)
+
+    # --mode carries no argparse default so it can sit in a mutually exclusive group with
+    # --source (see the parser). An unsupplied --mode means the projects path, as before.
+    if getattr(args, "mode", None) is None:
+        args.mode = "projects"
+
+    if getattr(args, "source", None) and getattr(args, "daemon", False):
+        print("mempalace: --source does not support --daemon yet", file=sys.stderr)
         sys.exit(2)
 
     if getattr(args, "daemon", False):
@@ -721,6 +809,12 @@ def cmd_mine(args):
             palace_dir=palace_path,
             llm_provider=None,
         )
+
+    # RFC 002 source-adapter seam: an explicit --source routes mine through the
+    # registry; absent it, the legacy --mode dispatch below runs unchanged.
+    if getattr(args, "source", None):
+        _mine_via_source_adapter(args, palace_path)
+        return
 
     from .palace import MineAlreadyRunning, MineValidationError
 
@@ -2301,14 +2395,30 @@ def main():
         default=None,
         help="Storage backend to use for this mine (default: config/env/detected/chroma)",
     )
-    p_mine.add_argument(
+    # --mode and --source select the ingest path and cannot both apply. argparse counts an
+    # option as "seen" for exclusivity only when its value differs from its default, so a
+    # default of "projects" here would let `--source X --mode projects` through while
+    # `--source X --mode convos` errored. default=None makes both spellings fail alike;
+    # cmd_mine restores "projects" when --mode goes unsupplied.
+    mine_path = p_mine.add_mutually_exclusive_group()
+    mine_path.add_argument(
         "--mode",
         choices=["projects", "convos", "extract"],
-        default="projects",
+        default=None,
         help=(
             "Ingest mode: 'projects' for code/docs (default), 'convos' for chat "
             "exports, 'extract' for office documents (PDF/DOCX/RTF/etc., requires "
             "mempalace[extract])"
+        ),
+    )
+    mine_path.add_argument(
+        "--source",
+        default=None,
+        metavar="NAME",
+        help=(
+            "RFC 002 source adapter to mine through (e.g. a third-party "
+            "mempalace-source-<name> package). Explicit selection only — no "
+            "auto-detect. Omit to use the legacy --mode dispatch."
         ),
     )
     p_mine.add_argument("--wing", default=None, help="Wing name (default: directory name)")

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -354,15 +354,28 @@ class MempalaceConfig:
         """Initialize config.
 
         Args:
-            config_dir: Override config directory (useful for testing).
-                        Defaults to ~/.mempalace.
+            config_dir: Explicit config directory. Takes precedence over the
+                        ``MEMPALACE_CONFIG_DIR`` environment variable, which in
+                        turn takes precedence over the ~/.mempalace default.
             palace_path: Explicit palace data directory. This is primarily
                          used by CLI operations that received ``--palace``;
                          it takes precedence over environment and file config.
         """
-        self._config_dir = (
-            Path(config_dir) if config_dir else Path(os.path.expanduser("~/.mempalace"))
-        )
+        # Explicit arg > MEMPALACE_CONFIG_DIR > ~/.mempalace, mirroring how
+        # ``palace_path`` resolves. A host that embeds mempalace as a library
+        # needs to point a spawned process at its own config root: without an
+        # env lever the directory hardwires to ~/.mempalace, so every spawned
+        # process reads a user-level config it does not own. The config file
+        # supplies backend, collection_name, embedding_model, write_routing and
+        # ~20 more, so an embedding host inherits all of them by default.
+        env_config_dir = os.environ.get("MEMPALACE_CONFIG_DIR")
+        if config_dir:
+            resolved_config_dir = str(config_dir)
+        elif env_config_dir and env_config_dir.strip():
+            resolved_config_dir = env_config_dir.strip()
+        else:
+            resolved_config_dir = "~/.mempalace"
+        self._config_dir = Path(os.path.expanduser(resolved_config_dir))
         self._config_file = self._config_dir / "config.json"
         self._people_map_file = self._config_dir / "people_map.json"
         self._palace_path_override = (

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -1481,6 +1481,11 @@ def search_memories(
             "effective_distance": round(effective_dist, 4),
             "closet_boost": round(boost, 3),
             "matched_via": matched_via,
+            # The drawer's stored metadata rides through whole: consumers that
+            # filter or re-rank hits (session-aware recall, provenance rules,
+            # custom pipelines) need the fields they stamped at ingest — a hit
+            # flattened to display fields blinds every downstream filter.
+            "metadata": dict(meta or {}),
             # Internal: retain the full source_file path + chunk_index so the
             # enrichment step below doesn't have to reverse-lookup via
             # basename-suffix matching (which silently collides when two

--- a/mempalace/sources/__init__.py
+++ b/mempalace/sources/__init__.py
@@ -35,6 +35,7 @@ from .base import (
     TransformationViolationError,
 )
 from .context import PalaceContext, ProgressHook
+from .ndjson import NdjsonSourceAdapter
 from .registry import (
     available_adapters,
     get_adapter,
@@ -45,6 +46,11 @@ from .registry import (
     unregister,
 )
 
+# First-party in-tree adapters register on import (RFC 002 §3.2 — explicit
+# registration, not the third-party entry-point group). This makes
+# ``mine --source ndjson`` resolve without an install step.
+register(NdjsonSourceAdapter.name, NdjsonSourceAdapter)
+
 __all__ = [
     "AdapterClosedError",
     "AdapterSchema",
@@ -54,6 +60,7 @@ __all__ = [
     "FieldSpec",
     "IngestMode",
     "IngestResult",
+    "NdjsonSourceAdapter",
     "PalaceContext",
     "ProgressHook",
     "RouteHint",

--- a/mempalace/sources/ndjson.py
+++ b/mempalace/sources/ndjson.py
@@ -1,0 +1,118 @@
+"""NDJSON source adapter (RFC 002) — ingest a JSON-Lines spool of pre-extracted records.
+
+For any pipeline that has already extracted and chunked content elsewhere and wants
+to hand MemPalace ready-to-file records: each line of the spool is one record, filed
+as one drawer. The adapter is byte-preserving — it stores ``content`` verbatim and
+declares no transformations (the foundational promise; see ``CLAUDE.md`` "Verbatim
+always"). It carries no opinion about *where* the records came from.
+
+One NDJSON line is one record::
+
+    {"content": "...", "source_file": "...", "metadata": {...}, "chunk_index": 0}
+
+``content`` and ``source_file`` are required strings; ``metadata`` (flat scalars) and
+``chunk_index`` (int) are optional. ``metadata`` passes through verbatim — producers
+may attach any flat-scalar fields, opaque to this adapter. When ``chunk_index`` is
+absent the adapter assigns a running per-``source_file`` ordinal so two records that
+share a ``source_file`` never collide on the deterministic drawer id
+(``sha256(source_file)_chunk``).
+
+``SourceRef.local_path`` points at the spool file. The optional ``--wing`` routing
+flag (``SourceRef.options['wing']``) fills the ``wing`` metadata key only where a
+record left it unset (RFC 002 §2.5 — the record's own routing wins).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Iterator
+
+from .base import (
+    AdapterSchema,
+    BaseSourceAdapter,
+    DrawerRecord,
+    IngestResult,
+    SourceAdapterError,
+    SourceNotFoundError,
+    SourceRef,
+)
+
+
+class NdjsonSourceAdapter(BaseSourceAdapter):
+    """File a newline-delimited JSON spool of pre-extracted records into verbatim drawers.
+
+    First-party, in-tree — registered manually (RFC 002 §3.2), not via the
+    third-party entry-point group.
+    """
+
+    name = "ndjson"
+    adapter_version = "0.1.0"
+    capabilities = frozenset({"byte_preserving"})
+    supported_modes = frozenset({"whole_record"})
+    declared_transformations = frozenset()  # verbatim — the producer pre-chunked
+    default_privacy_class = "pii_potential"
+
+    def ingest(
+        self,
+        *,
+        source: SourceRef,
+        palace: "object",  # PalaceContext — broad to avoid the import cycle
+    ) -> Iterator[IngestResult]:
+        path = source.local_path
+        if not path or not os.path.isfile(path):
+            raise SourceNotFoundError(
+                f"ndjson: spool file not found: {path!r} (expected a newline-delimited JSON file)"
+            )
+
+        # Honor the --wing routing precedence (§2.5): a record's own wing wins;
+        # the flag fills in only where the producer left routing unannotated.
+        fallback_wing = source.options.get("wing") if source.options else None
+
+        # Per-source_file ordinal so absent chunk_index values never collide on
+        # the deterministic drawer id. Provided chunk_index values pass through.
+        ordinals: dict[str, int] = {}
+
+        with open(path, encoding="utf-8") as fh:
+            for line_no, raw in enumerate(fh, start=1):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise SourceAdapterError(
+                        f"ndjson: malformed JSON at {path}:{line_no}: {exc}"
+                    ) from exc
+                if not isinstance(record, dict):
+                    raise SourceAdapterError(f"ndjson: line {path}:{line_no} is not a JSON object")
+
+                content = record.get("content")
+                source_file = record.get("source_file")
+                if not isinstance(content, str) or not isinstance(source_file, str):
+                    raise SourceAdapterError(
+                        f"ndjson: line {path}:{line_no} lacks string 'content' and 'source_file'"
+                    )
+
+                metadata = dict(record.get("metadata") or {})
+                if fallback_wing and "wing" not in metadata:
+                    metadata["wing"] = fallback_wing
+
+                provided = record.get("chunk_index")
+                if isinstance(provided, int):
+                    chunk_index = provided
+                else:
+                    chunk_index = ordinals.get(source_file, 0)
+                ordinals[source_file] = chunk_index + 1
+
+                yield DrawerRecord(
+                    content=content,
+                    source_file=source_file,
+                    chunk_index=chunk_index,
+                    metadata=metadata,
+                )
+
+    def describe_schema(self) -> AdapterSchema:
+        # No fixed structured schema: metadata is producer-defined and flows
+        # through verbatim (upsert_drawer does not reject undeclared fields).
+        return AdapterSchema(version="1.0", fields={})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,6 +317,7 @@ def seeded_collection(collection):
                 "chunk_index": 0,
                 "added_by": "miner",
                 "filed_at": "2026-01-01T00:00:00",
+                "origin_handle": "session-alpha",
             },
             {
                 "wing": "project",

--- a/tests/test_config_dir_env.py
+++ b/tests/test_config_dir_env.py
@@ -1,0 +1,63 @@
+"""MEMPALACE_CONFIG_DIR — the config-directory lever, mirroring MEMPALACE_PALACE_PATH.
+
+A host that embeds mempalace as a sidecar spawns it as a process, so it can pass env and argv and
+nothing else. Without an env lever the config directory hardwires to ~/.mempalace and every spawned
+process reads a user-level config it does not own — carrying backend, collection_name,
+embedding_model, write_routing and ~20 more keys across a boundary the embedding was meant to hold.
+
+These cover the resolution order the docstring promises: explicit arg > env > default.
+"""
+
+import json
+import os
+
+from mempalace.config import MempalaceConfig
+
+
+def test_env_var_sets_the_config_dir(tmp_path, monkeypatch):
+    """MEMPALACE_CONFIG_DIR redirects both config-dir-derived files."""
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", str(tmp_path))
+    cfg = MempalaceConfig()
+    assert cfg._config_dir == tmp_path
+    assert cfg._config_file == tmp_path / "config.json"
+    assert cfg._people_map_file == tmp_path / "people_map.json"
+
+
+def test_env_var_config_file_actually_loads(tmp_path, monkeypatch):
+    """A config.json under the env-named dir feeds the resolved values — the point of the lever."""
+    (tmp_path / "config.json").write_text(json.dumps({"collection_name": "sidecar_only"}))
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", str(tmp_path))
+    cfg = MempalaceConfig()
+    assert cfg._file_config.get("collection_name") == "sidecar_only"
+
+
+def test_explicit_arg_outranks_the_env_var(tmp_path, monkeypatch):
+    """Explicit arg > env, matching how palace_path resolves an explicit --palace over its env."""
+    env_dir = tmp_path / "from_env"
+    arg_dir = tmp_path / "from_arg"
+    env_dir.mkdir()
+    arg_dir.mkdir()
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", str(env_dir))
+    cfg = MempalaceConfig(config_dir=str(arg_dir))
+    assert cfg._config_dir == arg_dir
+
+
+def test_unset_env_keeps_the_home_default(monkeypatch):
+    """Absent the env var the directory stands where it always stood — behaviour-preserving."""
+    monkeypatch.delenv("MEMPALACE_CONFIG_DIR", raising=False)
+    cfg = MempalaceConfig()
+    assert cfg._config_dir == type(cfg._config_dir)(os.path.expanduser("~/.mempalace"))
+
+
+def test_blank_env_falls_through_to_the_default(monkeypatch):
+    """An exported-but-empty value reads as unset rather than as the current directory."""
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", "   ")
+    cfg = MempalaceConfig()
+    assert cfg._config_dir == type(cfg._config_dir)(os.path.expanduser("~/.mempalace"))
+
+
+def test_env_var_expands_a_tilde(monkeypatch):
+    """`~` expands, so an operator may export a home-relative path."""
+    monkeypatch.setenv("MEMPALACE_CONFIG_DIR", "~/some-sidecar-root")
+    cfg = MempalaceConfig()
+    assert str(cfg._config_dir) == os.path.expanduser("~/some-sidecar-root")

--- a/tests/test_hub_forward.py
+++ b/tests/test_hub_forward.py
@@ -34,6 +34,7 @@ def _mine_args(source_dir, **overrides):
         backend=None,
         global_backend=None,
         mode="convos",
+        source=None,
         wing=None,
         no_gitignore=False,
         include_ignored=None,
@@ -281,6 +282,7 @@ class TestForwardability:
             (dict(no_gitignore=True), []),
             (dict(max_chunks_per_file=10), []),
             (dict(backend="qdrant"), []),
+            (dict(source="ndjson"), []),
             (dict(), ["*.log"]),
         ],
     )

--- a/tests/test_mine_source_registry.py
+++ b/tests/test_mine_source_registry.py
@@ -1,0 +1,122 @@
+"""RFC 002 source-adapter CLI seam: ``mine --source NAME`` routes through the
+registry and files adapter-authored ``DrawerRecord``s via ``PalaceContext``.
+
+This covers the seam wired into ``cmd_mine`` — the registry/ingest-loop path is
+opt-in and leaves the legacy ``--mode`` dispatch untouched.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from argparse import Namespace
+from typing import Iterator
+
+import pytest
+
+from mempalace.sources.base import (
+    AdapterSchema,
+    BaseSourceAdapter,
+    DrawerRecord,
+    FieldSpec,
+    IngestResult,
+    SourceItemMetadata,
+    SourceRef,
+)
+from mempalace.sources.registry import register, reset_adapters, unregister
+
+
+class _FakeAdapter(BaseSourceAdapter):
+    name = "fake-test"
+    adapter_version = "0.1.0"
+    capabilities = frozenset({"byte_preserving"})
+    supported_modes = frozenset({"whole_record"})
+    declared_transformations = frozenset()
+    default_privacy_class = "internal"
+
+    def ingest(self, *, source: SourceRef, palace) -> Iterator[IngestResult]:
+        yield SourceItemMetadata(source_file="fake://item/1", version="v1")
+        yield DrawerRecord(
+            content="the operator said the verb leads",
+            source_file="fake://item/1",
+            metadata={"wing": "wing_test", "room": "general", "lar_demo": "1"},
+        )
+
+    def describe_schema(self) -> AdapterSchema:
+        return AdapterSchema(
+            version="1.0",
+            fields={"lar_demo": FieldSpec(type="string", required=False, description="demo field")},
+        )
+
+
+@pytest.fixture
+def _fake_adapter():
+    register("fake-test", _FakeAdapter)
+    yield
+    reset_adapters()
+    unregister("fake-test")
+
+
+def test_mine_source_files_pre_annotated_record(tmp_dir, palace_path, _fake_adapter):
+    from mempalace.cli import _mine_via_source_adapter
+    from mempalace.palace import get_collection
+
+    args = Namespace(source="fake-test", dir=tmp_dir, wing=None, dry_run=False)
+    _mine_via_source_adapter(args, palace_path)
+
+    col = get_collection(palace_path, create=True)
+    got = col.get(where={"source_file": "fake://item/1"})
+    assert got["documents"] == ["the operator said the verb leads"]
+    meta = got["metadatas"][0]
+    assert meta["lar_demo"] == "1"  # adapter-authored metadata lands verbatim
+    assert meta["adapter_name"] == "fake-test"  # stamped by PalaceContext, not by the adapter
+    assert meta["adapter_version"] == "0.1.0"
+
+
+def test_mine_source_dry_run_files_nothing(tmp_dir, palace_path, _fake_adapter):
+    from mempalace.cli import _mine_via_source_adapter
+    from mempalace.palace import get_collection
+
+    args = Namespace(source="fake-test", dir=tmp_dir, wing=None, dry_run=True)
+    _mine_via_source_adapter(args, palace_path)
+
+    col = get_collection(palace_path, create=True)
+    assert col.get(where={"source_file": "fake://item/1"})["ids"] == []
+
+
+def test_mine_source_unknown_adapter_exits(tmp_dir, palace_path):
+    from mempalace.cli import _mine_via_source_adapter
+
+    args = Namespace(source="does-not-exist", dir=tmp_dir, wing=None, dry_run=False)
+    with pytest.raises(SystemExit):
+        _mine_via_source_adapter(args, palace_path)
+
+
+def _run_mine(*argv: str):
+    """Invoke the real CLI so the assertions read the parser users actually meet."""
+    return subprocess.run(
+        [sys.executable, "-m", "mempalace.cli", "mine", *argv],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_mine_source_and_explicit_mode_are_mutually_exclusive():
+    """`--source` and an explicitly supplied `--mode` cannot both apply.
+
+    All three spellings must fail alike. argparse counts an option as "seen" for exclusivity
+    only when its value differs from its default, so a `--mode` default of "projects" would
+    admit `--mode projects` here while rejecting `--mode convos`; the parser carries no
+    default, so the three behave the same.
+    """
+    for mode in ("projects", "convos", "extract"):
+        out = _run_mine("/tmp/does-not-matter", "--source", "fake-test", "--mode", mode)
+        assert out.returncode == 2, f"--mode {mode} alongside --source should fail the parser"
+        assert "not allowed with" in out.stderr
+
+
+def test_mine_help_documents_source_as_the_extension_path():
+    out = _run_mine("--help")
+    assert out.returncode == 0
+    assert "--source" in out.stdout and "RFC 002" in out.stdout

--- a/tests/test_ndjson_source_adapter.py
+++ b/tests/test_ndjson_source_adapter.py
@@ -1,0 +1,169 @@
+"""Tests for the first-party ``ndjson`` source adapter (RFC 002).
+
+A pipeline that pre-extracts records writes a JSON-Lines spool and runs
+``mempalace mine --source ndjson <spool>``; this adapter reads it back into
+verbatim drawers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from argparse import Namespace
+
+import pytest
+
+from mempalace.sources import available_adapters
+from mempalace.sources.base import SourceAdapterError, SourceNotFoundError, SourceRef
+from mempalace.sources.ndjson import NdjsonSourceAdapter
+
+
+def _write_spool(tmp_dir, records) -> str:
+    path = os.path.join(tmp_dir, "batch-0.ndjson")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(json.dumps(r) for r in records) + "\n")
+    return path
+
+
+def test_ndjson_is_registered_first_party():
+    # Registered on import of mempalace.sources — no install step needed.
+    assert "ndjson" in available_adapters()
+
+
+def test_ingest_reads_spool_verbatim(tmp_dir):
+    spool = _write_spool(
+        tmp_dir,
+        [
+            {
+                "content": "the record stored exactly as written",
+                "source_file": "feed://abc/item/1",
+                "metadata": {"opaque_field": "kept", "wing": "wing_a"},
+            }
+        ],
+    )
+    adapter = NdjsonSourceAdapter()
+    out = list(adapter.ingest(source=SourceRef(local_path=spool), palace=None))
+
+    assert len(out) == 1
+    drawer = out[0]
+    assert drawer.content == "the record stored exactly as written"  # verbatim
+    assert drawer.source_file == "feed://abc/item/1"
+    assert drawer.chunk_index == 0
+    assert drawer.metadata["opaque_field"] == "kept"  # producer metadata flows through
+    assert drawer.metadata["wing"] == "wing_a"
+
+
+def test_absent_chunk_index_gets_per_source_ordinal(tmp_dir):
+    # Two records sharing a source_file with no chunk_index must NOT collide on
+    # the deterministic drawer id (sha256(source_file)_chunk).
+    spool = _write_spool(
+        tmp_dir,
+        [
+            {"content": "first", "source_file": "feed://x"},
+            {"content": "second", "source_file": "feed://x"},
+            {"content": "other", "source_file": "feed://y"},
+        ],
+    )
+    out = list(NdjsonSourceAdapter().ingest(source=SourceRef(local_path=spool), palace=None))
+
+    triples = [(d.source_file, d.chunk_index, d.content) for d in out]
+    assert triples == [
+        ("feed://x", 0, "first"),
+        ("feed://x", 1, "second"),
+        ("feed://y", 0, "other"),
+    ]
+
+
+def test_provided_chunk_index_passes_through(tmp_dir):
+    spool = _write_spool(
+        tmp_dir,
+        [{"content": "c", "source_file": "feed://x", "chunk_index": 7}],
+    )
+    out = list(NdjsonSourceAdapter().ingest(source=SourceRef(local_path=spool), palace=None))
+    assert out[0].chunk_index == 7
+
+
+def test_wing_option_fills_only_when_absent(tmp_dir):
+    spool = _write_spool(
+        tmp_dir,
+        [
+            {"content": "a", "source_file": "s://1"},
+            {"content": "b", "source_file": "s://2", "metadata": {"wing": "wing_own"}},
+        ],
+    )
+    out = list(
+        NdjsonSourceAdapter().ingest(
+            source=SourceRef(local_path=spool, options={"wing": "wing_flag"}), palace=None
+        )
+    )
+    assert out[0].metadata["wing"] == "wing_flag"  # filled from the flag
+    assert out[1].metadata["wing"] == "wing_own"  # the record's own wing wins
+
+
+def test_blank_lines_skipped(tmp_dir):
+    path = os.path.join(tmp_dir, "batch.ndjson")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write('\n{"content": "c", "source_file": "s"}\n\n')
+    out = list(NdjsonSourceAdapter().ingest(source=SourceRef(local_path=path), palace=None))
+    assert len(out) == 1
+
+
+def test_malformed_json_raises(tmp_dir):
+    path = os.path.join(tmp_dir, "bad.ndjson")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("{not json}\n")
+    with pytest.raises(SourceAdapterError):
+        list(NdjsonSourceAdapter().ingest(source=SourceRef(local_path=path), palace=None))
+
+
+def test_missing_required_fields_raises(tmp_dir):
+    spool = _write_spool(tmp_dir, [{"content": "no source_file"}])
+    with pytest.raises(SourceAdapterError):
+        list(NdjsonSourceAdapter().ingest(source=SourceRef(local_path=spool), palace=None))
+
+
+def test_missing_spool_raises_not_found(tmp_dir):
+    with pytest.raises(SourceNotFoundError):
+        list(
+            NdjsonSourceAdapter().ingest(
+                source=SourceRef(local_path=os.path.join(tmp_dir, "nope.ndjson")), palace=None
+            )
+        )
+
+
+def test_end_to_end_mine_source_ndjson_files_drawers(tmp_dir, palace_path):
+    from mempalace.cli import _mine_via_source_adapter
+    from mempalace.palace import get_collection
+
+    spool = _write_spool(
+        tmp_dir,
+        [
+            {
+                "content": "pre-extracted record line",
+                "source_file": "feed://e2e/1",
+                "metadata": {"opaque_field": "kept"},
+            }
+        ],
+    )
+    args = Namespace(source="ndjson", dir=spool, wing=None, dry_run=False)
+    _mine_via_source_adapter(args, palace_path)
+
+    col = get_collection(palace_path, create=True)
+    got = col.get(where={"source_file": "feed://e2e/1"})
+    assert got["documents"] == ["pre-extracted record line"]
+    meta = got["metadatas"][0]
+    assert meta["opaque_field"] == "kept"
+    assert meta["adapter_name"] == "ndjson"  # stamped by PalaceContext, not by the adapter
+    assert meta["adapter_version"] == "0.1.0"
+
+
+def test_end_to_end_dry_run_files_nothing(tmp_dir, palace_path):
+    from mempalace.cli import _mine_via_source_adapter
+    from mempalace.palace import get_collection
+
+    spool = _write_spool(tmp_dir, [{"content": "c", "source_file": "feed://dry/1"}])
+    args = Namespace(source="ndjson", dir=spool, wing=None, dry_run=True)
+    _mine_via_source_adapter(args, palace_path)
+
+    col = get_collection(palace_path, create=True)
+    assert col.get(where={"source_file": "feed://dry/1"})["ids"] == []

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -75,6 +75,19 @@ class TestSearchMemories:
         assert len(result["results"]) > 0
         assert result["query"] == "JWT authentication"
 
+    def test_hits_carry_their_stored_metadata(self, palace_path, seeded_collection):
+        """Consumers that filter or re-rank hits need the fields they stamped at
+        ingest; a hit flattened to display fields blinds every downstream filter."""
+        result = search_memories("JWT authentication", palace_path)
+        hit = result["results"][0]
+        assert "metadata" in hit
+        assert hit["metadata"].get("origin_handle") == "session-alpha"
+        assert hit["metadata"].get("wing") == "project"
+        # a drawer without custom stamps still carries its stored metadata whole
+        other = search_memories("React frontend", palace_path)["results"][0]
+        assert "origin_handle" not in other["metadata"]
+        assert other["metadata"].get("room") == "frontend"
+
     def test_wing_filter(self, palace_path, seeded_collection):
         result = search_memories("planning", palace_path, wing="notes")
         assert all(r["wing"] == "notes" for r in result["results"])


### PR DESCRIPTION
Draft — the remaining three faces of #2110, held until #2173 lands.

**Stacked on #2173.** The ndjson adapter reaches a palace through `mine --source`, so its end-to-end tests import `_mine_via_source_adapter` from that PR. The registry commit therefore rides at the base of this diff, and drops out once #2173 merges and this rebases onto `develop`.

**`MEMPALACE_CONFIG_DIR`** — `MempalaceConfig` takes `config_dir` as a constructor argument with no environment lever, while `palace_path` already honors `MEMPALACE_PALACE_PATH`. Every process on a machine therefore reads one `~/.mempalace/config.json`: `backend`, `collection_name`, `embedding_model`, `write_routing`, the milvus/qdrant/pgvector sets. This makes the two resolutions mirror.

**ndjson source adapter** — an RFC 002 citizen for a host that already holds its records: a JSON-Lines spool of pre-extracted records, one per line, filed verbatim. Declares `byte_preserving`, `whole_record`, no transformations, and registers in-tree the way RFC 002 reserves for first-party adapters.

**Stored metadata on search hits** — a hit returns what the store already knew, so a caller reading a result does not re-derive fields the drawer carries. Complements the `source_file` filtering from #1815.

Each of the three is independent and touches a disjoint file set, so any subset can be taken and the rest dropped.

Suite on the stack: ruff clean; ndjson / config-dir / searcher / source selection 179 passed.
