### PR TITLE
chore(release): 3.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 36 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 36 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 36 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [3.7.1] — 2026-08-12
+
+Post-3.7.0 integrity patch: ingest no longer hangs on non-regular files, incomplete mines can be retried instead of permanently skipped, chromadb reconnect no longer rewinds the HNSW index, and MCP releases the writer lease on SIGTERM/SIGHUP.
+
 ### Bug Fixes
 
 - **Ingest commands no longer hang on a named pipe.** `os.walk` and `glob` list a FIFO as an ordinary filename and MemPalace decides what to read from the suffix, so a pipe called `notes.md` in a mined directory wedged `mine` in the kernel forever: opening a FIFO for reading waits for a writer that never arrives, and the `S_ISREG` refusal written on the next line could never run. `mine --mode convos`, `sweep`, `init`, `compress` and `split` blocked the same way through their own readers. The four affected opens now pass `O_NONBLOCK`, which makes the existing type check reachable — a pipe is refused on its mode, with or without a live writer — and the discovery walks drop non-regular entries with a `SKIP: <name> (not a regular file)` line, so the readers that use a plain `open()` never see one. Regular files read back byte-identical; the one case where the flag is not inert, a reader breaking a write lease, re-checks the file type and retries without it rather than dropping the file. `mine --mode extract` was already immune through its zero-size gate. (#2221)
@@ -706,7 +712,8 @@ Initial public release.
 
 ---
 
-[Unreleased]: https://github.com/MemPalace/mempalace/compare/v3.7.0...HEAD
+[Unreleased]: https://github.com/MemPalace/mempalace/compare/v3.7.1...HEAD
+[3.7.1]: https://github.com/MemPalace/mempalace/compare/v3.7.0...v3.7.1
 [3.7.0]: https://github.com/MemPalace/mempalace/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/MemPalace/mempalace/compare/v3.5.0...v3.6.0
 [3.5.0]: https://github.com/MemPalace/mempalace/compare/v3.4.1...v3.5.0

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 MIT — see [LICENSE](LICENSE).
 
 <!-- Link Definitions -->
-[version-shield]: https://img.shields.io/badge/version-3.7.0-4dc9f6?style=flat-square&labelColor=0a0e14
+[version-shield]: https://img.shields.io/badge/version-3.7.1-4dc9f6?style=flat-square&labelColor=0a0e14
 [release-link]: https://github.com/MemPalace/mempalace/releases
 [python-shield]: https://img.shields.io/badge/python-3.9+-7dd8f8?style=flat-square&labelColor=0a0e14&logo=python&logoColor=7dd8f8
 [python-link]: https://www.python.org/

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mempalace
 description: "MemPalace — Local AI memory with 96.6% recall. Semantic search, temporal knowledge graph, palace architecture (wings/rooms/drawers). Free, no cloud, no API keys."
-version: 3.7.0
+version: 3.7.1
 homepage: https://github.com/MemPalace/mempalace
 user-invocable: true
 metadata:

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.7.0"
+__version__ = "3.7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.7.0"
+version = "3.7.1"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -2004,7 +2004,7 @@ wheels = [
 
 [[package]]
 name = "mempalace"
-version = "3.7.0"
+version = "3.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Prepare the **3.7.1** patch release on `develop`. Version sources, lock, README badge, OpenClaw skill, and changelog all agree on `3.7.1`.

This is the **version-bump PR only**. After review and merge here, promote with a second PR: **`develop` → `main`** (same path as #2129). Do **not** push the bump or the tag directly to `main`.

### In 3.7.1 (already on develop via #2228)

- **#2221** — ingest never hangs on a named pipe / non-regular file
- **#2088 / #2122 / #2151** — project re-mine completeness (`chunk_total`, same-fstat mtime, purge abort, partial-batch cleanup)
- **#2183** — conversation mine completeness parity
- **#2002 / #2028** — drop chromadb SharedSystemClient cache on reconnect (no HNSW rewind)
- **#2205** — SIGTERM/SIGHUP releases the palace writer lease

### Version sources (must match)

| Source | Version |
| --- | --- |
| `mempalace/version.py` | `3.7.1` |
| `pyproject.toml` | `3.7.1` |
| `.claude-plugin/marketplace.json` | `3.7.1` |
| `.claude-plugin/plugin.json` | `3.7.1` |
| `.codex-plugin/plugin.json` | `3.7.1` |

Entry-point check: `mempalace-mcp = mempalace.mcp_server:main` still matches plugin configs.

## After this lands on develop

1. Open **`develop` → `main`** as a normal PR (branch protection, reviews, CI). Title e.g. `Release v3.7.1 — promote develop to main`.
2. Merge that PR through the usual checks — no force-push, no admin bypass.
3. On GitHub: **Releases → Draft a new release**
   - Target: `main`
   - Tag: `v3.7.1` (must match `version.py`)
   - Notes: fold from `CHANGELOG.md` `[3.7.1]`
4. Publish the release. `publish.yml` builds, then waits for **pypi** environment approval.

## Test plan

- [x] Five version sources agree
- [x] Changelog folded: Unreleased empty, `[3.7.1] — 2026-08-12` + compare links
- [x] README badge + OpenClaw skill + `uv.lock` package version bumped
- [ ] `version-guard.yml` green on this PR
- [ ] CI green (lint / linux / macos / windows)