### PR TITLE
fix(codex): make marketplace plugin installable

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -8,11 +8,11 @@
       "name": "mempalace",
       "source": {
         "source": "local",
-        "path": "./.codex-plugin"
+        "path": "./"
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "NONE"
+        "authentication": "ON_INSTALL"
       },
       "category": "Coding"
     }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -18,12 +18,7 @@
     "search"
   ],
   "skills": "./skills/",
-  "hooks": "./hooks.json",
-  "mcpServers": {
-    "mempalace": {
-      "command": "mempalace-mcp"
-    }
-  },
+  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "MemPalace",
     "shortDescription": "AI memory system for Codex",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "mempalace": {
+      "command": "mempalace-mcp"
+    }
+  }
+}

--- a/tests/test_codex_plugin_manifest.py
+++ b/tests/test_codex_plugin_manifest.py
@@ -1,0 +1,47 @@
+"""Contract tests for the Codex plugin marketplace metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MARKETPLACE_PATH = REPO_ROOT / ".agents" / "plugins" / "marketplace.json"
+MANIFEST_PATH = REPO_ROOT / ".codex-plugin" / "plugin.json"
+MCP_PATH = REPO_ROOT / ".mcp.json"
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_marketplace_entry_uses_supported_codex_schema():
+    marketplace = _read_json(MARKETPLACE_PATH)
+    plugin = marketplace["plugins"][0]
+
+    assert plugin["name"] == "mempalace"
+    assert plugin["source"] == {"source": "local", "path": "./"}
+    assert plugin["policy"] == {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL",
+    }
+
+
+def test_plugin_manifest_references_supported_components():
+    manifest = _read_json(MANIFEST_PATH)
+
+    assert manifest["mcpServers"] == "./.mcp.json"
+    assert "hooks" not in manifest
+
+
+def test_mcp_config_registers_mempalace_server():
+    config = _read_json(MCP_PATH)
+
+    assert config == {
+        "mcpServers": {
+            "mempalace": {
+                "command": "mempalace-mcp",
+            }
+        }
+    }


### PR DESCRIPTION
## Summary

- point the Codex marketplace entry at the repository plugin root
- replace the unsupported `NONE` authentication policy with `ON_INSTALL`
- move the MCP server declaration into the canonical root `.mcp.json`
- remove the unsupported `hooks` manifest field while preserving the existing hook files
- add focused contract tests for the Codex marketplace, plugin manifest, and MCP configuration

## Root cause

Current Codex marketplace parsing rejects `policy.authentication: "NONE"`; the accepted values are
`ON_INSTALL` and `ON_USE`. After that first parser failure is corrected, the existing marketplace
source path still treats `.codex-plugin` as the plugin root, and the current plugin validator
rejects the hook declaration.

The result is that adding `https://github.com/MemPalace/mempalace` as a Codex marketplace fails
before the plugin can be installed.

## User impact

Codex users can add the repository as a marketplace and install the MemPalace plugin with metadata
that matches the current Codex ingestion schema.

This supersedes the closed, unmerged draft #1743 and applies the same compatibility direction to
the current `develop` branch with regression coverage.

## Validation

- `uv run pytest tests/test_codex_plugin_manifest.py -v` — 3 passed
- Codex plugin validator — passed
- `jq empty .agents/plugins/marketplace.json .codex-plugin/plugin.json .mcp.json` — passed
- `ruff check tests/test_codex_plugin_manifest.py` — passed
- `ruff format --check tests/test_codex_plugin_manifest.py` — passed
