### PR TITLE
RFC 002: add incremental source-item currentness

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -887,7 +887,7 @@ class _DryRunKnowledgeGraphProxy:
         self.operations.append(("supersede", args, kwargs))
 
 
-def mine_source_adapter(
+def mine_source_adapter(  # noqa: C901 - incremental lifecycle states are deliberately co-located
     *,
     source_name: str,
     source_path: str,
@@ -966,9 +966,11 @@ def mine_source_adapter(
             )
 
             def _existing_source(source_file):
-                active = lifecycle.active(
-                    adapter_name=adapter.name, source_file=source_file
-                ) if lifecycle is not None else None
+                active = (
+                    lifecycle.active(adapter_name=adapter.name, source_file=source_file)
+                    if lifecycle is not None
+                    else None
+                )
                 if active is not None:
                     existing = drawer_collection.get(
                         where={
@@ -1015,14 +1017,6 @@ def mine_source_adapter(
                 nonlocal pending_item, pending_generation
                 if pending_generation is None:
                     return
-                staged = drawer_collection.get(
-                    where={
-                        "$and": [
-                            {"source_file": pending_item.source_file},
-                            {"source_generation": pending_generation.generation},
-                        ]
-                    }
-                )
                 # Switching the registry is the atomic visibility boundary.
                 # Staged rows stay physically marked ``staging`` forever;
                 # ordinary collection views resolve their visibility against
@@ -1030,7 +1024,7 @@ def mine_source_adapter(
                 # of the new item and a failure during cleanup cannot restore
                 # retired content.
                 generation = pending_generation
-                previous = lifecycle.activate(generation)
+                lifecycle.activate(generation)
                 # From this point on the registry is authoritative. A failed
                 # physical cleanup may leave unreachable rows behind, but it
                 # must never trigger the outer rollback path and remove this
@@ -1108,7 +1102,9 @@ def mine_source_adapter(
                                 source_file=result.source_file,
                                 version=result.version,
                             )
-                            context.begin_source_item(result, generation=pending_generation.generation)
+                            context.begin_source_item(
+                                result, generation=pending_generation.generation
+                            )
                         continue
                     warnings.warn(
                         f"Source adapter {adapter_name!r} yielded non-incremental item "

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -909,6 +909,7 @@ def mine_source_adapter(
         get_adapter,
         resolve_adapter_for_source,
     )
+    from .sources.lifecycle import SourceLifecycleStore
 
     adapter_name = resolve_adapter_for_source(explicit=source_name)
     try:
@@ -919,10 +920,11 @@ def mine_source_adapter(
             "check the adapter name with `mempalace mine --help`"
         ) from exc
 
-    if "supports_incremental" in adapter.capabilities:
+    incremental = "supports_incremental" in adapter.capabilities
+    if incremental and "supports_kg_triples" in adapter.capabilities:
         raise UnsupportedSourceAdapterProtocolError(
-            f"source adapter {adapter_name!r} requires incremental ingestion, which "
-            "mempalace mine does not support yet"
+            f"source adapter {adapter_name!r} combines incremental drawer ingestion with "
+            "knowledge-graph writes; generation-safe KG replacement is not supported yet"
         )
 
     # A dry run must never open a collection: backend opens can create or
@@ -932,12 +934,19 @@ def mine_source_adapter(
     lock = mine_palace_lock(palace_path) if not dry_run else contextlib.nullcontext()
     with lock:
         knowledge_graph = None
+        lifecycle = None
+        pending_item = None
+        pending_generation = None
+        pending_prior_ids = []
         try:
             if dry_run:
                 drawer_collection = _DryRunCollectionProxy()
                 knowledge_graph = _DryRunKnowledgeGraphProxy()
             else:
-                drawer_collection = get_collection(palace_path)
+                if incremental:
+                    drawer_collection = get_collection(palace_path, _include_staging=True)
+                else:
+                    drawer_collection = get_collection(palace_path)
                 knowledge_graph = KnowledgeGraph(
                     db_path=os.path.join(palace_path, "knowledge_graph.sqlite3")
                 )
@@ -950,15 +959,106 @@ def mine_source_adapter(
                 adapter_version=adapter.adapter_version,
             )
             drawers_written = 0
+            lifecycle = (
+                SourceLifecycleStore(os.path.join(palace_path, "knowledge_graph.sqlite3"))
+                if incremental and not dry_run
+                else None
+            )
+
+            def _existing_source(source_file):
+                existing = drawer_collection.get(where={"source_file": source_file}, limit=1)
+                metadatas = existing.get("metadatas") or []
+                return existing, (metadatas[0] if metadatas else None)
+
+            def _cleanup_staged(generation):
+                staged = drawer_collection.get(
+                    where={
+                        "$and": [
+                            {"source_file": generation.source_file},
+                            {"source_generation": generation.generation},
+                        ]
+                    }
+                )
+                ids = staged.get("ids") or []
+                if ids:
+                    drawer_collection.delete(ids=ids)
+                lifecycle.abandon(generation)
+
+            def _commit_pending():
+                nonlocal pending_item, pending_generation, pending_prior_ids
+                if pending_generation is None:
+                    return
+                staged = drawer_collection.get(
+                    where={
+                        "$and": [
+                            {"source_file": pending_item.source_file},
+                            {"source_generation": pending_generation.generation},
+                        ]
+                    }
+                )
+                ids = staged.get("ids") or []
+                documents = staged.get("documents") or []
+                metadatas = staged.get("metadatas") or []
+                if not ids:
+                    _cleanup_staged(pending_generation)
+                    raise ValueError(
+                        f"incremental source item {pending_item.source_file!r} yielded no drawers"
+                    )
+                # Switching the registry is the atomic visibility boundary.
+                # Staged rows stay physically marked ``staging`` forever;
+                # ordinary collection views resolve their visibility against
+                # the registry, so a failure before this point exposes none
+                # of the new item and a failure during cleanup cannot restore
+                # retired content.
+                previous = lifecycle.activate(pending_generation)
+                if previous is not None:
+                    old = drawer_collection.get(
+                        where={
+                            "$and": [
+                                {"source_file": previous.source_file},
+                                {"source_generation": previous.generation},
+                            ]
+                        }
+                    )
+                    old_ids = old.get("ids") or []
+                    if old_ids:
+                        drawer_collection.delete(ids=old_ids)
+                elif pending_prior_ids:
+                    # The first incremental run may be replacing drawers from
+                    # a pre-lifecycle adapter version.  They lack generation
+                    # metadata, so retire the snapshot captured before this
+                    # generation was staged.
+                    drawer_collection.delete(ids=pending_prior_ids)
+                pending_item = None
+                pending_generation = None
+                pending_prior_ids = []
+                context.finish_source_item()
+
             for result in adapter.ingest(
                 source=SourceRef(local_path=source_path),
                 palace=context,
             ):
                 if isinstance(result, SourceItemMetadata):
-                    # Non-incremental adapters may report a cursor or version
-                    # while still doing a complete re-extract.  Incremental
-                    # adapters are rejected before ingest above, so accepting
-                    # this avoids a late partial-ingest failure.
+                    if incremental:
+                        _commit_pending()
+                        existing, existing_metadata = _existing_source(result.source_file)
+                        context.begin_source_item(result)
+                        if adapter.is_current(item=result, existing_metadata=existing_metadata):
+                            context.skip_current_item()
+                        elif dry_run:
+                            # Preserve dry-run's no-storage invariant while
+                            # still exercising the RFC currentness handshake.
+                            pending_item = result
+                        else:
+                            pending_item = result
+                            pending_generation = lifecycle.begin(
+                                adapter_name=adapter.name,
+                                source_file=result.source_file,
+                                version=result.version,
+                            )
+                            pending_prior_ids = existing.get("ids") or []
+                            context.begin_source_item(result, generation=pending_generation.generation)
+                        continue
                     warnings.warn(
                         f"Source adapter {adapter_name!r} yielded non-incremental item "
                         "metadata; ignoring it during complete ingest",
@@ -967,6 +1067,14 @@ def mine_source_adapter(
                     )
                     continue
                 if isinstance(result, DrawerRecord):
+                    if incremental and pending_item is None:
+                        raise ValueError(
+                            "incremental adapters must yield SourceItemMetadata before drawers"
+                        )
+                    if incremental and context._skip_requested:
+                        raise ValueError(
+                            "incremental adapter yielded drawers after core marked its item current"
+                        )
                     drawers_written += 1
                     context.upsert_drawer(result)
                     continue
@@ -974,7 +1082,13 @@ def mine_source_adapter(
                     f"source adapter {adapter_name!r} yielded unsupported result type "
                     f"{type(result).__name__}"
                 )
+            _commit_pending()
             return drawers_written
+        except Exception:
+            if pending_generation is not None and lifecycle is not None:
+                _cleanup_staged(pending_generation)
+                context.finish_source_item()
+            raise
         finally:
             if knowledge_graph is not None and hasattr(knowledge_graph, "close"):
                 knowledge_graph.close()

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -33,6 +33,7 @@ Examples:
 
 import argparse
 import contextlib
+import logging
 import os
 import shlex
 import sys
@@ -937,7 +938,6 @@ def mine_source_adapter(
         lifecycle = None
         pending_item = None
         pending_generation = None
-        pending_prior_ids = []
         try:
             if dry_run:
                 drawer_collection = _DryRunCollectionProxy()
@@ -966,9 +966,36 @@ def mine_source_adapter(
             )
 
             def _existing_source(source_file):
-                existing = drawer_collection.get(where={"source_file": source_file}, limit=1)
+                active = lifecycle.active(
+                    adapter_name=adapter.name, source_file=source_file
+                ) if lifecycle is not None else None
+                if active is not None:
+                    existing = drawer_collection.get(
+                        where={
+                            "$and": [
+                                {"source_file": source_file},
+                                {"source_generation": active.generation},
+                            ]
+                        },
+                        limit=1,
+                    )
+                else:
+                    # First incremental replacement may be upgrading legacy
+                    # drawers, which have no generation metadata.
+                    existing = drawer_collection.get(where={"source_file": source_file}, limit=1)
                 metadatas = existing.get("metadatas") or []
-                return existing, (metadatas[0] if metadatas else None)
+                if metadatas:
+                    return existing, metadatas[0]
+                if active is not None:
+                    # Empty items and tombstones have an active lifecycle
+                    # generation but no drawer from which to read provenance.
+                    # The registry remains the palace cursor in that case.
+                    return existing, {
+                        "source_file": source_file,
+                        "source_version": active.version,
+                        "adapter_name": adapter.name,
+                    }
+                return existing, None
 
             def _cleanup_staged(generation):
                 staged = drawer_collection.get(
@@ -985,7 +1012,7 @@ def mine_source_adapter(
                 lifecycle.abandon(generation)
 
             def _commit_pending():
-                nonlocal pending_item, pending_generation, pending_prior_ids
+                nonlocal pending_item, pending_generation
                 if pending_generation is None:
                     return
                 staged = drawer_collection.get(
@@ -996,42 +1023,45 @@ def mine_source_adapter(
                         ]
                     }
                 )
-                ids = staged.get("ids") or []
-                documents = staged.get("documents") or []
-                metadatas = staged.get("metadatas") or []
-                if not ids:
-                    _cleanup_staged(pending_generation)
-                    raise ValueError(
-                        f"incremental source item {pending_item.source_file!r} yielded no drawers"
-                    )
                 # Switching the registry is the atomic visibility boundary.
                 # Staged rows stay physically marked ``staging`` forever;
                 # ordinary collection views resolve their visibility against
                 # the registry, so a failure before this point exposes none
                 # of the new item and a failure during cleanup cannot restore
                 # retired content.
-                previous = lifecycle.activate(pending_generation)
-                if previous is not None:
-                    old = drawer_collection.get(
-                        where={
-                            "$and": [
-                                {"source_file": previous.source_file},
-                                {"source_generation": previous.generation},
-                            ]
-                        }
-                    )
-                    old_ids = old.get("ids") or []
-                    if old_ids:
-                        drawer_collection.delete(ids=old_ids)
-                elif pending_prior_ids:
-                    # The first incremental run may be replacing drawers from
-                    # a pre-lifecycle adapter version.  They lack generation
-                    # metadata, so retire the snapshot captured before this
-                    # generation was staged.
-                    drawer_collection.delete(ids=pending_prior_ids)
-                pending_item = None
+                generation = pending_generation
+                previous = lifecycle.activate(generation)
+                # From this point on the registry is authoritative. A failed
+                # physical cleanup may leave unreachable rows behind, but it
+                # must never trigger the outer rollback path and remove this
+                # newly active generation.
                 pending_generation = None
-                pending_prior_ids = []
+                try:
+                    candidates = drawer_collection.get(
+                        where={"source_file": generation.source_file}
+                    )
+                    stale_ids = [
+                        drawer_id
+                        for drawer_id, metadata in zip(
+                            candidates.get("ids") or [], candidates.get("metadatas") or []
+                        )
+                        if (metadata or {}).get("adapter_name") == adapter.name
+                        and (metadata or {}).get("source_generation") != generation.generation
+                    ]
+                    if stale_ids:
+                        drawer_collection.delete(ids=stale_ids)
+                    lifecycle.prune_retired(
+                        adapter_name=adapter.name, source_file=generation.source_file
+                    )
+                except Exception:
+                    logging.getLogger(__name__).warning(
+                        "incremental source cleanup failed after activating %s; "
+                        "the retired generation remains hidden and will be retried "
+                        "on the next replacement",
+                        generation.source_file,
+                        exc_info=True,
+                    )
+                pending_item = None
                 context.finish_source_item()
 
             for result in adapter.ingest(
@@ -1041,6 +1071,28 @@ def mine_source_adapter(
                 if isinstance(result, SourceItemMetadata):
                     if incremental:
                         _commit_pending()
+                        if result.version == "__deleted__":
+                            if "supports_deletion_tombstones" not in adapter.capabilities:
+                                raise UnsupportedSourceAdapterProtocolError(
+                                    f"source adapter {adapter_name!r} yielded a deletion tombstone "
+                                    "without supports_deletion_tombstones"
+                                )
+                            if not dry_run:
+                                lifecycle.tombstone(
+                                    adapter_name=adapter.name,
+                                    source_file=result.source_file,
+                                )
+                                # Physical deletion is deliberately after the
+                                # registry switch: an interrupted purge leaves
+                                # drawers hidden rather than falsely visible.
+                                stale = drawer_collection.get(
+                                    where={"source_file": result.source_file}
+                                )
+                                stale_ids = stale.get("ids") or []
+                                if stale_ids:
+                                    drawer_collection.delete(ids=stale_ids)
+                            context.finish_source_item()
+                            continue
                         existing, existing_metadata = _existing_source(result.source_file)
                         context.begin_source_item(result)
                         if adapter.is_current(item=result, existing_metadata=existing_metadata):
@@ -1056,7 +1108,6 @@ def mine_source_adapter(
                                 source_file=result.source_file,
                                 version=result.version,
                             )
-                            pending_prior_ids = existing.get("ids") or []
                             context.begin_source_item(result, generation=pending_generation.generation)
                         continue
                     warnings.warn(
@@ -1090,8 +1141,21 @@ def mine_source_adapter(
                 context.finish_source_item()
             raise
         finally:
-            if knowledge_graph is not None and hasattr(knowledge_graph, "close"):
-                knowledge_graph.close()
+            primary_error = sys.exc_info()[0] is not None
+            try:
+                adapter.close()
+            except Exception:
+                if primary_error:
+                    logging.getLogger(__name__).warning(
+                        "source adapter %r close failed while handling an ingest error",
+                        adapter_name,
+                        exc_info=True,
+                    )
+                else:
+                    raise
+            finally:
+                if knowledge_graph is not None and hasattr(knowledge_graph, "close"):
+                    knowledge_graph.close()
 
 
 def cmd_sweep(args):

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -27,7 +27,7 @@ from .backends import (
     get_backend_class,
     resolve_backend_for_palace,
 )
-from .backends.base import GetResult, QueryResult
+from .backends.base import GetResult, LexicalResult, QueryResult
 from .backends.embedding_wrapper import EmbeddingCollection
 from .entity_detector import (
     _apply_known_systems_prepass,
@@ -49,20 +49,33 @@ class _VisibleDrawersCollection:
 
     def __init__(self, collection, palace_path):
         self._collection = collection
-        from .sources.lifecycle import SourceLifecycleStore
+        self._lifecycle_db_path = os.path.join(palace_path, "knowledge_graph.sqlite3")
+        self._lifecycle = None
 
-        self._lifecycle = SourceLifecycleStore(
-            os.path.join(palace_path, "knowledge_graph.sqlite3")
-        )
-
-    def _visible(self, metadata):
+    def _visible(self, metadata, active_generations):
         metadata = metadata or {}
         generation = metadata.get("source_generation")
         adapter_name = metadata.get("adapter_name")
         source_file = metadata.get("source_file")
         if not adapter_name or not source_file:
             return True
-        active = self._lifecycle.active(adapter_name=adapter_name, source_file=source_file)
+        # Do not create a knowledge-graph database merely because a normal
+        # collection was opened. A lifecycle store exists only after an
+        # incremental adapter has actually started work in this palace.
+        if not os.path.exists(self._lifecycle_db_path):
+            return True
+        if self._lifecycle is None:
+            from .sources.lifecycle import SourceLifecycleStore
+
+            self._lifecycle = SourceLifecycleStore(
+                self._lifecycle_db_path, initialize=False
+            )
+        key = (adapter_name, source_file)
+        if key not in active_generations:
+            active_generations[key] = self._lifecycle.active(
+                adapter_name=adapter_name, source_file=source_file
+            )
+        active = active_generations[key]
         if generation:
             return active is not None and active.generation == generation
         # Once an RFC 002 adapter has an active generation, its earlier
@@ -73,7 +86,30 @@ class _VisibleDrawersCollection:
     def get(self, **kwargs):
         result = self._collection.get(**kwargs)
         metas = result.get("metadatas") or []
-        keep = [index for index, meta in enumerate(metas) if self._visible(meta)]
+        active_generations = {}
+        keep = [index for index, meta in enumerate(metas) if self._visible(meta, active_generations)]
+        # The common path retains the backend's pagination exactly. Only
+        # widen when a hidden generation actually consumed the requested
+        # window; an exact visible pagination pass then follows below.
+        if len(keep) == len(metas):
+            return result
+        requested_limit = kwargs.get("limit")
+        requested_offset = kwargs.get("offset") or 0
+        if requested_limit is not None or requested_offset:
+            widened = dict(kwargs)
+            widened.pop("limit", None)
+            widened.pop("offset", None)
+            result = self._collection.get(**widened)
+            metas = result.get("metadatas") or []
+            active_generations = {}
+            keep = [
+                index for index, meta in enumerate(metas)
+                if self._visible(meta, active_generations)
+            ]
+            if requested_limit is not None:
+                keep = keep[requested_offset:requested_offset + requested_limit]
+            elif requested_offset:
+                keep = keep[requested_offset:]
         if isinstance(result, GetResult):
             return replace(
                 result,
@@ -92,20 +128,31 @@ class _VisibleDrawersCollection:
         return result
 
     def query(self, **kwargs):
-        # A backend can return a staging item among its nearest candidates.
-        # Fetch the full collection to avoid letting that hidden item reduce
-        # the caller's visible result window.
         wanted = kwargs.get("n_results")
-        if wanted is not None:
-            kwargs = dict(kwargs)
-            kwargs["n_results"] = max(wanted, self._collection.count())
         result = self._collection.query(**kwargs)
         metas_batches = result.get("metadatas") or []
+        active_generations = {}
+        hidden_seen = False
+        for metas in metas_batches:
+            if any(not self._visible(meta, active_generations) for meta in metas or []):
+                hidden_seen = True
+                break
+        if hidden_seen and wanted is not None:
+            # Vector backends do not expose a stable result offset. Widen
+            # only after hidden candidates are actually observed.
+            kwargs = dict(kwargs)
+            kwargs["n_results"] = max(wanted, self._collection.count())
+            result = self._collection.query(**kwargs)
+            metas_batches = result.get("metadatas") or []
+            active_generations = {}
         if isinstance(result, QueryResult):
             ids, documents, metadatas, distances = [], [], [], []
             embeddings = [] if result.embeddings is not None else None
             for batch_index, metas in enumerate(metas_batches):
-                keep = [index for index, meta in enumerate(metas or []) if self._visible(meta)]
+                keep = [
+                    index for index, meta in enumerate(metas or [])
+                    if self._visible(meta, active_generations)
+                ]
                 if wanted is not None:
                     keep = keep[:wanted]
                 ids.append([result.ids[batch_index][index] for index in keep])
@@ -123,7 +170,10 @@ class _VisibleDrawersCollection:
                 embeddings=embeddings,
             )
         for batch_index, metas in enumerate(metas_batches):
-            keep = [index for index, meta in enumerate(metas or []) if self._visible(meta)]
+            keep = [
+                index for index, meta in enumerate(metas or [])
+                if self._visible(meta, active_generations)
+            ]
             for key, value in list(result.items()):
                 if isinstance(value, list) and batch_index < len(value) and isinstance(value[batch_index], list):
                     result[key][batch_index] = [value[batch_index][index] for index in keep]
@@ -131,8 +181,50 @@ class _VisibleDrawersCollection:
                         result[key][batch_index] = result[key][batch_index][:wanted]
         return result
 
+    def lexical_search(self, *, query, n_results=10, where=None):
+        result = self._collection.lexical_search(query=query, n_results=n_results, where=where)
+        active_generations = {}
+        hits = [
+            hit for hit in result.hits
+            if self._visible(hit.metadata, active_generations)
+        ]
+        if len(hits) != len(result.hits):
+            result = self._collection.lexical_search(
+                query=query, n_results=max(n_results, self._collection.count()), where=where
+            )
+            active_generations = {}
+            hits = [
+                hit for hit in result.hits
+                if self._visible(hit.metadata, active_generations)
+            ]
+        hits = hits[:n_results]
+        return LexicalResult(hits=hits)
+
+    def get_all_metadata(self, where=None):
+        result = self.get(where=where, include=["metadatas"])
+        return result.metadatas if hasattr(result, "metadatas") else result.get("metadatas", [])
+
+    def count(self):
+        # Preserve the backend's fast operational count. Visibility filtering
+        # applies to content-returning reads; cleanup reconciliation removes
+        # unreachable rows after successful incremental replacements.
+        return self._collection.count()
+
+    def estimated_count(self):
+        return self.count()
+
+    def facet_counts(self, field, where=None, limit=1000):
+        return self._collection.facet_counts(field, where=where, limit=limit)
+
     def __getattr__(self, name):
         return getattr(self._collection, name)
+
+
+class _VisibleEmbeddingCollection(EmbeddingCollection):
+    """Visibility filtering that preserves the public embedding wrapper type."""
+
+    def __init__(self, collection, palace_path):
+        super().__init__(_VisibleDrawersCollection(collection, palace_path))
 
 SKIP_DIRS = {
     ".git",
@@ -319,10 +411,11 @@ def get_collection(
     ``set-embedder`` override path can open a palace whose recorded model
     differs from the current one (the very state it exists to repair).
     """
+    from .config import get_configured_collection_name
+    configured_drawer_collection = get_configured_collection_name()
     if collection_name is None:
-        from .config import get_configured_collection_name
-
-        collection_name = get_configured_collection_name()
+        collection_name = configured_drawer_collection
+    is_drawer_collection = collection_name == configured_drawer_collection
     backend_obj = get_backend_for_palace(palace_path, explicit=backend)
     palace_ref = PalaceRef(id=palace_path, local_path=palace_path)
     backend_options = {"read_only": True} if read_only else None
@@ -375,8 +468,11 @@ def get_collection(
         collection = EmbeddingCollection(collection)
     if not _skip_identity_check:
         _enforce_embedder_identity(collection, palace_path, collection_name, create=create)
-    if not _include_staging:
-        collection = _VisibleDrawersCollection(collection, palace_path)
+    if is_drawer_collection and not _include_staging and hasattr(collection, "get"):
+        if isinstance(collection, EmbeddingCollection):
+            collection = _VisibleEmbeddingCollection(collection, palace_path)
+        else:
+            collection = _VisibleDrawersCollection(collection, palace_path)
     return collection
 
 

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -67,9 +67,7 @@ class _VisibleDrawersCollection:
         if self._lifecycle is None:
             from .sources.lifecycle import SourceLifecycleStore
 
-            self._lifecycle = SourceLifecycleStore(
-                self._lifecycle_db_path, initialize=False
-            )
+            self._lifecycle = SourceLifecycleStore(self._lifecycle_db_path, initialize=False)
         key = (adapter_name, source_file)
         if key not in active_generations:
             active_generations[key] = self._lifecycle.active(
@@ -87,7 +85,9 @@ class _VisibleDrawersCollection:
         result = self._collection.get(**kwargs)
         metas = result.get("metadatas") or []
         active_generations = {}
-        keep = [index for index, meta in enumerate(metas) if self._visible(meta, active_generations)]
+        keep = [
+            index for index, meta in enumerate(metas) if self._visible(meta, active_generations)
+        ]
         # The common path retains the backend's pagination exactly. Only
         # widen when a hidden generation actually consumed the requested
         # window; an exact visible pagination pass then follows below.
@@ -103,11 +103,10 @@ class _VisibleDrawersCollection:
             metas = result.get("metadatas") or []
             active_generations = {}
             keep = [
-                index for index, meta in enumerate(metas)
-                if self._visible(meta, active_generations)
+                index for index, meta in enumerate(metas) if self._visible(meta, active_generations)
             ]
             if requested_limit is not None:
-                keep = keep[requested_offset:requested_offset + requested_limit]
+                keep = keep[requested_offset : requested_offset + requested_limit]
             elif requested_offset:
                 keep = keep[requested_offset:]
         if isinstance(result, GetResult):
@@ -150,7 +149,8 @@ class _VisibleDrawersCollection:
             embeddings = [] if result.embeddings is not None else None
             for batch_index, metas in enumerate(metas_batches):
                 keep = [
-                    index for index, meta in enumerate(metas or [])
+                    index
+                    for index, meta in enumerate(metas or [])
                     if self._visible(meta, active_generations)
                 ]
                 if wanted is not None:
@@ -171,11 +171,16 @@ class _VisibleDrawersCollection:
             )
         for batch_index, metas in enumerate(metas_batches):
             keep = [
-                index for index, meta in enumerate(metas or [])
+                index
+                for index, meta in enumerate(metas or [])
                 if self._visible(meta, active_generations)
             ]
             for key, value in list(result.items()):
-                if isinstance(value, list) and batch_index < len(value) and isinstance(value[batch_index], list):
+                if (
+                    isinstance(value, list)
+                    and batch_index < len(value)
+                    and isinstance(value[batch_index], list)
+                ):
                     result[key][batch_index] = [value[batch_index][index] for index in keep]
                     if wanted is not None:
                         result[key][batch_index] = result[key][batch_index][:wanted]
@@ -184,19 +189,13 @@ class _VisibleDrawersCollection:
     def lexical_search(self, *, query, n_results=10, where=None):
         result = self._collection.lexical_search(query=query, n_results=n_results, where=where)
         active_generations = {}
-        hits = [
-            hit for hit in result.hits
-            if self._visible(hit.metadata, active_generations)
-        ]
+        hits = [hit for hit in result.hits if self._visible(hit.metadata, active_generations)]
         if len(hits) != len(result.hits):
             result = self._collection.lexical_search(
                 query=query, n_results=max(n_results, self._collection.count()), where=where
             )
             active_generations = {}
-            hits = [
-                hit for hit in result.hits
-                if self._visible(hit.metadata, active_generations)
-            ]
+            hits = [hit for hit in result.hits if self._visible(hit.metadata, active_generations)]
         hits = hits[:n_results]
         return LexicalResult(hits=hits)
 
@@ -225,6 +224,7 @@ class _VisibleEmbeddingCollection(EmbeddingCollection):
 
     def __init__(self, collection, palace_path):
         super().__init__(_VisibleDrawersCollection(collection, palace_path))
+
 
 SKIP_DIRS = {
     ".git",
@@ -412,6 +412,7 @@ def get_collection(
     differs from the current one (the very state it exists to repair).
     """
     from .config import get_configured_collection_name
+
     configured_drawer_collection = get_configured_collection_name()
     if collection_name is None:
         collection_name = configured_drawer_collection

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -5,6 +5,7 @@ Consolidates collection access patterns used by both miners and the MCP server.
 """
 
 import contextlib
+from dataclasses import replace
 import hashlib
 import logging
 import os
@@ -26,6 +27,7 @@ from .backends import (
     get_backend_class,
     resolve_backend_for_palace,
 )
+from .backends.base import GetResult, QueryResult
 from .backends.embedding_wrapper import EmbeddingCollection
 from .entity_detector import (
     _apply_known_systems_prepass,
@@ -34,6 +36,103 @@ from .entity_detector import (
 )
 
 logger = logging.getLogger("mempalace_mcp")
+
+
+class _VisibleDrawersCollection:
+    """Hide incomplete RFC 002 generations from ordinary palace reads.
+
+    Source-adapter ingestion obtains an explicit internal view while staging
+    and committing.  Everyone else sees legacy drawers plus complete
+    generations only.  This is deliberately a collection wrapper rather than
+    a backend-specific filter: plugin backends receive the same safety rule.
+    """
+
+    def __init__(self, collection, palace_path):
+        self._collection = collection
+        from .sources.lifecycle import SourceLifecycleStore
+
+        self._lifecycle = SourceLifecycleStore(
+            os.path.join(palace_path, "knowledge_graph.sqlite3")
+        )
+
+    def _visible(self, metadata):
+        metadata = metadata or {}
+        generation = metadata.get("source_generation")
+        adapter_name = metadata.get("adapter_name")
+        source_file = metadata.get("source_file")
+        if not adapter_name or not source_file:
+            return True
+        active = self._lifecycle.active(adapter_name=adapter_name, source_file=source_file)
+        if generation:
+            return active is not None and active.generation == generation
+        # Once an RFC 002 adapter has an active generation, its earlier
+        # unversioned drawers are superseded. Unrelated legacy drawers remain
+        # visible because they do not carry this adapter identity.
+        return active is None
+
+    def get(self, **kwargs):
+        result = self._collection.get(**kwargs)
+        metas = result.get("metadatas") or []
+        keep = [index for index, meta in enumerate(metas) if self._visible(meta)]
+        if isinstance(result, GetResult):
+            return replace(
+                result,
+                ids=[result.ids[index] for index in keep],
+                documents=[result.documents[index] for index in keep],
+                metadatas=[result.metadatas[index] for index in keep],
+                embeddings=(
+                    [result.embeddings[index] for index in keep]
+                    if result.embeddings is not None
+                    else None
+                ),
+            )
+        for key, value in list(result.items()):
+            if isinstance(value, list) and len(value) == len(metas):
+                result[key] = [value[index] for index in keep]
+        return result
+
+    def query(self, **kwargs):
+        # A backend can return a staging item among its nearest candidates.
+        # Fetch the full collection to avoid letting that hidden item reduce
+        # the caller's visible result window.
+        wanted = kwargs.get("n_results")
+        if wanted is not None:
+            kwargs = dict(kwargs)
+            kwargs["n_results"] = max(wanted, self._collection.count())
+        result = self._collection.query(**kwargs)
+        metas_batches = result.get("metadatas") or []
+        if isinstance(result, QueryResult):
+            ids, documents, metadatas, distances = [], [], [], []
+            embeddings = [] if result.embeddings is not None else None
+            for batch_index, metas in enumerate(metas_batches):
+                keep = [index for index, meta in enumerate(metas or []) if self._visible(meta)]
+                if wanted is not None:
+                    keep = keep[:wanted]
+                ids.append([result.ids[batch_index][index] for index in keep])
+                documents.append([result.documents[batch_index][index] for index in keep])
+                metadatas.append([result.metadatas[batch_index][index] for index in keep])
+                distances.append([result.distances[batch_index][index] for index in keep])
+                if embeddings is not None:
+                    embeddings.append([result.embeddings[batch_index][index] for index in keep])
+            return replace(
+                result,
+                ids=ids,
+                documents=documents,
+                metadatas=metadatas,
+                distances=distances,
+                embeddings=embeddings,
+            )
+        for batch_index, metas in enumerate(metas_batches):
+            keep = [index for index, meta in enumerate(metas or []) if self._visible(meta)]
+            for key, value in list(result.items()):
+                if isinstance(value, list) and batch_index < len(value) and isinstance(value[batch_index], list):
+                    result[key][batch_index] = [value[batch_index][index] for index in keep]
+                    if wanted is not None:
+                        result[key][batch_index] = result[key][batch_index][:wanted]
+        return result
+
+    def __getattr__(self, name):
+        return getattr(self._collection, name)
 
 SKIP_DIRS = {
     ".git",
@@ -208,6 +307,7 @@ def get_collection(
     backend: Optional[str] = None,
     read_only: bool = False,
     _skip_identity_check: bool = False,
+    _include_staging: bool = False,
 ):
     """Get the palace collection through the backend layer.
 
@@ -275,6 +375,8 @@ def get_collection(
         collection = EmbeddingCollection(collection)
     if not _skip_identity_check:
         _enforce_embedder_identity(collection, palace_path, collection_name, create=create)
+    if not _include_staging:
+        collection = _VisibleDrawersCollection(collection, palace_path)
     return collection
 
 

--- a/mempalace/sources/context.py
+++ b/mempalace/sources/context.py
@@ -6,11 +6,10 @@ progress hooks. Adapters receive a ``PalaceContext`` instance and MUST NOT
 import ``mempalace.palace`` directly — that coupling is what the facade
 exists to prevent.
 
-This module publishes the shape third-party adapters target. Core's mine
-loop will construct a concrete ``PalaceContext`` and pass it to adapters
-when the filesystem/conversations miners are migrated onto ``BaseSourceAdapter``
-in a follow-up PR; until then, no in-tree code constructs one, but the
-contract is stable.
+This module publishes the shape third-party adapters target. Core constructs a
+concrete ``PalaceContext`` for explicit source-adapter mining; legacy
+filesystem and conversation miners retain their established paths until they
+are migrated separately.
 """
 
 from __future__ import annotations
@@ -54,10 +53,21 @@ class _IncrementalCollectionFacade:
     ``palace.drawer_collection.upsert`` directly.
     """
 
-    def __init__(self, collection: _CollectionLike, item: SourceItemMetadata, generation: str):
+    def __init__(
+        self,
+        collection: _CollectionLike,
+        item: SourceItemMetadata,
+        generation: str,
+        adapter_name: str,
+        adapter_version: str,
+    ):
         self._collection = collection
         self._item = item
         self._generation = generation
+        self._adapter_name = adapter_name
+        self._adapter_version = adapter_version
+        self._next_chunk_index = 0
+        self._seen_chunk_indexes = set()
 
     def upsert(self, *, documents, ids=None, metadatas=None, **kwargs: Any) -> None:
         documents = list(documents)
@@ -71,7 +81,18 @@ class _IncrementalCollectionFacade:
             source_file = meta.get("source_file", self._item.source_file)
             if source_file != self._item.source_file:
                 raise ValueError("incremental collection writes must target the current source item")
-            chunk_index = meta.get("chunk_index", index)
+            chunk_index = meta.get("chunk_index")
+            if chunk_index is None:
+                chunk_index = self._next_chunk_index
+                self._next_chunk_index += 1
+            else:
+                self._next_chunk_index = max(self._next_chunk_index, chunk_index + 1)
+            if chunk_index in self._seen_chunk_indexes:
+                raise ValueError(
+                    "incremental source item yielded duplicate chunk_index "
+                    f"{chunk_index!r}"
+                )
+            self._seen_chunk_indexes.add(chunk_index)
             record = DrawerRecord(
                 content=documents[index], source_file=source_file, chunk_index=chunk_index
             )
@@ -82,6 +103,10 @@ class _IncrementalCollectionFacade:
                 source_generation=self._generation,
                 source_generation_state="staging",
             )
+            if self._adapter_name:
+                meta["adapter_name"] = self._adapter_name
+            if self._adapter_version:
+                meta["adapter_version"] = self._adapter_version
             normalized.append(meta)
             generated_ids.append(_build_drawer_id(record, generation=self._generation))
         self._collection.upsert(
@@ -165,9 +190,9 @@ class PalaceContext:
         meta.setdefault("source_file", record.source_file)
         meta.setdefault("chunk_index", record.chunk_index)
         if self.adapter_name:
-            meta.setdefault("adapter_name", self.adapter_name)
+            meta["adapter_name"] = self.adapter_name
         if self.adapter_version:
-            meta.setdefault("adapter_version", self.adapter_version)
+            meta["adapter_version"] = self.adapter_version
         if self._current_item is not None:
             if record.source_file != self._current_item.source_file:
                 raise ValueError(
@@ -209,7 +234,11 @@ class PalaceContext:
         if generation is not None:
             self._unscoped_drawer_collection = self.drawer_collection
             self.drawer_collection = _IncrementalCollectionFacade(
-                self.drawer_collection, item, generation
+                self.drawer_collection,
+                item,
+                generation,
+                self.adapter_name,
+                self.adapter_version,
             )
 
     def finish_source_item(self) -> None:

--- a/mempalace/sources/context.py
+++ b/mempalace/sources/context.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional, Protocol
 
-from .base import DrawerRecord
+from .base import DrawerRecord, SourceItemMetadata
 
 
 class _CollectionLike(Protocol):
@@ -43,6 +43,66 @@ class _KnowledgeGraphLike(Protocol):
 
 # Progress hook signature: ``fn(event_name, **details) -> None``.
 ProgressHook = Callable[..., None]
+
+
+class _IncrementalCollectionFacade:
+    """A write-safe compatible collection view for one incremental item.
+
+    Reads retain the backend's native result shape.  Writes are constrained to
+    the current source item and receive core-owned IDs and provenance, so an
+    adapter cannot overwrite the previously active generation by calling
+    ``palace.drawer_collection.upsert`` directly.
+    """
+
+    def __init__(self, collection: _CollectionLike, item: SourceItemMetadata, generation: str):
+        self._collection = collection
+        self._item = item
+        self._generation = generation
+
+    def upsert(self, *, documents, ids=None, metadatas=None, **kwargs: Any) -> None:
+        documents = list(documents)
+        metadatas = list(metadatas or [{} for _ in documents])
+        if len(documents) != len(metadatas):
+            raise ValueError("documents and metadatas must have the same length")
+        normalized = []
+        generated_ids = []
+        for index, metadata in enumerate(metadatas):
+            meta = dict(metadata or {})
+            source_file = meta.get("source_file", self._item.source_file)
+            if source_file != self._item.source_file:
+                raise ValueError("incremental collection writes must target the current source item")
+            chunk_index = meta.get("chunk_index", index)
+            record = DrawerRecord(
+                content=documents[index], source_file=source_file, chunk_index=chunk_index
+            )
+            meta.update(
+                source_file=source_file,
+                chunk_index=chunk_index,
+                source_version=self._item.version,
+                source_generation=self._generation,
+                source_generation_state="staging",
+            )
+            normalized.append(meta)
+            generated_ids.append(_build_drawer_id(record, generation=self._generation))
+        self._collection.upsert(
+            documents=documents, ids=generated_ids, metadatas=normalized, **kwargs
+        )
+
+    def add(self, **kwargs: Any) -> None:
+        # Treat add as upsert: deterministic generation IDs make retries safe.
+        self.upsert(**kwargs)
+
+    def delete(self, **kwargs: Any) -> None:
+        raise RuntimeError("incremental adapters cannot delete drawers directly")
+
+    def query(self, **kwargs: Any) -> Any:
+        return self._collection.query(**kwargs)
+
+    def get(self, **kwargs: Any) -> Any:
+        return self._collection.get(**kwargs)
+
+    def count(self) -> int:
+        return self._collection.count()
 
 
 @dataclass
@@ -78,6 +138,13 @@ class PalaceContext:
     adapter_version: str = ""
     progress_hooks: list[ProgressHook] = field(default_factory=list)
 
+    # Set by the incremental runner after it receives SourceItemMetadata.  A
+    # generation-specific ID ensures a staged replacement never overwrites a
+    # drawer from the last complete generation.
+    _current_item: Optional[SourceItemMetadata] = field(default=None, init=False, repr=False)
+    _current_generation: Optional[str] = field(default=None, init=False, repr=False)
+    _unscoped_drawer_collection: Optional[_CollectionLike] = field(default=None, init=False, repr=False)
+
     # Internal: flag set by :meth:`skip_current_item` and checked by the core
     # mine loop between yields. Not part of the adapter-facing contract; the
     # adapter only needs to know that calling :meth:`skip_current_item` stops
@@ -101,7 +168,17 @@ class PalaceContext:
             meta.setdefault("adapter_name", self.adapter_name)
         if self.adapter_version:
             meta.setdefault("adapter_version", self.adapter_version)
-        drawer_id = _build_drawer_id(record)
+        if self._current_item is not None:
+            if record.source_file != self._current_item.source_file:
+                raise ValueError(
+                    "incremental adapter yielded a drawer for a different source item "
+                    "than its current SourceItemMetadata"
+                )
+            meta.setdefault("source_version", self._current_item.version)
+        if self._current_generation is not None:
+            meta.setdefault("source_generation", self._current_generation)
+            meta.setdefault("source_generation_state", "staging")
+        drawer_id = _build_drawer_id(record, generation=self._current_generation)
         self.drawer_collection.upsert(
             documents=[record.content],
             ids=[drawer_id],
@@ -114,6 +191,36 @@ class PalaceContext:
         advancing past the item."""
         self._skip_requested = True
 
+    def begin_source_item(
+        self,
+        item: SourceItemMetadata,
+        *,
+        generation: Optional[str] = None,
+    ) -> None:
+        """Bind subsequent drawer writes to one source item and generation.
+
+        This is runner-owned state.  Adapters keep the existing public
+        ``PalaceContext`` surface and only observe it indirectly through the
+        documented ``skip_current_item`` signal.
+        """
+        self._current_item = item
+        self._current_generation = generation
+        self._skip_requested = False
+        if generation is not None:
+            self._unscoped_drawer_collection = self.drawer_collection
+            self.drawer_collection = _IncrementalCollectionFacade(
+                self.drawer_collection, item, generation
+            )
+
+    def finish_source_item(self) -> None:
+        """Clear runner-owned item state after commit or abandonment."""
+        self._current_item = None
+        self._current_generation = None
+        self._skip_requested = False
+        if self._unscoped_drawer_collection is not None:
+            self.drawer_collection = self._unscoped_drawer_collection
+            self._unscoped_drawer_collection = None
+
     def emit(self, event: str, **details: Any) -> None:
         """Invoke each registered progress hook with ``(event, **details)``."""
         for hook in self.progress_hooks:
@@ -125,8 +232,8 @@ class PalaceContext:
                 logging.getLogger(__name__).exception("progress hook failed on %r", event)
 
 
-def _build_drawer_id(record: DrawerRecord) -> str:
-    """Deterministic drawer id: ``<sha256(source_file)[:24]>_<chunk_index>``.
+def _build_drawer_id(record: DrawerRecord, *, generation: Optional[str] = None) -> str:
+    """Deterministic drawer id, optionally namespaced by a source generation.
 
     Matches the shape existing miners rely on (``source_file`` + chunk index
     pair) while keeping the id chroma-safe (no separators that collide with
@@ -138,5 +245,8 @@ def _build_drawer_id(record: DrawerRecord) -> str:
     """
     import hashlib
 
-    digest = hashlib.sha256(record.source_file.encode("utf-8")).hexdigest()[:24]
+    identity = record.source_file
+    if generation is not None:
+        identity = f"{identity}\0{generation}"
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:24]
     return f"{digest}_{record.chunk_index}"

--- a/mempalace/sources/context.py
+++ b/mempalace/sources/context.py
@@ -80,7 +80,9 @@ class _IncrementalCollectionFacade:
             meta = dict(metadata or {})
             source_file = meta.get("source_file", self._item.source_file)
             if source_file != self._item.source_file:
-                raise ValueError("incremental collection writes must target the current source item")
+                raise ValueError(
+                    "incremental collection writes must target the current source item"
+                )
             chunk_index = meta.get("chunk_index")
             if chunk_index is None:
                 chunk_index = self._next_chunk_index
@@ -89,8 +91,7 @@ class _IncrementalCollectionFacade:
                 self._next_chunk_index = max(self._next_chunk_index, chunk_index + 1)
             if chunk_index in self._seen_chunk_indexes:
                 raise ValueError(
-                    "incremental source item yielded duplicate chunk_index "
-                    f"{chunk_index!r}"
+                    f"incremental source item yielded duplicate chunk_index {chunk_index!r}"
                 )
             self._seen_chunk_indexes.add(chunk_index)
             record = DrawerRecord(
@@ -168,7 +169,9 @@ class PalaceContext:
     # drawer from the last complete generation.
     _current_item: Optional[SourceItemMetadata] = field(default=None, init=False, repr=False)
     _current_generation: Optional[str] = field(default=None, init=False, repr=False)
-    _unscoped_drawer_collection: Optional[_CollectionLike] = field(default=None, init=False, repr=False)
+    _unscoped_drawer_collection: Optional[_CollectionLike] = field(
+        default=None, init=False, repr=False
+    )
 
     # Internal: flag set by :meth:`skip_current_item` and checked by the core
     # mine loop between yields. Not part of the adapter-facing contract; the

--- a/mempalace/sources/lifecycle.py
+++ b/mempalace/sources/lifecycle.py
@@ -1,0 +1,140 @@
+"""Durable currentness state for RFC 002 source items.
+
+The registry lives in the palace knowledge-graph SQLite database rather than a
+separate cursor file: a palace remains the authoritative cursor for adapters.
+It records which fully written generation is visible for one
+``(adapter_name, source_file)`` pair.  Drawer writes and retrieval filtering
+are wired by the source-adapter runner in follow-up code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import sqlite3
+from typing import Optional
+import uuid
+
+
+_STAGING = "staging"
+_ACTIVE = "active"
+_RETIRED = "retired"
+
+
+@dataclass(frozen=True)
+class SourceGeneration:
+    adapter_name: str
+    source_file: str
+    generation: str
+    version: str
+    state: str
+
+
+class SourceLifecycleStore:
+    """Small transactional registry for incremental source-item generations."""
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, timeout=10)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _initialize(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS source_item_generations (
+                    adapter_name TEXT NOT NULL,
+                    source_file TEXT NOT NULL,
+                    generation TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    state TEXT NOT NULL CHECK (state IN ('staging', 'active', 'retired')),
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    activated_at TEXT,
+                    PRIMARY KEY (adapter_name, source_file, generation)
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_source_item_one_active
+                    ON source_item_generations(adapter_name, source_file)
+                    WHERE state = 'active';
+                CREATE INDEX IF NOT EXISTS idx_source_item_generations_lookup
+                    ON source_item_generations(adapter_name, source_file, state);
+                """
+            )
+
+    def active(self, *, adapter_name: str, source_file: str) -> Optional[SourceGeneration]:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT adapter_name, source_file, generation, version, state
+                FROM source_item_generations
+                WHERE adapter_name = ? AND source_file = ? AND state = ?
+                """,
+                (adapter_name, source_file, _ACTIVE),
+            ).fetchone()
+        return SourceGeneration(**dict(row)) if row else None
+
+    def begin(self, *, adapter_name: str, source_file: str, version: str) -> SourceGeneration:
+        """Create a fresh, non-visible generation for a changed source item."""
+        generation = uuid.uuid4().hex
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO source_item_generations
+                    (adapter_name, source_file, generation, version, state)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (adapter_name, source_file, generation, version, _STAGING),
+            )
+        return SourceGeneration(adapter_name, source_file, generation, version, _STAGING)
+
+    def activate(self, generation: SourceGeneration) -> Optional[SourceGeneration]:
+        """Atomically switch the visible generation, returning the previous one."""
+        if generation.state != _STAGING:
+            raise ValueError("only a staging generation can be activated")
+        with self._connect() as conn:
+            previous_row = conn.execute(
+                """
+                SELECT adapter_name, source_file, generation, version, state
+                FROM source_item_generations
+                WHERE adapter_name = ? AND source_file = ? AND state = ?
+                """,
+                (generation.adapter_name, generation.source_file, _ACTIVE),
+            ).fetchone()
+            conn.execute(
+                """
+                UPDATE source_item_generations
+                SET state = ?
+                WHERE adapter_name = ? AND source_file = ? AND state = ?
+                """,
+                (_RETIRED, generation.adapter_name, generation.source_file, _ACTIVE),
+            )
+            changed = conn.execute(
+                """
+                UPDATE source_item_generations
+                SET state = ?, activated_at = CURRENT_TIMESTAMP
+                WHERE adapter_name = ? AND source_file = ? AND generation = ? AND state = ?
+                """,
+                (
+                    _ACTIVE,
+                    generation.adapter_name,
+                    generation.source_file,
+                    generation.generation,
+                    _STAGING,
+                ),
+            ).rowcount
+            if changed != 1:
+                raise ValueError("staging generation does not exist")
+        return SourceGeneration(**dict(previous_row)) if previous_row else None
+
+    def abandon(self, generation: SourceGeneration) -> None:
+        """Remove a non-visible generation after a handled ingest failure."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                DELETE FROM source_item_generations
+                WHERE adapter_name = ? AND source_file = ? AND generation = ? AND state = ?
+                """,
+                (generation.adapter_name, generation.source_file, generation.generation, _STAGING),
+            )

--- a/mempalace/sources/lifecycle.py
+++ b/mempalace/sources/lifecycle.py
@@ -3,8 +3,8 @@
 The registry lives in the palace knowledge-graph SQLite database rather than a
 separate cursor file: a palace remains the authoritative cursor for adapters.
 It records which fully written generation is visible for one
-``(adapter_name, source_file)`` pair.  Drawer writes and retrieval filtering
-are wired by the source-adapter runner in follow-up code.
+``(adapter_name, source_file)`` pair. The source-adapter runner stages drawer
+writes against it and ordinary drawer reads resolve visibility through it.
 """
 
 from __future__ import annotations
@@ -32,9 +32,11 @@ class SourceGeneration:
 class SourceLifecycleStore:
     """Small transactional registry for incremental source-item generations."""
 
-    def __init__(self, db_path: str):
+    def __init__(self, db_path: str, *, initialize: bool = True):
         self.db_path = db_path
-        self._initialize()
+        self._initialized = initialize
+        if initialize:
+            self._initialize()
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.db_path, timeout=10)
@@ -64,15 +66,20 @@ class SourceLifecycleStore:
             )
 
     def active(self, *, adapter_name: str, source_file: str) -> Optional[SourceGeneration]:
-        with self._connect() as conn:
-            row = conn.execute(
-                """
-                SELECT adapter_name, source_file, generation, version, state
-                FROM source_item_generations
-                WHERE adapter_name = ? AND source_file = ? AND state = ?
-                """,
-                (adapter_name, source_file, _ACTIVE),
-            ).fetchone()
+        try:
+            with self._connect() as conn:
+                row = conn.execute(
+                    """
+                    SELECT adapter_name, source_file, generation, version, state
+                    FROM source_item_generations
+                    WHERE adapter_name = ? AND source_file = ? AND state = ?
+                    """,
+                    (adapter_name, source_file, _ACTIVE),
+                ).fetchone()
+        except sqlite3.OperationalError as exc:
+            if not self._initialized and "no such table" in str(exc).lower():
+                return None
+            raise
         return SourceGeneration(**dict(row)) if row else None
 
     def begin(self, *, adapter_name: str, source_file: str, version: str) -> SourceGeneration:
@@ -137,4 +144,28 @@ class SourceLifecycleStore:
                 WHERE adapter_name = ? AND source_file = ? AND generation = ? AND state = ?
                 """,
                 (generation.adapter_name, generation.source_file, generation.generation, _STAGING),
+            )
+
+    def tombstone(self, *, adapter_name: str, source_file: str) -> SourceGeneration:
+        """Make an item logically deleted before its physical purge completes.
+
+        The active tombstone keeps old generation and legacy drawers hidden if
+        deletion is interrupted. A later re-ingest simply activates a normal
+        generation and supersedes the tombstone.
+        """
+        generation = self.begin(
+            adapter_name=adapter_name, source_file=source_file, version="__deleted__"
+        )
+        self.activate(generation)
+        return generation
+
+    def prune_retired(self, *, adapter_name: str, source_file: str) -> None:
+        """Remove registry history once its physical drawers are purged."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                DELETE FROM source_item_generations
+                WHERE adapter_name = ? AND source_file = ? AND state = ?
+                """,
+                (adapter_name, source_file, _RETIRED),
             )

--- a/tests/test_cli_source_adapters.py
+++ b/tests/test_cli_source_adapters.py
@@ -43,9 +43,39 @@ class _FixtureAdapter(BaseSourceAdapter):
 class _FakeCollection:
     def __init__(self):
         self.upserts = []
+        self.rows = {}
 
     def upsert(self, **kwargs):
         self.upserts.append(kwargs)
+        for drawer_id, document, metadata in zip(
+            kwargs["ids"], kwargs["documents"], kwargs["metadatas"]
+        ):
+            self.rows[drawer_id] = {"document": document, "metadata": metadata}
+
+    def get(self, *, where=None, limit=None, **_kwargs):
+        def matches(row):
+            if not where:
+                return True
+            if "$and" in where:
+                return all(_matches(row["metadata"], clause) for clause in where["$and"])
+            return _matches(row["metadata"], where)
+
+        rows = [(key, value) for key, value in self.rows.items() if matches(value)]
+        if limit is not None:
+            rows = rows[:limit]
+        return {
+            "ids": [key for key, _ in rows],
+            "documents": [value["document"] for _, value in rows],
+            "metadatas": [value["metadata"] for _, value in rows],
+        }
+
+    def delete(self, *, ids=None, **_kwargs):
+        for drawer_id in ids or []:
+            self.rows.pop(drawer_id, None)
+
+
+def _matches(metadata, where):
+    return all(metadata.get(key) == value for key, value in where.items())
 
 
 class _FakeKnowledgeGraph:
@@ -103,7 +133,8 @@ class _IncrementalAdapter(BaseSourceAdapter):
     capabilities = frozenset({"supports_incremental"})
 
     def ingest(self, *, source, palace):
-        raise AssertionError("incremental adapters must be rejected before ingest")
+        yield SourceItemMetadata(source_file="fixture://incremental", version="v1")
+        yield DrawerRecord(content="incremental content", source_file="fixture://incremental")
 
     def describe_schema(self):
         return AdapterSchema(version="1.0", fields={})
@@ -384,15 +415,23 @@ def test_mine_source_dry_run_preserves_initialized_sqlite_exact_artifacts(tmp_pa
     assert after == before
 
 
-def test_mine_source_rejects_incremental_adapter_before_ingest():
-    register("incremental", _IncrementalAdapter)
+def test_mine_source_runs_incremental_adapter(monkeypatch, tmp_path):
+    from mempalace import knowledge_graph, palace
 
-    with pytest.raises(cli.UnsupportedSourceAdapterProtocolError, match="incremental ingestion"):
-        cli.mine_source_adapter(
-            source_name="incremental",
-            source_path="/source",
-            palace_path="/fake/palace",
-        )
+    collection = _FakeCollection()
+    register("incremental", _IncrementalAdapter)
+    monkeypatch.setattr(cli, "MempalaceConfig", _FakeConfig)
+    monkeypatch.setattr(palace, "get_collection", lambda *_a, **_k: collection)
+    monkeypatch.setattr(knowledge_graph, "KnowledgeGraph", _FakeKnowledgeGraph)
+
+    assert cli.mine_source_adapter(
+        source_name="incremental",
+        source_path="/source",
+        palace_path=str(tmp_path),
+    ) == 1
+    metadata = next(iter(collection.rows.values()))["metadata"]
+    assert metadata["source_generation_state"] == "staging"
+    assert metadata["source_version"] == "v1"
 
 
 def test_mine_source_accepts_non_incremental_metadata(monkeypatch, recwarn):

--- a/tests/test_cli_source_adapters.py
+++ b/tests/test_cli_source_adapters.py
@@ -74,6 +74,17 @@ class _FakeCollection:
             self.rows.pop(drawer_id, None)
 
 
+class _CleanupFailingCollection(_FakeCollection):
+    def __init__(self):
+        super().__init__()
+        self.fail_cleanup = False
+
+    def delete(self, *, ids=None, **kwargs):
+        if self.fail_cleanup:
+            raise RuntimeError("simulated cleanup failure")
+        super().delete(ids=ids, **kwargs)
+
+
 def _matches(metadata, where):
     return all(metadata.get(key) == value for key, value in where.items())
 
@@ -142,16 +153,24 @@ class _IncrementalAdapter(BaseSourceAdapter):
 
 class _VersionedIncrementalAdapter(BaseSourceAdapter):
     name = "versioned-incremental"
-    capabilities = frozenset({"supports_incremental"})
+    capabilities = frozenset({"supports_incremental", "supports_deletion_tombstones"})
 
     def __init__(self):
         self.version = "v1"
         self.content = "first"
         self.fail_after_drawer = False
+        self.deleted = False
+        self.empty = False
+        self.close_calls = 0
 
     def ingest(self, *, source, palace):
         item = SourceItemMetadata(source_file="fixture://versioned", version=self.version)
+        if self.deleted:
+            yield SourceItemMetadata(source_file=item.source_file, version="__deleted__")
+            return
         yield item
+        if self.empty:
+            return
         if palace._skip_requested:
             return
         yield DrawerRecord(content=self.content, source_file=item.source_file)
@@ -163,6 +182,9 @@ class _VersionedIncrementalAdapter(BaseSourceAdapter):
 
     def describe_schema(self):
         return AdapterSchema(version="1.0", fields={})
+
+    def close(self):
+        self.close_calls += 1
 
 
 class _MetadataAdapter(BaseSourceAdapter):
@@ -502,6 +524,139 @@ def test_incremental_sqlite_exact_failure_keeps_last_active_item(tmp_path, monke
     visible = get_collection(palace_path).get(where={"source_file": "fixture://versioned"})
     assert visible.documents == ["first"]
     assert visible.metadatas[0]["source_version"] == "v1"
+
+    adapter.fail_after_drawer = False
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 1
+
+    visible = get_collection(palace_path).get(where={"source_file": "fixture://versioned"})
+    assert visible.documents == ["broken replacement"]
+    assert visible.metadatas[0]["source_version"] == "v2"
+
+
+def test_incremental_cleanup_failure_does_not_roll_back_active_generation(tmp_path, monkeypatch):
+    from mempalace import knowledge_graph, palace
+    from mempalace.sources.lifecycle import SourceLifecycleStore
+
+    adapter = _VersionedIncrementalAdapter()
+    collection = _CleanupFailingCollection()
+    register(adapter.name, lambda: adapter)
+    monkeypatch.setattr(cli, "MempalaceConfig", _FakeConfig)
+    monkeypatch.setattr(palace, "get_collection", lambda *_a, **_k: collection)
+    monkeypatch.setattr(knowledge_graph, "KnowledgeGraph", _FakeKnowledgeGraph)
+    palace_path = str(tmp_path)
+
+    cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=palace_path)
+    adapter.version = "v2"
+    adapter.content = "second"
+    collection.fail_cleanup = True
+
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 1
+    active = SourceLifecycleStore(str(tmp_path / "knowledge_graph.sqlite3")).active(
+        adapter_name=adapter.name, source_file="fixture://versioned"
+    )
+    assert active.version == "v2"
+    assert any(row["metadata"]["source_version"] == "v2" for row in collection.rows.values())
+
+    collection.fail_cleanup = False
+    adapter.version = "v3"
+    adapter.content = "third"
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 1
+    assert [row["metadata"]["source_version"] for row in collection.rows.values()] == ["v3"]
+
+
+def test_source_adapter_is_closed_after_ingest(tmp_path, monkeypatch):
+    from mempalace import knowledge_graph, palace
+
+    adapter = _VersionedIncrementalAdapter()
+    collection = _FakeCollection()
+    register(adapter.name, lambda: adapter)
+    monkeypatch.setattr(cli, "MempalaceConfig", _FakeConfig)
+    monkeypatch.setattr(palace, "get_collection", lambda *_a, **_k: collection)
+    monkeypatch.setattr(knowledge_graph, "KnowledgeGraph", _FakeKnowledgeGraph)
+
+    cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=str(tmp_path))
+
+    assert adapter.close_calls == 1
+
+
+def test_incremental_sqlite_exact_tombstone_hides_and_purges_item(tmp_path, monkeypatch):
+    from mempalace.palace import get_collection
+
+    adapter = _VersionedIncrementalAdapter()
+    register(adapter.name, lambda: adapter)
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    palace_path = str(tmp_path / "palace")
+
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 1
+    adapter.deleted = True
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 0
+
+    visible = get_collection(palace_path).get(where={"source_file": "fixture://versioned"})
+    assert visible.ids == []
+
+
+def test_incremental_sqlite_exact_empty_replacement_hides_prior_item_and_skips_retry(tmp_path, monkeypatch):
+    from mempalace.palace import get_collection
+
+    adapter = _VersionedIncrementalAdapter()
+    register(adapter.name, lambda: adapter)
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    palace_path = str(tmp_path / "palace")
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 1
+
+    adapter.version = "v2"
+    adapter.empty = True
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 0
+    assert get_collection(palace_path).get(where={"source_file": "fixture://versioned"}).ids == []
+    # The registry-provided source_version lets the adapter skip this empty
+    # generation rather than repeatedly treating it as unseen.
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 0
+
+
+def test_incremental_visibility_filters_lexical_results_and_refreshes_per_read(tmp_path, monkeypatch):
+    from mempalace.palace import get_collection
+
+    adapter = _VersionedIncrementalAdapter()
+    register(adapter.name, lambda: adapter)
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    palace_path = str(tmp_path / "palace")
+    cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=palace_path)
+
+    visible = get_collection(palace_path)
+    raw = get_collection(palace_path, _include_staging=True)
+    raw.upsert(
+        ids=["staged-only"],
+        documents=["stagedonlytoken"],
+        metadatas=[{
+            "source_file": "fixture://versioned",
+            "adapter_name": adapter.name,
+            "source_generation": "not-active",
+            "source_generation_state": "staging",
+        }],
+    )
+    assert visible.lexical_search(query="stagedonlytoken", n_results=5).hits == []
+
+    adapter.version = "v2"
+    adapter.content = "second"
+    cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=palace_path)
+    refreshed = visible.get(where={"source_file": "fixture://versioned"})
+    assert refreshed.documents == ["second"]
 
 
 def test_mine_source_accepts_non_incremental_metadata(monkeypatch, recwarn):

--- a/tests/test_cli_source_adapters.py
+++ b/tests/test_cli_source_adapters.py
@@ -471,11 +471,14 @@ def test_mine_source_runs_incremental_adapter(monkeypatch, tmp_path):
     monkeypatch.setattr(palace, "get_collection", lambda *_a, **_k: collection)
     monkeypatch.setattr(knowledge_graph, "KnowledgeGraph", _FakeKnowledgeGraph)
 
-    assert cli.mine_source_adapter(
-        source_name="incremental",
-        source_path="/source",
-        palace_path=str(tmp_path),
-    ) == 1
+    assert (
+        cli.mine_source_adapter(
+            source_name="incremental",
+            source_path="/source",
+            palace_path=str(tmp_path),
+        )
+        == 1
+    )
     metadata = next(iter(collection.rows.values()))["metadata"]
     assert metadata["source_generation_state"] == "staging"
     assert metadata["source_version"] == "v1"
@@ -489,17 +492,26 @@ def test_incremental_sqlite_exact_replaces_changed_item_and_skips_current(tmp_pa
     monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
     palace_path = str(tmp_path / "palace")
 
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 1
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 1
+    )
     adapter.version = "v2"
     adapter.content = "second"
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 1
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 0
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 1
+    )
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 0
+    )
 
     visible = get_collection(palace_path).get(where={"source_file": "fixture://versioned"})
     assert visible.documents == ["second"]
@@ -514,21 +526,28 @@ def test_incremental_sqlite_exact_failure_keeps_last_active_item(tmp_path, monke
     monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
     palace_path = str(tmp_path / "palace")
 
-    cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=palace_path)
+    cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    )
     adapter.version = "v2"
     adapter.content = "broken replacement"
     adapter.fail_after_drawer = True
     with pytest.raises(RuntimeError, match="simulated extraction failure"):
-        cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=palace_path)
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
 
     visible = get_collection(palace_path).get(where={"source_file": "fixture://versioned"})
     assert visible.documents == ["first"]
     assert visible.metadatas[0]["source_version"] == "v1"
 
     adapter.fail_after_drawer = False
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 1
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 1
+    )
 
     visible = get_collection(palace_path).get(where={"source_file": "fixture://versioned"})
     assert visible.documents == ["broken replacement"]
@@ -547,14 +566,19 @@ def test_incremental_cleanup_failure_does_not_roll_back_active_generation(tmp_pa
     monkeypatch.setattr(knowledge_graph, "KnowledgeGraph", _FakeKnowledgeGraph)
     palace_path = str(tmp_path)
 
-    cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=palace_path)
+    cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    )
     adapter.version = "v2"
     adapter.content = "second"
     collection.fail_cleanup = True
 
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 1
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 1
+    )
     active = SourceLifecycleStore(str(tmp_path / "knowledge_graph.sqlite3")).active(
         adapter_name=adapter.name, source_file="fixture://versioned"
     )
@@ -564,9 +588,12 @@ def test_incremental_cleanup_failure_does_not_roll_back_active_generation(tmp_pa
     collection.fail_cleanup = False
     adapter.version = "v3"
     adapter.content = "third"
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 1
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 1
+    )
     assert [row["metadata"]["source_version"] for row in collection.rows.values()] == ["v3"]
 
 
@@ -580,7 +607,9 @@ def test_source_adapter_is_closed_after_ingest(tmp_path, monkeypatch):
     monkeypatch.setattr(palace, "get_collection", lambda *_a, **_k: collection)
     monkeypatch.setattr(knowledge_graph, "KnowledgeGraph", _FakeKnowledgeGraph)
 
-    cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=str(tmp_path))
+    cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=str(tmp_path)
+    )
 
     assert adapter.close_calls == 1
 
@@ -593,68 +622,93 @@ def test_incremental_sqlite_exact_tombstone_hides_and_purges_item(tmp_path, monk
     monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
     palace_path = str(tmp_path / "palace")
 
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 1
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 1
+    )
     adapter.deleted = True
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 0
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 0
+    )
 
     visible = get_collection(palace_path).get(where={"source_file": "fixture://versioned"})
     assert visible.ids == []
 
 
-def test_incremental_sqlite_exact_empty_replacement_hides_prior_item_and_skips_retry(tmp_path, monkeypatch):
+def test_incremental_sqlite_exact_empty_replacement_hides_prior_item_and_skips_retry(
+    tmp_path, monkeypatch
+):
     from mempalace.palace import get_collection
 
     adapter = _VersionedIncrementalAdapter()
     register(adapter.name, lambda: adapter)
     monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
     palace_path = str(tmp_path / "palace")
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 1
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 1
+    )
 
     adapter.version = "v2"
     adapter.empty = True
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 0
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 0
+    )
     assert get_collection(palace_path).get(where={"source_file": "fixture://versioned"}).ids == []
     # The registry-provided source_version lets the adapter skip this empty
     # generation rather than repeatedly treating it as unseen.
-    assert cli.mine_source_adapter(
-        source_name=adapter.name, source_path="/source", palace_path=palace_path
-    ) == 0
+    assert (
+        cli.mine_source_adapter(
+            source_name=adapter.name, source_path="/source", palace_path=palace_path
+        )
+        == 0
+    )
 
 
-def test_incremental_visibility_filters_lexical_results_and_refreshes_per_read(tmp_path, monkeypatch):
+def test_incremental_visibility_filters_lexical_results_and_refreshes_per_read(
+    tmp_path, monkeypatch
+):
     from mempalace.palace import get_collection
 
     adapter = _VersionedIncrementalAdapter()
     register(adapter.name, lambda: adapter)
     monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
     palace_path = str(tmp_path / "palace")
-    cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=palace_path)
+    cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    )
 
     visible = get_collection(palace_path)
     raw = get_collection(palace_path, _include_staging=True)
     raw.upsert(
         ids=["staged-only"],
         documents=["stagedonlytoken"],
-        metadatas=[{
-            "source_file": "fixture://versioned",
-            "adapter_name": adapter.name,
-            "source_generation": "not-active",
-            "source_generation_state": "staging",
-        }],
+        metadatas=[
+            {
+                "source_file": "fixture://versioned",
+                "adapter_name": adapter.name,
+                "source_generation": "not-active",
+                "source_generation_state": "staging",
+            }
+        ],
     )
     assert visible.lexical_search(query="stagedonlytoken", n_results=5).hits == []
 
     adapter.version = "v2"
     adapter.content = "second"
-    cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=palace_path)
+    cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    )
     refreshed = visible.get(where={"source_file": "fixture://versioned"})
     assert refreshed.documents == ["second"]
 

--- a/tests/test_cli_source_adapters.py
+++ b/tests/test_cli_source_adapters.py
@@ -140,6 +140,31 @@ class _IncrementalAdapter(BaseSourceAdapter):
         return AdapterSchema(version="1.0", fields={})
 
 
+class _VersionedIncrementalAdapter(BaseSourceAdapter):
+    name = "versioned-incremental"
+    capabilities = frozenset({"supports_incremental"})
+
+    def __init__(self):
+        self.version = "v1"
+        self.content = "first"
+        self.fail_after_drawer = False
+
+    def ingest(self, *, source, palace):
+        item = SourceItemMetadata(source_file="fixture://versioned", version=self.version)
+        yield item
+        if palace._skip_requested:
+            return
+        yield DrawerRecord(content=self.content, source_file=item.source_file)
+        if self.fail_after_drawer:
+            raise RuntimeError("simulated extraction failure")
+
+    def is_current(self, *, item, existing_metadata):
+        return bool(existing_metadata and existing_metadata.get("source_version") == item.version)
+
+    def describe_schema(self):
+        return AdapterSchema(version="1.0", fields={})
+
+
 class _MetadataAdapter(BaseSourceAdapter):
     name = "metadata"
 
@@ -432,6 +457,51 @@ def test_mine_source_runs_incremental_adapter(monkeypatch, tmp_path):
     metadata = next(iter(collection.rows.values()))["metadata"]
     assert metadata["source_generation_state"] == "staging"
     assert metadata["source_version"] == "v1"
+
+
+def test_incremental_sqlite_exact_replaces_changed_item_and_skips_current(tmp_path, monkeypatch):
+    from mempalace.palace import get_collection
+
+    adapter = _VersionedIncrementalAdapter()
+    register(adapter.name, lambda: adapter)
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    palace_path = str(tmp_path / "palace")
+
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 1
+    adapter.version = "v2"
+    adapter.content = "second"
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 1
+    assert cli.mine_source_adapter(
+        source_name=adapter.name, source_path="/source", palace_path=palace_path
+    ) == 0
+
+    visible = get_collection(palace_path).get(where={"source_file": "fixture://versioned"})
+    assert visible.documents == ["second"]
+    assert visible.metadatas[0]["source_version"] == "v2"
+
+
+def test_incremental_sqlite_exact_failure_keeps_last_active_item(tmp_path, monkeypatch):
+    from mempalace.palace import get_collection
+
+    adapter = _VersionedIncrementalAdapter()
+    register(adapter.name, lambda: adapter)
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    palace_path = str(tmp_path / "palace")
+
+    cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=palace_path)
+    adapter.version = "v2"
+    adapter.content = "broken replacement"
+    adapter.fail_after_drawer = True
+    with pytest.raises(RuntimeError, match="simulated extraction failure"):
+        cli.mine_source_adapter(source_name=adapter.name, source_path="/source", palace_path=palace_path)
+
+    visible = get_collection(palace_path).get(where={"source_file": "fixture://versioned"})
+    assert visible.documents == ["first"]
+    assert visible.metadatas[0]["source_version"] == "v1"
 
 
 def test_mine_source_accepts_non_incremental_metadata(monkeypatch, recwarn):

--- a/tests/test_palace.py
+++ b/tests/test_palace.py
@@ -5,13 +5,47 @@ import chromadb
 from _chroma_palace_helper import make_minimal_chroma_sqlite
 
 from mempalace.backends import CollectionNotInitializedError, PalaceNotFoundError
+from mempalace.backends.base import GetResult
 from mempalace.palace import (
+    _VisibleDrawersCollection,
     _candidate_entity_words,
     _metadata_matches_extract_mode,
     _open_collection_or_explain,
     backend_requires_single_writer,
     get_collection,
 )
+from mempalace.sources.lifecycle import SourceLifecycleStore
+
+
+class _OrderedGetCollection:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def get(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.result
+
+
+def test_visible_collection_applies_limit_after_hiding_generations(tmp_path):
+    store = SourceLifecycleStore(str(tmp_path / "knowledge_graph.sqlite3"))
+    active = store.begin(adapter_name="fixture", source_file="fixture://one", version="v2")
+    store.activate(active)
+    raw = _OrderedGetCollection(GetResult(
+        ids=["hidden", "active"],
+        documents=["old", "new"],
+        metadatas=[
+            {"adapter_name": "fixture", "source_file": "fixture://one", "source_generation": "old"},
+            {"adapter_name": "fixture", "source_file": "fixture://one", "source_generation": active.generation},
+        ],
+    ))
+    collection = _VisibleDrawersCollection(raw, str(tmp_path))
+
+    result = collection.get(where={"source_file": "fixture://one"}, limit=1)
+
+    assert result.ids == ["active"]
+    assert raw.calls[0]["limit"] == 1
+    assert "limit" not in raw.calls[1]
 
 
 def test_backend_writer_ownership_distinguishes_milvus_lite_from_server(tmp_path, monkeypatch):

--- a/tests/test_palace.py
+++ b/tests/test_palace.py
@@ -31,14 +31,24 @@ def test_visible_collection_applies_limit_after_hiding_generations(tmp_path):
     store = SourceLifecycleStore(str(tmp_path / "knowledge_graph.sqlite3"))
     active = store.begin(adapter_name="fixture", source_file="fixture://one", version="v2")
     store.activate(active)
-    raw = _OrderedGetCollection(GetResult(
-        ids=["hidden", "active"],
-        documents=["old", "new"],
-        metadatas=[
-            {"adapter_name": "fixture", "source_file": "fixture://one", "source_generation": "old"},
-            {"adapter_name": "fixture", "source_file": "fixture://one", "source_generation": active.generation},
-        ],
-    ))
+    raw = _OrderedGetCollection(
+        GetResult(
+            ids=["hidden", "active"],
+            documents=["old", "new"],
+            metadatas=[
+                {
+                    "adapter_name": "fixture",
+                    "source_file": "fixture://one",
+                    "source_generation": "old",
+                },
+                {
+                    "adapter_name": "fixture",
+                    "source_file": "fixture://one",
+                    "source_generation": active.generation,
+                },
+            ],
+        )
+    )
     collection = _VisibleDrawersCollection(raw, str(tmp_path))
 
     result = collection.get(where={"source_file": "fixture://one"}, limit=1)

--- a/tests/test_source_lifecycle.py
+++ b/tests/test_source_lifecycle.py
@@ -10,7 +10,10 @@ def test_generation_is_invisible_until_activated(tmp_path):
     assert store.active(adapter_name="fixture", source_file="fixture://one") is None
 
     assert store.activate(staged) is None
-    assert store.active(adapter_name="fixture", source_file="fixture://one").generation == staged.generation
+    assert (
+        store.active(adapter_name="fixture", source_file="fixture://one").generation
+        == staged.generation
+    )
 
 
 def test_activation_retires_prior_generation(tmp_path):
@@ -52,7 +55,9 @@ def test_read_only_lookup_does_not_create_lifecycle_schema(tmp_path):
 
     assert store.active(adapter_name="fixture", source_file="fixture://one") is None
     with sqlite3.connect(db_path) as conn:
-        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+        tables = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
     assert tables == {"existing"}
 
 

--- a/tests/test_source_lifecycle.py
+++ b/tests/test_source_lifecycle.py
@@ -38,3 +38,31 @@ def test_abandon_keeps_active_generation(tmp_path):
 
     active = store.active(adapter_name="fixture", source_file="fixture://one")
     assert active.generation == first.generation
+
+
+def test_read_only_lookup_does_not_create_lifecycle_schema(tmp_path):
+    db_path = tmp_path / "knowledge_graph.sqlite3"
+    # A pre-existing KG database without RFC 002 lifecycle state is normal.
+    import sqlite3
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE existing (id INTEGER PRIMARY KEY)")
+
+    store = SourceLifecycleStore(str(db_path), initialize=False)
+
+    assert store.active(adapter_name="fixture", source_file="fixture://one") is None
+    with sqlite3.connect(db_path) as conn:
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+    assert tables == {"existing"}
+
+
+def test_tombstone_supersedes_active_generation(tmp_path):
+    store = SourceLifecycleStore(str(tmp_path / "knowledge_graph.sqlite3"))
+    first = store.begin(adapter_name="fixture", source_file="fixture://one", version="v1")
+    store.activate(first)
+
+    tombstone = store.tombstone(adapter_name="fixture", source_file="fixture://one")
+
+    active = store.active(adapter_name="fixture", source_file="fixture://one")
+    assert active.generation == tombstone.generation
+    assert active.version == "__deleted__"

--- a/tests/test_source_lifecycle.py
+++ b/tests/test_source_lifecycle.py
@@ -1,0 +1,40 @@
+from mempalace.sources.lifecycle import SourceLifecycleStore
+
+
+def test_generation_is_invisible_until_activated(tmp_path):
+    store = SourceLifecycleStore(str(tmp_path / "knowledge_graph.sqlite3"))
+
+    staged = store.begin(adapter_name="fixture", source_file="fixture://one", version="v1")
+
+    assert staged.state == "staging"
+    assert store.active(adapter_name="fixture", source_file="fixture://one") is None
+
+    assert store.activate(staged) is None
+    assert store.active(adapter_name="fixture", source_file="fixture://one").generation == staged.generation
+
+
+def test_activation_retires_prior_generation(tmp_path):
+    store = SourceLifecycleStore(str(tmp_path / "knowledge_graph.sqlite3"))
+    first = store.begin(adapter_name="fixture", source_file="fixture://one", version="v1")
+    store.activate(first)
+    second = store.begin(adapter_name="fixture", source_file="fixture://one", version="v2")
+
+    previous = store.activate(second)
+
+    assert previous is not None
+    assert previous.generation == first.generation
+    active = store.active(adapter_name="fixture", source_file="fixture://one")
+    assert active.generation == second.generation
+    assert active.version == "v2"
+
+
+def test_abandon_keeps_active_generation(tmp_path):
+    store = SourceLifecycleStore(str(tmp_path / "knowledge_graph.sqlite3"))
+    first = store.begin(adapter_name="fixture", source_file="fixture://one", version="v1")
+    store.activate(first)
+    failed = store.begin(adapter_name="fixture", source_file="fixture://one", version="v2")
+
+    store.abandon(failed)
+
+    active = store.active(adapter_name="fixture", source_file="fixture://one")
+    assert active.generation == first.generation

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -344,6 +344,8 @@ def test_incremental_collection_facade_cannot_overwrite_other_source():
         drawer_collection=drawers,
         knowledge_graph=_FakeKG(),
         palace_path="/tmp/p",
+        adapter_name="fixture",
+        adapter_version="0.2.0",
     )
     item = SourceItemMetadata(source_file="fixture://item", version="v2")
 
@@ -360,6 +362,8 @@ def test_incremental_collection_facade_owns_ids_and_provenance():
         drawer_collection=drawers,
         knowledge_graph=_FakeKG(),
         palace_path="/tmp/p",
+        adapter_name="fixture",
+        adapter_version="0.2.0",
     )
     item = SourceItemMetadata(source_file="fixture://item", version="v2")
 
@@ -373,6 +377,45 @@ def test_incremental_collection_facade_owns_ids_and_provenance():
     assert written["metadatas"][0]["source_file"] == item.source_file
     assert written["metadatas"][0]["source_version"] == "v2"
     assert written["metadatas"][0]["source_generation_state"] == "staging"
+    assert written["metadatas"][0]["adapter_name"] == "fixture"
+    assert written["metadatas"][0]["adapter_version"] == "0.2.0"
+
+
+def test_incremental_collection_facade_assigns_distinct_fallback_chunk_indexes():
+    drawers = _FakeCollection()
+    ctx = PalaceContext(
+        drawer_collection=drawers,
+        knowledge_graph=_FakeKG(),
+        palace_path="/tmp/p",
+    )
+    ctx.begin_source_item(
+        SourceItemMetadata(source_file="fixture://item", version="v2"),
+        generation="generation-two",
+    )
+
+    ctx.drawer_collection.upsert(documents=["first"], ids=["one"], metadatas=[{}])
+    ctx.drawer_collection.upsert(documents=["second"], ids=["two"], metadatas=[{}])
+
+    assert [call["metadatas"][0]["chunk_index"] for call in drawers.upserts] == [0, 1]
+    assert drawers.upserts[0]["ids"] != drawers.upserts[1]["ids"]
+
+
+def test_incremental_collection_facade_rejects_duplicate_chunk_indexes():
+    ctx = PalaceContext(
+        drawer_collection=_FakeCollection(),
+        knowledge_graph=_FakeKG(),
+        palace_path="/tmp/p",
+    )
+    ctx.begin_source_item(
+        SourceItemMetadata(source_file="fixture://item", version="v2"),
+        generation="generation-two",
+    )
+    ctx.drawer_collection.upsert(documents=["first"], ids=["one"], metadatas=[{"chunk_index": 0}])
+
+    with pytest.raises(ValueError, match="duplicate chunk_index"):
+        ctx.drawer_collection.upsert(
+            documents=["second"], ids=["two"], metadatas=[{"chunk_index": 0}]
+        )
 
 
 def test_palace_context_emit_dispatches_to_hooks_and_swallows_errors():

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -315,6 +315,66 @@ def test_palace_context_skip_current_item_sets_flag():
     assert ctx._skip_requested is True
 
 
+def test_palace_context_generation_namespaces_drawer_ids_and_stamps_version():
+    from mempalace.sources.context import _build_drawer_id
+
+    drawers = _FakeCollection()
+    ctx = PalaceContext(
+        drawer_collection=drawers,
+        knowledge_graph=_FakeKG(),
+        palace_path="/tmp/p",
+        adapter_name="test-adapter",
+        adapter_version="0.1.0",
+    )
+    item = SourceItemMetadata(source_file="fixture://item", version="v2")
+    record = DrawerRecord(content="content", source_file=item.source_file)
+
+    ctx.begin_source_item(item, generation="generation-two")
+    ctx.upsert_drawer(record)
+
+    written = drawers.upserts[0]
+    assert written["ids"][0] != _build_drawer_id(record)
+    assert written["metadatas"][0]["source_generation"] == "generation-two"
+    assert written["metadatas"][0]["source_version"] == "v2"
+
+
+def test_incremental_collection_facade_cannot_overwrite_other_source():
+    drawers = _FakeCollection()
+    ctx = PalaceContext(
+        drawer_collection=drawers,
+        knowledge_graph=_FakeKG(),
+        palace_path="/tmp/p",
+    )
+    item = SourceItemMetadata(source_file="fixture://item", version="v2")
+
+    ctx.begin_source_item(item, generation="generation-two")
+    with pytest.raises(ValueError, match="current source item"):
+        ctx.drawer_collection.upsert(
+            documents=["content"], ids=["malicious-id"], metadatas=[{"source_file": "other"}]
+        )
+
+
+def test_incremental_collection_facade_owns_ids_and_provenance():
+    drawers = _FakeCollection()
+    ctx = PalaceContext(
+        drawer_collection=drawers,
+        knowledge_graph=_FakeKG(),
+        palace_path="/tmp/p",
+    )
+    item = SourceItemMetadata(source_file="fixture://item", version="v2")
+
+    ctx.begin_source_item(item, generation="generation-two")
+    ctx.drawer_collection.upsert(
+        documents=["content"], ids=["adapter-id"], metadatas=[{"chunk_index": 7}]
+    )
+
+    written = drawers.upserts[0]
+    assert written["ids"] != ["adapter-id"]
+    assert written["metadatas"][0]["source_file"] == item.source_file
+    assert written["metadatas"][0]["source_version"] == "v2"
+    assert written["metadatas"][0]["source_generation_state"] == "staging"
+
+
 def test_palace_context_emit_dispatches_to_hooks_and_swallows_errors():
     calls = []
     err_calls = []


### PR DESCRIPTION
## What does this PR do?

Implements incremental source-item currentness for RFC 002 adapters.

- Stages drawer writes under generation-specific IDs and atomically switches registry-backed visibility only after a successful item ingest.
- Keeps the prior active generation visible if extraction fails; stale rows are cleaned up only after activation, and cleanup retries on a later successful replacement.
- Supports declared deletion tombstones and valid empty replacements.
- Prevents direct adapter collection writes from bypassing generation IDs or provenance, and rejects duplicate chunk indexes within one staged item.

### Scope / non-goals

Builds on the source-adapter dispatch foundation in #2068.

This is deliberately drawer-only v1. Incremental adapters that declare KG triple output are rejected until source-scoped KG generation replacement exists. The RFC itself is unchanged.

Follow-up: **#2225** will add source-scoped incremental KG replacement; this PR intentionally limits incremental lifecycle to drawers.

Closes #2222

## How to test

```bash
python -m pytest tests/test_cli_source_adapters.py tests/test_sources.py tests/test_source_lifecycle.py tests/test_backend_conformance.py tests/test_backends.py tests/test_sqlite_exact_backend.py tests/test_palace.py -q
# 217 passed

python -m pytest tests/ -v --ignore=tests/benchmarks --ignore=tests/test_repair.py --cov=mempalace --cov-report=term-missing --cov-fail-under=80 --durations=10
# 4,136 passed, 32 skipped; 81.88% coverage

ruff check .
ruff format --check .
```

`tests/test_repair.py::test_maybe_autoheal_fts5_index_heals_isolated_corruption` is excluded from the full local run because the host SQLite build does not report the fixture's FTS5 corruption; it reproduces independently of this change.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`), except for the documented host-specific FTS5 repair fixture
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)