### PR TITLE
fix(encoding): require local evidence before repairing the ambiguous [ÂÃ] window (#2193)

### DIFF
--- a/mempalace/encoding_repair.py
+++ b/mempalace/encoding_repair.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import unicodedata
 from pathlib import Path
 from typing import Callable, Iterator, Optional, TextIO, Union
 
@@ -79,25 +80,140 @@ _HIGH_CONFIDENCE_RUN = re.compile(
     rf")+"
 )
 
+# A single mojibake unit, so a chained run can be told apart from a lone
+# two-character window.
+_MOJIBAKE_UNIT = re.compile(
+    rf"[ÂÃ][{_CONTINUATION_CLASS}]"
+    rf"|â[{_CONTINUATION_CLASS}]{{2}}"
+    rf"|ð[{_CONTINUATION_CLASS}]{{3}}"
+    rf"|ï[{_CONTINUATION_CLASS}]{{2}}"
+)
+
+# Continuation bytes whose CP1252 character is typographic punctuation that
+# legitimately follows a letter in prose.
+#
+# The [ÂÃ] alternative above is only TWO characters wide, and Portuguese,
+# Vietnamese and Turkish really do end all-caps words in Ã/Â — IRMÃ, MAÇÃ,
+# MANHÃ, AMANHÃ, BÃO, NHÃ, HÂLÂ, IMÂ. Prose then puts a closing quote,
+# guillemet, ellipsis or dash straight after, and every one of those lives in
+# the continuation class. "«MAÇÃ»." and "“IRMÃ”" therefore match a shape that is
+# also perfectly clean text, and repairing them collapses two characters into
+# one — silently, and reported as a success.
+#
+# This is the same argument that already excluded Ä/Å as lead characters, applied
+# to the continuation side. The wider â/ð/ï windows are 3-4 characters and no
+# clean text produces those shapes, so they keep the full class.
+_PROSE_PUNCTUATION = frozenset(
+    _cp1252_character(byte_value)
+    for byte_value in (
+        0x82,  # ‚ single low-9 quotation mark
+        0x84,  # „ double low-9 quotation mark
+        0x85,  # … horizontal ellipsis
+        0x8B,  # ‹ single left-pointing angle quotation mark
+        0x91,  # ' left single quotation mark
+        0x92,  # ' right single quotation mark
+        0x93,  # " left double quotation mark
+        0x94,  # " right double quotation mark
+        0x95,  # • bullet
+        0x96,  # – en dash
+        0x97,  # — em dash
+        0x9B,  # › single right-pointing angle quotation mark
+        0xAB,  # « left-pointing double angle quotation mark
+        0xBB,  # » right-pointing double angle quotation mark
+    )
+)
+
+
+def _is_text_character(
+    character: str,
+) -> bool:
+    """Reject decode products that are invisible control characters.
+
+    Â followed by 0x80-0x9F decodes to exactly the C1 control block, so
+    "İMÂ… edildi." becomes "İM\\u0085 edildi." — visible text swapped for an
+    invisible control and reported as a repair. Natural text contains no C1
+    controls, so refusing these costs nothing.
+
+    Cf (format) stays allowed: U+FEFF is the legitimate product of the "ï»¿"
+    BOM run and U+200D joins emoji sequences.
+    """
+    if character in "\t\n\r":
+        return True
+
+    return unicodedata.category(character) not in {
+        "Cc",
+        "Cs",
+        "Cn",
+    }
+
+
+def _is_ambiguous_window(
+    candidate: str,
+) -> bool:
+    """True for the one shape clean prose can also produce.
+
+    A lone [ÂÃ] followed by prose punctuation. Chained units ("aÃ§Ã£o") and the
+    3-4 character â/ð/ï windows cannot occur in clean text, so they stay
+    unconditional.
+    """
+    units = _MOJIBAKE_UNIT.findall(candidate) or [candidate]
+
+    if len(units) > 1 or units[0][0] not in "ÂÃ":
+        return False
+
+    return units[0][1] in _PROSE_PUNCTUATION
+
+
+def _preceded_by_lowercase(
+    text: str,
+    start: int,
+) -> bool:
+    """Evidence that the run is mojibake rather than clean prose.
+
+    Mojibaked letters sit INSIDE a word, so a lowercase letter runs straight into
+    the lead: "coÃ»te", "NoÃ«l", "catalàÂ»". The false-positive family is the
+    exact opposite — an ALL-CAPS word whose final letter genuinely is Ã/Â, as in
+    IRMÃ”, MAÇÃ», MANHÃ…, HÂLÂ», IMÂ». Clean prose does not put a lowercase
+    letter directly before an uppercase Ã/Â.
+
+    Deliberately local. Inferring "this drawer is mojibake" from a run elsewhere
+    in the text destroys clean prose in a MIXED drawer, and drawers are mixed by
+    construction because the miner concatenates several sources into one.
+    """
+    return start > 0 and text[start - 1].isalpha() and text[start - 1].islower()
+
 
 def _decode_high_confidence_run(
     match: re.Match,
+    text: str,
 ) -> str:
     candidate = match.group(0)
 
     try:
-        return _encode_mojibake_candidate(candidate).decode("utf-8")
+        decoded = _encode_mojibake_candidate(candidate).decode("utf-8")
     except (
         UnicodeEncodeError,
         UnicodeDecodeError,
     ):
         return candidate
 
+    if not decoded or not all(_is_text_character(character) for character in decoded):
+        return candidate
+
+    # An ambiguous window is repaired only on positive local evidence. With no
+    # evidence the text is returned untouched: a missed repair costs nothing
+    # because the drawer is unchanged and the tool can be re-run, while a wrong
+    # repair destroys good text irrecoverably.
+    if _is_ambiguous_window(candidate) and not _preceded_by_lowercase(text, match.start()):
+        return candidate
+
+    return decoded
+
 
 def repair_mojibake_once(text: str) -> str:
     """Repair one layer of high-confidence UTF-8-as-CP1252 mojibake."""
     return _HIGH_CONFIDENCE_RUN.sub(
-        _decode_high_confidence_run,
+        lambda match: _decode_high_confidence_run(match, text),
         text,
     )
 

--- a/tests/test_encoding_repair.py
+++ b/tests/test_encoding_repair.py
@@ -1,12 +1,14 @@
 import json
 import os
 import stat
+import unicodedata
 
 import pytest
 
 from mempalace.encoding_repair import (
     repair_collection,
     repair_mojibake,
+    repair_mojibake_once,
     restore_collection,
 )
 
@@ -102,6 +104,56 @@ AMBIGUOUS_CASES = [
 ]
 
 
+# An UPPERCASE Ã/Â ending a word, followed by ordinary typographic punctuation.
+# Portuguese, Vietnamese and Turkish produce this constantly, and it matches the
+# same two-character shape as mojibake — so it must survive untouched (#2193).
+CLEAN_UPPERCASE_LEAD = [
+    "“IRMÃ” é o título do filme.",
+    "«MAÇÃ».",
+    "O prémio «AMANHÃ» foi entregue.",
+    "MANHÃ… tarde e noite.",
+    "A palavra “LÃ” significa wool.",
+    "TÍTULO: “A IRMÃ”, de 1998.",
+    "IRMÃ–MÃE: a relação central.",
+    "NÃO! disse a IRMÃ.",
+    "BÃO số 5 đổ bộ.",
+    "“NHÃ”: nghĩa là nhà.",
+    "“HÂLÂ” bekliyoruz.",
+    "İMÂ… edildi.",
+    "HÂLÂ—yine de.",
+    "HÂLÂ» ve zarar.",
+    "IMÂ« edildi.",
+    "IRMÃ”, MAÇÃ» e MANHÃ… juntas.",
+]
+
+
+# A single drawer holding genuine mojibake AND clean prose. The miner
+# concatenates several sources into one drawer, so this is the normal case, not
+# a corner case: repairing the damaged half must not corrupt the clean half.
+MIXED_DRAWERS = [
+    (
+        "cafÃ© e «MAÇÃ».",
+        "café e «MAÇÃ».",
+    ),
+    (
+        "MÃ¼nchen. A IRMÃ” chegou.",
+        "München. A IRMÃ” chegou.",
+    ),
+    (
+        "EspaÃ±a e MANHÃ… fria.",
+        "España e MANHÃ… fria.",
+    ),
+    (
+        "aÃ§Ã£o «AMANHÃ» hoje.",
+        "ação «AMANHÃ» hoje.",
+    ),
+    (
+        "Copyright Â© 2026 — IRMÃ” Ltda.",
+        "Copyright © 2026 — IRMÃ” Ltda.",
+    ),
+]
+
+
 @pytest.mark.parametrize(
     "text",
     CLEAN_MULTILINGUAL,
@@ -140,6 +192,88 @@ def test_repair_is_idempotent():
     repaired = repair_mojibake("cafÃ© â†’ done")
 
     assert repair_mojibake(repaired) == repaired
+
+
+@pytest.mark.parametrize(
+    "text",
+    CLEAN_UPPERCASE_LEAD,
+)
+def test_preserves_clean_uppercase_lead_prose(
+    text,
+):
+    """An all-caps word ending in Ã/Â is prose, not mojibake (#2193)."""
+    assert repair_mojibake(text) == text
+
+
+@pytest.mark.parametrize(
+    (
+        "damaged",
+        "expected",
+    ),
+    MIXED_DRAWERS,
+)
+def test_repairs_damaged_half_without_corrupting_clean_half(
+    damaged,
+    expected,
+):
+    """Corroboration must stay local: one damaged run does not condemn the drawer."""
+    assert repair_mojibake(damaged) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    CLEAN_UPPERCASE_LEAD + CLEAN_MULTILINGUAL,
+)
+def test_repair_never_emits_control_characters(
+    text,
+):
+    """ "İMÂ… edildi." must not become "İM\\u0085 edildi." — visible text for a control."""
+    repaired = repair_mojibake(text)
+
+    assert not [
+        character
+        for character in repaired
+        if unicodedata.category(character) == "Cc" and character not in "\t\n\r"
+    ]
+
+
+def test_repair_does_not_destroy_its_own_correct_output():
+    """The multi-pass loop repaired correctly on pass 1 and corrupted on pass 2 (#2193)."""
+    clean = "“IRMÃ” é o título."
+    damaged = "".join(
+        chr(byte_value)
+        if byte_value in (0x81, 0x8D, 0x8F, 0x90, 0x9D)
+        else bytes([byte_value]).decode("cp1252")
+        for byte_value in clean.encode("utf-8")
+    )
+
+    first_pass = repair_mojibake_once(damaged)
+
+    assert first_pass == clean
+    assert repair_mojibake_once(first_pass) == clean
+    assert repair_mojibake(damaged) == clean
+
+
+@pytest.mark.parametrize(
+    (
+        "damaged",
+        "expected",
+    ),
+    [
+        ("coÃ»te", "coûte"),
+        ("NoÃ«l", "Noël"),
+        ("brÃ»lÃ©e", "brûlée"),
+        # NBSP is the continuation byte for à, so the guillemet run chains onto
+        # it and is repaired as part of a multi-unit run.
+        ("catalÃ Â»", "català»"),
+    ],
+)
+def test_still_repairs_ambiguous_window_with_local_evidence(
+    damaged,
+    expected,
+):
+    """A lowercase letter running into the lead proves corruption — repair it."""
+    assert repair_mojibake(damaged) == expected
 
 
 def test_rejects_invalid_max_passes():


### PR DESCRIPTION
## What and Why

`repair_mojibake` rewrites text that was never damaged, and reports it as a successful repair. Anyone who has run `mempalace repair-encoding --apply` on a palace containing Portuguese, Vietnamese or Turkish prose has lost characters.

```
"«MAÇÃ»."           ->  "«MAÇû."          two characters collapsed into one
"“IRMÃ”"            ->  "“IRMÔ"
"İMÂ… edildi."      ->  "İM edildi." visible text replaced by an invisible control
```

## Root Cause

`encoding_repair.py` — the first alternative of `_HIGH_CONFIDENCE_RUN` is a **two-character** window:

```python
rf"[ÂÃ][{_CONTINUATION_CLASS}]"
```

Portuguese, Vietnamese and Turkish end all-caps words in Ã/Â — `IRMÃ`, `MAÇÃ`, `MANHÃ`, `AMANHÃ`, `BÃO`, `NHÃ`, `HÂLÂ`, `IMÂ`. Prose then puts a closing quote, guillemet, ellipsis or dash straight after, and **all 14 of those characters are inside `_CONTINUATION_CLASS`** (CP1252 bytes 0x80–0xBF). So clean text matches the same shape as mojibake, decodes as UTF-8, and two characters become one.

Three distinct failures share this root cause:

1. **Clean text destroyed** — the cases above.
2. **Visible text replaced by invisible controls.** `Â` + 0x80–0x9F decodes to exactly the C1 control block, so the repair swaps a character you can see for one you cannot.
3. **Not idempotent.** `repair_mojibake` runs up to `max_passes=3`. Genuinely mojibaked Portuguese is repaired *correctly* on pass 1 and then destroyed on pass 2:

```
damaged : â€œIRMÃƒâ€ Ã© o tÃ­tulo.
pass 1  : “IRMÃ” é o título.     <- correct
pass 2  : “IRMÔ é o título.      <- destroys its own correct output
```

The existing test corpus never caught this because every clean string in it puts `Ã` before a **letter** (`CORAÇÃO`, `São`) and never before punctuation.

## The Fix

This follows the precedent already in the file. `Ä`/`Å` were excluded as leads with the comment *"strings such as Å² can be legitimate scientific text"* — the identical argument, applied to the continuation side.

A **lone** `[ÂÃ]` window ending in typographic punctuation is no longer treated as high-confidence. It is repaired only when a lowercase letter runs directly into the lead — which is where mojibake actually occurs, *inside* a word:

| | |
|---|---|
| `coÃ»te`, `NoÃ«l` | lowercase before the lead → **repaired** |
| `IRMÃ”`, `MAÇÃ»`, `HÂLÂ»` | all-caps word boundary → **left alone** |

Unaffected: chained units (`aÃ§Ã£o`, `CORAÃ‡ÃƒO`) and the 3–4 character `â`/`ð`/`ï` windows, which no clean text can produce. Separately, a decode product containing a C0/C1 control is now always refused — that costs nothing, since natural text contains no C1 controls.

**Corroboration is deliberately local.** Four different approaches I tried inferred "this drawer is mojibake" from a run found elsewhere in the same text, and every one of them then destroyed clean prose in a **mixed** drawer. Drawers are mixed by construction — the miner concatenates several sources into one — so `cafÃ© e «MAÇÃ».` must repair the first half and preserve the second.

## Test Plan

- [x] 23 new assertions, verified **RED before the fix / GREEN after** (`git stash` on the module, tests kept)
- [x] `tests/test_encoding_repair.py`: 70 passed
- [x] Full suite: **3929 passed, 31 skipped**
- [x] `ruff format --check .` + `ruff check .` clean (212 files)
- [x] Exhaustive sweep: **14,040** generated clean strings — every `Ã`/`Â`-final word × 13 prose punctuation marks × 6 quote wrappers × 9 sentence frames — **0 false positives**
- [x] Idempotence checked on every corpus string: `repair(repair(x)) == repair(x)`

Tests added: clean uppercase-lead prose (16 cases across pt/vi/tr), mixed drawers (5), never-emit-control-characters, does-not-destroy-its-own-output, and a guard that evidence-backed repairs still work.

> One unrelated flake: `test_antigravity_hooks_shell.py::test_save_hook_rejects_non_jsonl_transcript_path` failed on one full-suite run (that run took 338s vs 115s — the machine was loaded and the test spawns subprocesses). It passes in isolation and in its own file on **both** this branch and clean `develop`, and the full suite is green on re-run. Not related to this change, but reporting it rather than hiding it.

## What this deliberately gives up

Measured against `develop` on a 30-string multilingual corpus: **21/30 repairs are unchanged, 6 are given up, and 0 clean strings that `develop` preserved are corrupted by this change.**

The 6 are words whose accented capital is **word-initial**, so there is no lowercase letter to corroborate:

```
Österreich · Übermäßig süß — Öl und Äpfel. · Smörgåsbord, Ångström and Øresund.
La canción «PERÚ» abre el disco. · L'Àngels diu: «això és català». · HÂLÂ bekliyoruz.
```

I chose this knowingly, because **the costs are asymmetric**: a missed repair leaves the drawer byte-identical and it can be repaired again later by a smarter rule, while a wrong repair silently destroys good text and is not recoverable from the result. For a tool whose own commit history says *"make repair conservative and reversible"*, refusing an ambiguous case is the correct default.

If you would rather recover some of those, the natural follow-up is a second evidence source (word-initial runs followed by lowercase). I prototyped it and **rejected it**: it reintroduced 180 false positives in the sweep above, which is exactly the trade this PR exists to refuse.

Closes #2193
