### PR TITLE
feat(hooks): opt-in cwd-derived wing for transcript mining

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -140,6 +140,30 @@ export MEMPALACE_HOOKS_AUTO_SAVE=false
 
 When disabled, both the stop hook and precompact hook pass through without blocking. You can still save manually with `mempalace mine <dir> --mode convos`.
 
+### Mining Into a Per-Project Wing
+
+By default the hooks mine with no `--wing`. Because your transcripts live under `~/.claude/projects` (or `~/.codex`, `~/.gemini`), the miner recognizes an AI-tool path and files everything into the shared `wing_api` wing. That keeps all assistant conversations in one place, which is what you want if you don't maintain per-project wings.
+
+If you *do* keep per-project wings, that default means automatic mining lands in a wing your searches never touch. Enable `hooks.wing_from_cwd` to mine into a wing derived from the working directory the hook payload reports instead:
+
+**Option 1 — config file** (`~/.mempalace/config.json`):
+```json
+{
+  "hooks": {
+    "wing_from_cwd": true
+  }
+}
+```
+
+**Option 2 — environment variable:**
+```bash
+export MEMPALACE_HOOKS_WING_FROM_CWD=true
+```
+
+A session whose cwd is `/home/you/code/my-app` then mines into `home_you_code_my_app` — the same slug `mempalace mine --wing` and the miner's own directory-name fallback produce, so wing-scoped searches find it.
+
+Off by default; existing installs keep filing into `wing_api` until they opt in. This only affects where *new* mining lands — drawers already in `wing_api` stay there.
+
 ### mempalace CLI
 
 The relevant commands are:

--- a/hooks/mempal_precompact_hook.sh
+++ b/hooks/mempal_precompact_hook.sh
@@ -132,8 +132,14 @@ fi
 _MEMPAL_PARSE_MARKER=$(printf '%s\n' "$_mempal_parsed" | sed -n '1p')
 SESSION_ID=$(printf '%s\n' "$_mempal_parsed" | sed -n '2p')
 TRANSCRIPT_PATH=$(printf '%s\n' "$_mempal_parsed" | sed -n '3p')
+# Line 4 is the destination wing, already resolved by hook_shell: the slug
+# derived from the payload's cwd when `hooks.wing_from_cwd` is enabled, and
+# empty otherwise. The shell deliberately holds no slug or config logic —
+# empty simply means "mine with no --wing", i.e. today's default.
+MINE_WING=$(printf '%s\n' "$_mempal_parsed" | sed -n '4p')
 SESSION_ID="${SESSION_ID:-unknown}"
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-}"
+MINE_WING="${MINE_WING:-}"
 
 # Defense-in-depth: if INPUT was non-empty but Python never reached the
 # print() calls (sentinel missing), parsing silently failed. Surface the
@@ -181,9 +187,17 @@ echo "[$(date '+%H:%M:%S')] PRE-COMPACT triggered for session $SESSION_ID" >> "$
 # independent targets — both run if both are set:
 #   1. TRANSCRIPT_PATH (from Claude Code) → parent dir, --mode convos
 #   2. MEMPAL_DIR → --mode projects
+# $MINE_WING is passed as a separate quoted argument rather than spliced
+# into one command string, so a wing can never word-split into extra flags.
+# The two branches differ only by that argument.
 if is_valid_transcript_path "$TRANSCRIPT_PATH" && [ -f "$TRANSCRIPT_PATH" ]; then
-    "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
-        >> "$STATE_DIR/hook.log" 2>&1
+    if [ -n "$MINE_WING" ]; then
+        "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
+            --wing "$MINE_WING" >> "$STATE_DIR/hook.log" 2>&1
+    else
+        "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
+            >> "$STATE_DIR/hook.log" 2>&1
+    fi
 elif [ -n "$TRANSCRIPT_PATH" ]; then
     echo "[$(date '+%H:%M:%S')] Skipping missing or invalid transcript path after normalization: $TRANSCRIPT_PATH" \
         >> "$STATE_DIR/hook.log"

