### PR TITLE
fix(docker): drop the null `environment:` block that invalidated compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **MCP and daemon lifecycle harden multi-agent use.** Read-only mode refuses config and checkpoint-ack tools that rewrite host state; stdio MCP exits on stdin EOF/broken pipe so orphaned sessions release locks; daemon jobs refused the palace lock are deferred instead of failed permanently. (#2126, #2103, #2101, #2072, #2029, #2014)
 - **Entity-candidate extraction no longer hangs on long ASCII runs** (base64, minified blobs) while preserving CJK/non-ASCII text. (#2127, #2065, #2063)
 - **Mining windowing rejects `chunk_overlap` above half the chunk size**, stopping infinite chunk_text loops. (#2056, #2058)
+- **`docker-compose.yml` is valid again.** The `environment:` key was declared with only comments beneath it, which YAML parses as null, so Compose rejected the whole file (`services.mcp.environment must be a mapping`) — every documented Compose command failed before starting. The key is commented out along with its examples, which now use mapping syntax so uncommenting them yields a valid block. (#2188)
 
 ### Documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,12 +21,15 @@ services:
     tty: false
     volumes:
       - mempalace-data:/data
-    environment:
-      # Everything defaults correctly from HOME=/data (palace ->
-      # /data/.mempalace/palace, config -> /data/.mempalace, model cache ->
-      # /data/.cache). Override here only for non-default locations, e.g.:
-      # - MEMPALACE_EMBEDDING_MODEL=embeddinggemma   # multilingual (default: minilm)
-      # - MEMPALACE_PALACE_PATH=/data/custom/palace
+    # Everything defaults correctly from HOME=/data (palace ->
+    # /data/.mempalace/palace, config -> /data/.mempalace, model cache ->
+    # /data/.cache), so no environment block is needed. Uncomment the key
+    # *together with* an entry under it for non-default locations — a bare
+    # `environment:` with only comments beneath parses as null, and Compose
+    # rejects the whole file with "services.mcp.environment must be a mapping".
+    # environment:
+    #   MEMPALACE_EMBEDDING_MODEL: embeddinggemma   # multilingual (default: minilm)
+    #   MEMPALACE_PALACE_PATH: /data/custom/palace
 
 volumes:
   mempalace-data:


### PR DESCRIPTION
## The bug

Every documented Compose command fails, on any machine, before anything starts:

```
$ docker compose run --rm mcp cli search "GraphQL"
validating /…/docker-compose.yml: services.mcp.environment must be a mapping
```

`environment:` was declared with nothing but comments under it. YAML parses that as `null`, and Compose rejects the file — so `docker compose build`, `docker compose run`, and `docker compose down` all refuse to do anything. The README points users at this file, and it has never worked.

Reported symptom in #2177 ("no real working isolated docker setup").

## The fix

Comment the key out together with its example entries, and record in the file *why* it cannot be left bare, so the next person adding an override does not reintroduce it. The examples move to mapping syntax, so uncommenting them produces a valid block rather than a list.

## Verification

- `docker compose config` on the shipped file: rejected before, valid after.
- `deploy/docker-compose.server.yml` checked for the same defect — unaffected, validates clean.
- The documented flow, run against an image built from this tree: `docker compose run --rm mcp cli mine …` files a drawer, and a second `docker compose run --rm mcp cli search …` returns it verbatim from the persisted named volume.

## Note

CI builds the Docker image but never runs it, and never validates the Compose files — which is why a file that fails on the first command shipped. A smoke step in `docker-publish.yml` (`compose config` on both files, plus one `docker run` of the built image) would have caught this; happy to send it separately if you want it in 3.7.0 too.