### PR TITLE
fix(extractor): ignore markdown emphasis as emotion

### DIFF
--- a/mempalace/general_extractor.py
+++ b/mempalace/general_extractor.py
@@ -159,7 +159,6 @@ EMOTION_MARKERS = [
     r"i need",
     r"never told anyone",
     r"nobody knows",
-    r"\*[^*]+\*",
 ]
 
 ALL_MARKERS = {

--- a/tests/test_general_extractor.py
+++ b/tests/test_general_extractor.py
@@ -310,3 +310,29 @@ def test_extract_memories_chunk_index_contiguous_across_segments():
     assert indices == list(range(len(memories))), (
         f"chunk_index must be 0..N-1 sequential; got {indices}"
     )
+
+
+def test_markdown_emphasis_does_not_score_as_emotional():
+    """Markdown formatting syntax must not count as emotional content."""
+    text = (
+        "**Key reasons:** transactional guarantees and mature tooling. "
+        "The rollout plan is documented under **Migration notes**."
+    )
+
+    score, _ = _score_markers(text, ALL_MARKERS["emotional"])
+
+    assert score == 0.0
+
+
+def test_markdown_bold_does_not_override_decision_classification():
+    """Markdown-heavy technical prose must not outrank a real decision marker."""
+    text = (
+        "We decided to use PostgreSQL for the new service. "
+        "**Key reasons:** transactional guarantees and mature tooling. "
+        "The rollout details are documented under **Migration notes**."
+    )
+
+    memories = extract_memories(text, min_confidence=0.1)
+
+    assert len(memories) == 1
+    assert memories[0]["memory_type"] == "decision"


### PR DESCRIPTION
## Summary

Remove the `r"\*[^*]+\*"` entry from `EMOTION_MARKERS` in `general_extractor.py`.

That regex matches Markdown formatting syntax rather than emotional content, so Markdown-heavy technical prose can accumulate enough `emotional` hits to outrank real decision/problem/milestone markers.

## Reproduction

Added two regression tests:

- Markdown emphasis/bold alone must score `0.0` against `EMOTION_MARKERS`.
- Markdown-heavy technical prose containing a real decision marker must classify as `decision`, not `emotional`.

Before the production change:

- `2 failed, 30 passed`
- two `**bold**` spans produced an `emotional` score of `3.0`
- the decision example was misclassified as `emotional`

The `3.0` score is worth calling out: the regex does not only match the two formatted spans; it can also bridge between adjacent `*` delimiters across ordinary text, making the false-positive behavior even broader than a one-hit-per-span interpretation.

## Fix

Delete only the Markdown asterisk marker from `EMOTION_MARKERS`. No other emotional markers or scoring behavior are changed.

## Verification

- focused extractor suite: `32 passed`
- extractor + convo miner regression suites: `122 passed, 3 skipped`
- `ruff check`: clean
- `ruff format --check`: clean
- `git diff --check`: clean

Fixes #2197