### PR TITLE
docs(readme): lead the Docker section with the published image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Operator write-routing / single-writer recovery notes in `docs/write-routing-policy.md`. (#2079)
 - Remote-server guide wording for read-only tools that change host state. (#2126)
+- **The README's Docker section leads with the published image.** It previously documented only `docker build`, even though `ghcr.io/mempalace/mempalace` ships multi-arch — and a clone builds `develop`, not the release, so a build and a pull could differ silently. It now covers what the omissions actually cost: the MCP client config mounts a transcripts directory (without one the server starts and every mine finds nothing), the first embedding call downloads ~80 MB into `/data` and looks like a hang, bind mounts keep host ownership against the image's uid 1000 so a `0700` directory fails with a bare `PermissionError` on Linux (and `--user` is the wrong fix — `/data` is mode 700 owned by that uid), mining sources can be mounted read-only, and the GPU image is x86_64-only. (#2196)
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -72,39 +72,83 @@ pip install mempalace
 ### Docker
 
 A container image is also available for running the MCP server or the CLI
-without a local Python toolchain. Everything persists under `/data` (palace,
-config, and the cached embedding model), so mount a volume there.
+without a local Python toolchain. Multi-arch (amd64 + arm64), so it runs
+natively on Apple Silicon:
 
 ```bash
-# Build the image (CPU; bundles the `extract` + `spellcheck` extras)
-docker build -t mempalace .
-
-# MCP server over stdio — note the `-i` flag (JSON-RPC needs stdin)
-docker run -i --rm -v mempalace-data:/data mempalace
-
-# Run any CLI command instead (mount the host directory you want to mine)
-docker run --rm -v mempalace-data:/data -v /path/to/project:/work mempalace mine /work
-docker run --rm -v mempalace-data:/data mempalace search "why GraphQL"
+docker pull ghcr.io/mempalace/mempalace:latest
 ```
 
-Wire it into an MCP client (e.g. Claude Code) as a stdio server:
+Everything persists under `/data` — palace, config, and the cached embedding
+model — so mount a volume there and reuse it across runs:
+
+```bash
+# MCP server over stdio — note the `-i` flag (JSON-RPC needs stdin)
+docker run -i --rm -v mempalace-data:/data ghcr.io/mempalace/mempalace
+
+# Run any CLI command instead. The container only sees what you mount, so
+# mount the directory you want to mine — read-only is enough, mining never
+# writes to the source.
+docker run --rm -v mempalace-data:/data -v /path/to/project:/work:ro \
+  ghcr.io/mempalace/mempalace mine /work
+docker run --rm -v mempalace-data:/data ghcr.io/mempalace/mempalace search "why GraphQL"
+```
+
+The first command that needs embeddings downloads the model into `/data`
+(~80 MB for the default `minilm`, ~300 MB for `embeddinggemma`). It is a
+one-off as long as the volume persists, but it does mean the first call is
+slow and needs network — worth knowing before assuming a hung container.
+
+Wire it into an MCP client (e.g. Claude Code) as a stdio server. Mount
+anything you want the server to be able to mine — it cannot reach your
+transcripts otherwise:
 
 ```json
 {
   "mcpServers": {
     "mempalace": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "-v", "mempalace-data:/data", "mempalace"]
+      "args": [
+        "run", "-i", "--rm",
+        "-v", "mempalace-data:/data",
+        "-v", "/absolute/path/to/.claude/projects:/transcripts:ro",
+        "ghcr.io/mempalace/mempalace"
+      ]
     }
   }
 }
 ```
 
-`docker compose run --rm mcp` works too (see `docker-compose.yml`). For
-CUDA-accelerated embeddings, build the GPU variant with
-`docker build -f Dockerfile.gpu -t mempalace:gpu .` and run it with
-`--gpus all`. Customise the bundled extras at build time, e.g.
-`docker build --build-arg EXTRAS="extract,spellcheck" -t mempalace .`.
+Use a real absolute path there — `~` and `$HOME` are not expanded by every
+MCP client. Paths are container paths from then on: mine `/transcripts`, not
+`~/.claude/projects`.
+
+**Mount permissions on Linux.** The image runs as uid 1000 and bind mounts
+keep their host ownership, so a mounted directory has to be readable by that
+uid — an ordinary `0755` checkout is fine, a `0700` directory is not, and the
+failure surfaces as `PermissionError: [Errno 13]` rather than anything about
+Docker. Docker Desktop maps uids on macOS and Windows, so this only bites on
+Linux. Do **not** work around it with `--user`: `/data` is owned by uid 1000
+inside the image, so another uid cannot write the palace at all.
+
+`docker compose run --rm mcp` works too (see `docker-compose.yml`), and
+`deploy/docker-compose.server.yml` stands up the team server. To build the
+image yourself instead of pulling — required for the GPU variant, which is not
+published:
+
+```bash
+docker build -t mempalace .                                  # CPU
+docker build --build-arg EXTRAS="extract,spellcheck" -t mempalace .
+docker build -f Dockerfile.gpu -t mempalace:gpu .            # CUDA; run with --gpus all
+```
+
+The GPU image is x86_64-only: `onnxruntime-gpu` publishes no aarch64 Linux
+wheels, so that last build fails on an ARM host (including Apple Silicon) with
+a dependency-resolution error rather than an obvious one.
+
+Note that a build from a clone uses whatever branch you checked out; `develop`
+is the default branch, so pull the published image if you want the released
+version.
 
 ## Storage backends
 


### PR DESCRIPTION
Last piece of the #2177 follow-up, after #2187, #2188, #2189 and making the GHCR package public.

## Why

The section only documented `docker build`, so every reader compiled locally even though the image is published multi-arch. And a clone builds `develop` — the default branch — not the release, so a build and a pull can hand you different versions with nothing saying so.

Beyond that it omitted the things that actually cost people time. All of these are verified below, not guessed.

## What changed

- **Leads with `docker pull ghcr.io/mempalace/mempalace:latest`**; building moved to the end, where it belongs (still required for the GPU variant, which is not published).
- **The MCP client config now mounts a transcripts directory.** The old snippet mounted only the data volume, so the server started fine, the agent called `mempalace_mine`, and there was nothing there. Notes that paths are container paths from then on, and that `~` / `$HOME` are not expanded by every MCP client.
- **First-run model download** (~80 MB minilm, ~300 MB embeddinggemma) into `/data` — it reads as a hung container otherwise.
- **Linux bind-mount permissions.** The image runs as uid 1000 and bind mounts keep host ownership, so a `0700` directory fails with a bare `PermissionError: [Errno 13]`. Docker Desktop maps uids on macOS/Windows, which is why this is invisible to most of us — our own CI hit it in #2189. `--user` is explicitly called out as the *wrong* fix.
- **Examples mount the source `:ro`**, since mining never writes to it.
- **The GPU image is x86_64-only.**

## Verification

Every command in the new section was run as written, against the published image on a fresh volume: `pull` → `mine /work:ro` files a drawer → `search` returns it verbatim from a separate container → the MCP `args` array, verbatim, completes an `initialize` handshake. The untagged `ghcr.io/mempalace/mempalace` form used in the examples resolves correctly.

Claims checked rather than assumed:

| claim | how |
|---|---|
| `/data` is uid 1000, mode 700 | `stat` inside the image |
| `--user` is the wrong fix | `--user 1234:1234` fails on a **fresh** volume, not just an existing one |
| read-only source mount suffices | mined + read back verbatim through `:ro` |
| transcripts mount enables convo mining | synthetic transcript mounted `:ro`, `mine --mode convos` filed and returned it |
| a clone builds `develop`, not the release | local build reports 3.7.0; published image reports 3.6.0 |
| GPU image is x86_64-only | `Dockerfile.gpu` build reproduced failing on aarch64: `onnxruntime-gpu (v1.25.0) only has wheels for manylinux_2_27_x86_64, manylinux_2_28_x86_64, win_amd64` |

`tests/test_readme_claims.py`: 42 passed.

## Not included

`website/guide/` still has no `docker.md` — the docs site covers Antigravity, Cursor, OpenClaw and others, but not Docker, so this README section remains the only Docker documentation. Separate PR if you want it.