### PR TITLE
fix(config): handle non-object JSON documents

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -375,7 +375,8 @@ class MempalaceConfig:
         if self._config_file.exists():
             try:
                 with open(self._config_file, "r", encoding="utf-8") as f:
-                    self._file_config = json.load(f)
+                    loaded = json.load(f)
+                    self._file_config = loaded if isinstance(loaded, dict) else {}
             except (json.JSONDecodeError, UnicodeDecodeError, OSError):
                 self._file_config = {}
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ import tempfile
 
 import pytest
 from mempalace.config import (
+    DEFAULT_PALACE_PATH,
     MempalaceConfig,
     normalize_wing_name,
     sanitize_iso_date,
@@ -28,6 +29,20 @@ def test_config_from_file():
         json.dump({"palace_path": "/custom/palace"}, f)
     cfg = MempalaceConfig(config_dir=tmpdir)
     assert cfg.palace_path == "/custom/palace"
+
+
+@pytest.mark.parametrize("payload", [None, [], "oops", 42, True])
+def test_non_object_config_document_falls_back_to_defaults(tmp_path, payload):
+    """Valid JSON scalars/arrays are not valid MemPalace configurations."""
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump(payload, f)
+
+    cfg = MempalaceConfig(config_dir=str(tmp_path))
+
+    assert cfg.palace_path == DEFAULT_PALACE_PATH
+    assert cfg.collection_name == "mempalace_drawers"
+    assert cfg.backend == "chroma"
+    assert cfg.hooks_auto_save is True
 
 
 def test_backend_from_config_wins_over_env(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

- Validates that a successfully parsed `config.json` is a JSON object before storing it as MemPalace configuration.
- Falls back to the existing empty/default configuration for valid JSON scalars and arrays instead of crashing on the first `.get()` call.
- Adds regressions for `null`, array, string, number, and boolean top-level documents.

Closes #2234.

## Why?

JSON permits non-object values at the top level. `MempalaceConfig` previously assigned any successful `json.load()` result to `_file_config`, while all downstream properties assume a mapping. A file containing `null`, `[]`, a string, a number, or a boolean therefore raised `AttributeError` across CLI, MCP, mining, and hook consumers.

The fallback matches the class's existing fail-soft behavior for malformed JSON, Unicode decode errors, and unreadable files. It does not rewrite the user's file, emit output on the MCP stdio channel, or alter valid object configurations.

## How to test

```bash
python -m pytest -q tests/test_config.py tests/test_hooks_cli.py
pre-commit run --all-files
```

Local result after rebasing onto current `develop`: 286 passed, 1 skipped. Ruff check, Ruff format, and `git diff --check` pass.

## Checklist

- [x] Focused and adjacent tests pass
- [x] No hardcoded paths
- [x] Linter and formatter pass
