### PR TITLE
fix: decode git subprocess output as UTF-8 regardless of locale

### DIFF
--- a/mempalace/project_scanner.py
+++ b/mempalace/project_scanner.py
@@ -260,10 +260,18 @@ def _run_git(cwd: Path, *args: str, timeout: int = GIT_TIMEOUT) -> str:
             ["git", "-C", str(cwd), *args],
             capture_output=True,
             text=True,
+            # git emits UTF-8 on every platform, but bare text=True decodes
+            # with the locale codepage (e.g. cp1254 on Turkish Windows), which
+            # crashes the stdout reader thread on non-ASCII names ("Ş" is
+            # 0xc5 0x9e in UTF-8; 0x9e is undefined in cp1254) and silently
+            # leaves r.stdout as None. Decode explicitly; errors="replace"
+            # keeps legacy-encoded history from aborting a whole scan.
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             check=False,
         )
-        return r.stdout if r.returncode == 0 else ""
+        return (r.stdout or "") if r.returncode == 0 else ""
     except (OSError, subprocess.SubprocessError):
         return ""
 
@@ -281,6 +289,9 @@ def _global_git_identity() -> tuple[str, str]:
             ["git", "config", "--global", "user.name"],
             capture_output=True,
             text=True,
+            # Same UTF-8 rationale as _run_git above.
+            encoding="utf-8",
+            errors="replace",
             timeout=2,
             check=False,
         ).stdout.strip()
@@ -288,6 +299,8 @@ def _global_git_identity() -> tuple[str, str]:
             ["git", "config", "--global", "user.email"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=2,
             check=False,
         ).stdout.strip()

--- a/tests/test_project_scanner.py
+++ b/tests/test_project_scanner.py
@@ -23,6 +23,9 @@ from mempalace.project_scanner import (
     _parse_package_json,
     _parse_pom,
     _parse_pyproject,
+    _git_user_identity,
+    _global_git_identity,
+    _run_git,
     _UnionFind,
     discover_entities,
     find_git_repos,
@@ -294,6 +297,51 @@ def test_find_git_repos_empty_dir(tmp_path):
     assert find_git_repos(tmp_path) == []
 
 
+# ── git subprocess decoding ─────────────────────────────────────────────
+
+
+def test_run_git_decodes_utf8_regardless_of_locale(monkeypatch):
+    """git emits UTF-8; decoding must not depend on the locale codepage.
+
+    With bare text=True, Python decodes the pipe with the ANSI codepage on
+    Windows (e.g. cp1254 on Turkish systems). A name like "Gürkan ŞANLI"
+    ("Ş" = 0xc5 0x9e; 0x9e is undefined in cp1254) crashed the stdout
+    reader thread and left stdout=None, aborting `mempalace init`.
+    """
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout="ok\n")
+
+    monkeypatch.setattr("mempalace.project_scanner.subprocess.run", fake_run)
+    assert _run_git(Path("."), "config", "user.name") == "ok\n"
+    assert captured["encoding"] == "utf-8"
+    assert captured["errors"] == "replace"
+
+
+def test_run_git_returns_empty_string_when_stdout_is_none(monkeypatch):
+    """A missing stdout must surface as "" — callers chain .strip() on it."""
+    monkeypatch.setattr(
+        "mempalace.project_scanner.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=None),
+    )
+    assert _run_git(Path("."), "config", "user.name") == ""
+
+
+def test_global_git_identity_decodes_utf8_regardless_of_locale(monkeypatch):
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(kwargs)
+        stdout = "Gürkan ŞANLI\n" if "user.name" in cmd else "gurkan@example.com\n"
+        return SimpleNamespace(returncode=0, stdout=stdout)
+
+    monkeypatch.setattr("mempalace.project_scanner.subprocess.run", fake_run)
+    assert _global_git_identity() == ("Gürkan ŞANLI", "gurkan@example.com")
+    assert all(k["encoding"] == "utf-8" and k["errors"] == "replace" for k in captured)
+
+
 # ── scan ────────────────────────────────────────────────────────────────
 
 
