### PR TITLE
fix(mcp): answer every JSON-RPC request that carries an id (#2231)

### DIFF
--- a/mempalace/mcp_server/http.py
+++ b/mempalace/mcp_server/http.py
@@ -365,7 +365,10 @@ def _http_dispatch(request):
     the lock; palace writes take it exclusively. Unclassified tools fail
     closed onto the exclusive side.
     """
-    method = request.get("method") or "" if isinstance(request, dict) else ""
+    # Same envelope trap as handle_request, on a dispatcher added after it: the
+    # `or ""` fallback only rescues falsy values, so a truthy non-string method
+    # reached .startswith() below and raised out of the handler thread.
+    method, _ = _normalize_envelope(request) if isinstance(request, dict) else ("", {})
     if method in _HTTP_PROTOCOL_METHODS or method.startswith("notifications/"):
         return handle_request(request)
     tool_name = None
@@ -1012,7 +1015,29 @@ def _build_http_server(host: str, port: int):
 
             # Locking policy lives in _http_dispatch: global lock for
             # Chroma-touching tools, lock-free for logstream tools.
-            response = _http_dispatch(request)
+            try:
+                response = _http_dispatch(request)
+            except Exception:
+                # Without this the exception escaped into BaseHTTPRequestHandler,
+                # which closes the connection with no reply at all -- the client
+                # sees a dropped socket instead of a JSON-RPC error. Log with the
+                # traceback: -32603 tells the client nothing diagnostic, so the
+                # stack is the only record of what actually failed.
+                logger.exception("HTTP JSON-RPC dispatch error")
+                req_id = request.get("id") if isinstance(request, dict) else None
+                if req_id is None:
+                    # A notification is owed no response body, failure included,
+                    # matching the 202 branch below and the stdio loop. The
+                    # status still reports the failure at the transport level.
+                    self._record_request(500)
+                    self.send_response(500)
+                    self.send_header("Content-Length", "0")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    self.close_connection = True
+                    return
+                self._send_json(500, _json_rpc_internal_error(req_id))
+                return
 
             if response is None:
                 # JSON-RPC notifications intentionally have no response body.

--- a/mempalace/mcp_server/protocol.py
+++ b/mempalace/mcp_server/protocol.py
@@ -663,6 +663,30 @@ def _decorate_mcp_tool_result(tool_name: str, result):
     return result
 
 
+def _normalize_envelope(request: dict) -> "tuple[str, dict]":
+    """Read `method` and `params` off a request without raising.
+
+    `or ""` / `or {}` only rescue falsy values, so a truthy non-string method
+    reached `.startswith()` and truthy non-object params reached `.get()`,
+    raising AttributeError out of `handle_request`. Over stdio that surfaced
+    as no response at all, leaving the client waiting on an id forever.
+
+    A malformed value falls back to the same default its falsy counterpart has
+    always been given, so nothing that used to be answered stops being
+    answered: `params: []` is legal by-position params this server does not
+    support, and it kept working as an empty mapping before this guard existed.
+    """
+    method = request.get("method")
+    if not isinstance(method, str):
+        method = ""
+
+    params = request.get("params")
+    if not isinstance(params, dict):
+        params = {}
+
+    return method, params
+
+
 def handle_request(request):
     global _last_request_time
     if not isinstance(request, dict):
@@ -672,9 +696,8 @@ def handle_request(request):
             "error": {"code": -32600, "message": "Invalid Request"},
         }
     _last_request_time = time.monotonic()
-    method = request.get("method") or ""
-    params = request.get("params") or {}
     req_id = request.get("id")
+    method, params = _normalize_envelope(request)
 
     if method == "initialize":
         client_version = params.get("protocolVersion", SUPPORTED_PROTOCOL_VERSIONS[-1])
@@ -722,6 +745,12 @@ def handle_request(request):
                     "message": "Invalid params: 'name' is required for tools/call",
                 },
             }
+        if _tool_call_members_invalid(params):
+            return _json_rpc_error(
+                req_id,
+                -32602,
+                "Invalid params: 'name' must be a string and 'arguments' an object",
+            )
         tool_name = params.get("name")
         tool_args = params.get("arguments") or {}
         if tool_name not in TOOLS:
@@ -849,11 +878,7 @@ def handle_request(request):
     # Notifications (missing id) must never get a response
     if req_id is None:
         return None
-    return {
-        "jsonrpc": "2.0",
-        "id": req_id,
-        "error": {"code": -32601, "message": f"Unknown method: {method}"},
-    }
+    return _unknown_method_error(req_id, request)
 
 
 def _restore_stdout():
@@ -1185,9 +1210,54 @@ def _start_idle_exit_watchdog() -> None:
     t.start()
 
 
-def _json_rpc_parse_error(req_id=None):
+def _json_rpc_error(req_id, code: int, message: str) -> dict:
     return {
         "jsonrpc": "2.0",
         "id": req_id,
-        "error": {"code": -32700, "message": "Parse error"},
+        "error": {"code": code, "message": message},
     }
+
+
+def _json_rpc_parse_error(req_id=None):
+    return _json_rpc_error(req_id, -32700, "Parse error")
+
+
+def _tool_call_members_invalid(params: dict) -> bool:
+    """True when `tools/call` params carry an unusable `name` / `arguments`.
+
+    The same `or {}` trap as the envelope, one level down: a truthy non-mapping
+    `arguments` survived the fallback and blew up on `**` unpacking, and an
+    unhashable `name` raised TypeError on the `in TOOLS` membership test.
+    """
+    name = params.get("name")
+    args = params.get("arguments")
+    return not isinstance(name, str) or not isinstance(args, (dict, type(None)))
+
+
+def _unknown_method_error(req_id, request: dict) -> dict:
+    """Name the real problem when `method` was coerced for dispatch.
+
+    A non-string method is mapped to "" so it lands on the long-standing
+    `method: null` path, but rendering that verbatim gives "Unknown method: "
+    with nothing after it, and makes 123 indistinguishable from "123".
+    """
+    raw_method = request.get("method")
+    if not isinstance(raw_method, str):
+        return _json_rpc_error(
+            req_id,
+            -32601,
+            f"Unknown method: expected a string, got {type(raw_method).__name__}",
+        )
+    return _json_rpc_error(req_id, -32601, f"Unknown method: {raw_method}")
+
+
+def _json_rpc_internal_error(req_id) -> dict:
+    """Dispatch-level failure.
+
+    Deliberately generic: unlike `_internal_tool_error`, which reports a known
+    handler's own exception text, this fires for arbitrary code paths whose
+    exception may name internal helpers or filesystem layout. `-32603` also
+    keeps the transport-level failure distinct from the `-32000` this module
+    already uses for application-level tool failures.
+    """
+    return _json_rpc_error(req_id, -32603, "Internal error")

--- a/mempalace/mcp_server/runtime.py
+++ b/mempalace/mcp_server/runtime.py
@@ -96,8 +96,13 @@ def _forward_request_to_hub(base_url: str, headers: dict, request: dict, palace_
 def _request_is_mutating(request: dict) -> bool:
     if request.get("method") != "tools/call":
         return False
-    name = ((request.get("params") or {}).get("name")) or ""
-    return name in _MUTATING_TOOLS
+    # This decides whether a mid-flight failure may be replayed locally, so it
+    # must return a verdict rather than raise: the same `or {}` trap made a
+    # non-mapping `params` throw AttributeError instead of answering "not
+    # mutating", and an unhashable name broke the membership test.
+    _, params = _normalize_envelope(request)
+    name = params.get("name")
+    return isinstance(name, str) and name in _MUTATING_TOOLS
 
 
 def _dispatch_stdio_request(request: dict):
@@ -214,14 +219,34 @@ def _run_stdio_loop() -> None:
         payload = None
         try:
             request = json.loads(line)
-            response = _dispatch_stdio_request(request)
-            if response is not None:
-                payload = json.dumps(response, ensure_ascii=False)
         except KeyboardInterrupt:
             break
-        except Exception as e:
-            logger.error(f"Server error: {e}")
-            continue
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            # Narrow on purpose: reporting a MemoryError or RecursionError as
+            # "Parse error" would be a lie. The id is unknowable here, so it is
+            # null per JSON-RPC 2.0 section 5 -- the "never answer a
+            # notification" rule cannot bind when the notification is exactly
+            # what could not be parsed. Staying silent left the client waiting
+            # on a request it had already sent, while the HTTP transport has
+            # answered -32700 all along.
+            logger.error("Server error: %s", exc)
+            payload = json.dumps(_json_rpc_parse_error(), ensure_ascii=False)
+        else:
+            try:
+                response = _dispatch_stdio_request(request)
+                if response is not None:
+                    payload = json.dumps(response, ensure_ascii=False)
+            except KeyboardInterrupt:
+                break
+            except Exception:
+                # Log with the traceback: the client only gets a generic
+                # -32603, so the stack is the only record of what failed.
+                logger.exception("Server error")
+                req_id = request.get("id") if isinstance(request, dict) else None
+                if req_id is None:
+                    # A notification is owed no response, failure included.
+                    continue
+                payload = json.dumps(_json_rpc_internal_error(req_id), ensure_ascii=False)
 
         if payload is None:
             continue

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -406,6 +406,47 @@ def test_invalid_json_returns_parse_error(http_server):
     assert json.loads(body)["error"]["code"] == -32700
 
 
+def test_non_string_method_gets_jsonrpc_error(http_server):
+    """A malformed envelope must come back as JSON-RPC, not a dropped socket."""
+    port, _ = http_server
+    status, body = _post(port, "/mcp", {"jsonrpc": "2.0", "id": 3, "method": 123})
+    assert status == 200
+    payload = json.loads(body)
+    assert payload["id"] == 3
+    assert payload["error"]["code"] == -32601
+
+
+def test_dispatch_failure_returns_jsonrpc_error(http_server, monkeypatch):
+    """An unexpected dispatch failure answers -32603 instead of closing the socket."""
+    port, _ = http_server
+
+    def _boom(_request):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(mcp, "_http_dispatch", _boom)
+
+    status, body = _post(port, "/mcp", {"jsonrpc": "2.0", "id": 4, "method": "ping"})
+    assert status == 500
+    payload = json.loads(body)
+    assert payload["id"] == 4
+    assert payload["error"]["code"] == -32603
+    assert "kaboom" not in body.decode("utf-8")
+
+
+def test_dispatch_failure_on_notification_sends_no_body(http_server, monkeypatch):
+    """A notification is owed no response body, a failed one included."""
+    port, _ = http_server
+
+    def _boom(_request):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(mcp, "_http_dispatch", _boom)
+
+    status, body = _post(port, "/mcp", {"jsonrpc": "2.0", "method": "notifications/initialized"})
+    assert status == 500
+    assert body == b""
+
+
 def test_oversized_request_rejected_413(http_server):
     """A declared Content-Length over the cap is rejected before the body is read."""
     port, _ = http_server

--- a/tests/test_mcp_jsonrpc_envelope.py
+++ b/tests/test_mcp_jsonrpc_envelope.py
@@ -1,0 +1,196 @@
+"""JSON-RPC envelope handling: every request carrying an id gets a response.
+
+The stdio loop used to swallow any exception raised while handling a request
+and continue without writing anything, so a client that sent an id waited
+forever. The reachable way in was the envelope read: `method` and `params`
+were taken with `or ""` / `or {}`, which rescues only falsy values, so a
+truthy non-string / non-dict reached `.startswith()` / `.get()`.
+"""
+
+import io
+import json
+import sys
+
+import pytest
+
+import mempalace.mcp_server as mcp
+
+
+def _run_loop(monkeypatch, lines):
+    """Drive _run_stdio_loop over `lines` and return the parsed responses.
+
+    Startup side effects (preflight probe, watchdog threads, embedder warmup)
+    are stubbed out: they open the palace, and this exercises the protocol
+    loop only. stdin is a StringIO, so the loop always reaches EOF and exits.
+    """
+    for name in (
+        "_restore_stdout",
+        "_startup_preflight",
+        "_start_idle_exit_watchdog",
+        "_start_write_stall_watchdog",
+        "_maybe_eager_warmup_embedder",
+    ):
+        monkeypatch.setattr(mcp, name, lambda *a, **k: None)
+    # No hub configured: dispatch stays local instead of proxying.
+    monkeypatch.setattr(mcp, "_hub_proxy_target", lambda: None)
+
+    out = io.StringIO()
+    monkeypatch.setattr(sys, "stdin", io.StringIO("".join(line + "\n" for line in lines)))
+    monkeypatch.setattr(sys, "stdout", out)
+
+    mcp._run_stdio_loop()
+
+    return [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+
+
+class TestEnvelopeShapes:
+    """handle_request must answer malformed envelopes instead of raising."""
+
+    @pytest.mark.parametrize("method", [123, True, 1.5, ["notifications/x"], {"a": 1}])
+    def test_non_string_method_answers_instead_of_raising(self, method):
+        resp = mcp.handle_request({"jsonrpc": "2.0", "id": 99, "method": method})
+
+        assert resp is not None
+        assert resp["id"] == 99
+        assert resp["error"]["code"] == -32601
+        # The message must name the real problem, not render an empty name.
+        assert "expected a string" in resp["error"]["message"]
+
+    @pytest.mark.parametrize("method", [123, True, ["x"]])
+    def test_non_string_method_without_id_stays_silent(self, method):
+        """A notification carries no id, so it still gets no response."""
+        assert mcp.handle_request({"jsonrpc": "2.0", "method": method}) is None
+
+    @pytest.mark.parametrize("params", ["oops", 5, True, ["a"], [], 0, "", False, None])
+    def test_odd_params_never_raise(self, params):
+        """Malformed params degrade to "no params" rather than crashing.
+
+        `initialize` reads params, so this is the branch that used to raise.
+        """
+        resp = mcp.handle_request(
+            {"jsonrpc": "2.0", "id": 100, "method": "initialize", "params": params}
+        )
+
+        assert resp["id"] == 100
+        assert resp["result"]["serverInfo"]["name"] == "mempalace"
+
+    @pytest.mark.parametrize("params", [[], 0, "", False, ["a"], "oops"])
+    def test_params_ignoring_methods_keep_working(self, params):
+        """`ping` never reads params, so odd params must not make it fail.
+
+        Falsy values were normalised to {} long before this guard existed;
+        rejecting them would break requests the server used to answer.
+        """
+        resp = mcp.handle_request({"jsonrpc": "2.0", "id": 60, "method": "ping", "params": params})
+
+        assert resp == {"jsonrpc": "2.0", "id": 60, "result": {}}
+
+    def test_null_id_is_a_request_and_gets_answered(self):
+        """`id: null` is a Request, not a notification, so it owes a reply."""
+        resp = mcp.handle_request({"jsonrpc": "2.0", "id": None, "method": "ping", "params": []})
+
+        assert resp == {"jsonrpc": "2.0", "id": None, "result": {}}
+
+    def test_missing_params_key_still_works(self):
+        resp = mcp.handle_request({"jsonrpc": "2.0", "id": 101, "method": "initialize"})
+
+        assert resp["result"]["serverInfo"]["name"] == "mempalace"
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"name": "mempalace_status", "arguments": 5},
+            {"name": "mempalace_status", "arguments": True},
+            {"name": {}, "arguments": {}},
+            {"name": ["x"], "arguments": {}},
+        ],
+    )
+    def test_malformed_tools_call_members_answer_instead_of_raising(self, params):
+        """The same `or {}` trap one level down: name/arguments were unchecked."""
+        resp = mcp.handle_request(
+            {"jsonrpc": "2.0", "id": 5, "method": "tools/call", "params": params}
+        )
+
+        assert resp["id"] == 5
+        assert resp["error"]["code"] == -32602
+
+
+class TestRequestIsMutating:
+    """The replay guard must return a verdict, never raise."""
+
+    @pytest.mark.parametrize("params", ["x", ["a"], 5, True, None])
+    def test_non_dict_params_is_not_mutating(self, params):
+        assert mcp._request_is_mutating({"method": "tools/call", "params": params}) is False
+
+    def test_unhashable_name_is_not_mutating(self):
+        assert mcp._request_is_mutating({"method": "tools/call", "params": {"name": {}}}) is False
+
+    def test_real_mutating_tool_still_detected(self):
+        name = next(iter(mcp._MUTATING_TOOLS))
+
+        assert mcp._request_is_mutating({"method": "tools/call", "params": {"name": name}})
+
+
+class TestStdioLoopAlwaysResponds:
+    """The loop must never drop a request that carried an id."""
+
+    def test_malformed_json_gets_parse_error(self, monkeypatch):
+        responses = _run_loop(
+            monkeypatch,
+            ['{"jsonrpc":"2.0","id":1,"method":"ping"', '{"jsonrpc":"2.0","id":2,"method":"ping"}'],
+        )
+
+        assert responses[0] == {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32700, "message": "Parse error"},
+        }
+        # The loop stays alive and serves the next line.
+        assert responses[1]["id"] == 2
+
+    def test_non_string_method_is_answered_over_stdio(self, monkeypatch):
+        responses = _run_loop(
+            monkeypatch,
+            ['{"jsonrpc":"2.0","id":7,"method":123}', '{"jsonrpc":"2.0","id":8,"method":"ping"}'],
+        )
+
+        assert [r["id"] for r in responses] == [7, 8]
+        assert responses[0]["error"]["code"] == -32601
+
+    def test_handler_exception_is_answered_not_swallowed(self, monkeypatch):
+        """An unexpected failure below dispatch still owes the client a reply."""
+
+        def _boom(_request):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(mcp, "_dispatch_stdio_request", _boom)
+
+        responses = _run_loop(monkeypatch, ['{"jsonrpc":"2.0","id":11,"method":"ping"}'])
+
+        assert len(responses) == 1
+        assert responses[0]["id"] == 11
+        assert responses[0]["error"]["code"] == -32603
+        # The message must not leak the exception text to the client.
+        assert "kaboom" not in json.dumps(responses[0])
+
+    def test_notification_failure_stays_silent(self, monkeypatch):
+        """No id means no response, even when dispatch raises."""
+
+        def _boom(_request):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(mcp, "_dispatch_stdio_request", _boom)
+
+        assert _run_loop(monkeypatch, ['{"jsonrpc":"2.0","method":"notifications/x"}']) == []
+
+    def test_successful_notification_writes_nothing(self, monkeypatch):
+        """The ordinary MCP notification still produces no output."""
+        responses = _run_loop(
+            monkeypatch,
+            [
+                '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+                '{"jsonrpc":"2.0","id":12,"method":"ping"}',
+            ],
+        )
+
+        assert [r["id"] for r in responses] == [12]


### PR DESCRIPTION
## What does this PR do?

Fixes #2231: every JSON-RPC request carrying an `id` now gets a response.

`or` was being used as a type guard, and it rescues only *falsy* values. A truthy non-string `method` reached `.startswith()` and a truthy non-object `params` reached `.get()`, raising `AttributeError`. The stdio loop then caught everything and continued without writing a reply, so the client waited on that `id` forever; HTTP had no `try` around `_http_dispatch`, so the socket simply closed.

The pattern sits at four depths, so the fix follows it down:

* `_normalize_envelope()` gives `method` / `params` the same defaults their falsy counterparts always got.
* `_http_dispatch` reads `method` through it too. That dispatcher landed after this branch opened and repeats the same `or ""`, so a non-string method raised inside the handler thread before `handle_request` ever saw it.
* `tools/call` validates `name` and `arguments` (`arguments: 5` reached `**` unpacking; an unhashable `name` broke the `in TOOLS` test) and answers `-32602`.
* `_request_is_mutating` returns a verdict instead of raising. It decides whether a mid-flight call may be replayed locally, so an exception there defeated the guarantee it exists for.

Then neither transport loses what still escapes: stdio answers `-32700` on a parse failure (via `_json_rpc_parse_error`, until now wired only into HTTP) and `-32603` on a dispatch failure; HTTP answers `500` with `-32603` instead of dropping the connection. Neither new error path answers a notification: no `id`, no error response.

Nothing that used to be answered stops being answered: `params: []`, `0`, `""` and `false` were normalised to `{}` before this guard existed and still are.

**On the codes:** a non-string `method` returns `-32601`, not `-32600`, to match the `method: null` behaviour pinned by `test_malformed_method_none`. `-32603` covers dispatch-level failures while `_internal_tool_error` keeps `-32000` for tool-level ones. On a parse failure the id is unknowable, so the reply carries `id: null` per JSON-RPC 2.0 section 5.

Out of scope and unchanged: batch arrays get one `-32600` rather than one response per element, and a `notifications/*` method sent *with* an `id` still gets no reply.

## How to test

```bash
printf '%s\n' \
  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"r","version":"1"}}}' \
  '{"jsonrpc":"2.0","id":2,"method":123}' \
  '{"jsonrpc":"2.0","id":3,"method":"ping"}' > rpc.jsonl
python -m mempalace.mcp_server < rpc.jsonl
```

On `develop` only ids 1 and 3 come back; with this branch all three do.

`python -m pytest tests/test_mcp_jsonrpc_envelope.py tests/test_mcp_http_transport.py -q` covers it: 41 cases in the new file and 3 added to the HTTP suite. Reverting each of the nine guards in turn reddens only its own tests (10 / 8 / 4 / 5 / 4 / 1 / 1 / 1 / 1), and both files are green again once it is restored.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)

Full suite: 4948 passed, 53 skipped, 1 failed. The failure is `test_cli_import_under_startup_budget`, a startup-time budget that fails 3 runs out of 3 on unmodified `develop` too.

