### PR TITLE
docs: document MEMPALACE_MCP_IDLE_HOURS

### DIFF
--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -172,3 +172,4 @@ python -m mempalace.mcp_server --palace /custom/palace
 | `MEMPAL_DIR` | Directory for auto-mining in hooks |
 | `MEMPALACE_MAX_BACKUPS` | Override `max_backups` retention count (`0` disables pruning) |
 | `MEMPALACE_BACKEND` | Select the storage backend (default `chroma`) — see [Storage backends](#storage-backends) for each backend's connection variables |
+| `MEMPALACE_MCP_IDLE_HOURS` | Hours with no MCP request before the server exits by itself (default `8`; `0` disables). See [Remote server](/guide/remote-server#operating-notes) |

--- a/website/guide/remote-server.md
+++ b/website/guide/remote-server.md
@@ -202,7 +202,15 @@ messages between machines.
   server state, `GET /statusz` returns JSON with version, uptime, request
   counters, SQLite integrity, writer mode, and recent observed MCP clients.
   `/statusz` follows the bearer-token policy because it exposes operational
-  metadata; it is not a public liveness probe.
+  metadata; it is not a public liveness probe. Probe traffic does **not**
+  count as activity for the idle watchdog below; only MCP requests do.
+- **Idle shutdown**: the server exits by itself once `MEMPALACE_MCP_IDLE_HOURS`
+  have passed with no MCP request (default `8`). That default is there to reap
+  the per-session stdio servers that would otherwise pile up holding ChromaDB
+  and HNSW file handles, which is not the case a dedicated always-on server is
+  in. Set `MEMPALACE_MCP_IDLE_HOURS=0` to disable it, and make sure your
+  supervisor restarts on a *clean* exit (`Restart=always` rather than
+  `Restart=on-failure`), because the watchdog exits `0`.
 - **Fronting proxies (Tailscale, nginx)**: the recommended personal-fleet
   setup is a loopback bind behind a tailnet-only proxy — nothing touches the
   physical LAN and the tailnet provides encryption plus device identity:


### PR DESCRIPTION
## What does this PR do?

Documents `MEMPALACE_MCP_IDLE_HOURS`, which decides whether a long-lived server is still running tomorrow and appeared in no markdown in the repo.

Two changes. `website/guide/configuration.md` gains a row in the Environment Variables table. `website/guide/remote-server.md` gains an idle shutdown entry in the operating notes, covering the 8 hour default, that `0` disables it, and the part that is easiest to get wrong: the watchdog exits `0`, so a supervisor set to restart only on failure will leave the server down.

It also adds one clause to the existing health check entry. `/healthz` is recommended there as a load balancer or Kubernetes liveness probe, but probe traffic does not reset the idle timer, because `_last_request_time` is assigned only in `handle_request` and `do_GET` answers `/healthz` before reaching it. Without that clause an operator can reasonably read the current text as meaning a probed server stays alive.

Closes #2202.

## How to test

Prose only, so reading it is the test. `npm run docs:dev` in `website/` renders both pages; the new table row and the operating notes entry should read cleanly, and the `/guide/remote-server#operating-notes` link from the configuration table should resolve to the right anchor.

## Checklist
- [ ] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

On the first box, I did not run the suite. This changes only `website/guide/configuration.md` and `website/guide/remote-server.md`. The one test that reads the docs tree, `tests/test_readme_claims.py`, is scoped to `website/reference/mcp-tools.md` and `website/reference/modules.md`, so it does not cover either file. `ruff check .` passes on the branch. Glad to run the suite if you would prefer it recorded.
