### PR TITLE
fix: stream JSONL transcript normalization

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -28,7 +28,7 @@ from .ids import (
     make_convo_sentinel_id,
     make_exchange_drawer_id,
 )
-from .normalize import MAX_STREAMING_JSONL_FILE_SIZE, normalize_conversations
+from .normalize import normalize_conversations
 from .entities import entities_metadata
 from .palace import (
     NORMALIZE_VERSION,
@@ -166,15 +166,9 @@ _LINE_GROUP_SIZE = 25  # lines per fallback group when no paragraph breaks
 _LINE_FALLBACK_MIN_NEWLINES = 20  # trigger line-group fallback above this newline count
 DRAWER_UPSERT_BATCH_SIZE = 1000
 MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB — skip files larger than this.
-# Matches miner.py for formats that still require whole-file reads. Known
-# JSONL formats use a bounded streaming normalizer and can safely use its
-# larger limit without admitting multi-gigabyte JSON bundles or plain text.
-
-
-def _source_file_size_limit(filepath: Path) -> int:
-    if filepath.suffix.lower() == ".jsonl":
-        return MAX_STREAMING_JSONL_FILE_SIZE
-    return MAX_FILE_SIZE
+# Matches miner.py. Streaming recognized JSONL avoids retaining the complete
+# source string, but normalized conversation text is still materialized before
+# chunking, so every format stays behind the same conservative input cap.
 
 
 def _path_within_root(path: Path, root: Path) -> bool:
@@ -203,7 +197,7 @@ def _is_regular_source_file(filepath: Path, root: Path) -> bool:
                 raise
             fd = os.open(filepath, flags & ~getattr(os, "O_NONBLOCK", 0))
         st = os.fstat(fd)
-        return stat.S_ISREG(st.st_mode) and st.st_size <= _source_file_size_limit(filepath)
+        return stat.S_ISREG(st.st_mode) and st.st_size <= MAX_FILE_SIZE
     except OSError:
         return False
     finally:
@@ -567,7 +561,7 @@ def scan_convos(convo_dir: str, include_subagents: bool = False) -> list:
                         )
                         continue
                     file_size = file_stat.st_size