--- a/hooks/mempal_save_hook.sh
+++ b/hooks/mempal_save_hook.sh
@@ -166,9 +166,15 @@ _MEMPAL_PARSE_MARKER=$(printf '%s\n' "$_mempal_parsed" | sed -n '1p')
 SESSION_ID=$(printf '%s\n' "$_mempal_parsed" | sed -n '2p')
 STOP_HOOK_ACTIVE=$(printf '%s\n' "$_mempal_parsed" | sed -n '3p')
 TRANSCRIPT_PATH=$(printf '%s\n' "$_mempal_parsed" | sed -n '4p')
+# Line 5 is the destination wing, already resolved by hook_shell: the slug
+# derived from the payload's cwd when `hooks.wing_from_cwd` is enabled, and
+# empty otherwise. The shell deliberately holds no slug or config logic —
+# empty simply means "mine with no --wing", i.e. today's default.
+MINE_WING=$(printf '%s\n' "$_mempal_parsed" | sed -n '5p')
 SESSION_ID="${SESSION_ID:-unknown}"
 STOP_HOOK_ACTIVE="${STOP_HOOK_ACTIVE:-False}"
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-}"
+MINE_WING="${MINE_WING:-}"
 
 # Defense-in-depth: if INPUT was non-empty but Python never reached the
 # print() calls (sentinel missing), parsing silently failed. Surface the
@@ -264,9 +270,17 @@ if [ "$SINCE_LAST" -ge "$SAVE_INTERVAL" ] && [ "$EXCHANGE_COUNT" -gt 0 ]; then
     #      (code, notes, docs)
     # MEMPAL_DIR is *additive*, not an override: a user with MEMPAL_DIR
     # pointed at their project still gets the active conversation mined.
+    # $MINE_WING is passed as a separate quoted argument rather than spliced
+    # into one command string, so a wing can never word-split into extra
+    # flags. The two branches differ only by that argument.
     if is_valid_transcript_path "$TRANSCRIPT_PATH" && [ -f "$TRANSCRIPT_PATH" ]; then
-        "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
-            >> "$STATE_DIR/hook.log" 2>&1 &
+        if [ -n "$MINE_WING" ]; then
+            "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
+                --wing "$MINE_WING" >> "$STATE_DIR/hook.log" 2>&1 &
+        else
+            "$MEMPAL_PYTHON_BIN" -m mempalace mine "$(dirname "$TRANSCRIPT_PATH")" --mode convos \
+                >> "$STATE_DIR/hook.log" 2>&1 &
+        fi
     elif [ -n "$TRANSCRIPT_PATH" ]; then
         echo "[$(date '+%H:%M:%S')] Skipping invalid transcript path: $TRANSCRIPT_PATH" \
             >> "$STATE_DIR/hook.log"

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -70,6 +70,24 @@ def normalize_wing_name(name: str) -> str:
     return name.lower().replace(" ", "_").replace("-", "_").strip("_")
 
 
