### PR TITLE
fix(deploy): survive the MCP idle watchdog exit in the systemd unit

### DIFF
--- a/deploy/mempalace-server.service
+++ b/deploy/mempalace-server.service
@@ -24,7 +24,10 @@ User=mempalace
 Group=mempalace
 EnvironmentFile=/etc/mempalace/server.env
 ExecStart=mempalace serve --host 0.0.0.0 --port 8765
-Restart=on-failure
+# The idle watchdog exits with status 0, which on-failure reads as an
+# intentional stop, so the server would stay down. server.env disables the
+# watchdog; Restart=always covers a deployment that has not set it.
+Restart=always
 RestartSec=2
 
 # --- Hardening ---------------------------------------------------------------

--- a/deploy/server.env.example
+++ b/deploy/server.env.example
@@ -23,6 +23,13 @@ MEMPALACE_EMBEDDING_DEVICE=auto
 # MEMPALACE_MCP_TLS_CERT=/etc/mempalace/tls/cert.pem
 # MEMPALACE_MCP_TLS_KEY=/etc/mempalace/tls/key.pem
 
+# --- Server lifecycle -----------------------------------------------------------
+# The MCP server exits by itself after this many idle hours (default 8) to free
+# the ChromaDB/HNSW file handles that per-session stdio servers leave behind.
+# A dedicated always-on server does not need that, so 0 disables it. Note that
+# /healthz traffic does not count as activity; only MCP requests reset the timer.
+MEMPALACE_MCP_IDLE_HOURS=0
+
 # --- Palace location (systemd / bare-metal) -------------------------------------
 # In Docker the palace lives on the mempalace-data volume by default.
 # MEMPALACE_PALACE_PATH=/var/lib/mempalace/palace


### PR DESCRIPTION
## What does this PR do?

The idle watchdog terminates the MCP server with `os._exit(0)`. systemd does not restart a unit that exits 0 when the policy is `Restart=on-failure`, so a server installed from `deploy/mempalace-server.service` stops for good after the idle timeout rather than restarting.

This switches the unit to `Restart=always` and sets `MEMPALACE_MCP_IDLE_HOURS=0` in `deploy/server.env.example`. Both, deliberately. Disabling the watchdog is the correct default for this deployment shape, since a dedicated always-on server is not the per-session stdio case it was added for in #1552, and `Restart=always` still covers an existing installation whose env file predates this change.

Closes #2201.

The issue also raises a broader question that this PR intentionally leaves alone: whether `_run_http_loop` should arm the watchdog at all, given the stated purpose is reaping per-session stdio servers. That is a change in the core rather than in the deployment templates, so I asked there first instead of bundling it here.

## How to test

The default timeout is 8 hours, so shorten it. On a host running the unit, set `MEMPALACE_MCP_IDLE_HOURS=0.02` in `/etc/mempalace/server.env`, run `systemctl restart mempalace-server`, and leave it with no MCP requests for about 90 seconds. Polling `/healthz` does not count as activity, so it will not keep the timer alive.

Before this change the unit reaches `inactive (dead)` with result `success`, and does not come back. With `Restart=always` the process returns within `RestartSec=2`. With the env template unchanged from this PR, the watchdog never arms in the first place.

`systemd-analyze verify deploy/mempalace-server.service` will confirm the unit still parses.

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

On the first box, I did not run the suite and would rather say so than tick it. This changes only `deploy/mempalace-server.service` and `deploy/server.env.example`, no Python, and `grep -rln 'deploy/\|mempalace-server.service\|server.env' tests/` returns nothing, so no test reads either file. `ruff check .` passes on the branch. Happy to run the full suite if you would like it on the record.