-                    file_size_limit = _source_file_size_limit(filepath)
+                    file_size_limit = MAX_FILE_SIZE
                     if file_size > file_size_limit:
                         print(
                             f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"
@@ -974,9 +968,12 @@ def _normalize_convo_conversations(
     """
     try:
         conversations = [c for c in normalize_conversations(str(filepath)) if c]
-    except (OSError, ValueError):
-        if not dry_run:
-            _register_file(collection, source_file, wing, agent, extract_mode)
+    except (OSError, ValueError) as exc:
+        # A normalization failure is not an empty, successfully processed
+        # transcript. Registering a sentinel here makes the unchanged source
+        # look permanently mined, so future runs never retry after format,
+        # permission, or size-limit failures.
+        print(f"  SKIP: {filepath.name} (normalize error: {exc})", file=sys.stderr)
         return None
 
     total_len = sum(len(c.strip()) for c in conversations)

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -28,7 +28,7 @@ from .ids import (
     make_convo_sentinel_id,
     make_exchange_drawer_id,
 )
-from .normalize import normalize_conversations
+from .normalize import MAX_STREAMING_JSONL_FILE_SIZE, normalize_conversations
 from .entities import entities_metadata
 from .palace import (
     NORMALIZE_VERSION,
@@ -166,13 +166,15 @@ _LINE_GROUP_SIZE = 25  # lines per fallback group when no paragraph breaks
 _LINE_FALLBACK_MIN_NEWLINES = 20  # trigger line-group fallback above this newline count
 DRAWER_UPSERT_BATCH_SIZE = 1000
 MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB — skip files larger than this.
-# Matches miner.py at 500 MB. Long Claude Code sessions, multi-year
-# ChatGPT exports, and lifetime Slack dumps routinely exceed 10 MB; the
-# cap at that level silently dropped them with `continue`. Per-drawer
-# size is bounded by CHUNK_SIZE, but larger source files still produce
-# more drawers and therefore more embedding/storage work — and content
-# is normalized and loaded fully into memory before chunking, so memory
-# use also scales with source size.
+# Matches miner.py for formats that still require whole-file reads. Known
+# JSONL formats use a bounded streaming normalizer and can safely use its
+# larger limit without admitting multi-gigabyte JSON bundles or plain text.
+
+
+def _source_file_size_limit(filepath: Path) -> int:
+    if filepath.suffix.lower() == ".jsonl":
+        return MAX_STREAMING_JSONL_FILE_SIZE
+    return MAX_FILE_SIZE
 
 
 def _path_within_root(path: Path, root: Path) -> bool:
@@ -201,7 +203,7 @@ def _is_regular_source_file(filepath: Path, root: Path) -> bool:
                 raise
             fd = os.open(filepath, flags & ~getattr(os, "O_NONBLOCK", 0))
         st = os.fstat(fd)
-        return stat.S_ISREG(st.st_mode) and st.st_size <= MAX_FILE_SIZE
+        return stat.S_ISREG(st.st_mode) and st.st_size <= _source_file_size_limit(filepath)
     except OSError:
         return False
     finally:
@@ -565,10 +567,11 @@ def scan_convos(convo_dir: str, include_subagents: bool = False) -> list:
                         )
                         continue
                     file_size = file_stat.st_size
-                    if file_size > MAX_FILE_SIZE:
+                    file_size_limit = _source_file_size_limit(filepath)
+                    if file_size > file_size_limit:
                         print(
                             f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"
-                            f" exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit",
+                            f" exceeds {file_size_limit // (1024 * 1024)} MB limit",
                             file=sys.stderr,
                         )
                         continue

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -24,14 +24,18 @@ import json
 import os
 import re
 import stat
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Iterable, Iterator, Optional, TextIO
 
 # Provenance footer appended to Slack transcript output so downstream consumers
 # know the speaker roles are positionally assigned, not verified.
 _SLACK_PROVENANCE_FOOTER = (
     "\n[source: slack-export | multi-party chat — speaker roles are positional, not verified]"
 )
+
+MAX_IN_MEMORY_FILE_SIZE = 500 * 1024 * 1024
+MAX_STREAMING_JSONL_FILE_SIZE = 2 * 1024 * 1024 * 1024
 
 
 # ─── Noise stripping ─────────────────────────────────────────────────────
@@ -116,11 +120,11 @@ def strip_noise(text: str) -> str:
     return text.strip()
 
 
-def _read_transcript_file(filepath: str) -> str:
-    """Read a transcript source file with the same safety checks normalize()
-    and normalize_conversations() both need: no symlinks, regular files only,
-    size-capped, BOM-tolerant.
-    """
+@contextmanager
+def _open_transcript_file(
+    filepath: str, max_file_size: int = MAX_IN_MEMORY_FILE_SIZE
+) -> Iterator[TextIO]:
+    """Open a transcript source with the shared safety checks applied."""
     # O_NONBLOCK keeps the "not a regular file" check below reachable: a
     # blocking open of a FIFO waits in the kernel for a writer, so the
     # S_ISREG test never runs. See ``miner._read_text_no_follow``, including
@@ -141,12 +145,15 @@ def _read_transcript_file(filepath: str) -> str:
             # Text stays prefix-free: this raise is inside the ``try``, so the
             # ``except OSError`` below composes "Could not read <path>: ...".
             raise IOError("not a regular file")
-        if file_stat.st_size > 500 * 1024 * 1024:  # 500 MB safety limit
+        if file_stat.st_size > max_file_size:
             # Prefix-free for the same reason as the branch above.
-            raise IOError(f"file too large ({file_stat.st_size // (1024 * 1024)} MB)")
+            raise IOError(
+                f"file too large ({file_stat.st_size // (1024 * 1024)} MB; "
+                f"limit {max_file_size // (1024 * 1024)} MB)"
+            )
         with os.fdopen(fd, "r", encoding="utf-8-sig", errors="replace") as f:
             fd = -1
-            return f.read()
+            yield f
     except OSError as e:
         raise IOError(f"Could not read {filepath}: {e}") from e
     finally:
@@ -157,11 +164,23 @@ def _read_transcript_file(filepath: str) -> str:
                 pass
 
 
+def _read_transcript_file(filepath: str) -> str:
+    """Read a validated transcript source into memory."""
+    with _open_transcript_file(filepath) as f:
+        return f.read()
+
+
 def normalize(filepath: str) -> str:
     """
     Load a file and normalize to transcript format if it's a chat export.
     Plain text files pass through unchanged.
     """
+    ext = Path(filepath).suffix.lower()
+    if ext == ".jsonl":
+        normalized = _try_normalize_jsonl_file(filepath)
+        if normalized:
+            return normalized
+
     content = _read_transcript_file(filepath)
 
     if not content.strip():
@@ -175,7 +194,6 @@ def normalize(filepath: str) -> str:
     # Try JSON normalization. strip_noise is applied inside the Claude Code
     # JSONL parser (the only format that injects system tags/hook chrome);
     # other formats pass through verbatim.
-    ext = Path(filepath).suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         normalized = _try_normalize_json(content)
         if normalized:
@@ -204,6 +222,12 @@ def normalize_conversations(filepath: str) -> list:
     always normalize to one conversation, so this returns a one-element
     list for those — identical dedup granularity to before.
     """
+    ext = Path(filepath).suffix.lower()
+    if ext == ".jsonl":
+        normalized = _try_normalize_jsonl_file(filepath)
+        if normalized:
+            return [normalized]
+
     content = _read_transcript_file(filepath)
 
     if not content.strip():
@@ -213,7 +237,6 @@ def normalize_conversations(filepath: str) -> list:
     if sum(1 for line in lines if line.strip().startswith(">")) >= 3:
         return [content]
 
-    ext = Path(filepath).suffix.lower()
     if ext in (".json", ".jsonl") or content.strip()[:1] in ("{", "["):
         split = _try_normalize_json_split(content)
         if split:
@@ -278,13 +301,65 @@ def _try_normalize_json_split(content: str) -> Optional[list]:
     return None
 
 
+def _try_normalize_jsonl_file(filepath: str) -> Optional[str]:
+    """Try known JSONL schemas without loading the complete file.
+
+    A bounded preflight selects a parser from the format's required header or
+    message shape, then that parser consumes a fresh validated stream. Unknown
+    JSONL still falls back to the regular read path so plain-text pass-through
+    is unchanged.
+    """
+    with _open_transcript_file(filepath, MAX_STREAMING_JSONL_FILE_SIZE) as lines:
+        parser = _detect_jsonl_line_parser(lines)
+    if parser is None:
+        return None
+    with _open_transcript_file(filepath, MAX_STREAMING_JSONL_FILE_SIZE) as lines:
+        return parser(lines)
+
+
+def _detect_jsonl_line_parser(
+    lines: Iterable[str],
+) -> Optional[Callable[[Iterable[str]], Optional[str]]]:
+    """Select a JSONL parser from at most the first 1,000 records."""
+    for line_number, raw_line in enumerate(lines):
+        if line_number >= 1000:
+            break
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+
+        entry_type = entry.get("type", "")
+        if entry_type == "session_meta":
+            return _try_codex_jsonl_lines
+        if entry_type == "session_metadata":
+            return _try_gemini_jsonl_lines
+        if entry_type == "session" and "version" in entry:
+            return _try_pi_jsonl_lines
+        if entry_type in ("human", "user", "assistant") and isinstance(entry.get("message"), dict):
+            return _try_claude_code_jsonl_lines
+    return None
+
+
 def _try_claude_code_jsonl(content: str) -> Optional[str]:
     """Claude Code JSONL sessions."""
-    lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+    return _try_claude_code_jsonl_lines(content.split("\n"))
+
+
+def _try_claude_code_jsonl_lines(lines: Iterable[str]) -> Optional[str]:
+    """Parse Claude Code JSONL from an iterable of lines."""
     messages = []
     tool_use_map = {}  # tool_use_id → tool_name
 
-    for line in lines:
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
         try:
             entry = json.loads(line)
         except json.JSONDecodeError:
@@ -347,10 +422,17 @@ def _try_codex_jsonl(content: str) -> Optional[str]:
     the canonical conversation turns. response_item entries are skipped because
     they include synthetic context injections and duplicate the real messages.
     """
-    lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+    return _try_codex_jsonl_lines(content.split("\n"))
+
+
+def _try_codex_jsonl_lines(lines: Iterable[str]) -> Optional[str]:
+    """Parse OpenAI Codex CLI JSONL from an iterable of lines."""
     messages = []
     has_session_meta = False
-    for line in lines:
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
         try:
             entry = json.loads(line)
         except json.JSONDecodeError:
@@ -406,10 +488,17 @@ def _try_gemini_jsonl(content: str) -> Optional[str]:
     single message's content array are concatenated in order, separated
     by newlines.
     """
-    lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+    return _try_gemini_jsonl_lines(content.split("\n"))
+
+
+def _try_gemini_jsonl_lines(lines: Iterable[str]) -> Optional[str]:
+    """Parse Gemini CLI JSONL from an iterable of lines."""
     messages = []
     has_session_metadata = False
-    for line in lines:
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
         try:
             entry = json.loads(line)
         except json.JSONDecodeError:
@@ -467,10 +556,17 @@ def _try_pi_jsonl(content: str) -> Optional[str]:
 
     Format documented at github.com/badlogic/pi-mono session.md.
     """
-    lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+    return _try_pi_jsonl_lines(content.split("\n"))
+
+
+def _try_pi_jsonl_lines(lines: Iterable[str]) -> Optional[str]:
+    """Parse Pi agent JSONL from an iterable of lines."""
     messages = []
     has_session_header = False
-    for line in lines:
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
         try:
             entry = json.loads(line)
         except json.JSONDecodeError:

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -35,7 +35,6 @@ _SLACK_PROVENANCE_FOOTER = (
 )
 
 MAX_IN_MEMORY_FILE_SIZE = 500 * 1024 * 1024
-MAX_STREAMING_JSONL_FILE_SIZE = 2 * 1024 * 1024 * 1024
 
 
 # ─── Noise stripping ─────────────────────────────────────────────────────
@@ -309,11 +308,11 @@ def _try_normalize_jsonl_file(filepath: str) -> Optional[str]:
     JSONL still falls back to the regular read path so plain-text pass-through
     is unchanged.
     """
-    with _open_transcript_file(filepath, MAX_STREAMING_JSONL_FILE_SIZE) as lines:
+    with _open_transcript_file(filepath) as lines:
         parser = _detect_jsonl_line_parser(lines)
     if parser is None:
         return None
-    with _open_transcript_file(filepath, MAX_STREAMING_JSONL_FILE_SIZE) as lines:
+    with _open_transcript_file(filepath) as lines:
         return parser(lines)
 
 

--- a/tests/test_convo_miner_size_cap.py
+++ b/tests/test_convo_miner_size_cap.py
@@ -9,10 +9,7 @@ pattern as the project miner's.
 Written BEFORE the fix.
 """
 
-from pathlib import Path
-
-from mempalace.convo_miner import MAX_FILE_SIZE, _source_file_size_limit
-from mempalace.normalize import MAX_STREAMING_JSONL_FILE_SIZE
+from mempalace.convo_miner import MAX_FILE_SIZE
 
 
 class TestConvoMinerSizeCap:
@@ -32,7 +29,3 @@ class TestConvoMinerSizeCap:
             "Raise to at least 100 MB (match miner.py at 500 MB for "
             "consistency across both miners)."
         )
-
-    def test_jsonl_uses_streaming_size_limit(self):
-        assert _source_file_size_limit(Path("session.jsonl")) == MAX_STREAMING_JSONL_FILE_SIZE
-        assert _source_file_size_limit(Path("bundle.json")) == MAX_FILE_SIZE

--- a/tests/test_convo_miner_size_cap.py
+++ b/tests/test_convo_miner_size_cap.py
@@ -9,7 +9,10 @@ pattern as the project miner's.
 Written BEFORE the fix.
 """
 
-from mempalace.convo_miner import MAX_FILE_SIZE
+from pathlib import Path
+
+from mempalace.convo_miner import MAX_FILE_SIZE, _source_file_size_limit
+from mempalace.normalize import MAX_STREAMING_JSONL_FILE_SIZE
 
 
 class TestConvoMinerSizeCap:
@@ -29,3 +32,7 @@ class TestConvoMinerSizeCap:
             "Raise to at least 100 MB (match miner.py at 500 MB for "
             "consistency across both miners)."
         )
+
+    def test_jsonl_uses_streaming_size_limit(self):
+        assert _source_file_size_limit(Path("session.jsonl")) == MAX_STREAMING_JSONL_FILE_SIZE
+        assert _source_file_size_limit(Path("bundle.json")) == MAX_FILE_SIZE

--- a/tests/test_convo_miner_unit.py
+++ b/tests/test_convo_miner_unit.py
@@ -1,6 +1,7 @@
 """Unit tests for convo_miner pure functions (no chromadb needed)."""
 
 import contextlib
+import stat
 import sys
 
 import pytest
@@ -15,6 +16,43 @@ from mempalace.convo_miner import (
     detect_convo_room,
     scan_convos,
 )
+
+
+def test_normalize_failure_is_not_registered_as_mined(tmp_path, monkeypatch, capsys):
+    import mempalace.convo_miner as convo_mod
+    import mempalace.normalize as normalize_mod
+
+    source = tmp_path / "unknown.jsonl"
+    source.write_text('{"type":"future_format"}\n', encoding="utf-8")
+
+    class OversizedRegularFile:
+        st_mode = stat.S_IFREG | 0o644
+        st_size = normalize_mod.MAX_IN_MEMORY_FILE_SIZE + 1
+
+    monkeypatch.setattr(normalize_mod.os, "fstat", lambda _fd: OversizedRegularFile())
+
+    class Collection:
+        def __init__(self):
+            self.upserts = []
+
+        def upsert(self, **kwargs):
+            self.upserts.append(kwargs)
+
+    collection = Collection()
+    result = convo_mod._normalize_convo_conversations(
+        source,
+        str(source),
+        30,
+        collection,
+        "sessions",
+        "codex",
+        "exchange",
+        False,
+    )
+
+    assert result is None
+    assert collection.upserts == []
+    assert "normalize error" in capsys.readouterr().err
 
 
 class TestChunkExchanges:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -3,6 +3,8 @@ import stat
 from unittest.mock import patch
 
 from mempalace.normalize import (
+    MAX_IN_MEMORY_FILE_SIZE,
+    MAX_STREAMING_JSONL_FILE_SIZE,
     _SLACK_PROVENANCE_FOOTER,
     _extract_content,
     _format_tool_result,
@@ -83,6 +85,82 @@ def test_normalize_whitespace_only(tmp_path):
     f.write_text("   \n  \n  ")
     result = normalize(str(f))
     assert result.strip() == ""
+
+
+def test_known_jsonl_formats_bypass_full_file_read(tmp_path):
+    """Known JSONL schemas use the streaming path in both public entry points."""
+    cases = {
+        "claude.jsonl": (
+            _try_claude_code_jsonl,
+            [
+                {"type": "human", "message": {"content": "Q"}},
+                {"type": "assistant", "message": {"content": "A"}},
+            ],
+        ),
+        "codex.jsonl": (
+            _try_codex_jsonl,
+            [
+                {"type": "session_meta", "payload": {}},
+                {"type": "event_msg", "payload": {"type": "user_message", "message": "Q"}},
+                {"type": "event_msg", "payload": {"type": "agent_message", "message": "A"}},
+            ],
+        ),
+        "gemini.jsonl": (
+            _try_gemini_jsonl,
+            [
+                {"type": "session_metadata", "sessionId": "s"},
+                {"type": "user", "content": [{"text": "Q"}]},
+                {"type": "gemini", "content": [{"text": "A"}]},
+            ],
+        ),
+        "pi.jsonl": (
+            _try_pi_jsonl,
+            [
+                {"type": "session", "version": 1},
+                {"type": "message", "message": {"role": "user", "content": "Q"}},
+                {"type": "message", "message": {"role": "assistant", "content": "A"}},
+            ],
+        ),
+    }
+
+    for filename, (parser, entries) in cases.items():
+        content = "\n".join(json.dumps(entry) for entry in entries)
+        source = tmp_path / filename
+        source.write_text(content, encoding="utf-8")
+        expected = parser(content)
+
+        with patch(
+            "mempalace.normalize._read_transcript_file",
+            side_effect=AssertionError("known JSONL must not be read in full"),
+        ):
+            assert normalize(str(source)) == expected
+            assert normalize_conversations(str(source)) == [expected]
+
+
+def test_known_jsonl_can_exceed_in_memory_limit(tmp_path):
+    """The larger safety rail applies only after a known JSONL schema is detected."""
+    source = tmp_path / "codex.jsonl"
+    source.write_text(
+        "\n".join(
+            json.dumps(entry)
+            for entry in (
+                {"type": "session_meta", "payload": {}},
+                {"type": "event_msg", "payload": {"type": "user_message", "message": "Q"}},
+                {"type": "event_msg", "payload": {"type": "agent_message", "message": "A"}},
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    class _LargeRegularFile:
+        st_mode = stat.S_IFREG | 0o644
+        st_size = MAX_IN_MEMORY_FILE_SIZE + 1
+
+    with patch("mempalace.normalize.os.fstat", return_value=_LargeRegularFile()):
+        result = normalize(str(source))
+
+    assert result.startswith("> Q")
+    assert MAX_STREAMING_JSONL_FILE_SIZE > MAX_IN_MEMORY_FILE_SIZE
 
 
 # ── _extract_content ───────────────────────────────────────────────────

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,10 +1,10 @@
 import json
 import stat
+import tracemalloc
 from unittest.mock import patch
 
 from mempalace.normalize import (
     MAX_IN_MEMORY_FILE_SIZE,
-    MAX_STREAMING_JSONL_FILE_SIZE,
     _SLACK_PROVENANCE_FOOTER,
     _extract_content,
     _format_tool_result,
@@ -137,8 +137,8 @@ def test_known_jsonl_formats_bypass_full_file_read(tmp_path):
             assert normalize_conversations(str(source)) == [expected]
 
 
-def test_known_jsonl_can_exceed_in_memory_limit(tmp_path):
-    """The larger safety rail applies only after a known JSONL schema is detected."""
+def test_known_jsonl_cannot_exceed_in_memory_limit(tmp_path):
+    """Streaming input stays capped while normalized output is materialized in memory."""
     source = tmp_path / "codex.jsonl"
     source.write_text(
         "\n".join(
@@ -157,10 +157,57 @@ def test_known_jsonl_can_exceed_in_memory_limit(tmp_path):
         st_size = MAX_IN_MEMORY_FILE_SIZE + 1
 
     with patch("mempalace.normalize.os.fstat", return_value=_LargeRegularFile()):
-        result = normalize(str(source))
+        try:
+            normalize(str(source))
+            assert False, "Should have enforced the shared in-memory input cap"
+        except IOError as exc:
+            assert "too large" in str(exc).lower()
 
-    assert result.startswith("> Q")
-    assert MAX_STREAMING_JSONL_FILE_SIZE > MAX_IN_MEMORY_FILE_SIZE
+
+def test_known_jsonl_peak_memory_does_not_scale_with_ignored_source(tmp_path):
+    """Ignored JSONL records are consumed incrementally, not retained as one source string."""
+    source = tmp_path / "large-codex.jsonl"
+    ignored_line = (
+        json.dumps(
+            {
+                "type": "response_item",
+                "payload": {"type": "reasoning", "text": "x" * 2048},
+            }
+        )
+        + "\n"
+    )
+    with source.open("w", encoding="utf-8") as stream:
+        stream.write(json.dumps({"type": "session_meta", "payload": {}}) + "\n")
+        for _ in range(6144):
+            stream.write(ignored_line)
+        stream.write(
+            json.dumps({"type": "event_msg", "payload": {"type": "user_message", "message": "Q"}})
+            + "\n"
+        )
+        stream.write(
+            json.dumps(
+                {
+                    "type": "event_msg",
+                    "payload": {"type": "agent_message", "message": "A"},
+                }
+            )
+            + "\n"
+        )
+
+    source_size = source.stat().st_size
+    assert source_size >= 12 * 1024 * 1024
+
+    tracemalloc.start()
+    try:
+        result = normalize(str(source))
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert result == "> Q\nA\n"
+    assert peak < source_size // 3, (
+        f"streaming normalization peaked at {peak} bytes for a {source_size}-byte source"
+    )
 
 
 # ── _extract_content ───────────────────────────────────────────────────


### PR DESCRIPTION
## Review status / scope reset

Rebased onto current `develop` (`d9f0590`) and reduced back to the normalization-only boundary on 2026-09-03. This two-commit diff is ready for human review: current-head CI and Codex review are clean. #2408 owns current Codex v2 parsing and remains tracked separately; it does not block review of this normalization-only change.

Earlier review rounds temporarily combined this PR with current Codex v2 parsing and migration work from #2408. That made #2214 duplicate incremental re-mine, hook-performance, and migration-transaction responsibilities. Those experimental commits were removed; the final review diff is two commits and does not modify hook, migration, or palace-wide version behavior.

## Summary

- Stream the JSONL formats recognized by the current `develop` parsers instead of reading and splitting the complete source first.
- Reuse the current no-symlink, regular-file-only, FIFO-safe, UTF-8/BOM-tolerant descriptor path for streaming and non-streaming reads.
- Keep every format behind the existing 500 MiB input cap. Streaming removes duplicate full-source/split-line allocations below that cap; it does not claim that materialized normalized output/chunking is safe above it.
- Preserve parser behavior and unknown-JSONL plain-text fallback by reusing the same line-parser implementations.
- Do not write a registry sentinel when normalization raises: a failed source remains eligible for a later retry instead of being silently marked mined.
- Add a repeatable 12 MiB `tracemalloc` regression so returning to `f.read()` plus split-line copies fails mechanically.

## Root cause

Both public normalization entry points called `_read_transcript_file()` before format detection. For a recognized JSONL this retained the entire source string, then allocated split-line/parser structures and the normalized transcript. A valid near-limit transcript could therefore create several simultaneous source-sized allocations in a long-lived process.

The scanner also treated a caught normalization exception as successfully empty and wrote a registry sentinel. An over-limit fallback, permission failure, or future format error could consequently become a permanent skip with no drawers.

## Dependency on current Codex v2 support

Current Codex `event_msg/item_completed` parsing remains owned by #2408 and is intentionally not duplicated here. #2214 streams whichever parser recognizes the source after the dependency lands. Until then, #2214 alone does not claim to normalize present-day v2 rollouts.

A local integration branch combining #2214 with #2408 was used only as read-only validation against the reporting file:

- Source: 442,841,936 bytes (about 422 MiB)
- Elapsed: 1.38 seconds
- Maximum RSS: 45,684 KiB
- Swap: 0
- Normalized output: 863,559 characters

No Hub, miner, Chroma collection, or palace was opened or written. This evidence validates the combined path, not the standalone PR head.

## Verification

- Normalize/conversation-miner focused group: 275 passed.
- Local full suite: 4,827 passed, 31 skipped, 106 deselected.
- The sole local failure, `test_sqlite_integrity_errors_reports_a_path_python_cannot_encode`, reproduces on pristine `develop` under CPython 3.12.11 and is unrelated to this diff.
- Repo-wide Ruff check: passed.
- Repo-wide Ruff format check: passed.
- `git diff --check`: passed.
- GitHub Actions: 9/9 passed, including Linux 3.9/3.11/3.13, macOS, Windows, Docker build/smoke/GPU, and lint.
- Codex current-head review for `d3e0681`: completed with no finding.

## Explicit remaining limit

Files over 500 MiB remain rejected. Supporting them requires incremental normalized-output emission and incremental chunking, not only line-by-line input parsing.

## Upstream coordination

- #2408 is monitored for maintainer comments, reviews, commits, or merge activity before any further history/status change.
- #2419 remains a separate Draft for Hub concurrency/crash-safety work.
- If #2408 lands first, this PR will be rebased and the combined v2 path revalidated before merging.

Related: #396, #468, #998, #2403, #2408, #2419