+def wing_from_path(path: str) -> str:
+    r"""Derive a wing slug from a filesystem path.
+
+    ``normalize_wing_name`` expects a *dirname* — typically Claude Code's
+    path-encoded ``-home-user-proj`` — and deliberately leaves ``/`` alone.
+    Handing it a full path therefore returns a slug with separators still in
+    it, which ``sanitize_name`` rejects. This converts the separators first
+    so both routes into a wing name agree: ``/home/user/proj`` and the
+    encoded dirname ``-home-user-proj`` both yield ``home_user_proj``.
+
+    Windows paths are folded too. Backslashes become separators and the
+    drive colon becomes ``_``, because ``:`` is outside the character set
+    ``sanitize_name`` accepts.
+    """
+    converted = str(path or "").replace("\\", "/").replace(":", "_").replace("/", "_")
+    return normalize_wing_name(converted)
+
+
 def sanitize_name(value: str, field_name: str = "name") -> str:
     """Validate and sanitize a wing/room/entity name.
 
@@ -568,6 +586,25 @@ class MempalaceConfig:
             return env_val.lower() not in ("false", "0", "no")
         hooks = self._file_config.get("hooks", {})
         return hooks.get("auto_save", True)
+
+    @property
+    def hooks_wing_from_cwd(self):
+        """Whether hooks should mine into a wing derived from the payload cwd.
+
+        Off by default. With it off, ``mine --mode convos`` sees a transcript
+        under ``~/.claude/projects`` and files it into the shared ``wing_api``
+        bucket (``convo_miner._resolve_wing``) — the right grouping for a user
+        with no per-project wings.
+
+        Users who do keep per-project wings can opt in, so automatic mining
+        lands in the wing their recall already queries instead of one nothing
+        reads.
+        """
+        env_val = os.environ.get("MEMPALACE_HOOKS_WING_FROM_CWD")
+        if env_val is not None:
+            return env_val.lower() not in ("false", "0", "no")
+        hooks = self._file_config.get("hooks", {})
+        return bool(hooks.get("wing_from_cwd", False))
 
     @property
     def topic_wings(self):

--- a/mempalace/hook_shell.py
+++ b/mempalace/hook_shell.py
@@ -13,6 +13,8 @@ import os
 import re
 import sys
 
+from .config import MempalaceConfig, wing_from_path
+
 
 _SESSION_ID_RE = re.compile(r"[^a-zA-Z0-9_-]")
 _CONTROL_CHARS_RE = re.compile(r"[\x00\r\n]")
@@ -51,19 +53,44 @@ def _stop_hook_active(value: object) -> str:
     return "False"
 
 
-def parse_stop_payload(payload: dict) -> tuple[str, str, str]:
+def parse_stop_payload(payload: dict) -> tuple[str, str, str, str]:
     return (
         sanitize_session_id(payload.get("session_id", "")),
         _stop_hook_active(payload.get("stop_hook_active", False)),
         normalize_transcript_path(payload.get("transcript_path", "")),
+        normalize_transcript_path(payload.get("cwd", "")),
     )
 
 
-def parse_precompact_payload(payload: dict) -> tuple[str, str]:
+def parse_precompact_payload(payload: dict) -> tuple[str, str, str]:
     return (
         sanitize_session_id(payload.get("session_id", "")),
         normalize_transcript_path(payload.get("transcript_path", "")),
+        normalize_transcript_path(payload.get("cwd", "")),
     )
+
+
+def wing_line(cwd: object) -> str:
+    """The wing the hooks should mine into, or ``""`` when opted out.
+
+    Claude Code's Stop / PreCompact payloads carry the directory the user was
+    working in. When ``hooks.wing_from_cwd`` is enabled, the hooks pass the
+    slug derived from it to ``mempalace mine --wing``, which is priority 1 in
+    ``convo_miner._resolve_wing`` and so overrides the ``wing_api`` default
+    that AI-tool transcript paths otherwise get.
+
+    The decision lives here, not in the shell, so the hooks stay free of slug
+    rules and config parsing. Failures resolve to ``""`` — a misconfigured
+    ``config.json`` must degrade to the default wing, never break the hook.
+    """
+    if not cwd:
+        return ""
+    try:
+        if not MempalaceConfig().hooks_wing_from_cwd:
+            return ""
+        return wing_from_path(str(cwd))
+    except Exception:
+        return ""
 
 
 def count_human_messages(path: str) -> int:
@@ -137,18 +164,22 @@ def main(argv: list[str] | None = None) -> int:
     command = argv[0]
 
     if command == "parse-stop":
-        session_id, stop_hook_active, transcript_path = parse_stop_payload(_load_stdin_json())
+        session_id, stop_hook_active, transcript_path, cwd = parse_stop_payload(_load_stdin_json())
         print("__MEMPAL_PARSE_OK__")
         print(session_id)
         print(stop_hook_active)
         print(transcript_path)
+        # Appended LAST: the hooks read fields by fixed `sed -n 'Np'`
+        # offsets, so a new field may only go on the end.
+        print(wing_line(cwd))
         return 0
 
     if command == "parse-precompact":
-        session_id, transcript_path = parse_precompact_payload(_load_stdin_json())
+        session_id, transcript_path, cwd = parse_precompact_payload(_load_stdin_json())
         print("__MEMPAL_PARSE_OK__")
         print(session_id)
         print(transcript_path)
+        print(wing_line(cwd))
         return 0
 
     if command == "count-human-messages":

--- a/tests/test_hook_shell.py
+++ b/tests/test_hook_shell.py
@@ -24,7 +24,7 @@ def test_normalize_transcript_path_preserves_spaces_and_unicode():
 
 
 def test_parse_stop_payload_keeps_session_strict_but_path_not_over_sanitized():
-    session_id, stop_active, transcript_path = hook_shell.parse_stop_payload(
+    session_id, stop_active, transcript_path, cwd = hook_shell.parse_stop_payload(
         {
             "session_id": "../bad session!!",
             "stop_hook_active": "yes",
@@ -35,6 +35,7 @@ def test_parse_stop_payload_keeps_session_strict_but_path_not_over_sanitized():
     assert session_id == "badsession"
     assert stop_active == "True"
     assert transcript_path == "C:/Users/Me User/.claude/projects/emoji 🧠/session.jsonl"
+    assert cwd == ""
 
 
 def test_parse_precompact_cli_outputs_sentinel_and_normalized_path():
@@ -51,10 +52,14 @@ def test_parse_precompact_cli_outputs_sentinel_and_normalized_path():
         check=True,
     )
 
+    # Trailing "" is the wing line: the payload carries no cwd, and
+    # hooks.wing_from_cwd is off by default, so the hooks mine with no
+    # --wing exactly as before.
     assert result.stdout.splitlines() == [
         "__MEMPAL_PARSE_OK__",
         "sess-1",
         "D:/Claude/projects/-Users-me-App/session.jsonl",
+        "",
     ]
 
 

--- a/tests/test_hook_wing_from_cwd.py
+++ b/tests/test_hook_wing_from_cwd.py
@@ -1,0 +1,293 @@
+"""Opt-in: hooks mine into a cwd-derived wing instead of the ``wing_api`` default.
+
+Claude Code's Stop / PreCompact payloads carry ``cwd`` — the directory the
+user was actually working in. The hooks currently drop it, and run
+``mempalace mine --mode convos`` with no ``--wing``. Because the transcript
+lives under ``~/.claude/projects``, ``convo_miner._resolve_wing`` takes its
+AI-tool-path branch and files everything into the shared ``wing_api``
+bucket.
+
+That is a sensible default for a user with no per-project wings. For a user
+who *does* keep per-project wings, it means automatic mining lands in a wing
+their recall never queries — the writes and the reads never meet.
+
+Opting in via ``MEMPALACE_HOOKS_WING_FROM_CWD`` (or ``hooks.wing_from_cwd``
+in ``config.json``) makes both hooks pass an explicit ``--wing`` derived from
+``cwd``. Explicit ``--wing`` is priority 1 in ``_resolve_wing``, so it beats
+the AI-tool-path default. Default stays off; unset behavior is unchanged.
+
+Written BEFORE the implementation.
+"""
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from mempalace.config import MempalaceConfig, normalize_wing_name, wing_from_path
+from mempalace.hook_shell import parse_precompact_payload, parse_stop_payload
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAVE_HOOK = REPO_ROOT / "hooks" / "mempal_save_hook.sh"
+PRECOMPACT_HOOK = REPO_ROOT / "hooks" / "mempal_precompact_hook.sh"
+
+# Verbatim from a real captured Stop payload
+# (~/.mempalace/hook_state/last_input.log), not a hand-authored shape.
+REAL_CWD = "/home/daedalus/linux/nexus"
+REAL_WING = "home_daedalus_linux_nexus"
+
+
+class TestWingFromPath:
+    """``wing_from_path`` turns a filesystem path into a wing slug."""
+
+    def test_converts_posix_path_to_slug(self):
+        assert wing_from_path(REAL_CWD) == REAL_WING
+
+    def test_agrees_with_normalize_wing_name_on_the_encoded_dirname(self):
+        """The two routes into a wing name must produce the same string.
+
+        Claude Code encodes the project dir as ``-home-daedalus-linux-nexus``;
+        the miner's basename fallback runs that through
+        ``normalize_wing_name``. If the cwd route disagrees by even one
+        character, mining lands in a wing that recall never queries — the
+        exact failure this feature exists to fix.
+        """
+        assert wing_from_path(REAL_CWD) == normalize_wing_name("-home-daedalus-linux-nexus")
+
+    def test_trailing_separator_does_not_change_the_slug(self):
+        assert wing_from_path(REAL_CWD + "/") == REAL_WING
+
+    def test_windows_path_yields_a_sanitize_name_safe_slug(self):
+        """Drive colons and backslashes must not survive into the slug.
+
+        ``sanitize_name`` rejects ``/``, ``\\`` and any character outside
+        ``[\\w .'-]``, so an unconverted ``C:\\Users\\me`` would raise at
+        write time on Windows.
+        """
+        from mempalace.config import sanitize_name
+
+        slug = wing_from_path(r"C:\Users\me\proj")
+        assert "\\" not in slug and ":" not in slug
+        assert sanitize_name(slug) == slug
+
+    def test_empty_path_yields_empty_slug(self):
+        assert wing_from_path("") == ""
+
+
+class TestHooksWingFromCwdSetting:
+    """The feature is opt-in: env var, then config.json, then off."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch):
+        monkeypatch.delenv("MEMPALACE_HOOKS_WING_FROM_CWD", raising=False)
+
+    def test_defaults_to_false(self, tmp_path):
+        assert MempalaceConfig(config_dir=tmp_path).hooks_wing_from_cwd is False
+
+    def test_enabled_by_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MEMPALACE_HOOKS_WING_FROM_CWD", "true")
+        assert MempalaceConfig(config_dir=tmp_path).hooks_wing_from_cwd is True
+
+    def test_env_var_false_wins_over_enabled_config_file(self, tmp_path, monkeypatch):
+        (tmp_path / "config.json").write_text(json.dumps({"hooks": {"wing_from_cwd": True}}))
+        monkeypatch.setenv("MEMPALACE_HOOKS_WING_FROM_CWD", "false")
+        assert MempalaceConfig(config_dir=tmp_path).hooks_wing_from_cwd is False
+
+    def test_enabled_by_config_file(self, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps({"hooks": {"wing_from_cwd": True}}))
+        assert MempalaceConfig(config_dir=tmp_path).hooks_wing_from_cwd is True
+
+
+class TestPayloadParsersExposeCwd:
+    """``cwd`` is in the payload; the parsers must stop discarding it."""
+
+    def test_parse_stop_payload_returns_cwd(self):
+        payload = {
+            "session_id": "abc12345",
+            "stop_hook_active": False,
+            "transcript_path": "/tmp/t.jsonl",
+            "cwd": REAL_CWD,
+        }
+        assert parse_stop_payload(payload)[3] == REAL_CWD
+
+    def test_parse_precompact_payload_returns_cwd(self):
+        payload = {
+            "session_id": "abc12345",
+            "transcript_path": "/tmp/t.jsonl",
+            "cwd": REAL_CWD,
+        }
+        assert parse_precompact_payload(payload)[2] == REAL_CWD
+
+    def test_missing_cwd_is_empty_not_an_error(self):
+        assert parse_stop_payload({"session_id": "a"})[3] == ""
+        assert parse_precompact_payload({"session_id": "a"})[2] == ""
+
+
+# ── Shell-facing contract ────────────────────────────────────────────────
+# hook_shell prints one sanitized value per line and the hooks read them
+# back with fixed ``sed -n 'Np'`` offsets. The wing is appended as the LAST
+# line of each parser's output so existing offsets do not shift.
+
+pytestmark_posix = pytest.mark.skipif(
+    os.name == "nt", reason="bash hook scripts are POSIX-only"
+)
+
+
+def _run_hook_shell(command: str, payload: dict, home: Path, env_extra: dict | None = None):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env.pop("MEMPALACE_HOOKS_WING_FROM_CWD", None)
+    if env_extra:
+        env.update(env_extra)
+    p = subprocess.run(
+        ["python3", "-m", "mempalace.hook_shell", command],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert p.returncode == 0, f"rc={p.returncode} stderr={p.stderr!r}"
+    return p.stdout.splitlines()
+
+
+class TestHookShellEmitsWingLine:
+    """The wing line is emitted only when the feature is enabled."""
+
+    def _payload(self):
+        return {
+            "session_id": "abc12345",
+            "stop_hook_active": False,
+            "transcript_path": "/tmp/t.jsonl",
+            "cwd": REAL_CWD,
+        }
+
+    def test_parse_stop_appends_wing_when_enabled(self, tmp_path):
+        lines = _run_hook_shell(
+            "parse-stop",
+            self._payload(),
+            tmp_path,
+            {"MEMPALACE_HOOKS_WING_FROM_CWD": "true"},
+        )
+        assert lines[0] == "__MEMPAL_PARSE_OK__"
+        assert lines[4] == REAL_WING
+
+    def test_parse_stop_wing_line_is_empty_when_disabled(self, tmp_path):
+        lines = _run_hook_shell("parse-stop", self._payload(), tmp_path)
+        assert lines[4] == ""
+
+    def test_existing_line_offsets_are_unchanged(self, tmp_path):
+        """Regression: the hooks read fields by fixed line number."""
+        lines = _run_hook_shell(
+            "parse-stop",
+            self._payload(),
+            tmp_path,
+            {"MEMPALACE_HOOKS_WING_FROM_CWD": "true"},
+        )
+        assert lines[1] == "abc12345"
+        assert lines[2] == "False"
+        assert lines[3] == "/tmp/t.jsonl"
+
+    def test_parse_precompact_appends_wing_when_enabled(self, tmp_path):
+        lines = _run_hook_shell(
+            "parse-precompact",
+            {"session_id": "abc12345", "transcript_path": "/tmp/t.jsonl", "cwd": REAL_CWD},
+            tmp_path,
+            {"MEMPALACE_HOOKS_WING_FROM_CWD": "true"},
+        )
+        assert lines[1] == "abc12345"
+        assert lines[2] == "/tmp/t.jsonl"
+        assert lines[3] == REAL_WING
+
+
+# ── End-to-end: the hooks must actually pass --wing to `mempalace mine` ──
+
+
+def _stub_python(tmp_path: Path, record: Path) -> Path:
+    """A python shim that records `-m mempalace mine` calls, delegates the rest."""
+    stub = tmp_path / "stub_python"
+    stub.write_text(
+        "#!/bin/sh\n"
+        'case "$*" in\n'
+        f'    *"-m mempalace mine"*) echo "$*" >> "{record}" ; exit 0 ;;\n'
+        '    *) exec python3 "$@" ;;\n'
+        "esac\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return stub
+
+
+def _transcript_with_human_messages(path: Path, count: int) -> None:
+    path.write_text(
+        "".join(
+            json.dumps({"message": {"role": "user", "content": f"m{i}"}}) + "\n"
+            for i in range(count)
+        ),
+        encoding="utf-8",
+    )
+
+
+def _poll(record: Path, timeout: float = 15.0) -> str:
+    """The save hook backgrounds its mine call, so the record appears late."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if record.is_file() and record.read_text().strip():
+            return record.read_text()
+        time.sleep(0.1)
+    return record.read_text() if record.is_file() else ""
+
+
+@pytestmark_posix
+class TestSaveHookPassesWing:
+    def _run(self, tmp_path: Path, env_extra: dict) -> str:
+        home = tmp_path / "home"
+        home.mkdir()
+        # The hook mines the transcript's PARENT dir, and _is_ai_tool_path
+        # keys off `.claude/projects` — reproduce that real layout.
+        projects = home / ".claude" / "projects" / "-home-daedalus-linux-nexus"
+        projects.mkdir(parents=True)
+        transcript = projects / "session.jsonl"
+        _transcript_with_human_messages(transcript, 20)
+
+        record = tmp_path / "mine_calls.txt"
+        env = {
+            "HOME": str(home),
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "MEMPAL_PYTHON": str(_stub_python(tmp_path, record)),
+        }
+        env.update(env_extra)
+        p = subprocess.run(
+            ["bash", str(SAVE_HOOK)],
+            input=json.dumps(
+                {
+                    "session_id": "abc12345",
+                    "stop_hook_active": False,
+                    "transcript_path": str(transcript),
+                    "cwd": REAL_CWD,
+                }
+            ),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        assert p.returncode == 0, f"rc={p.returncode} stderr={p.stderr!r}"
+        return _poll(record)
+
+    def test_passes_cwd_derived_wing_when_enabled(self, tmp_path):
+        calls = self._run(tmp_path, {"MEMPALACE_HOOKS_WING_FROM_CWD": "true"})
+        assert "mine" in calls, f"hook never invoked the miner; got {calls!r}"
+        assert f"--wing {REAL_WING}" in calls, (
+            f"expected --wing {REAL_WING} in the mine call; got {calls!r}"
+        )
+
+    def test_omits_wing_when_disabled(self, tmp_path):
+        calls = self._run(tmp_path, {})
+        assert "mine" in calls, f"hook never invoked the miner; got {calls!r}"
+        assert "--wing" not in calls, (
+            f"default behavior must be unchanged (no --wing); got {calls!r}"
+        )


### PR DESCRIPTION
## Problem

The Stop and PreCompact hooks run `mempalace mine --mode convos` with no `--wing`. Transcripts live under `~/.claude/projects` (or `~/.codex`, `~/.gemini`), so `convo_miner._resolve_wing` takes its AI-tool-path branch and files **every** mined conversation into the shared `wing_api` wing.

For a user with no per-project wings that is exactly the right grouping, and this PR leaves it as the default.

For a user who *does* keep per-project wings, it means automatic mining lands in a wing their wing-scoped searches never query. The writes and the reads never meet, and recall looks silently empty even though mining is working perfectly. On my own palace that was 11,111 drawers of real session history sitting in a wing nothing ever opened.

The hook payloads already carry `cwd` — the hooks were parsing it and throwing it away.

## Change

Adds `hooks.wing_from_cwd` (env `MEMPALACE_HOOKS_WING_FROM_CWD`, or `config.json`, mirroring the existing `hooks.auto_save` pattern). When enabled, both hooks derive a wing from the payload's `cwd` and pass `--wing`, which is priority 1 in `_resolve_wing` and so overrides the AI-tool default.

- **`config.wing_from_path()`** — converts a full path to a wing slug. `normalize_wing_name` expects a *dirname* and deliberately leaves `/` alone, so handing it a path returns a slug `sanitize_name` then rejects. Both routes now agree: `/home/u/proj` and the encoded dirname `-home-u-proj` both yield `home_u_proj`. Windows drive colons are folded too, since `:` is outside the character set `sanitize_name` accepts.
- **`hook_shell.wing_line()`** — resolves the wing in Python so the shell holds no slug rules and no config parsing. Fails soft: a malformed `config.json` degrades to the default wing rather than breaking the hook.
- The wing is appended as the **last** output line of each parser, because the hooks read fields by fixed `sed -n 'Np'` offsets. Existing offsets are unchanged, and there's a regression test pinning that.

## Compatibility

Off by default. Existing installs behave exactly as before — `parse-stop` simply gains a trailing empty line, and the hooks mine with no `--wing`. Only *new* mining is affected; drawers already in `wing_api` stay where they are.

`parse_stop_payload` / `parse_precompact_payload` gain a tuple element. They're internal helpers for the shell hooks, but flagging it in case that counts as API surface for you.

## Testing

`tests/test_hook_wing_from_cwd.py` — 18 tests covering the slug function (including the cross-route agreement that makes this work at all, and Windows paths), the config precedence, the parsers, the emitted line offsets, and an end-to-end run of the real `mempal_save_hook.sh` under `bash` asserting the actual `--wing` argument reaches the miner.

Also verified outside the test suite, against a real captured Stop payload and a real transcript, into two throwaway palaces:

| run | result |
|---|---|
| `mine --mode convos` | 23 drawers → `wing_api` |
| `mine --mode convos --wing home_daedalus_linux_nexus` | 23 drawers → `home_daedalus_linux_nexus` |

Full suite: 4087 passed, 0 failed. Two pre-existing collection errors in my environment (`test_entity_detector.py`, `test_hooks_cli.py`) are a missing `hypothesis` dev dep, unrelated to this change. I was unable to run `ruff` locally — no binary available in this environment — so please let CI be the judge on lint/format.

Docs updated in `hooks/README.md`, next to the existing auto-save section.