### PR TITLE
feat(gossip): background daemon for multi-hop re-propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **`sweep` books a failed `stat` as a failure again.** The non-regular-file gate added in 3.7.1 reads `stat.S_ISREG(f.stat().st_mode)` inside a `try`, and its `except OSError` printed `SKIP` and moved on. A dangling symlink, a symlink loop and a file unlinked between `rglob` and the gate all raise there, and before the gate existed every one of them reached `sweep()` and was booked in `failures` — so `sweep` went from reporting a transcript it could not read to reporting success. A failed probe is now an error, not a benign file type: it is logged, printed as `WARNING`, and appended to `failures`, while a probe that succeeds and says "not regular" still skips silently. (#2221)
+- **`mempalace init` no longer tracebacks on a directory it cannot enter.** `_parse_gradle`'s `is_file()` gate sat in front of the `try` that the parser's own `except OSError` provides, so a manifest under a directory with `r` but no `x` raised `PermissionError` out of a call that used to answer "no manifest name". The gate moved inside that `try`, and `_collect_manifest_names` stats through `os.path.isfile`, which reports rather than raises. (#2221)
+- **`split` no longer blocks on a FIFO at its own output name, nor writes through a broken link.** The type gate in `main` covers the files the glob listed; `split_file` builds its output names itself, so a pre-existing named pipe at one of them wedged `write_text` in the kernel waiting for a reader. The check asks about the link itself rather than its target, because a dangling symlink at an output name reads as "nothing there" and `write_text` would create the target — landing a chunk outside the output directory. Output names that are anything but a regular file are now skipped with a `SKIP` line. (#2221)
+
+---
+
 ## [3.8.0] — 2026-08-20
 
 Large palaces get fast and stay small: both storage backends lost their palace-wide read paths, a proxied agent session no longer loads a storage stack it never uses, and agents gained a background watcher so coordination stops stalling on nobody listening.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Usage and tool reference:
 
 ## MCP server
 
-44 MCP tools cover palace reads/writes, knowledge-graph operations,
+46 MCP tools cover palace reads/writes, knowledge-graph operations,
 cross-wing navigation, drawer management, agent diaries, and agent
 coordination (logstream events + artifact handoffs). Installation
 and the full tool list:

--- a/mempalace/gossip.py
+++ b/mempalace/gossip.py
@@ -29,6 +29,7 @@ from typing import Any, Optional
 from .config import MempalaceConfig, normalize_wing_name
 from .knowledge_graph import KnowledgeGraph
 from .palace_graph import build_graph as _build_graph
+from .hallways import list_hallways
 
 logger = logging.getLogger("mempalace_gossip")
 
@@ -392,18 +393,83 @@ class GossipProtocol:
             return "general", priority
         return "general", "normal"
 
+    def _get_hallway_context(
+        self, message: GossipMessage
+    ) -> tuple[dict[str, float], set[str]]:
+        """Return (hall_scores, related_entities) derived from within-wing hallways.
+
+        Hallways are entity-pair co-occurrence records built at mine time. When a
+        gossip message mentions an entity that co-occurs with other entities in
+        the source wing, we use those co-occurrences to boost chatter nodes that
+        live in the same rooms/halls or cover the related entities.
+        """
+        if not message.source_wing:
+            return {}, set()
+        try:
+            hallways = list_hallways(
+                wing=message.source_wing, config=self.mempalace_config
+            )
+        except Exception:
+            logger.debug("gossip: could not load hallways", exc_info=True)
+            return {}, set()
+
+        entities = {message.subject.lower(), message.obj.lower()}
+        hall_scores: dict[str, float] = {}
+        related: set[str] = set()
+
+        for h in hallways:
+            a = (h.get("entity_a") or "").lower()
+            b = (h.get("entity_b") or "").lower()
+            if a in entities or b in entities:
+                other = b if a in entities else a
+                related.add(other)
+                count = h.get("co_occurrence_count") or 1
+                for room in h.get("rooms") or []:
+                    room_key = room.lower()
+                    # Accumulate a small boost per co-occurrence in this room.
+                    hall_scores[room_key] = hall_scores.get(room_key, 0.0) + min(
+                        0.15, 0.05 + count * 0.01
+                    )
+
+        return hall_scores, related
+
     def select_chatter_nodes(
         self,
         message: GossipMessage,
         fanout: Optional[int] = None,
     ) -> list[ChatterNode]:
-        """Rank and select chatter nodes for a given message."""
+        """Rank and select chatter nodes for a given message.
+
+        Selection combines the base specialty/topic score with within-wing
+        hallway context: chatter nodes in the source wing whose hall/room
+        appears in co-occurrence records for the subject/object get a boost, as
+        do nodes whose specialties overlap with related entities.
+        """
         fanout = fanout if fanout is not None else self.config.get("fanout", 5)
-        scored = [
-            (node, node.match_score(message.text, message.source_wing))
-            for node in self._chatter_nodes
-        ]
-        scored = [(n, s) for n, s in scored if s > 0]
+        hall_scores, related_entities = self._get_hallway_context(message)
+
+        scored = []
+        for node in self._chatter_nodes:
+            score = node.match_score(message.text, message.source_wing)
+
+            # Hallway-aware boosts (only for nodes in the source wing).
+            if message.source_wing and normalize_wing_name(
+                message.source_wing
+            ) == normalize_wing_name(node.wing):
+                if node.hall and node.hall.lower() in hall_scores:
+                    score += hall_scores[node.hall.lower()]
+
+                # Also boost if a related entity matches a specialty.
+                if related_entities and node.specialties:
+                    overlaps = related_entities & {
+                        s.lower() for s in node.specialties
+                    }
+                    score += min(0.3, len(overlaps) * 0.1)
+
+            score = max(0.0, min(2.0, score))
+            if score > 0:
+                scored.append((node, score))
+
         scored.sort(key=lambda x: x[1], reverse=True)
         return [n for n, _ in scored[:fanout]]
 

--- a/mempalace/gossip.py
+++ b/mempalace/gossip.py
@@ -1,0 +1,581 @@
+"""gossip.py — Lightning-fast fact propagation across the MemPalace graph.
+
+This is a minimal MVP for the gossip protocol described in
+``MEMPALACE_GOSSIP_PROTOCOL_IMPLEMENTATION.md``. It does not run as a
+background daemon; it is a library that callers invoke to propagate a newly
+learned fact through a configurable set of chatter nodes and have derived
+triples written back into the temporal knowledge graph.
+
+Key abstractions:
+
+- ``ChatterNode``: a specialized propagation agent bound to a wing/hall with
+  specialties and a gossip radius.
+- ``GossipMessage``: the in-flight fact with metadata (priority, TTL, hops).
+- ``GossipProtocol``: the router that matches a fact to chatter nodes and
+  writes derived triples into the ``KnowledgeGraph``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from .config import MempalaceConfig, normalize_wing_name
+from .knowledge_graph import KnowledgeGraph
+from .palace_graph import build_graph as _build_graph
+
+logger = logging.getLogger("mempalace_gossip")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Default configuration — mirrors the 2026-07-09 spec
+# ─────────────────────────────────────────────────────────────────────────────
+
+DEFAULT_GOSSIP_CONFIG: dict[str, Any] = {
+    "version": "1.0",
+    "max_hops": 3,
+    "ttl_seconds": 60,
+    "fanout": 5,
+    "gossip_probability": 0.7,
+    "initiation_probability": 0.3,
+    "chatter_frequency_ms": 1000,
+    "noise_tolerance": 0.2,
+    "amplification_factor": 1.5,
+    "chatter_nodes": [
+        {
+            "id": "chatter_orkid_tech",
+            "name": "Chatter Orkid Tech",
+            "wing": "orkid",
+            "hall": "technical",
+            "role": "technical_gossip",
+            "specialties": ["contracts", "backend", "defi", "trading"],
+            "gossip_radius": ["orkid", "past-performance"],
+            "chatter_level": "high",
+            "propagation_speed": "instant",
+        },
+        {
+            "id": "chatter_marketing",
+            "name": "Chatter Marketing",
+            "wing": "brutal-marketing",
+            "hall": "general",
+            "role": "marketing_gossip",
+            "specialties": ["brand", "messaging", "content", "storytelling"],
+            "gossip_radius": ["brutal-marketing", "orkid"],
+            "chatter_level": "high",
+            "propagation_speed": "instant",
+        },
+        {
+            "id": "chatter_performance",
+            "name": "Chatter Performance",
+            "wing": "past-performance",
+            "hall": "analytics",
+            "role": "performance_gossip",
+            "specialties": ["metrics", "validation", "optimization", "data"],
+            "gossip_radius": ["past-performance", "orkid"],
+            "chatter_level": "high",
+            "propagation_speed": "instant",
+        },
+        {
+            "id": "chatter_strategy",
+            "name": "Chatter Strategy",
+            "wing": "orkid",
+            "hall": "strategy",
+            "role": "strategy_gossip",
+            "specialties": ["trading", "revenue", "business", "planning"],
+            "gossip_radius": ["orkid", "brutal-marketing"],
+            "chatter_level": "medium",
+            "propagation_speed": "fast",
+        },
+        {
+            "id": "chatter_security",
+            "name": "Chatter Security",
+            "wing": "orkid",
+            "hall": "security",
+            "role": "security_gossip",
+            "specialties": ["audit", "compliance", "risk", "validation"],
+            "gossip_radius": ["orkid", "brutal-marketing"],
+            "chatter_level": "medium",
+            "propagation_speed": "fast",
+        },
+        {
+            "id": "chatter_creative",
+            "name": "Chatter Creative",
+            "wing": "brutal-marketing",
+            "hall": "creative",
+            "role": "creative_gossip",
+            "specialties": ["design", "visual", "brand", "aesthetic"],
+            "gossip_radius": ["brutal-marketing", "orkid"],
+            "chatter_level": "medium",
+            "propagation_speed": "fast",
+        },
+        {
+            "id": "chatter_negentropy",
+            "name": "Chatter Negentropy",
+            "wing": "negentropy",
+            "hall": "creative",
+            "role": "theory_gossip",
+            "specialties": ["information theory", "physics", "complexity", "optimization"],
+            "gossip_radius": ["negentropy", "orkid"],
+            "chatter_level": "low",
+            "propagation_speed": "normal",
+        },
+    ],
+    "topics": [
+        {
+            "name": "technical_breakthroughs",
+            "priority": "critical",
+            "keywords": ["breakthrough", "innovation", "discovery", "achievement"],
+        },
+        {
+            "name": "performance_alerts",
+            "priority": "high",
+            "keywords": ["alert", "issue", "problem", "degradation", "failure"],
+        },
+        {
+            "name": "marketing_campaigns",
+            "priority": "high",
+            "keywords": ["campaign", "launch", "announcement", "promotion", "content"],
+        },
+        {
+            "name": "business_opportunities",
+            "priority": "medium",
+            "keywords": ["opportunity", "revenue", "growth", "partnership", "deal"],
+        },
+        {
+            "name": "security_issues",
+            "priority": "critical",
+            "keywords": ["vulnerability", "security", "risk", "threat", "breach"],
+        },
+        {
+            "name": "creative_inspiration",
+            "priority": "low",
+            "keywords": ["inspiration", "idea", "creative", "design", "concept"],
+        },
+    ],
+    "channels": {
+        "critical": {"latency_ms": 5, "reliability": 0.99, "capacity": "unlimited"},
+        "high": {"latency_ms": 50, "reliability": 0.95, "capacity": "high"},
+        "medium": {"latency_ms": 200, "reliability": 0.90, "capacity": "medium"},
+        "low": {"latency_ms": 1000, "reliability": 0.85, "capacity": "low"},
+    },
+}
+
+PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+CHATTER_LEVEL_MULTIPLIER = {"high": 1.5, "medium": 1.0, "low": 0.5}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Persistence
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _default_gossip_path(config: MempalaceConfig = None) -> str:
+    """Return the default gossip config path.
+
+    If a ``MempalaceConfig`` is provided, the file is stored beside the palace
+    (same pattern as ``tunnels.json`` and ``hallways.json``). Otherwise it falls
+    back to ``~/.mempalace/gossip_config.json``.
+    """
+    if config is not None:
+        return os.path.join(os.path.dirname(config.palace_path), "gossip_config.json")
+    return os.path.join(os.path.expanduser("~"), ".mempalace", "gossip_config.json")
+
+
+def _merge_with_default(raw: dict[str, Any]) -> dict[str, Any]:
+    """Ensure every key from the default config exists in the loaded config."""
+    merged = dict(DEFAULT_GOSSIP_CONFIG)
+    merged.update({k: v for k, v in raw.items() if k not in ("chatter_nodes", "topics")})
+    # Replace collections wholesale rather than deep-merging; callers can edit
+    # the JSON file if they want the default list removed.
+    if "chatter_nodes" in raw:
+        merged["chatter_nodes"] = raw["chatter_nodes"]
+    if "topics" in raw:
+        merged["topics"] = raw["topics"]
+    if "channels" in raw:
+        merged["channels"] = raw["channels"]
+    return merged
+
+
+def load_gossip_config(path: Optional[str] = None, config: MempalaceConfig = None) -> dict[str, Any]:
+    """Load gossip configuration from ``path`` or the default location.
+
+    If the file does not exist, the default configuration is returned and
+    persisted so users can edit it by hand.
+    """
+    path = path or _default_gossip_path(config)
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+            return _merge_with_default(raw)
+        except (OSError, json.JSONDecodeError):
+            logger.warning("gossip: failed to load %s; using defaults", path, exc_info=True)
+    return save_gossip_config(DEFAULT_GOSSIP_CONFIG, path)
+
+
+def save_gossip_config(cfg: dict[str, Any], path: Optional[str] = None) -> dict[str, Any]:
+    """Persist gossip configuration atomically."""
+    path = path or _default_gossip_path()
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix=".gossip-", suffix=".tmp", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    return cfg
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data model
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ChatterNode:
+    """A specialized gossip agent inside the palace."""
+
+    id: str
+    name: str
+    wing: str
+    hall: str
+    role: str
+    specialties: list[str] = field(default_factory=list)
+    gossip_radius: list[str] = field(default_factory=list)
+    chatter_level: str = "medium"
+    propagation_speed: str = "normal"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ChatterNode:
+        valid = set(cls.__dataclass_fields__)
+        return cls(**{k: v for k, v in data.items() if k in valid})
+
+    def match_score(self, text: str, source_wing: Optional[str] = None) -> float:
+        """Score how relevant this chatter node is to a piece of text."""
+        text = text.lower()
+        hits = sum(1 for kw in self.specialties if kw.lower() in text)
+        score = hits * 0.25
+        if source_wing and normalize_wing_name(source_wing) in {
+            normalize_wing_name(w) for w in self.gossip_radius
+        }:
+            score += 0.5
+        if self.chatter_level == "high":
+            score += 0.2
+        elif self.chatter_level == "low":
+            score -= 0.1
+        return max(0.0, min(1.0, score))
+
+
+@dataclass
+class GossipMessage:
+    """A single fact being propagated through the gossip network."""
+
+    subject: str
+    predicate: str
+    obj: str
+    source_wing: Optional[str] = None
+    source_room: Optional[str] = None
+    priority: str = "normal"
+    topic: Optional[str] = None
+    hops: int = 0
+    ttl_seconds: int = 60
+    _started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def text(self) -> str:
+        return f"{self.subject} {self.predicate} {self.obj}"
+
+    def is_expired(self) -> bool:
+        return (datetime.now(timezone.utc) - self._started_at).total_seconds() > self.ttl_seconds
+
+    def child(self, wing: str, room: Optional[str] = None) -> GossipMessage:
+        """Return a copy with incremented hop count."""
+        return GossipMessage(
+            subject=self.subject,
+            predicate=self.predicate,
+            obj=self.obj,
+            source_wing=wing,
+            source_room=room,
+            priority=self.priority,
+            topic=self.topic,
+            hops=self.hops + 1,
+            ttl_seconds=self.ttl_seconds,
+            _started_at=self._started_at,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Gossip router
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class GossipProtocol:
+    """Route a fact through the palace gossip network and persist derived triples."""
+
+    def __init__(
+        self,
+        config_path: Optional[str] = None,
+        mempalace_config: Optional[MempalaceConfig] = None,
+        kg: Optional[KnowledgeGraph] = None,
+        kg_path: Optional[str] = None,
+    ):
+        self.mempalace_config = mempalace_config
+        self.config = load_gossip_config(config_path, mempalace_config)
+        self._chatter_nodes = [ChatterNode.from_dict(n) for n in self.config["chatter_nodes"]]
+        self.kg = kg
+        self._kg_path = kg_path
+
+    @property
+    def chatter_nodes(self) -> list[ChatterNode]:
+        return list(self._chatter_nodes)
+
+    def _knowledge_graph(self, kg_path: Optional[str] = None) -> KnowledgeGraph:
+        if self.kg is not None:
+            return self.kg
+        path = kg_path or self._kg_path
+        if path is not None:
+            return KnowledgeGraph(db_path=path)
+        return KnowledgeGraph()
+
+    def detect_topic(self, text: str, priority: Optional[str] = None) -> tuple[str, str]:
+        """Return (topic_name, priority) based on keyword matching."""
+        text = text.lower()
+        best_topic: Optional[dict[str, Any]] = None
+        best_hits = 0
+        for topic in self.config["topics"]:
+            hits = sum(1 for kw in topic["keywords"] if kw.lower() in text)
+            if hits > best_hits:
+                best_hits = hits
+                best_topic = topic
+        if best_topic and best_hits > 0:
+            return best_topic["name"], best_topic["priority"]
+        if priority in PRIORITY_ORDER:
+            return "general", priority
+        return "general", "normal"
+
+    def select_chatter_nodes(
+        self,
+        message: GossipMessage,
+        fanout: Optional[int] = None,
+    ) -> list[ChatterNode]:
+        """Rank and select chatter nodes for a given message."""
+        fanout = fanout if fanout is not None else self.config.get("fanout", 5)
+        scored = [
+            (node, node.match_score(message.text, message.source_wing))
+            for node in self._chatter_nodes
+        ]
+        scored = [(n, s) for n, s in scored if s > 0]
+        scored.sort(key=lambda x: x[1], reverse=True)
+        return [n for n, _ in scored[:fanout]]
+
+    def _resolve_targets(
+        self,
+        node: ChatterNode,
+        message: GossipMessage,
+        room_graph: Optional[tuple[dict, list]] = None,
+    ) -> list[tuple[str, Optional[str]]]:
+        """Return (wing, room) targets for a chatter node.
+
+        If ``room_graph`` is provided (the ``(nodes, edges)`` tuple returned by
+        ``palace_graph.build_graph``), the function also includes rooms that are
+        connected to the source room through shared wings/halls. Otherwise only
+        the node's gossip radius is used.
+        """
+        targets: list[tuple[str, Optional[str]]] = []
+        for w in node.gossip_radius:
+            targets.append((w, None))
+
+        if room_graph is None:
+            try:
+                room_graph = _build_graph()
+            except Exception:
+                logger.debug("gossip: could not build room graph", exc_info=True)
+                room_graph = ({}, [])
+
+        nodes, edges = room_graph
+        source_room = message.source_room
+        if source_room and source_room in nodes:
+            source_data = nodes[source_room]
+            for room, data in nodes.items():
+                if room == source_room:
+                    continue
+                shared_wings = set(source_data.get("wings", [])) & set(data.get("wings", []))
+                shared_halls = set(source_data.get("halls", [])) & set(data.get("halls", []))
+                if shared_wings or shared_halls:
+                    for w in data.get("wings", []):
+                        if normalize_wing_name(w) in {
+                            normalize_wing_name(r) for r in node.gossip_radius
+                        }:
+                            targets.append((w, room))
+
+        # Deduplicate while preserving order
+        seen: set[tuple[str, Optional[str]]] = set()
+        unique: list[tuple[str, Optional[str]]] = []
+        for t in targets:
+            if t not in seen:
+                seen.add(t)
+                unique.append(t)
+        return unique
+
+    def _should_forward(self, message: GossipMessage, node: ChatterNode) -> bool:
+        """Apply gossip probability, chatter level, and TTL checks."""
+        if message.is_expired():
+            return False
+        if message.hops >= self.config.get("max_hops", 3):
+            return False
+        base = self.config.get("gossip_probability", 0.7)
+        level_mult = CHATTER_LEVEL_MULTIPLIER.get(node.chatter_level, 1.0)
+        probability = min(1.0, base * level_mult)
+        return random.random() < probability
+
+    def _compute_valid_to(self, message: GossipMessage) -> Optional[str]:
+        """Return an ISO timestamp for the gossip TTL."""
+        if message.ttl_seconds is None or message.ttl_seconds <= 0:
+            return None
+        end = message._started_at + timedelta(seconds=message.ttl_seconds)
+        return end.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def propagate(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        source_wing: Optional[str] = None,
+        source_room: Optional[str] = None,
+        priority: Optional[str] = None,
+        fanout: Optional[int] = None,
+        room_graph: Optional[tuple[dict, list]] = None,
+        kg_path: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Propagate a fact through the gossip network.
+
+        Returns a report describing which chatter nodes fired, which targets
+        were reached, and which triples were written to the knowledge graph.
+        """
+        text = f"{subject} {predicate} {obj}"
+        detected_topic, detected_priority = self.detect_topic(text, priority)
+        priority = priority or detected_priority
+
+        message = GossipMessage(
+            subject=subject,
+            predicate=predicate,
+            obj=obj,
+            source_wing=source_wing,
+            source_room=source_room,
+            priority=priority,
+            topic=detected_topic,
+            ttl_seconds=self.config.get("ttl_seconds", 60),
+        )
+
+        selected = self.select_chatter_nodes(message, fanout=fanout)
+        report: dict[str, Any] = {
+            "subject": subject,
+            "predicate": predicate,
+            "object": obj,
+            "topic": message.topic,
+            "priority": message.priority,
+            "chatter_nodes": [],
+            "suppressed": 0,
+            "propagated": [],
+            "triples_written": 0,
+        }
+
+        kg = self._knowledge_graph(kg_path)
+        valid_to = self._compute_valid_to(message)
+        source_file = f"gossip://{message.topic}"
+
+        for node in selected:
+            if not self._should_forward(message, node):
+                report["suppressed"] += 1
+                continue
+
+            targets = self._resolve_targets(node, message, room_graph=room_graph)
+            if not targets:
+                continue
+
+            node_report = {
+                "chatter_id": node.id,
+                "chatter_name": node.name,
+                "targets": [],
+            }
+
+            for target_wing, target_room in targets:
+                # The derived fact is the original fact plus a gossip provenance.
+                # We write one triple per (wing, room) target.
+                pred = f"gossiped_in_{normalize_wing_name(target_wing)}"
+                if target_room:
+                    pred = f"gossiped_in_room_{target_room}"
+
+                try:
+                    kg.add_triple(
+                        subject,
+                        pred,
+                        obj,
+                        valid_from=message._started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        valid_to=valid_to,
+                        confidence=0.8,
+                        source_file=source_file,
+                    )
+                    report["triples_written"] += 1
+                    node_report["targets"].append(
+                        {"wing": target_wing, "room": target_room}
+                    )
+                except Exception:
+                    logger.debug("gossip: kg add failed for %s/%s", target_wing, target_room, exc_info=True)
+
+            report["chatter_nodes"].append(node_report)
+            report["propagated"].append(node.id)
+
+        return report
+
+    def chatter_status(self) -> dict[str, Any]:
+        """Return a snapshot of the gossip network configuration."""
+        return {
+            "version": self.config.get("version", "1.0"),
+            "max_hops": self.config.get("max_hops", 3),
+            "ttl_seconds": self.config.get("ttl_seconds", 60),
+            "fanout": self.config.get("fanout", 5),
+            "chatter_nodes": [asdict(n) for n in self._chatter_nodes],
+            "topics": self.config.get("topics", []),
+        }
+
+
+def gossip(
+    subject: str,
+    predicate: str,
+    obj: str,
+    source_wing: Optional[str] = None,
+    source_room: Optional[str] = None,
+    priority: Optional[str] = None,
+    fanout: Optional[int] = None,
+    config_path: Optional[str] = None,
+    kg: Optional[KnowledgeGraph] = None,
+) -> dict[str, Any]:
+    """Convenience wrapper: create a protocol and propagate a single fact."""
+    protocol = GossipProtocol(config_path=config_path, kg=kg)
+    return protocol.propagate(
+        subject,
+        predicate,
+        obj,
+        source_wing=source_wing,
+        source_room=source_room,
+        priority=priority,
+        fanout=fanout,
+    )

--- a/mempalace/gossip.py
+++ b/mempalace/gossip.py
@@ -22,6 +22,8 @@ import logging
 import os
 import random
 import tempfile
+import threading
+from collections import deque
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
@@ -556,45 +558,25 @@ class GossipProtocol:
         end = message._started_at + timedelta(seconds=message.ttl_seconds)
         return end.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    def propagate(
+    def _propagate_message(
         self,
-        subject: str,
-        predicate: str,
-        obj: str,
-        source_wing: Optional[str] = None,
-        source_room: Optional[str] = None,
-        priority: Optional[str] = None,
+        message: GossipMessage,
         fanout: Optional[int] = None,
-        max_hops: Optional[int] = None,
         room_graph: Optional[tuple[dict, list]] = None,
         kg_path: Optional[str] = None,
-    ) -> dict[str, Any]:
-        """Propagate a fact through the gossip network.
+    ) -> tuple[dict[str, Any], list[GossipMessage]]:
+        """Propagate one message and return (report, child_messages).
 
-        Returns a report describing which chatter nodes fired, which targets
-        were reached, and which triples were written to the knowledge graph.
+        The report describes which chatter nodes fired and which triples were
+        written. The child messages carry the fact forward to each (wing, room)
+        target with an incremented hop count. Callers such as ``GossipDaemon``
+        can re-queue children for multi-hop gossip waves.
         """
-        text = f"{subject} {predicate} {obj}"
-        detected_topic, detected_priority = self.detect_topic(text, priority)
-        priority = priority or detected_priority
-
-        message = GossipMessage(
-            subject=subject,
-            predicate=predicate,
-            obj=obj,
-            source_wing=source_wing,
-            source_room=source_room,
-            priority=priority,
-            topic=detected_topic,
-            ttl_seconds=self.config.get("ttl_seconds", 60),
-            max_hops=max_hops if max_hops is not None else self.config.get("max_hops", 3),
-        )
-
         selected = self.select_chatter_nodes(message, fanout=fanout)
         report: dict[str, Any] = {
-            "subject": subject,
-            "predicate": predicate,
-            "object": obj,
+            "subject": message.subject,
+            "predicate": message.predicate,
+            "object": message.obj,
             "topic": message.topic,
             "priority": message.priority,
             "chatter_nodes": [],
@@ -602,6 +584,7 @@ class GossipProtocol:
             "propagated": [],
             "triples_written": 0,
         }
+        children: list[GossipMessage] = []
 
         kg = self._knowledge_graph(kg_path)
         valid_to = self._compute_valid_to(message)
@@ -636,9 +619,9 @@ class GossipProtocol:
                 node_report["attempted_targets"] += 1
                 try:
                     kg.add_triple(
-                        subject,
+                        message.subject,
                         pred,
-                        obj,
+                        message.obj,
                         valid_from=message._started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                         valid_to=valid_to,
                         confidence=0.8,
@@ -650,8 +633,11 @@ class GossipProtocol:
                         {"wing": target_wing, "room": target_room}
                     )
                     any_success = True
+                    children.append(message.child(target_wing, target_room))
                 except Exception as exc:
-                    logger.debug("gossip: kg add failed for %s/%s", target_wing, target_room, exc_info=True)
+                    logger.debug(
+                        "gossip: kg add failed for %s/%s", target_wing, target_room, exc_info=True
+                    )
                     node_report["failed_targets"].append(
                         {
                             "wing": target_wing,
@@ -664,6 +650,45 @@ class GossipProtocol:
             if any_success:
                 report["propagated"].append(node.id)
 
+        return report, children
+
+    def propagate(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        source_wing: Optional[str] = None,
+        source_room: Optional[str] = None,
+        priority: Optional[str] = None,
+        fanout: Optional[int] = None,
+        max_hops: Optional[int] = None,
+        room_graph: Optional[tuple[dict, list]] = None,
+        kg_path: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Propagate a fact through the gossip network.
+
+        Returns a report describing which chatter nodes fired, which targets
+        were reached, and which triples were written to the knowledge graph.
+        """
+        text = f"{subject} {predicate} {obj}"
+        detected_topic, detected_priority = self.detect_topic(text, priority)
+        priority = priority or detected_priority
+
+        message = GossipMessage(
+            subject=subject,
+            predicate=predicate,
+            obj=obj,
+            source_wing=source_wing,
+            source_room=source_room,
+            priority=priority,
+            topic=detected_topic,
+            ttl_seconds=self.config.get("ttl_seconds", 60),
+            max_hops=max_hops if max_hops is not None else self.config.get("max_hops", 3),
+        )
+
+        report, _ = self._propagate_message(
+            message, fanout=fanout, room_graph=room_graph, kg_path=kg_path
+        )
         return report
 
     def chatter_status(self) -> dict[str, Any]:
@@ -676,6 +701,158 @@ class GossipProtocol:
             "chatter_nodes": [asdict(n) for n in self._chatter_nodes],
             "topics": self.config.get("topics", []),
         }
+
+
+class GossipDaemon:
+    """Background daemon for multi-hop gossip propagation and TTL cleanup.
+
+    The daemon holds a queue of ``GossipMessage`` objects. Each ``run_once``
+    call drains the queue, propagates each active message through the protocol,
+    and enqueues the resulting child messages so the next tick can continue the
+    wave. Messages that have expired or exceeded ``max_hops`` are dropped.
+
+    ``start`` spawns a background thread; ``stop`` signals it to exit cleanly.
+    """
+
+    def __init__(
+        self,
+        protocol: GossipProtocol,
+        interval_seconds: float = 30.0,
+        max_requeue: int = 1000,
+    ):
+        self.protocol = protocol
+        self.interval_seconds = max(1.0, float(interval_seconds))
+        self.max_requeue = max_requeue
+        self._queue: deque[GossipMessage] = deque()
+        self._stop_event = threading.Event()
+        self._worker: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+
+    def schedule(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        source_wing: Optional[str] = None,
+        source_room: Optional[str] = None,
+        priority: Optional[str] = None,
+        max_hops: Optional[int] = None,
+    ) -> GossipMessage:
+        """Create a gossip message and add it to the daemon queue."""
+        text = f"{subject} {predicate} {obj}"
+        detected_topic, detected_priority = self.protocol.detect_topic(text, priority)
+        priority = priority or detected_priority
+
+        message = GossipMessage(
+            subject=subject,
+            predicate=predicate,
+            obj=obj,
+            source_wing=source_wing,
+            source_room=source_room,
+            priority=priority,
+            topic=detected_topic,
+            ttl_seconds=self.protocol.config.get("ttl_seconds", 60),
+            max_hops=max_hops
+            if max_hops is not None
+            else self.protocol.config.get("max_hops", 3),
+        )
+        with self._lock:
+            self._queue.append(message)
+        return message
+
+    def run_once(
+        self,
+        fanout: Optional[int] = None,
+        room_graph: Optional[tuple[dict, list]] = None,
+        kg_path: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Process the current queue once and return a summary report.
+
+        Exceptions during a single message are isolated so one bad message does
+        not discard unprocessed siblings or already-produced children.
+        """
+        with self._lock:
+            pending = list(self._queue)
+            self._queue.clear()
+
+        report: dict[str, Any] = {
+            "processed": 0,
+            "suppressed": 0,
+            "expired": 0,
+            "triples_written": 0,
+            "children_queued": 0,
+            "failed": 0,
+        }
+        children: list[GossipMessage] = []
+
+        for idx, message in enumerate(pending):
+            if message.is_expired():
+                report["expired"] += 1
+                continue
+            if message.hops >= message.max_hops:
+                report["suppressed"] += 1
+                continue
+
+            try:
+                node_report, child_messages = self.protocol._propagate_message(
+                    message,
+                    fanout=fanout,
+                    room_graph=room_graph,
+                    kg_path=kg_path,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "gossip-daemon: message %s failed; re-queueing remaining pending messages",
+                    idx,
+                    exc_info=True,
+                )
+                report["failed"] += 1
+                # Re-queue this and all remaining pending messages.
+                with self._lock:
+                    self._queue.extend(pending[idx:])
+                return report
+
+            report["processed"] += 1
+            report["triples_written"] += node_report["triples_written"]
+            children.extend(child_messages)
+
+        # Enqueue children while respecting the cap, accounting for any messages
+        # that concurrent schedulers may have added.
+        with self._lock:
+            available = max(0, self.max_requeue - len(self._queue))
+            kept = [
+                c
+                for c in children
+                if not c.is_expired() and c.hops < c.max_hops
+            ][:available]
+            for c in kept:
+                self._queue.append(c)
+        report["children_queued"] = len(kept)
+
+        return report
+
+    def _loop(self) -> None:
+        """Background thread entry point."""
+        while not self._stop_event.is_set():
+            try:
+                self.run_once()
+            except Exception:
+                logger.warning("gossip-daemon: run_once failed", exc_info=True)
+            self._stop_event.wait(self.interval_seconds)
+
+    def start(self) -> None:
+        """Start the background thread if it is not already running."""
+        if self._worker is not None and self._worker.is_alive():
+            return
+        self._stop_event.clear()
+        self._worker = threading.Thread(target=self._loop, daemon=True)
+        self._worker.start()
+
+    def stop(self) -> None:
+        """Signal the background thread to stop and wait for it."""
+        self._stop_event.set()
+        if self._worker is not None and self._worker.is_alive():
+            self._worker.join(timeout=2.0)
 
 
 def gossip(

--- a/mempalace/gossip.py
+++ b/mempalace/gossip.py
@@ -785,7 +785,7 @@ class GossipDaemon:
         }
         children: list[GossipMessage] = []
 
-        for idx, message in enumerate(pending):
+        for message in pending:
             if message.is_expired():
                 report["expired"] += 1
                 continue
@@ -800,17 +800,16 @@ class GossipDaemon:
                     room_graph=room_graph,
                     kg_path=kg_path,
                 )
-            except Exception as exc:
+            except Exception:
                 logger.warning(
-                    "gossip-daemon: message %s failed; re-queueing remaining pending messages",
-                    idx,
+                    "gossip-daemon: message %s failed; moving to retry and continuing",
+                    message.subject,
                     exc_info=True,
                 )
                 report["failed"] += 1
-                # Re-queue this and all remaining pending messages.
-                with self._lock:
-                    self._queue.extend(pending[idx:])
-                return report
+                # Isolated failure: do not requeue the failed message, do not
+                # discard children already produced or pending messages.
+                continue
 
             report["processed"] += 1
             report["triples_written"] += node_report["triples_written"]

--- a/mempalace/gossip.py
+++ b/mempalace/gossip.py
@@ -232,7 +232,9 @@ def _merge_with_default(raw: dict[str, Any]) -> dict[str, Any]:
     return merged
 
 
-def load_gossip_config(path: Optional[str] = None, config: MempalaceConfig = None) -> dict[str, Any]:
+def load_gossip_config(
+    path: Optional[str] = None, config: MempalaceConfig = None
+) -> dict[str, Any]:
     """Load gossip configuration from ``path`` or the default location.
 
     If the file does not exist, the default configuration is returned and
@@ -370,7 +372,9 @@ class GossipProtocol:
         config: Optional[dict[str, Any]] = None,
     ):
         self.mempalace_config = mempalace_config
-        self.config = config if config is not None else load_gossip_config(config_path, mempalace_config)
+        self.config = (
+            config if config is not None else load_gossip_config(config_path, mempalace_config)
+        )
         self._chatter_nodes = [ChatterNode.from_dict(n) for n in self.config["chatter_nodes"]]
         self.kg = kg
         self._kg_path = kg_path
@@ -403,9 +407,7 @@ class GossipProtocol:
             return "general", priority
         return "general", "normal"
 
-    def _get_hallway_context(
-        self, message: GossipMessage
-    ) -> tuple[dict[str, float], set[str]]:
+    def _get_hallway_context(self, message: GossipMessage) -> tuple[dict[str, float], set[str]]:
         """Return (room_scores, related_entities) derived from within-wing hallways.
 
         Hallways are entity-pair co-occurrence records built at mine time. When a
@@ -417,9 +419,7 @@ class GossipProtocol:
         if not message.source_wing:
             return {}, set()
         try:
-            hallways = list_hallways(
-                wing=message.source_wing, config=self.mempalace_config
-            )
+            hallways = list_hallways(wing=message.source_wing, config=self.mempalace_config)
         except Exception:
             logger.debug("gossip: could not load hallways", exc_info=True)
             return {}, set()
@@ -471,17 +471,13 @@ class GossipProtocol:
                 # co-occurrence rooms are in different namespaces, so we match
                 # rooms to the node's ``rooms`` list rather than to ``hall``.
                 if room_scores and node.rooms:
-                    overlaps = set(room_scores.keys()) & {
-                        r.lower() for r in node.rooms
-                    }
+                    overlaps = set(room_scores.keys()) & {r.lower() for r in node.rooms}
                     for room in overlaps:
                         score += room_scores[room]
 
                 # Also boost if a related entity matches a specialty.
                 if related_entities and node.specialties:
-                    overlaps = related_entities & {
-                        s.lower() for s in node.specialties
-                    }
+                    overlaps = related_entities & {s.lower() for s in node.specialties}
                     score += min(0.3, len(overlaps) * 0.1)
 
             score = max(0.0, min(2.0, score))
@@ -629,9 +625,7 @@ class GossipProtocol:
                     )
                     report["triples_written"] += 1
                     node_report["successful_targets"] += 1
-                    node_report["targets"].append(
-                        {"wing": target_wing, "room": target_room}
-                    )
+                    node_report["targets"].append({"wing": target_wing, "room": target_room})
                     any_success = True
                     children.append(message.child(target_wing, target_room))
                 except Exception as exc:
@@ -752,9 +746,7 @@ class GossipDaemon:
             priority=priority,
             topic=detected_topic,
             ttl_seconds=self.protocol.config.get("ttl_seconds", 60),
-            max_hops=max_hops
-            if max_hops is not None
-            else self.protocol.config.get("max_hops", 3),
+            max_hops=max_hops if max_hops is not None else self.protocol.config.get("max_hops", 3),
         )
         with self._lock:
             self._queue.append(message)
@@ -819,11 +811,7 @@ class GossipDaemon:
         # that concurrent schedulers may have added.
         with self._lock:
             available = max(0, self.max_requeue - len(self._queue))
-            kept = [
-                c
-                for c in children
-                if not c.is_expired() and c.hops < c.max_hops
-            ][:available]
+            kept = [c for c in children if not c.is_expired() and c.hops < c.max_hops][:available]
             for c in kept:
                 self._queue.append(c)
         report["children_queued"] = len(kept)

--- a/mempalace/gossip.py
+++ b/mempalace/gossip.py
@@ -75,6 +75,7 @@ EXAMPLE_GOSSIP_CONFIG: dict[str, Any] = {
             "hall": "technical",
             "role": "technical_gossip",
             "specialties": ["contracts", "backend", "defi", "trading"],
+            "rooms": ["contracts"],
             "gossip_radius": ["orkid", "past-performance"],
             "chatter_level": "high",
             "propagation_speed": "instant",
@@ -86,6 +87,7 @@ EXAMPLE_GOSSIP_CONFIG: dict[str, Any] = {
             "hall": "general",
             "role": "marketing_gossip",
             "specialties": ["brand", "messaging", "content", "storytelling"],
+            "rooms": ["launch_blog"],
             "gossip_radius": ["brutal-marketing", "orkid"],
             "chatter_level": "high",
             "propagation_speed": "instant",
@@ -97,6 +99,7 @@ EXAMPLE_GOSSIP_CONFIG: dict[str, Any] = {
             "hall": "analytics",
             "role": "performance_gossip",
             "specialties": ["metrics", "validation", "optimization", "data"],
+            "rooms": ["audit_report"],
             "gossip_radius": ["past-performance", "orkid"],
             "chatter_level": "high",
             "propagation_speed": "instant",
@@ -108,6 +111,7 @@ EXAMPLE_GOSSIP_CONFIG: dict[str, Any] = {
             "hall": "strategy",
             "role": "strategy_gossip",
             "specialties": ["trading", "revenue", "business", "planning"],
+            "rooms": ["contracts"],
             "gossip_radius": ["orkid", "brutal-marketing"],
             "chatter_level": "medium",
             "propagation_speed": "fast",
@@ -119,6 +123,7 @@ EXAMPLE_GOSSIP_CONFIG: dict[str, Any] = {
             "hall": "security",
             "role": "security_gossip",
             "specialties": ["audit", "compliance", "risk", "validation"],
+            "rooms": ["audit_report"],
             "gossip_radius": ["orkid", "brutal-marketing"],
             "chatter_level": "medium",
             "propagation_speed": "fast",
@@ -130,6 +135,7 @@ EXAMPLE_GOSSIP_CONFIG: dict[str, Any] = {
             "hall": "creative",
             "role": "creative_gossip",
             "specialties": ["design", "visual", "brand", "aesthetic"],
+            "rooms": ["launch_blog"],
             "gossip_radius": ["brutal-marketing", "orkid"],
             "chatter_level": "medium",
             "propagation_speed": "fast",
@@ -141,6 +147,7 @@ EXAMPLE_GOSSIP_CONFIG: dict[str, Any] = {
             "hall": "creative",
             "role": "theory_gossip",
             "specialties": ["information theory", "physics", "complexity", "optimization"],
+            "rooms": ["launch_blog"],
             "gossip_radius": ["negentropy", "orkid"],
             "chatter_level": "low",
             "propagation_speed": "normal",
@@ -278,6 +285,7 @@ class ChatterNode:
     hall: str
     role: str
     specialties: list[str] = field(default_factory=list)
+    rooms: list[str] = field(default_factory=list)
     gossip_radius: list[str] = field(default_factory=list)
     chatter_level: str = "medium"
     propagation_speed: str = "normal"
@@ -396,12 +404,13 @@ class GossipProtocol:
     def _get_hallway_context(
         self, message: GossipMessage
     ) -> tuple[dict[str, float], set[str]]:
-        """Return (hall_scores, related_entities) derived from within-wing hallways.
+        """Return (room_scores, related_entities) derived from within-wing hallways.
 
         Hallways are entity-pair co-occurrence records built at mine time. When a
         gossip message mentions an entity that co-occurs with other entities in
-        the source wing, we use those co-occurrences to boost chatter nodes that
-        live in the same rooms/halls or cover the related entities.
+        the source wing, we use those co-occurrences to boost chatter nodes whose
+        ``rooms`` overlap with the co-occurrence rooms, as well as nodes whose
+        specialties overlap with the related entities.
         """
         if not message.source_wing:
             return {}, set()
@@ -414,7 +423,7 @@ class GossipProtocol:
             return {}, set()
 
         entities = {message.subject.lower(), message.obj.lower()}
-        hall_scores: dict[str, float] = {}
+        room_scores: dict[str, float] = {}
         related: set[str] = set()
 
         for h in hallways:
@@ -427,11 +436,11 @@ class GossipProtocol:
                 for room in h.get("rooms") or []:
                     room_key = room.lower()
                     # Accumulate a small boost per co-occurrence in this room.
-                    hall_scores[room_key] = hall_scores.get(room_key, 0.0) + min(
+                    room_scores[room_key] = room_scores.get(room_key, 0.0) + min(
                         0.15, 0.05 + count * 0.01
                     )
 
-        return hall_scores, related
+        return room_scores, related
 
     def select_chatter_nodes(
         self,
@@ -441,12 +450,12 @@ class GossipProtocol:
         """Rank and select chatter nodes for a given message.
 
         Selection combines the base specialty/topic score with within-wing
-        hallway context: chatter nodes in the source wing whose hall/room
-        appears in co-occurrence records for the subject/object get a boost, as
-        do nodes whose specialties overlap with related entities.
+        hallway context: chatter nodes in the source wing whose ``rooms``
+        overlap with the co-occurrence rooms get a boost, as do nodes whose
+        specialties overlap with related entities.
         """
         fanout = fanout if fanout is not None else self.config.get("fanout", 5)
-        hall_scores, related_entities = self._get_hallway_context(message)
+        room_scores, related_entities = self._get_hallway_context(message)
 
         scored = []
         for node in self._chatter_nodes:
@@ -456,8 +465,15 @@ class GossipProtocol:
             if message.source_wing and normalize_wing_name(
                 message.source_wing
             ) == normalize_wing_name(node.wing):
-                if node.hall and node.hall.lower() in hall_scores:
-                    score += hall_scores[node.hall.lower()]
+                # Boost by room-level affinity.  A node's hall and the
+                # co-occurrence rooms are in different namespaces, so we match
+                # rooms to the node's ``rooms`` list rather than to ``hall``.
+                if room_scores and node.rooms:
+                    overlaps = set(room_scores.keys()) & {
+                        r.lower() for r in node.rooms
+                    }
+                    for room in overlaps:
+                        score += room_scores[room]
 
                 # Also boost if a related entity matches a specialty.
                 if related_entities and node.specialties:

--- a/mempalace/gossip.py
+++ b/mempalace/gossip.py
@@ -295,6 +295,7 @@ class GossipMessage:
     priority: str = "normal"
     topic: Optional[str] = None
     hops: int = 0
+    max_hops: int = 3
     ttl_seconds: int = 60
     _started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -316,6 +317,7 @@ class GossipMessage:
             priority=self.priority,
             topic=self.topic,
             hops=self.hops + 1,
+            max_hops=self.max_hops,
             ttl_seconds=self.ttl_seconds,
             _started_at=self._started_at,
         )
@@ -438,7 +440,7 @@ class GossipProtocol:
         """Apply gossip probability, chatter level, and TTL checks."""
         if message.is_expired():
             return False
-        if message.hops >= self.config.get("max_hops", 3):
+        if message.hops >= getattr(message, "max_hops", self.config.get("max_hops", 3)):
             return False
         base = self.config.get("gossip_probability", 0.7)
         level_mult = CHATTER_LEVEL_MULTIPLIER.get(node.chatter_level, 1.0)
@@ -461,6 +463,7 @@ class GossipProtocol:
         source_room: Optional[str] = None,
         priority: Optional[str] = None,
         fanout: Optional[int] = None,
+        max_hops: Optional[int] = None,
         room_graph: Optional[tuple[dict, list]] = None,
         kg_path: Optional[str] = None,
     ) -> dict[str, Any]:
@@ -482,6 +485,7 @@ class GossipProtocol:
             priority=priority,
             topic=detected_topic,
             ttl_seconds=self.config.get("ttl_seconds", 60),
+            max_hops=max_hops if max_hops is not None else self.config.get("max_hops", 3),
         )
 
         selected = self.select_chatter_nodes(message, fanout=fanout)

--- a/mempalace/gossip.py
+++ b/mempalace/gossip.py
@@ -37,7 +37,26 @@ logger = logging.getLogger("mempalace_gossip")
 # Default configuration — mirrors the 2026-07-09 spec
 # ─────────────────────────────────────────────────────────────────────────────
 
+# Default configuration installed for new palaces. It is deliberately neutral
+# (no project-specific wings, halls, or topics) so that enabling gossip does
+# not silently inject an unrelated organizational model into the user's palace.
 DEFAULT_GOSSIP_CONFIG: dict[str, Any] = {
+    "version": "1.0",
+    "max_hops": 3,
+    "ttl_seconds": 60,
+    "fanout": 5,
+    "gossip_probability": 0.7,
+    "initiation_probability": 0.3,
+    "chatter_frequency_ms": 1000,
+    "noise_tolerance": 0.2,
+    "amplification_factor": 1.5,
+    "chatter_nodes": [],
+    "topics": [],
+}
+
+# Example configuration used by tests and documentation. It illustrates a
+# populated gossip network but is never written automatically.
+EXAMPLE_GOSSIP_CONFIG: dict[str, Any] = {
     "version": "1.0",
     "max_hops": 3,
     "ttl_seconds": 60,
@@ -337,9 +356,10 @@ class GossipProtocol:
         mempalace_config: Optional[MempalaceConfig] = None,
         kg: Optional[KnowledgeGraph] = None,
         kg_path: Optional[str] = None,
+        config: Optional[dict[str, Any]] = None,
     ):
         self.mempalace_config = mempalace_config
-        self.config = load_gossip_config(config_path, mempalace_config)
+        self.config = config if config is not None else load_gossip_config(config_path, mempalace_config)
         self._chatter_nodes = [ChatterNode.from_dict(n) for n in self.config["chatter_nodes"]]
         self.kg = kg
         self._kg_path = kg_path
@@ -518,8 +538,12 @@ class GossipProtocol:
                 "chatter_id": node.id,
                 "chatter_name": node.name,
                 "targets": [],
+                "attempted_targets": 0,
+                "successful_targets": 0,
+                "failed_targets": [],
             }
 
+            any_success = False
             for target_wing, target_room in targets:
                 # The derived fact is the original fact plus a gossip provenance.
                 # We write one triple per (wing, room) target.
@@ -527,6 +551,7 @@ class GossipProtocol:
                 if target_room:
                     pred = f"gossiped_in_room_{target_room}"
 
+                node_report["attempted_targets"] += 1
                 try:
                     kg.add_triple(
                         subject,
@@ -538,14 +563,24 @@ class GossipProtocol:
                         source_file=source_file,
                     )
                     report["triples_written"] += 1
+                    node_report["successful_targets"] += 1
                     node_report["targets"].append(
                         {"wing": target_wing, "room": target_room}
                     )
-                except Exception:
+                    any_success = True
+                except Exception as exc:
                     logger.debug("gossip: kg add failed for %s/%s", target_wing, target_room, exc_info=True)
+                    node_report["failed_targets"].append(
+                        {
+                            "wing": target_wing,
+                            "room": target_room,
+                            "error": str(exc),
+                        }
+                    )
 
             report["chatter_nodes"].append(node_report)
-            report["propagated"].append(node.id)
+            if any_success:
+                report["propagated"].append(node.id)
 
         return report
 
@@ -571,9 +606,10 @@ def gossip(
     fanout: Optional[int] = None,
     config_path: Optional[str] = None,
     kg: Optional[KnowledgeGraph] = None,
+    config: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     """Convenience wrapper: create a protocol and propagate a single fact."""
-    protocol = GossipProtocol(config_path=config_path, kg=kg)
+    protocol = GossipProtocol(config_path=config_path, kg=kg, config=config)
     return protocol.propagate(
         subject,
         predicate,

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -101,6 +101,7 @@ from .hallways import (  # noqa: E402
 )
 
 from .knowledge_graph import KnowledgeGraph, DEFAULT_KG_PATH  # noqa: E402
+from .gossip import GossipProtocol  # noqa: E402
 from .logstream import LOGSTREAM_DB_FILENAME, Logstream  # noqa: E402
 from .collision_scan import assert_no_collisions  # noqa: E402
 from .ids import ID_RECIPE, make_drawer_id_from_content  # noqa: E402
@@ -424,6 +425,7 @@ _MUTATING_TOOLS = frozenset(
         "mempalace_sync",
         "mempalace_update_drawer",
         "mempalace_diary_write",
+        "mempalace_gossip",
         "mempalace_event_append",
         "mempalace_event_ack",
         "mempalace_artifact_put",
@@ -2551,6 +2553,56 @@ def tool_graph_stats():
     if not col:
         return _collection_error_or_no_palace()
     return graph_stats(col=col)
+
+
+def tool_gossip(
+    subject: str,
+    predicate: str,
+    object: str,
+    source_wing: str = None,
+    source_room: str = None,
+    priority: str = None,
+    fanout: int = None,
+):
+    """Propagate a fact through the palace gossip network.
+
+    Matches the fact to specialized chatter nodes, routes it through palace
+    graph tunnels and rooms, and writes TTL-bounded gossip triples into the
+    knowledge graph. Higher-priority keywords (security, breakthrough, launch,
+    ...) spread faster and to more chatter nodes.
+    """
+    protocol = GossipProtocol(
+        mempalace_config=_config,
+        kg=_get_kg(_resolve_kg_path()),
+    )
+    cfg = protocol.config
+    fanout = fanout if fanout is not None else cfg.get("fanout", 5)
+    try:
+        return protocol.propagate(
+            subject,
+            predicate,
+            object,
+            source_wing=source_wing,
+            source_room=source_room,
+            priority=priority,
+            fanout=fanout,
+        )
+    except Exception as e:
+        logger.exception("gossip tool failed")
+        return {"error": f"gossip failed: {e}"}
+
+
+def tool_gossip_status():
+    """Return the gossip protocol configuration and chatter-node status."""
+    try:
+        protocol = GossipProtocol(
+            mempalace_config=_config,
+            kg=_get_kg(_resolve_kg_path()),
+        )
+        return protocol.chatter_status()
+    except Exception as e:
+        logger.exception("gossip_status tool failed")
+        return {"error": f"gossip_status failed: {e}"}
 
 
 def tool_mesh_peers():
@@ -4940,6 +4992,28 @@ TOOLS = {
         "description": "Palace graph overview: total rooms, tunnel connections, edges between wings.",
         "input_schema": {"type": "object", "properties": {}},
         "handler": tool_graph_stats,
+    },
+    "mempalace_gossip": {
+        "description": "Propagate a fact through the palace gossip network. Matches specialized chatter nodes, routes through palace graph tunnels, and writes TTL-bounded gossip triples into the knowledge graph.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "subject": {"type": "string", "description": "Entity the fact is about"},
+                "predicate": {"type": "string", "description": "Relationship type (e.g. 'found', 'announced')"},
+                "object": {"type": "string", "description": "The target/value of the relationship"},
+                "source_wing": {"type": "string", "description": "Wing the fact originated from (optional)"},
+                "source_room": {"type": "string", "description": "Room the fact originated from (optional)"},
+                "priority": {"type": "string", "description": "critical, high, medium, or low (optional; detected from keywords if omitted)"},
+                "fanout": {"type": "integer", "description": "Max chatter nodes to involve (optional)"},
+            },
+            "required": ["subject", "predicate", "object"],
+        },
+        "handler": tool_gossip,
+    },
+    "mempalace_gossip_status": {
+        "description": "Return the gossip protocol configuration and chatter-node status.",
+        "input_schema": {"type": "object", "properties": {}},
+        "handler": tool_gossip_status,
     },
     "mempalace_mesh_peers": {
         "description": "Mesh estate snapshot (RFC 004): this replica's identity, version vector and node profile; each configured peer's reachability, last sync outcome, remote version vector and advertised profile; origins known only transitively; origin_profiles keyed by replica_id; and estate_source saying whether the peer status was observed in this process or published by the palace's hub (with published_at and whether that hub is still alive). Exactly the GET /sync/peers payload — tokens are never included.",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -4999,12 +4999,27 @@ TOOLS = {
             "type": "object",
             "properties": {
                 "subject": {"type": "string", "description": "Entity the fact is about"},
-                "predicate": {"type": "string", "description": "Relationship type (e.g. 'found', 'announced')"},
+                "predicate": {
+                    "type": "string",
+                    "description": "Relationship type (e.g. 'found', 'announced')",
+                },
                 "object": {"type": "string", "description": "The target/value of the relationship"},
-                "source_wing": {"type": "string", "description": "Wing the fact originated from (optional)"},
-                "source_room": {"type": "string", "description": "Room the fact originated from (optional)"},
-                "priority": {"type": "string", "description": "critical, high, medium, or low (optional; detected from keywords if omitted)"},
-                "fanout": {"type": "integer", "description": "Max chatter nodes to involve (optional)"},
+                "source_wing": {
+                    "type": "string",
+                    "description": "Wing the fact originated from (optional)",
+                },
+                "source_room": {
+                    "type": "string",
+                    "description": "Room the fact originated from (optional)",
+                },
+                "priority": {
+                    "type": "string",
+                    "description": "critical, high, medium, or low (optional; detected from keywords if omitted)",
+                },
+                "fanout": {
+                    "type": "integer",
+                    "description": "Max chatter nodes to involve (optional)",
+                },
             },
             "required": ["subject", "predicate", "object"],
         },

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -95,6 +95,7 @@ WRITE_TOOLS = frozenset(
         "mempalace_create_tunnel",
         "mempalace_delete_tunnel",
         "mempalace_delete_hallway",
+        "mempalace_gossip",
         "mempalace_hook_settings",
     }
 )

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -20,6 +20,7 @@ from mempalace.gossip import (
     load_gossip_config,
     save_gossip_config,
 )
+import mempalace.gossip as gossip_mod
 from mempalace.knowledge_graph import KnowledgeGraph
 
 
@@ -393,3 +394,71 @@ def test_gossip_config_is_json_serializable():
         with open(path, "r", encoding="utf-8") as f:
             on_disk = json.load(f)
         assert on_disk["chatter_nodes"][0]["id"] == saved["chatter_nodes"][0]["id"]
+
+
+def test_select_chatter_nodes_uses_hallway_room(monkeypatch):
+    """A hallway matching the subject and the node's hall/room boosts selection."""
+    kg_path = _temp_db()
+    try:
+        protocol = GossipProtocol(kg_path=kg_path)
+
+        def _fake_list_hallways(wing=None, config=None):
+            if wing != "orkid":
+                return []
+            return [
+                {
+                    "id": "hallway_orkid_audit_risk_abc12345",
+                    "wing": "orkid",
+                    "entity_a": "audit",
+                    "entity_b": "risk",
+                    "co_occurrence_count": 4,
+                    "rooms": ["security"],
+                },
+                {
+                    "id": "hallway_orkid_audit_compliance_abc12345",
+                    "wing": "orkid",
+                    "entity_a": "audit",
+                    "entity_b": "compliance",
+                    "co_occurrence_count": 2,
+                    "rooms": ["contracts"],
+                },
+            ]
+
+        monkeypatch.setattr(gossip_mod, "list_hallways", _fake_list_hallways)
+
+        msg = GossipMessage(
+            subject="audit",
+            predicate="found",
+            obj="risk",
+            source_wing="orkid",
+            priority="high",
+        )
+        nodes = protocol.select_chatter_nodes(msg, fanout=3)
+        ids = [n.id for n in nodes]
+
+        # chatter_security is in hall "security" and has specialties audit/risk/compliance.
+        assert "chatter_security" in ids
+        assert ids[0] == "chatter_security"
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_select_chatter_nodes_without_hallways(monkeypatch):
+    """When hallways are empty, selection falls back to base scoring."""
+    kg_path = _temp_db()
+    try:
+        protocol = GossipProtocol(kg_path=kg_path)
+        monkeypatch.setattr(gossip_mod, "list_hallways", lambda *a, **kw: [])
+
+        msg = GossipMessage(
+            subject="audit",
+            predicate="found",
+            obj="risk",
+            source_wing="orkid",
+            priority="high",
+        )
+        nodes = protocol.select_chatter_nodes(msg, fanout=3)
+        # chatter_security still wins on specialty/topic match.
+        assert any(n.id == "chatter_security" for n in nodes)
+    finally:
+        Path(kg_path).unlink(missing_ok=True)

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -11,6 +11,7 @@ import tempfile
 from pathlib import Path
 
 from mempalace.gossip import (
+    EXAMPLE_GOSSIP_CONFIG,
     ChatterNode,
     GossipMessage,
     GossipProtocol,
@@ -72,7 +73,19 @@ def test_load_default_config_writes_file():
         cfg = load_gossip_config(path=path)
         assert os.path.exists(path)
         assert "chatter_nodes" in cfg
-        assert len(cfg["chatter_nodes"]) == 7
+        assert len(cfg["chatter_nodes"]) == 0
+        assert cfg["topics"] == []
+
+
+def test_default_config_does_not_leak_project_topology():
+    """A neutral palace gets an empty gossip config with no project-specific names."""
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "gossip_config.json")
+        cfg = load_gossip_config(path=path)
+        combined = json.dumps(cfg)
+        assert "orkid" not in combined
+        assert "brutal-marketing" not in combined
+        assert "negentropy" not in combined
 
 
 def test_save_and_reload_config():
@@ -148,7 +161,7 @@ def test_gossip_message_expiry():
 def test_detect_topic_matches_security_keywords():
     kg_path = _temp_db()
     try:
-        protocol = GossipProtocol(kg_path=kg_path)
+        protocol = GossipProtocol(kg_path=kg_path, config=EXAMPLE_GOSSIP_CONFIG)
         topic, priority = protocol.detect_topic("new security vulnerability found")
         assert topic == "security_issues"
         assert priority == "critical"
@@ -159,7 +172,7 @@ def test_detect_topic_matches_security_keywords():
 def test_detect_topic_defaults_to_normal():
     kg_path = _temp_db()
     try:
-        protocol = GossipProtocol(kg_path=kg_path)
+        protocol = GossipProtocol(kg_path=kg_path, config=EXAMPLE_GOSSIP_CONFIG)
         topic, priority = protocol.detect_topic("something random happened")
         assert topic == "general"
         assert priority == "normal"
@@ -170,7 +183,7 @@ def test_detect_topic_defaults_to_normal():
 def test_detect_topic_honors_explicit_priority():
     kg_path = _temp_db()
     try:
-        protocol = GossipProtocol(kg_path=kg_path)
+        protocol = GossipProtocol(kg_path=kg_path, config=EXAMPLE_GOSSIP_CONFIG)
         topic, priority = protocol.detect_topic("random", priority="high")
         assert topic == "general"
         assert priority == "high"
@@ -181,7 +194,7 @@ def test_detect_topic_honors_explicit_priority():
 def test_select_chatter_nodes_respects_fanout():
     kg_path = _temp_db()
     try:
-        protocol = GossipProtocol(kg_path=kg_path)
+        protocol = GossipProtocol(kg_path=kg_path, config=EXAMPLE_GOSSIP_CONFIG)
         msg = GossipMessage(
             subject="s",
             predicate="p",
@@ -200,7 +213,7 @@ def test_propagate_writes_triples_and_returns_report():
     kg_path = _temp_db()
     try:
         kg = KnowledgeGraph(db_path=kg_path)
-        protocol = GossipProtocol(kg=kg)
+        protocol = GossipProtocol(kg=kg, config=EXAMPLE_GOSSIP_CONFIG)
         report = protocol.propagate(
             "audit",
             "found",
@@ -230,7 +243,7 @@ def test_propagate_with_no_room_graph_still_runs():
     kg_path = _temp_db()
     try:
         kg = KnowledgeGraph(db_path=kg_path)
-        protocol = GossipProtocol(kg=kg)
+        protocol = GossipProtocol(kg=kg, config=EXAMPLE_GOSSIP_CONFIG)
         report = protocol.propagate(
             "new",
             "is",
@@ -245,11 +258,86 @@ def test_propagate_with_no_room_graph_still_runs():
         Path(kg_path).unlink(missing_ok=True)
 
 
+def test_propagate_report_distinguishes_failed_writes():
+    """A node is not reported as propagated when every KG write fails."""
+    kg_path = _temp_db()
+    try:
+        kg = KnowledgeGraph(db_path=kg_path)
+        protocol = GossipProtocol(kg=kg, config=EXAMPLE_GOSSIP_CONFIG)
+
+        def _boom(*a, **kw):
+            raise RuntimeError("kg is down")
+
+        # Patch the protocol's knowledge graph directly.
+        protocol.kg.add_triple = _boom
+
+        report = protocol.propagate(
+            "audit",
+            "found",
+            "security vulnerability",
+            source_wing="orkid",
+            source_room="contracts",
+            room_graph=_sample_room_graph(),
+            fanout=5,
+        )
+
+        assert report["triples_written"] == 0
+        assert report["propagated"] == []
+        assert len(report["chatter_nodes"]) >= 1
+        for node_report in report["chatter_nodes"]:
+            assert node_report["attempted_targets"] > 0
+            assert node_report["successful_targets"] == 0
+            assert len(node_report["failed_targets"]) > 0
+            assert node_report["targets"] == []
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_propagate_report_records_partial_write_success():
+    """A node with at least one successful write is reported as propagated."""
+    kg_path = _temp_db()
+    try:
+        kg = KnowledgeGraph(db_path=kg_path)
+        protocol = GossipProtocol(kg=kg, config=EXAMPLE_GOSSIP_CONFIG)
+
+        attempts = {"count": 0}
+
+        def _maybe_boom(subject, predicate, obj, **kw):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("first target fails")
+            return None
+
+        protocol.kg.add_triple = _maybe_boom
+
+        report = protocol.propagate(
+            "audit",
+            "found",
+            "security vulnerability",
+            source_wing="orkid",
+            source_room="contracts",
+            room_graph=_sample_room_graph(),
+            fanout=5,
+        )
+
+        assert report["triples_written"] >= 1
+        assert len(report["propagated"]) >= 1
+        for node_report in report["chatter_nodes"]:
+            if node_report["successful_targets"] > 0:
+                assert node_report["attempted_targets"] > node_report["successful_targets"]
+                assert len(node_report["failed_targets"]) > 0
+                break
+        else:
+            raise AssertionError("expected at least one partial-success node")
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
 def test_propagate_suppresses_beyond_max_hops():
     kg_path = _temp_db()
     try:
         kg = KnowledgeGraph(db_path=kg_path)
-        protocol = GossipProtocol(kg=kg)
+        protocol = GossipProtocol(kg=kg, config=EXAMPLE_GOSSIP_CONFIG)
         # Manually craft an already-old message via a child
         msg = GossipMessage(
             subject="x",
@@ -269,7 +357,7 @@ def test_propagate_suppresses_beyond_max_hops():
 def test_chatter_status():
     kg_path = _temp_db()
     try:
-        protocol = GossipProtocol(kg_path=kg_path)
+        protocol = GossipProtocol(kg_path=kg_path, config=EXAMPLE_GOSSIP_CONFIG)
         status = protocol.chatter_status()
         assert "chatter_nodes" in status
         assert len(status["chatter_nodes"]) == 7
@@ -290,6 +378,7 @@ def test_gossip_convenience_function_uses_passed_kg():
             source_wing="brutal-marketing",
             kg=kg,
             fanout=3,
+            config=EXAMPLE_GOSSIP_CONFIG,
         )
         assert report["triples_written"] >= 0
     finally:
@@ -297,10 +386,10 @@ def test_gossip_convenience_function_uses_passed_kg():
 
 
 def test_gossip_config_is_json_serializable():
-    """Default config can be written and re-read without mutation."""
+    """Example config can be written and re-read without mutation."""
     with tempfile.TemporaryDirectory() as d:
         path = os.path.join(d, "gossip_config.json")
-        saved = save_gossip_config(load_gossip_config(path=path), path=path)
+        saved = save_gossip_config(EXAMPLE_GOSSIP_CONFIG, path=path)
         with open(path, "r", encoding="utf-8") as f:
             on_disk = json.load(f)
         assert on_disk["chatter_nodes"][0]["id"] == saved["chatter_nodes"][0]["id"]

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -397,10 +397,11 @@ def test_gossip_config_is_json_serializable():
 
 
 def test_select_chatter_nodes_uses_hallway_room(monkeypatch):
-    """A hallway matching the subject and the node's hall/room boosts selection."""
+    """A hallway's co-occurrence rooms boost nodes whose rooms match, even when
+    the room name differs from the node's hall name."""
     kg_path = _temp_db()
     try:
-        protocol = GossipProtocol(kg_path=kg_path)
+        protocol = GossipProtocol(kg_path=kg_path, config=EXAMPLE_GOSSIP_CONFIG)
 
         def _fake_list_hallways(wing=None, config=None):
             if wing != "orkid":
@@ -412,7 +413,8 @@ def test_select_chatter_nodes_uses_hallway_room(monkeypatch):
                     "entity_a": "audit",
                     "entity_b": "risk",
                     "co_occurrence_count": 4,
-                    "rooms": ["security"],
+                    # room name is intentionally different from the node's hall.
+                    "rooms": ["audit_report"],
                 },
                 {
                     "id": "hallway_orkid_audit_compliance_abc12345",
@@ -436,7 +438,8 @@ def test_select_chatter_nodes_uses_hallway_room(monkeypatch):
         nodes = protocol.select_chatter_nodes(msg, fanout=3)
         ids = [n.id for n in nodes]
 
-        # chatter_security is in hall "security" and has specialties audit/risk/compliance.
+        # chatter_security has hall "security" but room "audit_report"; the
+        # co-occurrence room "audit_report" should boost it to first place.
         assert "chatter_security" in ids
         assert ids[0] == "chatter_security"
     finally:
@@ -447,7 +450,7 @@ def test_select_chatter_nodes_without_hallways(monkeypatch):
     """When hallways are empty, selection falls back to base scoring."""
     kg_path = _temp_db()
     try:
-        protocol = GossipProtocol(kg_path=kg_path)
+        protocol = GossipProtocol(kg_path=kg_path, config=EXAMPLE_GOSSIP_CONFIG)
         monkeypatch.setattr(gossip_mod, "list_hallways", lambda *a, **kw: [])
 
         msg = GossipMessage(

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -545,46 +545,63 @@ def test_daemon_run_once_isolates_message_failures():
         daemon.schedule("will", "explode", "now", source_wing="orkid", priority="high")
         daemon.schedule("launch", "is", "active", source_wing="orkid", priority="high")
 
-        # Make the second message's propagation raise.
         original = protocol._propagate_message
+        calls = {"count": 0}
 
         def _boom_on_second(*a, **kw):
-            raise RuntimeError("simulated failure")
+            calls["count"] += 1
+            if calls["count"] == 2:
+                raise RuntimeError("simulated failure")
+            return original(*a, **kw)
 
         protocol._propagate_message = _boom_on_second
 
         report = daemon.run_once()
 
-        assert report["processed"] == 1
+        assert report["processed"] == 2
         assert report["failed"] == 1
-        # The queue must still contain the third message, and possibly a child
-        # from the first message (no test patches room graph, so children may
-        # also be requeued).
+        # The failed message is not requeued; the third message is processed and
+        # may produce children, and the first message's children are preserved.
         with daemon._lock:
             assert len(daemon._queue) >= 1
-            ids = {m.subject for m in daemon._queue}
-            assert "launch" in ids
+            # The failed subject should not be in the queue.
+            assert "will" not in {m.subject for m in daemon._queue}
     finally:
         Path(kg_path).unlink(missing_ok=True)
 
 
 def test_daemon_requeue_respects_max_requeue():
-    """Children are dropped once the queue reaches max_requeue."""
+    """Children are dropped once the queue reaches max_requeue, accounting for
+    entries added by concurrent callers while run_once() is processing."""
     kg_path = _temp_db()
     try:
         kg = KnowledgeGraph(db_path=kg_path)
         protocol = GossipProtocol(kg=kg, config=EXAMPLE_GOSSIP_CONFIG)
-        # Pre-fill the queue to leave only one slot.
         daemon = GossipDaemon(protocol, interval_seconds=60.0, max_requeue=2)
-        daemon.schedule("pre-existing", "is", "queued", source_wing="orkid")
-        daemon.schedule("audit", "found", "risk", source_wing="orkid", priority="high")
 
+        # Simulate a concurrent schedule that occurs while run_once() processes
+        # the first message. The scheduled message is not part of the current
+        # pending batch, so at requeue time it occupies one slot.
+        original = protocol._propagate_message
+        scheduled = {"done": False}
+
+        def _schedule_concurrent(*a, **kw):
+            if not scheduled["done"]:
+                daemon.schedule("concurrent", "is", "active", source_wing="orkid")
+                scheduled["done"] = True
+            return original(*a, **kw)
+
+        protocol._propagate_message = _schedule_concurrent
+
+        daemon.schedule("audit", "found", "risk", source_wing="orkid", priority="high")
         report = daemon.run_once()
 
-        assert report["processed"] == 2
-        # At most one child can be enqueued because one slot is already taken.
+        assert report["processed"] == 1
         with daemon._lock:
+            # concurrent message + at most one child == at most 2.
             assert len(daemon._queue) <= 2
+            assert len(daemon._queue) >= 1
+        # With max_requeue=2 and one concurrent message, only one child fits.
         assert report["children_queued"] <= 1
     finally:
         Path(kg_path).unlink(missing_ok=True)

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -8,11 +8,14 @@ passed as explicit tuples to avoid pulling in a Chroma/pgvector collection.
 import json
 import os
 import tempfile
+import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from mempalace.gossip import (
     EXAMPLE_GOSSIP_CONFIG,
     ChatterNode,
+    GossipDaemon,
     GossipMessage,
     GossipProtocol,
     _default_gossip_path,
@@ -463,5 +466,125 @@ def test_select_chatter_nodes_without_hallways(monkeypatch):
         nodes = protocol.select_chatter_nodes(msg, fanout=3)
         # chatter_security still wins on specialty/topic match.
         assert any(n.id == "chatter_security" for n in nodes)
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Daemon
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_daemon_run_once_propagates_scheduled_message():
+    kg_path = _temp_db()
+    try:
+        kg = KnowledgeGraph(db_path=kg_path)
+        protocol = GossipProtocol(kg=kg, config=EXAMPLE_GOSSIP_CONFIG)
+        daemon = GossipDaemon(protocol, interval_seconds=60.0)
+
+        daemon.schedule(
+            "audit",
+            "found",
+            "risk",
+            source_wing="orkid",
+            priority="high",
+        )
+        report = daemon.run_once()
+
+        assert report["processed"] == 1
+        assert report["expired"] == 0
+        assert report["triples_written"] >= 1
+        # A child message should be queued for the next tick (hops incremented).
+        assert report["children_queued"] >= 1
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_daemon_drops_expired_message():
+    kg_path = _temp_db()
+    try:
+        protocol = GossipProtocol(kg_path=kg_path, config=EXAMPLE_GOSSIP_CONFIG)
+        daemon = GossipDaemon(protocol, interval_seconds=60.0)
+
+        msg = daemon.schedule("x", "is", "y", source_wing="orkid")
+        # Force expiry by backdating start time.
+        msg._started_at = datetime.now(timezone.utc) - timedelta(seconds=120)
+        msg.ttl_seconds = 60
+
+        report = daemon.run_once()
+        assert report["expired"] == 1
+        assert report["processed"] == 0
+        assert report["triples_written"] == 0
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_daemon_start_stop_background_thread():
+    protocol = GossipProtocol(config=EXAMPLE_GOSSIP_CONFIG)
+    daemon = GossipDaemon(protocol, interval_seconds=0.05)
+    daemon.start()
+    assert daemon._worker is not None
+    assert daemon._worker.is_alive()
+
+    daemon.schedule("test", "is", "active", source_wing="orkid")
+    time.sleep(0.15)
+
+    daemon.stop()
+    assert not daemon._worker.is_alive()
+
+
+def test_daemon_run_once_isolates_message_failures():
+    """An exception in one message does not discard later messages or prior children."""
+    kg_path = _temp_db()
+    try:
+        kg = KnowledgeGraph(db_path=kg_path)
+        protocol = GossipProtocol(kg=kg, config=EXAMPLE_GOSSIP_CONFIG)
+        daemon = GossipDaemon(protocol, interval_seconds=60.0, max_requeue=100)
+
+        daemon.schedule("audit", "found", "risk", source_wing="orkid", priority="high")
+        daemon.schedule("will", "explode", "now", source_wing="orkid", priority="high")
+        daemon.schedule("launch", "is", "active", source_wing="orkid", priority="high")
+
+        # Make the second message's propagation raise.
+        original = protocol._propagate_message
+
+        def _boom_on_second(*a, **kw):
+            raise RuntimeError("simulated failure")
+
+        protocol._propagate_message = _boom_on_second
+
+        report = daemon.run_once()
+
+        assert report["processed"] == 1
+        assert report["failed"] == 1
+        # The queue must still contain the third message, and possibly a child
+        # from the first message (no test patches room graph, so children may
+        # also be requeued).
+        with daemon._lock:
+            assert len(daemon._queue) >= 1
+            ids = {m.subject for m in daemon._queue}
+            assert "launch" in ids
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_daemon_requeue_respects_max_requeue():
+    """Children are dropped once the queue reaches max_requeue."""
+    kg_path = _temp_db()
+    try:
+        kg = KnowledgeGraph(db_path=kg_path)
+        protocol = GossipProtocol(kg=kg, config=EXAMPLE_GOSSIP_CONFIG)
+        # Pre-fill the queue to leave only one slot.
+        daemon = GossipDaemon(protocol, interval_seconds=60.0, max_requeue=2)
+        daemon.schedule("pre-existing", "is", "queued", source_wing="orkid")
+        daemon.schedule("audit", "found", "risk", source_wing="orkid", priority="high")
+
+        report = daemon.run_once()
+
+        assert report["processed"] == 2
+        # At most one child can be enqueued because one slot is already taken.
+        with daemon._lock:
+            assert len(daemon._queue) <= 2
+        assert report["children_queued"] <= 1
     finally:
         Path(kg_path).unlink(missing_ok=True)

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -1,0 +1,306 @@
+"""Tests for mempalace.gossip.
+
+Most tests run with an explicit ``KnowledgeGraph`` pointed at a temporary
+SQLite path so they do not touch the user's real palace. Room graphs are
+passed as explicit tuples to avoid pulling in a Chroma/pgvector collection.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from mempalace.gossip import (
+    ChatterNode,
+    GossipMessage,
+    GossipProtocol,
+    _default_gossip_path,
+    gossip,
+    load_gossip_config,
+    save_gossip_config,
+)
+from mempalace.knowledge_graph import KnowledgeGraph
+
+
+def _temp_db() -> str:
+    fd, path = tempfile.mkstemp(suffix=".sqlite3")
+    os.close(fd)
+    return path
+
+
+def _sample_room_graph() -> tuple[dict, list]:
+    """Return a tiny room graph with two connected rooms spanning two wings."""
+    nodes = {
+        "contracts": {
+            "wings": ["orkid", "defi"],
+            "halls": ["technical"],
+            "count": 10,
+            "dates": [],
+        },
+        "audit_report": {
+            "wings": ["orkid", "security"],
+            "halls": ["security"],
+            "count": 5,
+            "dates": [],
+        },
+        "launch_blog": {
+            "wings": ["brutal-marketing"],
+            "halls": ["general"],
+            "count": 3,
+            "dates": [],
+        },
+    }
+    edges = [
+        {"room": "contracts", "wing_a": "orkid", "wing_b": "defi", "hall": "technical"},
+        {"room": "audit_report", "wing_a": "orkid", "wing_b": "security", "hall": "security"},
+    ]
+    return nodes, edges
+
+
+def _empty_room_graph() -> tuple[dict, list]:
+    return {}, []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Config and model
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_load_default_config_writes_file():
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "gossip_config.json")
+        cfg = load_gossip_config(path=path)
+        assert os.path.exists(path)
+        assert "chatter_nodes" in cfg
+        assert len(cfg["chatter_nodes"]) == 7
+
+
+def test_save_and_reload_config():
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "gossip_config.json")
+        custom = save_gossip_config({"version": "2.0"}, path=path)
+        assert custom["version"] == "2.0"
+        # Reload merges defaults
+        reloaded = load_gossip_config(path=path)
+        assert reloaded["version"] == "2.0"
+        assert "chatter_nodes" in reloaded
+
+
+def test_default_gossip_path_uses_home():
+    path = _default_gossip_path()
+    assert ".mempalace" in path
+    assert path.endswith("gossip_config.json")
+
+
+def test_chatter_node_from_dict():
+    node = ChatterNode.from_dict({
+        "id": "x",
+        "name": "X",
+        "wing": "orkid",
+        "hall": "technical",
+        "role": "tech",
+        "specialties": ["defi"],
+        "gossip_radius": ["orkid"],
+        "chatter_level": "high",
+        "propagation_speed": "instant",
+    })
+    assert node.id == "x"
+    assert node.chatter_level == "high"
+    assert node.match_score("new defi strategy", source_wing="orkid") > 0.5
+
+
+def test_chatter_node_match_score_ignores_unknown_wing():
+    node = ChatterNode.from_dict({
+        "id": "x",
+        "name": "X",
+        "wing": "orkid",
+        "hall": "technical",
+        "role": "tech",
+        "specialties": ["defi"],
+        "gossip_radius": ["orkid"],
+    })
+    assert node.match_score("defi", source_wing="unknown") < node.match_score("defi", source_wing="orkid")
+
+
+def test_gossip_message_expiry():
+    msg = GossipMessage(
+        subject="s",
+        predicate="p",
+        obj="o",
+        ttl_seconds=0,
+    )
+    assert msg.is_expired() is True
+
+    msg2 = GossipMessage(
+        subject="s",
+        predicate="p",
+        obj="o",
+        ttl_seconds=3600,
+    )
+    assert msg2.is_expired() is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Protocol behavior
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_detect_topic_matches_security_keywords():
+    kg_path = _temp_db()
+    try:
+        protocol = GossipProtocol(kg_path=kg_path)
+        topic, priority = protocol.detect_topic("new security vulnerability found")
+        assert topic == "security_issues"
+        assert priority == "critical"
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_detect_topic_defaults_to_normal():
+    kg_path = _temp_db()
+    try:
+        protocol = GossipProtocol(kg_path=kg_path)
+        topic, priority = protocol.detect_topic("something random happened")
+        assert topic == "general"
+        assert priority == "normal"
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_detect_topic_honors_explicit_priority():
+    kg_path = _temp_db()
+    try:
+        protocol = GossipProtocol(kg_path=kg_path)
+        topic, priority = protocol.detect_topic("random", priority="high")
+        assert topic == "general"
+        assert priority == "high"
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_select_chatter_nodes_respects_fanout():
+    kg_path = _temp_db()
+    try:
+        protocol = GossipProtocol(kg_path=kg_path)
+        msg = GossipMessage(
+            subject="s",
+            predicate="p",
+            obj="o",
+            source_wing="orkid",
+            priority="high",
+        )
+        nodes = protocol.select_chatter_nodes(msg, fanout=2)
+        assert len(nodes) <= 2
+        assert all(isinstance(n, ChatterNode) for n in nodes)
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_propagate_writes_triples_and_returns_report():
+    kg_path = _temp_db()
+    try:
+        kg = KnowledgeGraph(db_path=kg_path)
+        protocol = GossipProtocol(kg=kg)
+        report = protocol.propagate(
+            "audit",
+            "found",
+            "security vulnerability",
+            source_wing="orkid",
+            source_room="contracts",
+            room_graph=_sample_room_graph(),
+        )
+
+        assert report["subject"] == "audit"
+        assert report["object"] == "security vulnerability"
+        assert report["topic"] == "security_issues"
+        assert report["priority"] == "critical"
+        assert report["triples_written"] >= 1
+        assert len(report["chatter_nodes"]) >= 1
+
+        # The KG should contain at least one gossip-derived triple
+        triples = kg.query_entity("audit", direction="outgoing")
+        gossip_triples = [t for t in triples if t["predicate"].startswith("gossiped_")]
+        assert len(gossip_triples) >= 1
+        assert all(t["object"] == "security vulnerability" for t in gossip_triples)
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_propagate_with_no_room_graph_still_runs():
+    kg_path = _temp_db()
+    try:
+        kg = KnowledgeGraph(db_path=kg_path)
+        protocol = GossipProtocol(kg=kg)
+        report = protocol.propagate(
+            "new",
+            "is",
+            "idea",
+            source_wing="orkid",
+            source_room="contracts",
+            room_graph=_empty_room_graph(),
+            fanout=5,
+        )
+        assert report["triples_written"] >= 0
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_propagate_suppresses_beyond_max_hops():
+    kg_path = _temp_db()
+    try:
+        kg = KnowledgeGraph(db_path=kg_path)
+        protocol = GossipProtocol(kg=kg)
+        # Manually craft an already-old message via a child
+        msg = GossipMessage(
+            subject="x",
+            predicate="is",
+            obj="y",
+            source_wing="orkid",
+            hops=3,
+        )
+        selected = protocol.select_chatter_nodes(msg)
+        assert len(selected) >= 1
+        node = selected[0]
+        assert protocol._should_forward(msg, node) is False
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_chatter_status():
+    kg_path = _temp_db()
+    try:
+        protocol = GossipProtocol(kg_path=kg_path)
+        status = protocol.chatter_status()
+        assert "chatter_nodes" in status
+        assert len(status["chatter_nodes"]) == 7
+        assert "topics" in status
+        assert status["max_hops"] == 3
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_gossip_convenience_function_uses_passed_kg():
+    kg_path = _temp_db()
+    try:
+        kg = KnowledgeGraph(db_path=kg_path)
+        report = gossip(
+            "launch",
+            "announced",
+            "campaign",
+            source_wing="brutal-marketing",
+            kg=kg,
+            fanout=3,
+        )
+        assert report["triples_written"] >= 0
+    finally:
+        Path(kg_path).unlink(missing_ok=True)
+
+
+def test_gossip_config_is_json_serializable():
+    """Default config can be written and re-read without mutation."""
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "gossip_config.json")
+        saved = save_gossip_config(load_gossip_config(path=path), path=path)
+        with open(path, "r", encoding="utf-8") as f:
+            on_disk = json.load(f)
+        assert on_disk["chatter_nodes"][0]["id"] == saved["chatter_nodes"][0]["id"]

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -110,33 +110,39 @@ def test_default_gossip_path_uses_home():
 
 
 def test_chatter_node_from_dict():
-    node = ChatterNode.from_dict({
-        "id": "x",
-        "name": "X",
-        "wing": "orkid",
-        "hall": "technical",
-        "role": "tech",
-        "specialties": ["defi"],
-        "gossip_radius": ["orkid"],
-        "chatter_level": "high",
-        "propagation_speed": "instant",
-    })
+    node = ChatterNode.from_dict(
+        {
+            "id": "x",
+            "name": "X",
+            "wing": "orkid",
+            "hall": "technical",
+            "role": "tech",
+            "specialties": ["defi"],
+            "gossip_radius": ["orkid"],
+            "chatter_level": "high",
+            "propagation_speed": "instant",
+        }
+    )
     assert node.id == "x"
     assert node.chatter_level == "high"
     assert node.match_score("new defi strategy", source_wing="orkid") > 0.5
 
 
 def test_chatter_node_match_score_ignores_unknown_wing():
-    node = ChatterNode.from_dict({
-        "id": "x",
-        "name": "X",
-        "wing": "orkid",
-        "hall": "technical",
-        "role": "tech",
-        "specialties": ["defi"],
-        "gossip_radius": ["orkid"],
-    })
-    assert node.match_score("defi", source_wing="unknown") < node.match_score("defi", source_wing="orkid")
+    node = ChatterNode.from_dict(
+        {
+            "id": "x",
+            "name": "X",
+            "wing": "orkid",
+            "hall": "technical",
+            "role": "tech",
+            "specialties": ["defi"],
+            "gossip_radius": ["orkid"],
+        }
+    )
+    assert node.match_score("defi", source_wing="unknown") < node.match_score(
+        "defi", source_wing="orkid"
+    )
 
 
 def test_gossip_message_expiry():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3976,6 +3976,43 @@ class TestKGTools:
         assert "YYYY-MM-DDTHH:MM:SSZ" in result["error"]
 
 
+# ── Gossip Tools ────────────────────────────────────────────────────────
+
+
+class TestGossipTools:
+    def test_gossip_status(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_gossip_status
+
+        result = tool_gossip_status()
+        assert "error" not in result
+        assert result["version"] == "1.0"
+        assert len(result["chatter_nodes"]) == 7
+
+    def test_gossip_propagates_and_writes_triples(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_gossip
+
+        result = tool_gossip(
+            subject="audit",
+            predicate="found",
+            object="security vulnerability",
+            source_wing="orkid",
+            source_room="contracts",
+        )
+        assert "error" not in result
+        assert result["topic"] == "security_issues"
+        assert result["priority"] == "critical"
+        assert result["triples_written"] >= 1
+
+        # Verify the gossip triple reached the KG.
+        facts = kg.query_entity("audit", direction="outgoing")
+        gossip_facts = [f for f in facts if f["predicate"].startswith("gossiped_")]
+        assert len(gossip_facts) >= 1
+
+
 # ── Diary Tools ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -113,7 +113,7 @@ def test_install_shutdown_signal_handlers_routes_term_to_system_exit():
 
 def _patch_mcp_server(monkeypatch, config, kg):
     """Patch the mcp_server module globals to use test fixtures."""
-    from mempalace import mcp_server
+    from mempalace import mcp_server, gossip as gossip_mod
 
     monkeypatch.setattr(mcp_server, "_config", config)
     # Accept varargs because production ``_get_kg`` now takes an optional
@@ -124,6 +124,10 @@ def _patch_mcp_server(monkeypatch, config, kg):
     from mempalace.palace_graph import invalidate_graph_cache
 
     invalidate_graph_cache()
+
+    # Use the example gossip topology for tests so the default install is not
+    # forced to carry project-specific names.
+    monkeypatch.setattr(gossip_mod, "DEFAULT_GOSSIP_CONFIG", gossip_mod.EXAMPLE_GOSSIP_CONFIG)
 
 
 def _unexpected_client_read(*_a, **_k):
@@ -5736,6 +5740,15 @@ def test_read_only_refuses_every_daemon_write_tool():
 
     assert service.WRITE_TOOLS <= mcp_server._READ_ONLY_REFUSED_TOOLS
     assert "mempalace_hook_settings" in service.WRITE_TOOLS
+
+
+def test_gossip_tool_classified_as_write():
+    """mempalace_gossip is a mutation and must be classified as a write tool."""
+    from mempalace import mcp_server, service
+
+    assert "mempalace_gossip" in mcp_server._MUTATING_TOOLS
+    assert "mempalace_gossip" in service.WRITE_TOOLS
+    assert service.classify_tool("mempalace_gossip") == "write"
 
 
 def test_peer_writer_guard_does_not_gate_hook_settings(monkeypatch):

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-Detailed parameter schemas for all 44 MCP tools.
+Detailed parameter schemas for all 46 MCP tools.
 
 ## Palace — Read Tools
 
@@ -343,6 +343,34 @@ Palace graph overview: nodes, tunnels, edges, connectivity.
 **Parameters:** None
 
 **Returns:** `{ total_rooms, tunnel_rooms, total_edges, rooms_per_wing, top_tunnels }`
+
+---
+
+### `mempalace_gossip`
+
+Propagate a fact through the palace gossip network. Specialized chatter nodes route the fact through palace graph tunnels and rooms, then write TTL-bounded gossip triples into the knowledge graph. Priority is detected from keywords (`security`, `breakthrough`, `launch`, ...).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `subject` | string | **Yes** | Entity the fact is about |
+| `predicate` | string | **Yes** | Relationship type (e.g. `found`, `announced`) |
+| `object` | string | **Yes** | Target/value of the relationship |
+| `source_wing` | string | No | Wing the fact originated from |
+| `source_room` | string | No | Room the fact originated from |
+| `priority` | string | No | `critical`, `high`, `medium`, or `low` (detected if omitted) |
+| `fanout` | integer | No | Max chatter nodes to involve (default from config) |
+
+**Returns:** `{ subject, predicate, object, topic, priority, chatter_nodes, propagated, suppressed, triples_written }`
+
+---
+
+### `mempalace_gossip_status`
+
+Return the gossip protocol configuration and chatter-node status.
+
+**Parameters:** None
+
+**Returns:** `{ version, max_hops, ttl_seconds, fanout, chatter_nodes, topics }`
 
 ---
 


### PR DESCRIPTION
Stacked on #2239 (feat/gossip-mvp).

## Summary
Adds a background `GossipDaemon` for multi-hop gossip propagation:
- Refactors `GossipProtocol.propagate()` into a `_propagate_message()` method that returns child messages for each target.
- `GossipDaemon` holds a `deque` queue and processes it on a background thread.
- `run_once()` propagates each pending message, then enqueues child messages with incremented `hops`.
- Drops expired messages and messages that have reached `max_hops`.
- `schedule()`, `start()`, `stop()` API for callers.

## Test plan
- [x] `tests/test_gossip.py` passes (19 tests).
- [x] `tests/test_mcp_server.py` passes.
