### PR TITLE
fix(ingest): never block on a non-regular file (#2221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Ingest commands no longer hang on a named pipe.** A FIFO carrying a mined suffix (`notes.md`, `session.jsonl`) parked `mine`, `mine --mode convos`, `sweep`, `init`, `compress` and `split` in a blocking `open()` forever, because every reader decided by name and checked the file type only after opening. The four affected opens now pass `O_NONBLOCK` so the `S_ISREG` refusal already written there is reachable, and the discovery walks drop non-regular entries with a `SKIP: <name> (not a regular file)` line. (#2221)
+
 ---
 
 ## [3.7.0] — 2026-08-11

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -131,6 +131,13 @@ def _gather_origin_samples(project_dir) -> list:
         if total_chars >= _PASS_ZERO_TOTAL_CAP:
             break
         try:
+            # ``scan_for_detection`` picks candidates by extension, so a FIFO
+            # named ``notes.md`` reaches this loop; opening one for reading
+            # blocks until a writer appears. ``is_file()`` stats instead.
+            # It belongs inside the try: it raises PermissionError on an
+            # unreadable directory, which the open below used to absorb.
+            if not filepath.is_file():
+                continue
             with open(filepath, encoding="utf-8", errors="replace") as f:
                 content = f.read(_PASS_ZERO_PER_FILE_CAP)
         except OSError:
@@ -263,9 +270,17 @@ def _ensure_mempalace_files_gitignored(project_dir) -> bool:
     if not (project_path / ".git").exists():
         return False
     gitignore = project_path / ".gitignore"
+    # ``exists()`` is true for a FIFO, and both the read below and the append
+    # at the end of this function would block in the kernel on one. Decide by
+    # type instead: an absent file still yields "" as before, a regular one
+    # is read, and anything else is left untouched.
+    if gitignore.exists() and not gitignore.is_file():
+        return False
     # Force UTF-8: Windows defaults to GBK and chokes on non-ASCII .gitignore
     # comments, killing auto-init even though the file is valid UTF-8.
-    existing = gitignore.read_text(encoding="utf-8", errors="replace") if gitignore.exists() else ""
+    existing = (
+        gitignore.read_text(encoding="utf-8", errors="replace") if gitignore.is_file() else ""
+    )
     existing_lines = {line.strip() for line in existing.splitlines()}
     missing = [p for p in _MEMPALACE_PROJECT_FILES if p not in existing_lines]
     if not missing:
@@ -420,9 +435,19 @@ def cmd_init(args):
         if confirmed["people"] or confirmed["projects"] or confirmed.get("topics"):
             project_path = Path(args.dir).expanduser().resolve()
             entities_path = project_path / "entities.json"
-            with open(entities_path, "w", encoding="utf-8") as f:
-                json.dump(confirmed, f, indent=2, ensure_ascii=False)
-            print(f"  Entities saved: {entities_path}")
+            # Opening a pre-existing FIFO for writing blocks in the kernel
+            # until a reader appears. Only a regular file is a valid target
+            # for the per-project audit trail; the global registry merge
+            # below is unaffected either way.
+            if entities_path.exists() and not entities_path.is_file():
+                print(
+                    f"  ! Not writing entities: {entities_path} is not a regular file",
+                    file=sys.stderr,
+                )
+            else:
+                with open(entities_path, "w", encoding="utf-8") as f:
+                    json.dump(confirmed, f, indent=2, ensure_ascii=False)
+                print(f"  Entities saved: {entities_path}")
 
             from .config import normalize_wing_name
             from .miner import add_to_known_entities
@@ -438,7 +463,14 @@ def cmd_init(args):
         print("  No entities detected -- proceeding with directory-based rooms.")
 
     # Pass 2: detect rooms from folder structure
-    detect_rooms_local(project_dir=args.dir, yes=getattr(args, "yes", False))
+    try:
+        detect_rooms_local(project_dir=args.dir, yes=getattr(args, "yes", False))
+    except OSError as exc:
+        # Writing mempalace.yaml is the point of init; a target it cannot
+        # write (a pre-existing pipe, a full disk) is a hard failure, and a
+        # message beats the traceback this used to produce.
+        print(f"\n  ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
     cfg.init()
     backend = _backend_arg(args)
     if backend:
@@ -2219,12 +2251,15 @@ def cmd_compress(args):
     # Load dialect (with optional entity config)
     config_path = args.config
     if not config_path:
+        # ``isfile`` rather than ``exists``: the latter is true for a FIFO,
+        # and ``Dialect.from_config`` opens whatever it is handed, which
+        # blocks in the kernel on a pipe named entities.json in the cwd.
         for candidate in ["entities.json", os.path.join(palace_path, "entities.json")]:
-            if os.path.exists(candidate):
+            if os.path.isfile(candidate):
                 config_path = candidate
                 break
 
-    if config_path and os.path.exists(config_path):
+    if config_path and os.path.isfile(config_path):
         dialect = Dialect.from_config(config_path)
         print(f"  Loaded entity config: {config_path}")
     else:

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -8,6 +8,7 @@ Normalizes format, chunks by exchange pair (Q+A = one unit), files to palace.
 Same palace as project mining. Different ingest strategy.
 """
 
+import errno
 import os
 import sys
 import json
@@ -185,10 +186,20 @@ def _path_within_root(path: Path, root: Path) -> bool:
 def _is_regular_source_file(filepath: Path, root: Path) -> bool:
     if not _path_within_root(filepath, root):
         return False
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    # O_NONBLOCK keeps the S_ISREG verdict below reachable: a blocking open
+    # of a FIFO waits in the kernel for a writer, so a named pipe called
+    # ``session.jsonl`` would hang this check instead of failing it. See the
+    # matching comment in ``miner._read_text_no_follow``, including why the
+    # EAGAIN branch re-checks the type and then opens without the flag.
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
     fd = -1
     try:
-        fd = os.open(filepath, flags)
+        try:
+            fd = os.open(filepath, flags)
+        except OSError as exc:
+            if exc.errno != errno.EAGAIN or not stat.S_ISREG(os.lstat(filepath).st_mode):
+                raise
+            fd = os.open(filepath, flags & ~getattr(os, "O_NONBLOCK", 0))
         st = os.fstat(fd)
         return stat.S_ISREG(st.st_mode) and st.st_size <= MAX_FILE_SIZE
     except OSError:
@@ -543,7 +554,17 @@ def scan_convos(convo_dir: str, include_subagents: bool = False) -> list:
                 # to stderr to match the SKIP: (symlink) line above; silent
                 # drops at this gate were the original #923 complaint.
                 try:
-                    file_size = filepath.stat().st_size
+                    file_stat = filepath.stat()
+                    # Drop non-regular entries (FIFO, socket, device node)
+                    # before any reader touches them — see the matching
+                    # gate in ``miner.scan_project``.
+                    if not stat.S_ISREG(file_stat.st_mode):
+                        print(
+                            f"  SKIP: {filepath.name} (not a regular file)",
+                            file=sys.stderr,
+                        )
+                        continue
+                    file_size = file_stat.st_size
                     if file_size > MAX_FILE_SIZE:
                         print(
                             f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"

--- a/mempalace/entity_detector.py
+++ b/mempalace/entity_detector.py
@@ -628,6 +628,13 @@ def detect_entities(
         if files_read >= max_files:
             break
         try:
+            # Decide by file type before opening: ``scan_for_detection``
+            # picks candidates by extension, so a FIFO named ``notes.md``
+            # reaches this loop and a blocking open of one waits in the
+            # kernel for a writer that may never come. ``is_file()`` stats
+            # instead of opening and never blocks.
+            if not Path(filepath).is_file():
+                continue
             with open(filepath, encoding="utf-8", errors="replace") as f:
                 content = f.read(MAX_BYTES_PER_FILE)
             all_text.append(content)

--- a/mempalace/hook_shell.py
+++ b/mempalace/hook_shell.py
@@ -9,6 +9,7 @@ hooks/mempal_save_hook.sh and hooks/mempal_precompact_hook.sh.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 
@@ -71,9 +72,18 @@ def count_human_messages(path: str) -> int:
     Claude transcripts are UTF-8. Windows Python defaults to cp1252 in many
     environments, so the encoding must be explicit. Invalid bytes are ignored
     to match the hooks' fail-soft behavior.
+
+    A path that exists but is not a regular file counts zero rather than
+    being opened: opening a FIFO for reading blocks in the kernel until a
+    writer appears, and this function has no timeout. A path that does not
+    exist still raises from the ``open`` below, as before.
+    ``mempal_save_hook.sh`` screens with ``[ -f ]``, which is false for a
+    pipe, so the guard here covers callers that do not.
     """
 
     count = 0
+    if os.path.exists(path) and not os.path.isfile(path):
+        return count
     with open(path, encoding="utf-8", errors="ignore") as fh:
         for line in fh:
             try:

--- a/mempalace/llm_refine.py
+++ b/mempalace/llm_refine.py
@@ -479,6 +479,13 @@ def collect_corpus_text(
     chunks: list[str] = []
     for p in selected:
         try:
+            # ``_walk_prose`` selects by suffix and the stat above reads only
+            # st_mtime, so a FIFO named ``notes.md`` reaches this loop and a
+            # blocking open of one waits for a writer that may never come.
+            # Inside the try: is_file() raises on an unreadable directory,
+            # which the open below already absorbed.
+            if not p.is_file():
+                continue
             with open(p, encoding="utf-8", errors="replace") as f:
                 chunks.append(f.read(max_bytes_per_file))
         except OSError:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -7,6 +7,7 @@ Routes each file to the right room based on content.
 Stores verbatim chunks as drawers. No summaries. Ever.
 """
 
+import errno
 import os
 import re
 import sys
@@ -60,10 +61,30 @@ def _path_within_root(path: Path, root: Path) -> bool:
 def _read_text_no_follow(filepath: Path, root: Path) -> Optional[str]:
     if not _path_within_root(filepath, root):
         return None
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    # O_NONBLOCK is what makes the S_ISREG check below reachable. Opening a
+    # FIFO for reading parks in the kernel until a writer shows up, so
+    # without it the fstat never runs and a named pipe carrying a
+    # READABLE_EXTENSIONS suffix wedges the mine forever. With it the open
+    # returns immediately and the *file type* decides — no errno guesswork,
+    # and a FIFO that does have a live writer is rejected just the same.
+    # Linux open(2): "this flag has no effect for regular files and block
+    # devices". POSIX leaves it unspecified outside FIFOs and special files,
+    # and one Linux case is not a no-op — see the EAGAIN branch below.
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
     fd = -1
     try:
-        fd = os.open(filepath, flags)
+        try:
+            fd = os.open(filepath, flags)
+        except OSError as exc:
+            # A reader that breaks a write lease gets EAGAIN when it passes
+            # O_NONBLOCK, where a blocking open waits out lease-break-time
+            # and succeeds. The kernel grants leases on regular files only
+            # (F_SETLEASE on a pipe fails EINVAL), so re-check the type and
+            # then read it the way this code did before the flag existed;
+            # dropping it would silently lose a file that used to be mined.
+            if exc.errno != errno.EAGAIN or not stat.S_ISREG(os.lstat(filepath).st_mode):
+                raise
+            fd = os.open(filepath, flags & ~getattr(os, "O_NONBLOCK", 0))
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode) or st.st_size > MAX_FILE_SIZE:
             return None
@@ -486,10 +507,14 @@ def load_config(project_dir: str) -> dict:
 
     resolved_project_dir = Path(project_dir).expanduser().resolve()
     config_path = resolved_project_dir / "mempalace.yaml"
-    if not config_path.exists():
+    # ``is_file()`` rather than ``exists()``: the latter is true for a FIFO,
+    # and the ``open`` at the end of this function would then block in the
+    # kernel until a writer appears. A config that is not a regular file is
+    # treated as absent, which lands on the auto-detected defaults below.
+    if not config_path.is_file():
         # Fallback to legacy name
         legacy_path = resolved_project_dir / "mempal.yaml"
-        if legacy_path.exists():
+        if legacy_path.is_file():
             config_path = legacy_path
         else:
             from .config import normalize_wing_name
@@ -1708,7 +1733,19 @@ def scan_project(
             # match the SKIP: (symlink) line above; silent drops at this
             # gate were the original #923 complaint.
             try:
-                file_size = filepath.stat().st_size
+                file_stat = filepath.stat()
+                # Reject anything that is not a regular file before it can
+                # reach a reader. os.walk lists FIFOs, sockets and device
+                # nodes as plain filenames and the extension filter above
+                # decides by name, so ``notes.md`` can be a named pipe.
+                # stat() itself never blocks on one; opening it can.
+                if not stat.S_ISREG(file_stat.st_mode):
+                    print(
+                        f"  SKIP: {filepath.name} (not a regular file)",
+                        file=sys.stderr,
+                    )
+                    continue
+                file_size = file_stat.st_size
                 if file_size > MAX_FILE_SIZE:
                     print(
                         f"  SKIP: {filepath.name} ({file_size / (1024 * 1024):.1f} MB)"

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -19,6 +19,7 @@ Supported:
 No API key. No internet. Everything local.
 """
 
+import errno
 import json
 import os
 import re
@@ -120,17 +121,29 @@ def _read_transcript_file(filepath: str) -> str:
     and normalize_conversations() both need: no symlinks, regular files only,
     size-capped, BOM-tolerant.
     """
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    # O_NONBLOCK keeps the "not a regular file" check below reachable: a
+    # blocking open of a FIFO waits in the kernel for a writer, so the
+    # S_ISREG test never runs. See ``miner._read_text_no_follow``, including
+    # why the EAGAIN branch re-checks the type and retries without the flag.
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
     if os.path.islink(filepath):
         raise IOError(f"Could not read {filepath}: symlinked files are skipped")
     fd = -1
     try:
-        fd = os.open(filepath, flags)
+        try:
+            fd = os.open(filepath, flags)
+        except OSError as exc:
+            if exc.errno != errno.EAGAIN or not stat.S_ISREG(os.lstat(filepath).st_mode):
+                raise
+            fd = os.open(filepath, flags & ~getattr(os, "O_NONBLOCK", 0))
         file_stat = os.fstat(fd)
         if not stat.S_ISREG(file_stat.st_mode):
-            raise IOError(f"Could not read {filepath}: not a regular file")
+            # Text stays prefix-free: this raise is inside the ``try``, so the
+            # ``except OSError`` below composes "Could not read <path>: ...".
+            raise IOError("not a regular file")
         if file_stat.st_size > 500 * 1024 * 1024:  # 500 MB safety limit
-            raise IOError(f"File too large ({file_stat.st_size // (1024 * 1024)} MB): {filepath}")
+            # Prefix-free for the same reason as the branch above.
+            raise IOError(f"file too large ({file_stat.st_size // (1024 * 1024)} MB)")
         with os.fdopen(fd, "r", encoding="utf-8-sig", errors="replace") as f:
             fd = -1
             return f.read()

--- a/mempalace/project_scanner.py
+++ b/mempalace/project_scanner.py
@@ -189,6 +189,14 @@ _GRADLE_ROOT_PROJECT_NAME_PATTERNS = [
 
 def _parse_gradle_root_project_name(path: Path) -> Optional[str]:
     try:
+        # Reached two ways: with the walk-vetted manifest path, and from
+        # ``_parse_gradle`` with a ``settings.gradle`` sibling it builds next
+        # to a vetted ``build.gradle`` — that one no walk ever saw. Opening a
+        # FIFO for reading blocks in the kernel until a writer appears;
+        # ``is_file()`` stats instead. It goes inside this ``try``, which
+        # already absorbs the PermissionError an unsearchable parent raises.
+        if not path.is_file():
+            return None
         text = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return None
@@ -421,7 +429,16 @@ def _collect_manifest_names(repo_root: Path) -> list[tuple[str, str, Path]]:
             parser = MANIFEST_PARSERS.get(fname)
             if not parser:
                 continue
-            name = parser(dirpath / fname)
+            manifest_path = dirpath / fname
+            # Every parser below opens the path. A FIFO named
+            # ``package.json`` would park that open in the kernel until a
+            # writer appears; ``is_file()`` stats instead and never blocks.
+            # ``os.path.isfile`` rather than ``Path.is_file``: each parser
+            # swallows OSError itself, so the gate must swallow it too — an
+            # unsearchable directory used to yield "no name", not a traceback.
+            if not os.path.isfile(manifest_path):
+                continue
+            name = parser(manifest_path)
             if name:
                 found.append((fname, name, dirpath))
     return sorted(found, key=lambda entry: _manifest_sort_key(entry, repo_root))

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -30,6 +30,7 @@ Usage (from CLI):
 """
 
 import argparse
+import errno
 import os
 import shutil
 import sqlite3
@@ -62,10 +63,29 @@ def _no_follow_flag() -> int:
     return getattr(os, "O_NOFOLLOW", 0)
 
 
+def _non_blocking_flag() -> int:
+    """Return O_NONBLOCK, or 0 where the platform has no such flag (Windows).
+
+    Without it the ``S_ISREG`` refusal in ``_open_regular_file_no_follow``
+    is unreachable for a FIFO: opening one for reading blocks in the kernel
+    until a writer appears, so ``repair`` would wedge instead of refusing.
+    """
+    return getattr(os, "O_NONBLOCK", 0)
+
+
 def _open_regular_file_no_follow(path: str) -> int:
     if os.path.islink(path):
         raise RuntimeError(f"Refusing symlinked file: {path}")
-    fd = os.open(path, os.O_RDONLY | _no_follow_flag())
+    flags = os.O_RDONLY | _no_follow_flag() | _non_blocking_flag()
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        # EAGAIN here is a write-lease break, which the kernel grants on
+        # regular files only, so re-check the type and open the way this
+        # helper did before the flag existed. Anything else propagates.
+        if exc.errno != errno.EAGAIN or not stat.S_ISREG(os.lstat(path).st_mode):
+            raise
+        fd = os.open(path, flags & ~_non_blocking_flag())
     try:
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode):

--- a/mempalace/room_detector_local.py
+++ b/mempalace/room_detector_local.py
@@ -292,6 +292,11 @@ def save_config(project_dir: str, project_name: str, rooms: list):
         ],
     }
     config_path = Path(project_dir).expanduser().resolve() / "mempalace.yaml"
