### PR TITLE
Fix duplicate hydrated search results

### DIFF
--- a/docs/CLOSETS.md
+++ b/docs/CLOSETS.md
@@ -71,11 +71,20 @@ it chooses the query-best chunk from that source and includes its neighbors.
 Applying that enrichment independently to every matching chunk therefore
 produced the same expanded text repeatedly.
 
-Search now keeps the best ranked result for each logical source before
-enrichment. The grouping key is the full `source_file` path plus
-`parent_drawer_id` when present, so unrelated logical drawers that share a
-file name remain separate. Records without a `source_file` remain
-chunk-level results.
+Search now keeps the best ranked result for each logical source only when
+closet enrichment will run. The grouping key is the full `source_file` path
+plus `parent_drawer_id` when present, so unrelated logical drawers that share
+a file name remain separate. Direct `drawer` results and records without a
+`source_file` retain their established chunk-level behavior.
+
+This follows the same retrieval principle as [Qdrant's grouped
+search](https://qdrant.tech/documentation/search/search/#grouping): group
+chunk matches by document identity and keep one representative hit
+(`group_size=1`) to avoid redundant document answers. It is deliberately
+narrower than Qdrant's groups API: MemPalace does not return group envelopes,
+does not add a public `group_by` parameter, and does not collapse ordinary
+direct drawer search. It prevents only the duplicate response introduced by
+closet hydration.
 
 To reproduce this regression in a throwaway palace, run:
 

--- a/docs/CLOSETS.md
+++ b/docs/CLOSETS.md
@@ -62,6 +62,31 @@ If no closets exist (palace created before this feature) — or all closet hits 
 
 > **BM25 hybrid re-rank** is on the roadmap (deferred to a follow-up PR alongside generic `LLM_*` env-var support); the current closet search ranks purely by ChromaDB cosine distance against the closet text.
 
+### One result per logical source
+
+A closet is evidence that a *source* is relevant; it does not make every
+chunk from that source a separate agent-facing answer. A chunked source can
+have several high-ranking drawer hits. When closet enrichment expands a hit,
+it chooses the query-best chunk from that source and includes its neighbors.
+Applying that enrichment independently to every matching chunk therefore
+produced the same expanded text repeatedly.
+
+Search now keeps the best ranked result for each logical source before
+enrichment. The grouping key is the full `source_file` path plus
+`parent_drawer_id` when present, so unrelated logical drawers that share a
+file name remain separate. Records without a `source_file` remain
+chunk-level results.
+
+To reproduce this regression in a throwaway palace, run:
+
+```bash
+uv run python examples/reproduce_duplicate_hydrated_results.py
+```
+
+Before this behavior was fixed, that example found three results for one
+source and each one hydrated around the same query-best chunk. The expected
+result is now one `drawer+closet` response for that source.
+
 ## Limits
 
 | Setting | Value | Reason |

--- a/examples/reproduce_duplicate_hydrated_results.py
+++ b/examples/reproduce_duplicate_hydrated_results.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Reproduce the duplicate hydrated-search-result regression.
+
+Run with:
+
+    uv run python examples/reproduce_duplicate_hydrated_results.py
+
+The fixture has five chunks from one source and a closet that boosts that
+source. Before the fix, the search returned three results from that source;
+each was hydrated around the same query-best chunk, so an agent saw the same
+expanded response repeatedly. The fixed behavior returns one hydrated result.
+"""
+
+from tempfile import TemporaryDirectory
+
+from mempalace.palace import get_closets_collection, get_collection
+from mempalace.searcher import search_memories
+
+
+SOURCE = "/examples/duplicate-hydration.md"
+QUERY = "JWT authentication"
+
+
+def seed(palace_path: str) -> None:
+    drawers = get_collection(palace_path)
+    for index in range(5):
+        drawers.upsert(
+            ids=[f"drawer_example_duplicate_hydration_{index:03d}"],
+            documents=[f"chunk {index}: JWT authentication flow details"],
+            metadatas=[
+                {
+                    "wing": "example",
+                    "room": "search",
+                    "source_file": SOURCE,
+                    "chunk_index": index,
+                    "filed_at": "2026-08-11T00:00:00",
+                }
+            ],
+        )
+
+    closets = get_closets_collection(palace_path)
+    closets.upsert(
+        ids=["closet_example_duplicate_hydration"],
+        documents=["JWT authentication|;|→drawer_example_duplicate_hydration_002"],
+        metadatas=[{"wing": "example", "room": "search", "source_file": SOURCE}],
+    )
+
+
+def main() -> None:
+    with TemporaryDirectory() as palace_path:
+        seed(palace_path)
+        result = search_memories(QUERY, palace_path, n_results=3)
+
+    source_hits = [hit for hit in result["results"] if hit["source_path"] == SOURCE]
+    print(f"Results for {SOURCE}: {len(source_hits)}")
+    for index, hit in enumerate(source_hits, start=1):
+        print(f"  {index}. matched_via={hit['matched_via']}; text={hit['text']!r}")
+
+    assert len(source_hits) == 1, (
+        "Expected one hydrated result per logical source. Before the fix, "
+        "three matching chunks each hydrated to the same query-best response."
+    )
+    assert source_hits[0]["matched_via"] == "drawer+closet"
+    print("PASS: source-level closet relevance produced one hydrated response.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -1303,17 +1303,22 @@ def _finalize_candidate_hits(
     return hits, None
 
 
-def _best_hit_per_source_group(scored: list, n_results: int) -> list:
-    """Keep the best hit per logical source before closet hydration.
+def _limit_hits_before_hydration(scored: list, n_results: int) -> list:
+    """Limit candidates while collapsing duplicate closet-hydrated results.
 
     A closet establishes relevance at the source level. Returning several
     chunks from the same logical source would hydrate each hit around the same
-    keyword-best chunk, producing duplicate agent-facing results. Unscoped
-    records (without source_file) stay distinct at chunk granularity.
+    keyword-best chunk, producing duplicate agent-facing results. Direct
+    drawer results keep their established chunk-level behavior.
     """
     hits = []
     seen_source_groups = set()
     for candidate in scored:
+        if candidate.get("matched_via") != "drawer+closet":
+            hits.append(candidate)
+            if len(hits) == n_results:
+                break
+            continue
         source = candidate.get("_source_file_full") or ""
         parent = candidate.get("_parent_drawer_id")
         group_key = (
@@ -1844,7 +1849,7 @@ def search_memories(
 
     scored.sort(key=lambda h: h["_sort_key"])
 
-    hits = _best_hit_per_source_group(scored, n_results)
+    hits = _limit_hits_before_hydration(scored, n_results)
 
     # Drawer-grep enrichment: for closet-boosted hits whose source has
     # multiple drawers, return the keyword-best chunk + its immediate

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -1303,6 +1303,33 @@ def _finalize_candidate_hits(
     return hits, None
 
 
+def _best_hit_per_source_group(scored: list, n_results: int) -> list:
+    """Keep the best hit per logical source before closet hydration.
+
+    A closet establishes relevance at the source level. Returning several
+    chunks from the same logical source would hydrate each hit around the same
+    keyword-best chunk, producing duplicate agent-facing results. Unscoped
+    records (without source_file) stay distinct at chunk granularity.
+    """
+    hits = []
+    seen_source_groups = set()
+    for candidate in scored:
+        source = candidate.get("_source_file_full") or ""
+        parent = candidate.get("_parent_drawer_id")
+        group_key = (
+            (source, parent)
+            if source
+            else (None, parent, candidate.get("_chunk_index"))
+        )
+        if group_key in seen_source_groups:
+            continue
+        seen_source_groups.add(group_key)
+        hits.append(candidate)
+        if len(hits) == n_results:
+            break
+    return hits
+
+
 def _search_error_result(error: str, **extra) -> dict:
     """Error envelope for programmatic search callers.
 
@@ -1816,7 +1843,8 @@ def search_memories(
         scored.append(entry)
 
     scored.sort(key=lambda h: h["_sort_key"])
-    hits = scored[:n_results]
+
+    hits = _best_hit_per_source_group(scored, n_results)
 
     # Drawer-grep enrichment: for closet-boosted hits whose source has
     # multiple drawers, return the keyword-best chunk + its immediate

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -1558,6 +1558,31 @@ class TestDrawerGrepExpansion:
         assert source_hits[0]["matched_via"] == "drawer+closet"
         assert source_hits[0]["total_drawers"] == 5
 
+    def test_direct_search_keeps_chunk_level_results(self, palace_path):
+        """Only closet-hydrated results collapse by source; direct hits do not."""
+        col = get_collection(palace_path)
+        source = "/proj/direct-chunks.md"
+        for i in range(3):
+            col.upsert(
+                ids=[f"drawer_proj_backend_direct_{i:03d}"],
+                documents=[f"chunk_{i} covers direct JWT search"],
+                metadatas=[
+                    {
+                        "wing": "project",
+                        "room": "backend",
+                        "source_file": source,
+                        "chunk_index": i,
+                        "filed_at": "2026-04-13T00:00:00",
+                    }
+                ],
+            )
+
+        result = search_memories("direct JWT search", palace_path, n_results=3)
+
+        source_hits = [h for h in result["results"] if h["source_path"] == source]
+        assert len(source_hits) == 3
+        assert all(hit["matched_via"] == "drawer" for hit in source_hits)
+
     def test_expand_isolates_chunks_by_parent_drawer_id_when_source_file_shared(self, palace_path):
         """Regression for #1580. After #1539 the chunked ``tool_add_drawer``
         path stores per-chunk drawers tagged with a ``parent_drawer_id``

--- a/tests/test_closets.py
+++ b/tests/test_closets.py
@@ -1526,6 +1526,38 @@ class TestDrawerGrepExpansion:
         # on each side (chunk boundary may clip).
         assert "chunk_" in top["text"]
 
+    def test_hybrid_search_returns_one_hydrated_hit_per_source(self, palace_path):
+        """Multiple matching chunks of one source must not expand to repeats."""
+        col = get_collection(palace_path)
+        source = "/proj/deduplicated.md"
+        for i in range(5):
+            col.upsert(
+                ids=[f"drawer_proj_backend_deduplicated_{i:03d}"],
+                documents=[f"chunk_{i} covers JWT authentication flow"],
+                metadatas=[
+                    {
+                        "wing": "project",
+                        "room": "backend",
+                        "source_file": source,
+                        "chunk_index": i,
+                        "filed_at": "2026-04-13T00:00:00",
+                    }
+                ],
+            )
+        closets = get_closets_collection(palace_path)
+        closets.upsert(
+            ids=["closet_proj_backend_deduplicated_01"],
+            documents=["JWT auth|;|→drawer_proj_backend_deduplicated_002"],
+            metadatas=[{"wing": "project", "room": "backend", "source_file": source}],
+        )
+
+        result = search_memories("JWT authentication", palace_path, n_results=3)
+
+        source_hits = [h for h in result["results"] if h["source_path"] == source]
+        assert len(source_hits) == 1
+        assert source_hits[0]["matched_via"] == "drawer+closet"
+        assert source_hits[0]["total_drawers"] == 5
+
     def test_expand_isolates_chunks_by_parent_drawer_id_when_source_file_shared(self, palace_path):
         """Regression for #1580. After #1539 the chunked ``tool_add_drawer``
         path stores per-chunk drawers tagged with a ``parent_drawer_id``


### PR DESCRIPTION
## Summary
- collapse only duplicate `drawer+closet` results by full source path and logical parent before hydration
- preserve existing chunk-level cardinality for ordinary direct `drawer` search
- add a runnable reproducer, contract documentation, and regressions for both paths

## Root cause
Closet relevance is source-level, but search could return several matching chunks from that source. Hydration then re-selected the same query-best chunk for each hit, so agents received the same expanded response multiple times.

## Why this is grouped search, not data deduplication
The behavior mirrors [Qdrant grouped search](https://qdrant.tech/documentation/search/search/#grouping) with `group_by=document_id` and `group_size=1`: one representative answer per document prevents redundant chunk results. This PR is intentionally narrower than Qdrant’s groups API: it returns no group envelope or public `group_by` option, and it only groups hits that closet hydration would otherwise duplicate.

## Compatibility
This is a targeted result-cardinality change for `drawer+closet` hits: one logical source is now represented once. Raw direct `drawer` search retains its existing per-chunk behavior.

## Reproduce
```bash
uv run python examples/reproduce_duplicate_hydrated_results.py
```
Before the fix, it finds three hydrated results for one source; after the fix, it prints one `drawer+closet` result.

## Validation
- `uv run ruff check mempalace/searcher.py tests/test_closets.py examples/reproduce_duplicate_hydrated_results.py`
- `uv run python examples/reproduce_duplicate_hydrated_results.py`
- `uv run pytest tests/test_closets.py::TestDrawerGrepExpansion -q`