@@ -502,6 +550,27 @@ def test_scan_excludes_bot_commits_from_totals(tmp_path):
     assert projects[0].total_commits == 1
     assert projects[0].user_commits == 1
     assert [person.name for person in people] == ["Jane Doe"]
+
+
+def test_git_user_identity_preserves_non_ascii_name(tmp_path):
+    """Regression: reading `git config user.name` crashed on cp1254 locales."""
+    _init_git_repo(tmp_path, name="Gürkan ŞANLI", email="gurkan@example.com")
+    assert _git_user_identity(tmp_path) == ("Gürkan ŞANLI", "gurkan@example.com")
+
+
+def test_scan_preserves_non_ascii_git_identity(tmp_path):
+    """End-to-end: a non-ASCII identity survives both git subprocess paths.
+
+    Exercises `git config user.name` (identity) and `git log --format=%aN|%aE`
+    (authors) through a real git repo. On a non-UTF-8 Windows codepage the
+    unfixed code either crashed outright (cp1254) or mojibake'd the name
+    (cp1252), so the equality below catches both failure modes.
+    """
+    (tmp_path / "package.json").write_text(json.dumps({"name": "utf8-app"}))
+    _init_git_repo(tmp_path, name="Gürkan ŞANLI", email="gurkan@example.com")
+    projects, people = scan(tmp_path)
+    assert [person.name for person in people] == ["Gürkan ŞANLI"]
+    assert projects[0].total_commits == 1
 
 
 def test_scan_empty_dir(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Fixes a startup crash of `mempalace init` on Windows systems whose ANSI codepage is not UTF-8 (e.g. Turkish cp1254), triggered whenever the git identity or commit history contains non-ASCII characters.

Reported on a Turkish-locale Windows 11 setup with `git config user.name` = `Gürkan ŞANLI`:

```
Exception in thread Thread-1 (_readerthread):
...
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9e in position 9: character maps to <undefined>
...
File "mempalace/project_scanner.py", line 267, in _git_user_identity
  name = _run_git(repo, "config", "user.name", timeout=2).strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```

**Root cause:** the three git `subprocess.run()` calls in `project_scanner.py` use `text=True` without an explicit encoding, so CPython decodes the pipe with `locale.getpreferredencoding()` — the ANSI codepage on Windows. git, however, emits UTF-8 on every platform. `Ş` encodes to `0xc5 0x9e`, and `0x9e` is undefined in cp1254, so the decode blows up inside subprocess's stdout reader thread; `subprocess.run()` then returns a `CompletedProcess` with `stdout=None` (returncode still 0), and `_run_git`'s `return r.stdout if r.returncode == 0 else ""` propagates that `None` into `.strip()`.

**Fix:**

- pass `encoding="utf-8", errors="replace"` to all three git subprocess calls (`_run_git` and both calls in `_global_git_identity`); `errors="replace"` keeps repos with legacy-encoded history from aborting a whole scan
- harden `_run_git` to return `""` if stdout is ever `None`, since every caller chains `.strip()`/`.splitlines()` on the result

## How to test

`uv run pytest tests/test_project_scanner.py -v` — 5 new regression tests:

- unit: `_run_git`/`_global_git_identity` must request UTF-8 decoding and must never propagate a `None` stdout
- integration (real git): a `Gürkan ŞANLI` identity survives both the `git config user.name` and `git log --format=%aN|%aE` paths through `scan()`; on a non-UTF-8 Windows codepage the unfixed code either crashed outright (cp1254) or mojibake'd the name (cp1252), so the equality assertions catch both failure modes

All five new tests fail on the unpatched code (verified on the affected cp1254 machine, reproducing the original traceback verbatim) and pass with the fix.

Manual repro: on Windows with a non-UTF-8 ANSI codepage (Turkish system locale → cp1254), set a non-ASCII `git config user.name` and run `mempalace init .` in any git repo — crashes before this patch, completes after.

Note on the full suite: on the affected Windows machine `pytest tests/ --ignore=tests/benchmarks` gives 3954 passed / 15 failed; all 15 are in `test_claude_plugin_hook_wrappers.py` and `test_mcp_http_transport.py` and reproduce identically on a clean `develop` checkout (local bash/socket environment), i.e. unrelated to this change.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)