+    # Opening a pre-existing FIFO for writing blocks in the kernel until a
+    # reader appears. Only a regular file is a valid config target; refuse
+    # loudly rather than park ``init`` with no output.
+    if config_path.exists() and not config_path.is_file():
+        raise OSError(f"Refusing to write config: {config_path} is not a regular file")
     with open(config_path, "w") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
 

--- a/mempalace/split_mega_files.py
+++ b/mempalace/split_mega_files.py
@@ -26,6 +26,7 @@ import argparse
 import json
 import os
 import re
+import stat
 from pathlib import Path
 
 HOME = Path.home()
@@ -223,6 +224,14 @@ def split_file(filepath, output_dir, dry_run=False):
         if dry_run:
             print(f"  [{i + 1}/{len(boundaries) - 1}] {name}  ({len(chunk)} lines)")
         else:
+            # The gate in ``main`` covers the files the glob listed; this name
+            # is built here, so nothing has vetted it. Opening a pre-existing
+            # FIFO for writing blocks in the kernel until a reader appears.
+            # ``os.path`` rather than ``Path``: neither call can raise, so a
+            # write that fails still fails at ``write_text`` as it always did.
+            if os.path.exists(out_path) and not os.path.isfile(out_path):
+                print(f"  SKIP: {name} (not a regular file)")
+                continue
             out_path.write_text("".join(chunk), encoding="utf-8")
             print(f"  + {name}  ({len(chunk)} lines)")
 
