### PR TITLE
fix(hooks): derive wing from project, not the git-worktree dir

### DIFF
--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -1226,6 +1226,12 @@ def _wing_from_jsonl_cwd(transcript_path: str) -> Optional[str]:
                 cwd_norm = cwd.replace("\\", "/").rstrip("/")
                 if not cwd_norm:
                     continue
+                # A cwd inside "<project>/.claude/worktrees/<wt>" (a git
+                # worktree) belongs to <project>, not the ephemeral worktree
+                # directory -- otherwise every worktree spawns its own wing.
+                _wt_marker = "/.claude/worktrees/"
+                if _wt_marker in cwd_norm:
+                    cwd_norm = cwd_norm.split(_wt_marker, 1)[0]
                 project = cwd_norm.rsplit("/", 1)[-1]
                 if project:
                     return f"wing_{_safe_wing_slug(project)}"


### PR DESCRIPTION
### Problem
`_wing_from_jsonl_cwd` derives the wing name from the **leaf segment** of the
transcript's `cwd`:
```python
cwd_norm = cwd.replace("\\", "/").rstrip("/")
project  = cwd_norm.rsplit("/", 1)[-1]
return f"wing_{_safe_wing_slug(project)}"
```
When Claude Code runs inside a **git worktree**, `cwd` is
`<project>/.claude/worktrees/<wt>`. The leaf is then `<wt>` (the ephemeral
worktree name), so each worktree mines into its own `wing_<worktree>`. A single
project's memory fragments across throwaway directories, and the wings vanish
in meaning once the worktree is pruned.
### Repro
```
cwd = "/home/me/projects/billtrack/.claude/worktrees/spike-auth"
# current:  wing_spike-auth
# expected: wing_billtrack
```
Any project that uses `git worktree` under `.claude/worktrees/` (a common CC
pattern for parallel tasks) hits this.
### Fix
Strip a trailing `/.claude/worktrees/<wt>` segment before taking the leaf, so
every worktree of a project shares that project's wing. Non-worktree cwds are
unchanged (the marker simply isn't present). 6-line change, no new deps.
Verified locally on real CC transcripts: a billtrack worktree transcript that
previously derived `wing_spike-auth` now derives `wing_billtrack`, and plain
(non-worktree) project transcripts are unaffected.