@@ -272,7 +281,14 @@ def main():
     mega_files = []
     max_scan_size = 500 * 1024 * 1024  # 500 MB
     for f in files:
-        if f.stat().st_size > max_scan_size:
+        file_stat = f.stat()
+        # ``glob`` lists a FIFO named ``x.txt`` like any other match, and
+        # read_text() on one blocks in the kernel until a writer appears.
+        # stat() never blocks, so the type decides before the open does.
+        if not stat.S_ISREG(file_stat.st_mode):
+            print(f"  SKIP: {f.name} (not a regular file)")
+            continue
+        if file_stat.st_size > max_scan_size:
             print(f"  SKIP: {f.name} exceeds {max_scan_size // (1024 * 1024)} MB limit")
             continue
         lines = f.read_text(errors="replace").splitlines(keepends=True)

--- a/mempalace/sweeper.py
+++ b/mempalace/sweeper.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import json
 import logging
+import stat
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -101,7 +102,16 @@ def parse_claude_jsonl(path: str) -> Iterator[dict]:
     queue-operation, last-prompt) are filtered out. Malformed lines are
     skipped silently — data quality is the transcript writer's problem,
     not ours.
+
+    Raises ``OSError`` when ``path`` is not a regular file. ``rglob`` in
+    ``sweep_directory`` lists a FIFO named ``session.jsonl`` like any
+    other match, and opening one for reading blocks in the kernel until a
+    writer appears — an unbounded hang for the whole sweep. ``stat`` never
+    blocks on one, and it raises for a missing path exactly as ``open``
+    did before, so callers see the same error for the same mistake.
     """
+    if not stat.S_ISREG(Path(path).stat().st_mode):
+        raise OSError(f"Refusing non-regular file: {path}")
     with open(path, "r", encoding="utf-8", errors="replace") as f:
         for line in f:
             line = line.strip()
@@ -337,6 +347,27 @@ def sweep_directory(dir_path: str, palace_path: str) -> dict:
 
     failures: list[dict] = []
     for f in files:
+        # A non-regular match is not a sweep failure, it is nothing to sweep.
+        # ``rglob`` lists a FIFO or a symlink to /dev/null like any other
+        # ``*.jsonl``; report it the way ``miner.scan_project`` reports one
+        # and leave ``failures`` (and the exit status) for real errors.
+        # ``parse_claude_jsonl`` still refuses one, for callers arriving by
+        # another route.
+        try:
+            regular = stat.S_ISREG(f.stat().st_mode)
+        except OSError as exc:
+            # A stat that FAILS is a real error, not a benign type. A dangling
+            # symlink, a symlink loop and a file unlinked between rglob and
+            # here all land here, and every one of them used to reach ``open``
+            # and be booked below. Keep booking them, or ``sweep`` reports
+            # success on a transcript it could not read.
+            logger.error("sweeper: stat failed on %s: %s", f, exc)
+            print(f"  WARNING: stat failed on {f}: {exc}", file=sys.stderr)
+            failures.append({"file": str(f), "error": str(exc)})
+            continue
+        if not regular:
+            print(f"  SKIP: {f.name} (not a regular file)", file=sys.stderr)
+            continue
         try:
             result = sweep(str(f), palace_path, source_label=str(f))
         except Exception as exc:

--- a/tests/test_non_regular_file_guards.py
+++ b/tests/test_non_regular_file_guards.py
@@ -1,0 +1,824 @@
+"""Non-regular files must never wedge an ingest command.
+
+``os.walk``/``rglob`` list a FIFO, a socket and a device node as ordinary
+filenames, and MemPalace decides what to read by extension. Opening a FIFO
+for reading parks in the kernel until a writer appears, so a named pipe
+called ``notes.md`` sitting in a mined directory used to hang ``mine``,
+``sweep`` and ``init`` forever — no output, no error, no progress.
+
+Every check here is wrapped in :func:`hard_timeout`. A regression must turn
+this file red; it must not hang the suite (an unbounded blocking open would
+otherwise stall pytest itself, which reports as "still running", not as a
+failure).
+"""
+
+import argparse
+import errno
+import hashlib
+import os
+import signal
+import socket
+import stat as stat_module
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from mempalace.cli import (
+    _ensure_mempalace_files_gitignored,
+    _gather_origin_samples,
+    cmd_compress,
+    cmd_init,
+)
+from mempalace.convo_miner import _is_regular_source_file, scan_convos
+from mempalace.entity_detector import detect_entities
+from mempalace.format_miner import ExtractionStatus, extract_text
+from mempalace.hook_shell import count_human_messages
+from mempalace.llm_refine import collect_corpus_text
+from mempalace.miner import _read_text_no_follow, load_config, mine, scan_project
+from mempalace.normalize import _read_transcript_file
+from mempalace.project_scanner import _collect_manifest_names, _parse_gradle
+from mempalace.repair import _copy_file_no_follow, _open_regular_file_no_follow
+from mempalace.room_detector_local import detect_rooms_local
+from mempalace.split_mega_files import main as split_main
+from mempalace.split_mega_files import split_file
+from mempalace.sweeper import parse_claude_jsonl, sweep_directory
+
+# ``os.mkfifo`` and ``SIGALRM`` are both POSIX-only. Windows has no FIFO in
+# the filesystem namespace at all (its named pipes live under \\.\pipe\ and
+# no directory walk can reach them), so there is nothing to reproduce there.
+posix_only = pytest.mark.skipif(
+    not hasattr(os, "mkfifo") or not hasattr(signal, "SIGALRM"),
+    reason="requires POSIX FIFOs and SIGALRM",
+)
+
+# Mirrors ``needs_unprivileged_posix`` in tests/test_backups.py. Root holds
+# CAP_DAC_OVERRIDE and walks straight into a directory with no ``x`` bit, so
+# the permission tests below assert nothing there — and the repo ships a
+# Dockerfile and a devcontainer that run as root.
+needs_unprivileged_posix = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="directory permission bits do not gate root",
+)
+
+TIMEOUT_SECONDS = 10.0
+
+
+class Blocked(BaseException):
+    """Raised when a call under test blocks past the deadline.
+
+    Deliberately derived from ``BaseException`` rather than ``Exception``.
+    Two separate handlers would otherwise eat the deadline and leave a
+    reverted fix looking green while it blocked for the full timeout:
+
+    * ``except OSError`` guards every read site here, and ``TimeoutError``
+      *is* an ``OSError`` — that one alone cost four vacuous passes.
+    * ``except Exception`` guards the paths the end-to-end tests cross,
+      including ``sweeper.sweep_directory`` and four sites inside
+      ``miner._mine_impl``, so a plain ``Exception`` subclass would be
+      swallowed there just as thoroughly.
+    """
+
+
+@contextmanager
+def hard_timeout(seconds: float, what: str):
+    """Fail the test instead of blocking forever.
+
+    ``signal.setitimer`` fires SIGALRM even while the interpreter sits in a
+    blocking ``open(2)``; the handler raises, and PEP 475 propagates that
+    exception rather than restarting the syscall. Without this, reverting
+    the fix would hang pytest rather than fail it.
+    """
+
+    def _fire(signum, frame):
+        raise Blocked(f"{what} blocked for more than {seconds}s")
+
+    previous = signal.signal(signal.SIGALRM, _fire)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+def make_fifo(directory: Path, name: str) -> Path:
+    path = directory / name
+    os.mkfifo(path)
+    return path
+
+
+def write_regular(directory: Path, name: str, content: str) -> Path:
+    path = directory / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# The four os.open read sites: the type check must be reachable
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@posix_only
+def test_read_text_no_follow_rejects_fifo(tmp_path):
+    fifo = make_fifo(tmp_path, "notes.md")
+    with hard_timeout(TIMEOUT_SECONDS, "_read_text_no_follow on a FIFO"):
+        assert _read_text_no_follow(fifo, tmp_path) is None
+
+
+@posix_only
+def test_is_regular_source_file_rejects_fifo(tmp_path):
+    fifo = make_fifo(tmp_path, "session.jsonl")
+    with hard_timeout(TIMEOUT_SECONDS, "_is_regular_source_file on a FIFO"):
+        assert _is_regular_source_file(fifo, tmp_path) is False
+
+
+@posix_only
+def test_read_transcript_file_rejects_fifo(tmp_path):
+    fifo = make_fifo(tmp_path, "session.jsonl")
+    with hard_timeout(TIMEOUT_SECONDS, "_read_transcript_file on a FIFO"):
+        with pytest.raises(IOError) as excinfo:
+            _read_transcript_file(str(fifo))
+    message = str(excinfo.value)
+    assert "not a regular file" in message
+    # The path belongs in the message exactly once — the raise inside the
+    # try block is prefix-free so the wrapper composes it.
+    assert message.count(str(fifo)) == 1
+
+
+@posix_only
+def test_open_regular_file_no_follow_rejects_fifo(tmp_path):
+    fifo = make_fifo(tmp_path, "chroma.sqlite3")
+    with hard_timeout(TIMEOUT_SECONDS, "_open_regular_file_no_follow on a FIFO"):
+        with pytest.raises(RuntimeError, match="Refusing non-regular file"):
+            _open_regular_file_no_follow(str(fifo))
+
+
+@posix_only
+def test_copy_file_no_follow_rejects_fifo_source(tmp_path):
+    fifo = make_fifo(tmp_path, "chroma.sqlite3")
+    with hard_timeout(TIMEOUT_SECONDS, "_copy_file_no_follow from a FIFO"):
+        with pytest.raises(RuntimeError, match="Refusing non-regular file"):
+            _copy_file_no_follow(str(fifo), str(tmp_path / "backup.sqlite3"))
+    assert not (tmp_path / "backup.sqlite3").exists()
+
+
+@posix_only
+def test_read_text_no_follow_rejects_fifo_that_has_a_live_writer(tmp_path):
+    """The verdict comes from the file type, not from "nobody is writing".
+
+    With a writer attached the open succeeds even without ``O_NONBLOCK``, so
+    this is not the hang regression — it pins the gate itself. Anyone who
+    "fixes" the hang by swallowing an errno instead of checking ``S_ISREG``
+    turns this red, and a pipe whose content would otherwise be mined as a
+    verbatim drawer stays out of the palace.
+    """
+    fifo = make_fifo(tmp_path, "notes.md")
+    writer_attached = threading.Event()
+    release_writer = threading.Event()
+    failures = []
+
+    def _hold_write_end():
+        try:
+            fd = os.open(fifo, os.O_WRONLY)  # blocks until a reader opens
+        except OSError as exc:  # pragma: no cover - only on a broken setup
+            failures.append(exc)
+            writer_attached.set()
+            return
+        writer_attached.set()
+        release_writer.wait(TIMEOUT_SECONDS)
+        os.close(fd)
+
+    thread = threading.Thread(target=_hold_write_end, daemon=True)
+    thread.start()
+    # Opening our own read end is what lets the writer's open(2) return.
+    reader_fd = os.open(fifo, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        assert writer_attached.wait(TIMEOUT_SECONDS), "writer never attached"
+        assert not failures, failures
+        with hard_timeout(TIMEOUT_SECONDS, "_read_text_no_follow on a written FIFO"):
+            assert _read_text_no_follow(fifo, tmp_path) is None
+    finally:
+        release_writer.set()
+        os.close(reader_fd)
+        thread.join(TIMEOUT_SECONDS)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# O_NONBLOCK must not change what a regular file reads back
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@posix_only
+def test_read_text_no_follow_still_reads_a_large_regular_file_whole(tmp_path):
+    """POSIX and Linux open(2) both say O_NONBLOCK has no effect on regular
+    files. This pins that: 2 MB is many buffered reads, and a short read or
+    an ``EAGAIN`` would truncate a drawer silently.
+    """
+    payload = "the quick brown fox jumps over the lazy dog\n" * 50_000
+    regular = write_regular(tmp_path, "big.md", payload)
+    with hard_timeout(TIMEOUT_SECONDS, "_read_text_no_follow on a 2 MB file"):
+        content = _read_text_no_follow(regular, tmp_path)
+    assert content == payload
+
+
+@posix_only
+def test_copy_file_no_follow_still_copies_a_large_regular_file_byte_for_byte(tmp_path):
+    """The palace backup path reads through the same non-blocking fd."""
+    payload = os.urandom(2 * 1024 * 1024)
+    src = tmp_path / "chroma.sqlite3"
+    src.write_bytes(payload)
+    dst = tmp_path / "chroma.sqlite3.backup"
+    with hard_timeout(TIMEOUT_SECONDS, "_copy_file_no_follow of a 2 MB file"):
+        _copy_file_no_follow(str(src), str(dst))
+    assert hashlib.sha256(dst.read_bytes()).hexdigest() == hashlib.sha256(payload).hexdigest()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Discovery walks must not hand a non-regular file to a reader
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@posix_only
+def test_scan_project_skips_fifo_and_keeps_regular_files(tmp_path, capsys):
+    make_fifo(tmp_path, "notes.md")
+    write_regular(tmp_path, "real.md", "# Real\n")
+    with hard_timeout(TIMEOUT_SECONDS, "scan_project over a FIFO"):
+        found = scan_project(str(tmp_path))
+    assert [path.name for path in found] == ["real.md"]
+    assert "SKIP: notes.md (not a regular file)" in capsys.readouterr().err
+
+
+@posix_only
+def test_scan_project_skips_unix_socket(tmp_path, capsys):
+    """Sockets fail the open with ENXIO rather than blocking, but they are
+    not readable either — the walk drops them at the same gate.
+    """
+    # Bind through a short-lived cwd rather than the absolute path: AF_UNIX
+    # caps sun_path at 104 bytes on macOS (108 on Linux), and pytest's
+    # tmp_path under the macOS runner's /var/folders/... TMPDIR overruns it.
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    previous_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        sock.bind("mcp.md")
+        write_regular(tmp_path, "real.md", "# Real\n")
+        with hard_timeout(TIMEOUT_SECONDS, "scan_project over a socket"):
+            found = scan_project(str(tmp_path))
+    finally:
+        os.chdir(previous_cwd)
+        sock.close()
+    assert (tmp_path / "mcp.md").is_socket()
+    assert [path.name for path in found] == ["real.md"]
+    assert "SKIP: mcp.md (not a regular file)" in capsys.readouterr().err
+
+
+@posix_only
+def test_scan_convos_skips_fifo_and_keeps_regular_files(tmp_path, capsys):
+    make_fifo(tmp_path, "piped.jsonl")
+    write_regular(tmp_path, "real.jsonl", '{"type": "user"}\n')
+    with hard_timeout(TIMEOUT_SECONDS, "scan_convos over a FIFO"):
+        found = scan_convos(str(tmp_path))
+    assert [path.name for path in found] == ["real.jsonl"]
+    assert "SKIP: piped.jsonl (not a regular file)" in capsys.readouterr().err
+
+
+@posix_only
+def test_parse_claude_jsonl_refuses_fifo(tmp_path):
+    fifo = make_fifo(tmp_path, "session.jsonl")
+    with hard_timeout(TIMEOUT_SECONDS, "parse_claude_jsonl on a FIFO"):
+        with pytest.raises(OSError, match="Refusing non-regular file"):
+            list(parse_claude_jsonl(str(fifo)))
+
+
+def test_parse_claude_jsonl_still_raises_for_a_missing_path(tmp_path):
+    """The type gate stats first, so a missing path must keep failing the
+    way the plain ``open`` used to.
+    """
+    with pytest.raises(FileNotFoundError):
+        list(parse_claude_jsonl(str(tmp_path / "nope.jsonl")))
+
+
+def test_parse_claude_jsonl_still_reads_a_regular_transcript(tmp_path):
+    path = write_regular(
+        tmp_path,
+        "session.jsonl",
+        '{"type": "user", "sessionId": "s1", "uuid": "u1", '
+        '"timestamp": "2026-01-01T00:00:00Z", '
+        '"message": {"role": "user", "content": "hello"}}\n',
+    )
+    records = list(parse_claude_jsonl(str(path)))
+    assert [record["content"] for record in records] == ["hello"]
+
+
+@posix_only
+def test_detect_entities_ignores_a_fifo_candidate(tmp_path):
+    """A FIFO must be invisible: same result as if it were never there, and
+    it must not consume the ``max_files`` budget.
+    """
+    regular = write_regular(
+        tmp_path,
+        "people.md",
+        "Met Sarah Connor and John Connor at the office today.\n" * 5,
+    )
+    fifo = make_fifo(tmp_path, "notes.md")
+    baseline = detect_entities([regular])
+    with hard_timeout(TIMEOUT_SECONDS, "detect_entities over a FIFO"):
+        with_fifo = detect_entities([fifo, regular])
+    assert with_fifo == baseline
+
+
+@posix_only
+def test_gather_origin_samples_ignores_a_fifo_candidate(tmp_path):
+    """``init``'s corpus-origin pass reads the same candidate list as
+    ``detect_entities`` and must drop a FIFO at the same gate.
+    """
+    write_regular(tmp_path, "real.md", "# Real\n\nSome prose about the project.\n")
+    make_fifo(tmp_path, "notes.md")
+    with hard_timeout(TIMEOUT_SECONDS, "_gather_origin_samples over a FIFO"):
+        samples = _gather_origin_samples(str(tmp_path))
+    assert len(samples) == 1
+    assert "Some prose about the project." in samples[0]
+
+
+@posix_only
+def test_split_mega_files_skips_fifo(tmp_path, capsys, monkeypatch):
+    make_fifo(tmp_path, "piped.txt")
+    # Two detectable sessions, so the regular file is reported rather than
+    # dropped for having nothing to split. Shape copied from
+    # tests/test_split_mega_files.py::test_find_session_boundaries_two_sessions.
+    session = "Claude Code v1.0\ncontent\n" + "\n" * 5
+    write_regular(tmp_path, "real.txt", session * 2)
+    monkeypatch.setattr("sys.argv", ["mempalace split", "--source", str(tmp_path), "--dry-run"])
+    with hard_timeout(TIMEOUT_SECONDS, "split_mega_files.main over a FIFO"):
+        split_main()
+    out = capsys.readouterr().out
+    assert "SKIP: piped.txt (not a regular file)" in out
+    # The gate must drop the pipe and nothing else: a version that skipped
+    # every entry would satisfy the SKIP assertion above on its own.
+    assert "SKIP: real.txt" not in out
+    assert "real.txt" in out
+
+
+@posix_only
+def test_split_file_skips_a_fifo_at_its_own_output_name(tmp_path, capsys):
+    """The walk gate covers the source; the output name is built here.
+
+    ``split_file`` synthesises each per-session filename from the transcript
+    and writes it into the source directory, so nothing has vetted that path.
+    A pre-existing FIFO sitting at one of those names turned the write into a
+    blocking open — the same hang, in the one path the discovery gate cannot
+    reach.
+    """
+    session = "Claude Code v1.0\n" + "content line\n" * 14 + "\n" * 5
+    source = write_regular(tmp_path, "real.txt", session * 2)
+    planned = split_file(str(source), None, dry_run=True)
+    assert len(planned) >= 2, "fixture must produce at least two output files"
+    blocked = Path(planned[0])
+    os.mkfifo(blocked)
+
+    with hard_timeout(TIMEOUT_SECONDS, "split_file writing over a FIFO output"):
+        written = split_file(str(source), None, dry_run=False)
+
+    out = capsys.readouterr().out
+    assert f"SKIP: {blocked.name} (not a regular file)" in out
+    assert blocked not in written
+    # The pipe must cost only its own chunk: every other session still lands.
+    assert len(written) == len(planned) - 1
+    assert all(path.is_file() for path in written)
+
+
+@posix_only
+@needs_unprivileged_posix
+def test_collect_manifest_names_survives_an_unreadable_directory(tmp_path):
+    """The type gate must not turn a skipped manifest into a crash.
+
+    ``os.walk`` lists the children of a directory with ``r`` but no ``x``,
+    and stating one of them raises ``PermissionError``. Each parser already
+    swallowed that through its own ``except OSError``, so the gate in front
+    of them has to swallow it too — otherwise ``mempalace init`` gains a
+    traceback where it used to report no manifest name.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text('{"name": "inner"}', encoding="utf-8")
+    os.chmod(repo, 0o444)
+    try:
+        with hard_timeout(TIMEOUT_SECONDS, "_collect_manifest_names over an unreadable dir"):
+            found = _collect_manifest_names(repo)
+    finally:
+        os.chmod(repo, 0o755)
+    assert found == []
+
+
+@posix_only
+@needs_unprivileged_posix
+def test_parse_gradle_survives_an_unreadable_directory(tmp_path):
+    """The sibling ``settings.gradle`` is stat'd inside the parser's own try."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    build = repo / "build.gradle"
+    build.write_text("plugins { id 'java' }\n", encoding="utf-8")
+    os.chmod(repo, 0o444)
+    try:
+        with hard_timeout(TIMEOUT_SECONDS, "_parse_gradle over an unreadable dir"):
+            name = _parse_gradle(build)
+    finally:
+        os.chmod(repo, 0o755)
+    # Falls back to the directory name, exactly as it did before the gate.
+    assert name == "repo"
+
+
+@posix_only
+def test_format_miner_extract_text_does_not_block_on_fifo(tmp_path):
+    """``mine --mode extract`` was already immune — its zero-size gate fires
+    first, because a FIFO stats as 0 bytes. Pinned so a future reshuffle of
+    those checks cannot reintroduce the hang here.
+    """
+    fifo = make_fifo(tmp_path, "doc.pdf")
+    with hard_timeout(TIMEOUT_SECONDS, "extract_text on a FIFO"):
+        text, status = extract_text(fifo)
+    assert text is None
+    assert status is ExtractionStatus.SKIP_EMPTY
+
+
+@posix_only
+def test_collect_manifest_names_ignores_a_fifo_manifest(tmp_path):
+    real_repo = tmp_path / "real"
+    real_repo.mkdir()
+    (real_repo / "package.json").write_text('{"name": "real-project"}', encoding="utf-8")
+    piped = tmp_path / "piped"
+    piped.mkdir()
+    os.mkfifo(piped / "package.json")
+
+    with hard_timeout(TIMEOUT_SECONDS, "_collect_manifest_names over a FIFO manifest"):
+        found = _collect_manifest_names(tmp_path)
+    assert [entry[1] for entry in found] == ["real-project"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Fixed-name reads: `exists()` is not a type check
+#
+# The sites above are fed by a directory walk. These are read by a name the
+# code already knows, behind an `exists()` guard — which is true for a FIFO,
+# so the open right after it blocks anyway.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@posix_only
+def test_load_config_treats_a_fifo_yaml_as_absent(tmp_path):
+    """`mempalace.yaml` is the first thing `mine` reads."""
+    make_fifo(tmp_path, "mempalace.yaml")
+    with hard_timeout(TIMEOUT_SECONDS, "load_config on a FIFO mempalace.yaml"):
+        config = load_config(str(tmp_path))
+    assert [room["name"] for room in config["rooms"]] == ["general"]
+
+
+@posix_only
+def test_load_config_still_reads_a_regular_yaml(tmp_path):
+    (tmp_path / "mempalace.yaml").write_text(
+        yaml.dump({"wing": "realwing", "rooms": [{"name": "docs", "description": "d"}]}),
+        encoding="utf-8",
+    )
+    config = load_config(str(tmp_path))
+    assert config["wing"] == "realwing"
+    assert [room["name"] for room in config["rooms"]] == ["docs"]
+
+
+@posix_only
+def test_ensure_gitignore_leaves_a_fifo_gitignore_alone(tmp_path):
+    (tmp_path / ".git").mkdir()
+    make_fifo(tmp_path, ".gitignore")
+    with hard_timeout(TIMEOUT_SECONDS, "_ensure_mempalace_files_gitignored on a FIFO"):
+        assert _ensure_mempalace_files_gitignored(str(tmp_path)) is False
+
+
+def test_ensure_gitignore_still_appends_to_a_regular_gitignore(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".gitignore").write_text("*.pyc\n", encoding="utf-8")
+    assert _ensure_mempalace_files_gitignored(str(tmp_path)) is True
+    written = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert "mempalace.yaml" in written and "entities.json" in written
+
+
+@posix_only
+def test_cmd_compress_ignores_a_fifo_entities_json(tmp_path, monkeypatch, capsys):
+    """`compress` picks up `./entities.json` when no --config is given."""
+    monkeypatch.chdir(tmp_path)
+    make_fifo(tmp_path, "entities.json")
+    args = argparse.Namespace(palace=None, wing=None, dry_run=False, config=None)
+    with patch("mempalace.cli.MempalaceConfig") as mock_config_cls:
+        mock_config_cls.return_value.palace_path = str(tmp_path / "nonexistent")
+        with hard_timeout(TIMEOUT_SECONDS, "cmd_compress with a FIFO entities.json"):
+            with pytest.raises(SystemExit):
+                cmd_compress(args)
+    out = capsys.readouterr().out
+    assert "No palace found" in out
+    assert "Loaded entity config" not in out
+
+
+@posix_only
+def test_cmd_compress_fifo_entities_json_does_not_shadow_the_palace_copy(
+    tmp_path, monkeypatch, capsys
+):
+    """The candidate loop must not stop at a pipe.
+
+    An `entities.json` FIFO in the cwd would otherwise be picked as the
+    config and then rejected by the load guard, hiding a perfectly good
+    `<palace>/entities.json` behind it.
+    """
+    monkeypatch.chdir(tmp_path)
+    make_fifo(tmp_path, "entities.json")
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    (palace / "entities.json").write_text('{"entities": {"Alice": "ALC"}}', encoding="utf-8")
+    args = argparse.Namespace(palace=None, wing=None, dry_run=False, config=None)
+    with patch("mempalace.cli.MempalaceConfig") as mock_config_cls:
+        mock_config_cls.return_value.palace_path = str(palace)
+        with hard_timeout(TIMEOUT_SECONDS, "cmd_compress candidate loop"):
+            with pytest.raises(SystemExit):
+                cmd_compress(args)
+    assert f"Loaded entity config: {palace / 'entities.json'}" in capsys.readouterr().out
+
+
+@posix_only
+def test_parse_gradle_ignores_a_fifo_sibling_settings_file(tmp_path):
+    """`build.gradle` is a regular file and clears the manifest gate; the
+    parser then reads the SIBLING `settings.gradle`, which no walk vetted.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "build.gradle").write_text("plugins { id 'java' }\n", encoding="utf-8")
+    make_fifo(repo, "settings.gradle")
+    with hard_timeout(TIMEOUT_SECONDS, "_collect_manifest_names with a FIFO settings.gradle"):
+        found = _collect_manifest_names(tmp_path)
+    assert [entry[1] for entry in found] == ["repo"]
+
+
+@posix_only
+def test_count_human_messages_ignores_a_fifo_transcript(tmp_path):
+    fifo = make_fifo(tmp_path, "transcript.jsonl")
+    with hard_timeout(TIMEOUT_SECONDS, "count_human_messages on a FIFO"):
+        assert count_human_messages(str(fifo)) == 0
+
+
+def test_count_human_messages_still_raises_for_a_missing_path(tmp_path):
+    """The type gate is narrowed to paths that exist, so a missing transcript
+    keeps failing the way the plain ``open`` did.
+    """
+    with pytest.raises(FileNotFoundError):
+        count_human_messages(str(tmp_path / "nope.jsonl"))
+
+
+def test_count_human_messages_still_counts_a_regular_transcript(tmp_path):
+    path = write_regular(
+        tmp_path,
+        "transcript.jsonl",
+        '{"message": {"role": "user", "content": "one"}}\n'
+        '{"message": {"role": "assistant", "content": "two"}}\n'
+        '{"message": {"role": "user", "content": "three"}}\n',
+    )
+    assert count_human_messages(str(path)) == 2
+
+
+@posix_only
+def test_cmd_init_refuses_to_write_entities_over_a_fifo(tmp_path, capsys):
+    """`init` writes `<project>/entities.json`; opening a pre-existing FIFO
+    for writing blocks until a reader appears.
+    """
+    make_fifo(tmp_path, "entities.json")
+    args = argparse.Namespace(dir=str(tmp_path), yes=True, no_llm=True)
+    detected = {"people": [{"name": "Alice"}], "projects": [], "topics": [], "uncertain": []}
+    confirmed = {"people": ["Alice"], "projects": [], "topics": []}
+    with (
+        patch("mempalace.cli.MempalaceConfig"),
+        patch("mempalace.project_scanner.discover_entities", return_value=detected),
+        patch("mempalace.entity_detector.confirm_entities", return_value=confirmed),
+        patch("mempalace.room_detector_local.detect_rooms_local"),
+        patch("mempalace.cli._run_pass_zero", return_value=None),
+        patch("mempalace.cli._maybe_run_mine_after_init"),
+    ):
+        with hard_timeout(TIMEOUT_SECONDS, "cmd_init with a FIFO entities.json"):
+            cmd_init(args)
+    captured = capsys.readouterr()
+    assert "is not a regular file" in captured.err
+    assert "Entities saved" not in captured.out
+
+
+@posix_only
+def test_detect_rooms_local_refuses_a_fifo_config(tmp_path):
+    """`init` writes `mempalace.yaml`; a write open on a pipe blocks until a
+    reader appears, which parked `init` with no output at all.
+    """
+    write_regular(tmp_path, "README.md", "note\n")
+    make_fifo(tmp_path, "mempalace.yaml")
+    with hard_timeout(TIMEOUT_SECONDS, "detect_rooms_local over a FIFO config"):
+        with pytest.raises(OSError, match="not a regular file"):
+            detect_rooms_local(project_dir=str(tmp_path), yes=True)
+
+
+@posix_only
+def test_collect_corpus_text_ignores_a_fifo(tmp_path):
+    """LLM refinement walks prose by suffix and stats only for mtime."""
+    write_regular(tmp_path, "a.md", "real prose\n")
+    make_fifo(tmp_path, "notes.md")
+    with hard_timeout(TIMEOUT_SECONDS, "collect_corpus_text over a FIFO"):
+        text = collect_corpus_text(str(tmp_path))
+    assert text == "real prose\n"
+
+
+@posix_only
+def test_sweep_directory_skips_a_fifo_without_booking_a_failure(tmp_path, capsys):
+    """A pipe is nothing to sweep, not a sweep failure.
+
+    Booking it as a failure flips the command's exit status to 2 through
+    ``cli.cmd_sweep``, which breaks any script gating on it — and the same
+    input on a directory walk is a benign ``SKIP`` in ``mine``.
+    """
+    convos = tmp_path / "convos"
+    convos.mkdir()
+    write_regular(
+        convos,
+        "real.jsonl",
+        '{"type": "user", "sessionId": "s1", "uuid": "u1", '
+        '"timestamp": "2026-01-01T00:00:00Z", '
+        '"message": {"role": "user", "content": "hello"}}\n',
+    )
+    make_fifo(convos, "piped.jsonl")
+    with hard_timeout(TIMEOUT_SECONDS, "sweep_directory over a FIFO"):
+        result = sweep_directory(str(convos), str(tmp_path / "palace"))
+    # ``failures`` is what ``cli.cmd_sweep`` turns into ``sys.exit(2)``.
+    assert result["failures"] == []
+    # ``files_attempted`` counts discovery, per its docstring, so the pipe
+    # stays in it; ``files_succeeded`` counts what was actually swept.
+    assert result["files_attempted"] == 2
+    assert result["files_succeeded"] == 1
+    assert result["drawers_added"] == 1
+    assert "SKIP: piped.jsonl (not a regular file)" in capsys.readouterr().err
+
+
+@posix_only
+def test_sweep_directory_still_books_a_stat_failure_as_a_failure(tmp_path, capsys):
+    """A pipe is nothing to sweep; a stat that FAILS is a real error.
+
+    The type gate has to tell those apart. A dangling symlink, a symlink loop
+    and a file unlinked between ``rglob`` and the gate all raise from
+    ``stat`` — and every one of them used to reach ``open`` inside ``sweep``
+    and be booked. Swallowing them would flip ``mempalace sweep`` from exit 2
+    to exit 0 on a transcript it could not read.
+    """
+    convos = tmp_path / "convos"
+    convos.mkdir()
+    write_regular(
+        convos,
+        "real.jsonl",
+        '{"type": "user", "sessionId": "s1", "uuid": "u1", '
+        '"timestamp": "2026-01-01T00:00:00Z", '
+        '"message": {"role": "user", "content": "hello"}}\n',
+    )
+    os.symlink(convos / "gone.jsonl", convos / "dangling.jsonl")
+    with hard_timeout(TIMEOUT_SECONDS, "sweep_directory over a dangling symlink"):
+        result = sweep_directory(str(convos), str(tmp_path / "palace"))
+    # ``cli.cmd_sweep`` turns a non-empty ``failures`` into ``sys.exit(2)``.
+    assert [Path(entry["file"]).name for entry in result["failures"]] == ["dangling.jsonl"]
+    assert result["files_succeeded"] == 1
+    assert "stat failed" in capsys.readouterr().err
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# O_NONBLOCK must not drop a regular file the blocking open would have read
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@posix_only
+def test_read_text_no_follow_retries_when_a_lease_break_returns_eagain(tmp_path, monkeypatch):
+    """A write lease is the one case where the flag changes `open` itself.
+
+    Breaking a lease with ``O_NONBLOCK`` fails ``EAGAIN`` immediately, where
+    a blocking open waits out ``lease-break-time`` and succeeds. Left alone
+    that turns into a silently dropped file. The kernel grants leases on
+    regular files only, so the retry is authorised by the file *type*; the
+    errno only decides whether to look again.
+
+    ``EAGAIN`` is injected rather than staged with a real lease so the test
+    costs milliseconds instead of the 45 s default lease-break-time.
+    """
+    payload = "PAYLOAD THAT MUST STILL BE MINED\n" * 20
+    target = write_regular(tmp_path, "notes.md", payload)
+    real_open = os.open
+    calls = {"n": 0}
+
+    def _fake_open(path, flags, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert flags & os.O_NONBLOCK, "first attempt should carry the flag"
+            raise OSError(errno.EAGAIN, os.strerror(errno.EAGAIN), str(path))
+        assert not flags & os.O_NONBLOCK, "retry should drop the flag"
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr("mempalace.miner.os.open", _fake_open)
+    with hard_timeout(TIMEOUT_SECONDS, "_read_text_no_follow under an injected EAGAIN"):
+        content = _read_text_no_follow(target, tmp_path)
+    assert content == payload
+    assert calls["n"] == 2
+
+
+@posix_only
+def test_read_text_no_follow_does_not_retry_eagain_on_a_fifo(tmp_path, monkeypatch):
+    """The retry is gated on the type, so a pipe never gets a blocking open.
+
+    The stand-in raises if it is ever called without the flag, so a retry
+    that trusted the errno alone would fail this test rather than hang it.
+    """
+    fifo = make_fifo(tmp_path, "notes.md")
+
+    def _fake_open(path, flags, *args, **kwargs):
+        if flags & os.O_NONBLOCK:
+            raise OSError(errno.EAGAIN, os.strerror(errno.EAGAIN), str(path))
+        raise AssertionError("must not retry a blocking open on a FIFO")
+
+    monkeypatch.setattr("mempalace.miner.os.open", _fake_open)
+    with hard_timeout(TIMEOUT_SECONDS, "_read_text_no_follow EAGAIN on a FIFO"):
+        assert _read_text_no_follow(fifo, tmp_path) is None
+
+
+@posix_only
+@needs_unprivileged_posix
+def test_gather_origin_samples_survives_an_unreadable_directory(tmp_path):
+    """The type gate must not turn a skipped file into a crash.
+
+    ``Path.is_file()`` raises ``PermissionError`` on a directory without
+    ``x``; the ``open`` it replaced was already inside the ``try`` that
+    absorbs exactly that, so the gate has to sit there too.
+    """
+    write_regular(tmp_path, "real.md", "# Real\n\nsome prose here\n")
+    walled = tmp_path / "walled"
+    walled.mkdir()
+    write_regular(walled, "notes.md", "y" * 200)
+    os.chmod(walled, 0o444)
+    try:
+        with hard_timeout(TIMEOUT_SECONDS, "_gather_origin_samples over an unreadable dir"):
+            samples = _gather_origin_samples(str(tmp_path))
+    finally:
+        os.chmod(walled, 0o755)
+    assert len(samples) == 1
+    assert "some prose here" in samples[0]
+
+
+def test_read_transcript_file_size_message_names_the_path_once(tmp_path):
+    """Both refusal branches compose the path through the same wrapper."""
+    big = write_regular(tmp_path, "huge.jsonl", "not actually huge")
+
+    class _HugeStat:
+        st_mode = stat_module.S_IFREG | 0o644
+        st_size = 600 * 1024 * 1024
+
+    with patch("mempalace.normalize.os.fstat", return_value=_HugeStat()):
+        with pytest.raises(IOError) as excinfo:
+            _read_transcript_file(str(big))
+    message = str(excinfo.value)
+    assert "too large" in message.lower()
+    assert message.count(str(big)) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# End to end through the real miner
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@posix_only
+def test_mine_completes_with_a_fifo_in_the_corpus(tmp_path):
+    """The original report: ``mempalace mine <dir>`` never returned."""
+    project_root = tmp_path / "corpus"
+    project_root.mkdir()
+    (project_root / "mempalace.yaml").write_text(
+        yaml.dump(
+            {
+                "wing": "fifo_repro",
+                "rooms": [{"name": "general", "description": "General"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    write_regular(
+        project_root,
+        "real.md",
+        "# Real note\n\n" + "The quick brown fox jumps over the lazy dog. " * 40,
+    )
+    make_fifo(project_root, "notes.md")
+
+    palace_path = tmp_path / "palace"
+    with hard_timeout(TIMEOUT_SECONDS, "mine() over a corpus holding a FIFO"):
+        mine(str(project_root), str(palace_path))
+
+    import chromadb
+
+    collection = chromadb.PersistentClient(path=str(palace_path)).get_collection(
+        "mempalace_drawers"
+    )
+    stored = collection.get(include=["metadatas"])
+    sources = {Path(meta["source_file"]).name for meta in stored["metadatas"]}
+    assert sources == {"real.md"}


### PR DESCRIPTION
## What does this PR do?

Fixes #2221. A named pipe in a mined directory wedged `mempalace mine` forever; `mine --mode convos`, `sweep`, `init`, `compress` and `split` blocked the same way. All ten scenarios in the issue hang on `develop` under a 180 s cap and complete here.

Two shapes, neither of which asks what the file *is*.

**Open first, check the type second.** `scan_project` accepts `notes.md` on its suffix (`miner.py:1683`) and `stat` never blocks on a pipe, so `process_file` reaches `miner.py:66`:

```python
fd = os.open(filepath, flags)          # blocks forever on a FIFO
st = os.fstat(fd)
if not stat.S_ISREG(st.st_mode) or st.st_size > MAX_FILE_SIZE:
    return None                        # correct, and unreachable
```

`convo_miner.py:191`, `normalize.py:128` and `repair.py:68` carry the identical dead guard.

**`exists()` is not a type check.** It is true for a pipe, and `mempalace.yaml`, `.gitignore`, `entities.json` and a gradle `settings.gradle` all reach an `open` behind one.

## The change

`O_NONBLOCK` on those four opens, so the `S_ISREG` refusal already written there can run — the verdict is the file mode, not an errno, so a pipe with a live writer is refused too. Everywhere else a type gate: the walks drop non-regular entries with a `SKIP: <name> (not a regular file)` line beside the existing symlink and size lines, and fixed-name reads use `is_file()`. `scan_project` and `scan_convos` already stat for the size limit, so one `stat()` now answers both questions.

Two traps:

- **The flag is not inert under a write lease** — it fails `EAGAIN` where a blocking open waits out `lease-break-time` and succeeds, silently dropping a file the old code read. The retry re-checks the type first, and the kernel grants leases on regular files only (`F_SETLEASE` on a pipe fails `EINVAL`), so it is authorised by the type, not the errno.
- **A gate goes where the read was, and must not eat a real error.** `Path.is_file()` raises `PermissionError` on a directory without `x` (through 3.13), so it belongs inside whatever `try` the `open` sat in — including each `project_scanner` parser, which swallows its own `OSError`. And `sweep_directory` skips a non-regular *type* as a benign `SKIP` but still books a failed `stat`: a dangling symlink is a real error, and `sweep` still exits 2 on it.

## Audit

Every `os.open`, `open`, `read_text`, `read_bytes` and parser entry in `mempalace/` was traced to where its path comes from and probed with a real `mkfifo` on both commits. **Nineteen sites block on `develop`; none block here.** Two are hardening rather than live hangs, and I would rather say so than overclaim: `repair`'s helper sits behind `contains_palace_database` (`cli.py:1866`) and `repair.py:1692`, `hook_shell` behind `[ -f ]` in `mempal_save_hook.sh:228`. `detect_entities` is the chokepoint for all four callers of `scan_for_detection`. The one site no discovery gate could reach is a write: `split_file` synthesises its own output names, so a pipe at one of them blocked the write with the new `SKIP:` line for that pipe already on screen. `format_miner.extract_text` is left alone — immune by ordering rather than by type, which deserves its own change; the ordering is pinned by a test here. **Known limit:** the stat-then-open gates stay TOCTOU-racy, unlike `_read_text_no_follow`, which re-checks the type on the descriptor.

## How to test

```bash
mkdir -p /tmp/fifo-repro/corpus
printf 'wing: fifo-repro\nrooms:\n  - name: general\n    description: All project files\n' \
  > /tmp/fifo-repro/corpus/mempalace.yaml
python3 -c "open('/tmp/fifo-repro/corpus/real.md','w').write('# Real\n\n' + 'the quick brown fox. ' * 60)"
mkfifo /tmp/fifo-repro/corpus/notes.md

timeout 180 mempalace --palace /tmp/fifo-repro/palace mine /tmp/fifo-repro/corpus; echo "exit=$?"
```

`develop`: prints `Files: 2`, files `real.md`, then nothing — `exit=124`. Here: `SKIP: notes.md (not a regular file)`, `Files: 1`, `Drawers filed: 2`, `exit=0`, and `search` afterwards returns `real.md`.

The exit statuses are the easiest thing here to get wrong:

```bash
mkdir -p /tmp/sweep-repro && cd /tmp/sweep-repro
printf '{"type":"user","sessionId":"s","uuid":"u","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"hi"}}\n' > real.jsonl
mkfifo piped.jsonl                                    # nothing to sweep
mempalace --palace ./palace sweep .; echo "exit=$?"   # 0, with a SKIP line
rm piped.jsonl; ln -s /tmp/sweep-repro/gone.jsonl dangling.jsonl   # a real error
mempalace --palace ./palace sweep .; echo "exit=$?"   # 2, as on develop
```

## Tests

`tests/test_non_regular_file_guards.py`, 42 tests, each under a `SIGALRM` deadline so a regression turns the file red instead of hanging pytest — the deadline raises a `BaseException` subclass, because `except OSError` guards every site here and `TimeoutError` *is* an `OSError`. Every production hunk was reverted on its own in an isolated copy; two are not covered by a unit test and I would rather name them than round the count up — the `except OSError` around `detect_rooms_local` in `cmd_init`, and the legacy `mempal.yaml` name in `load_config`. 36 of the 42 are POSIX-only (Windows has no FIFO in the filesystem namespace), and three more skip as root, matching `tests/test_backups.py`.

The suite's only failures here are the palace-lock family under full-suite load, and they are load artefacts rather than anything this branch does: the same commit produced one failure on a quiet machine and twelve on a busy one, and every one of them passes when the file is run on its own. CI is the arbiter. One unrelated fix rides along on a line this PR had to touch: `normalize._read_transcript_file` was wrapping its two refusals a second time, printing the path twice.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`, and `ruff format --check .`, at the ruff 0.16.1 pinned in CI)
