### PR TITLE
fix(embedding): never let CoreML return NaN vectors for embeddinggemma

### DIFF
--- a/mempalace/embedding.py
+++ b/mempalace/embedding.py
@@ -39,6 +39,10 @@ in ``~/.mempalace/config.json``):
 
 Requesting an unavailable accelerator emits a warning and falls back to CPU
 rather than hard-failing — mining must still work on a laptop without CUDA.
+The same applies to an accelerator that runs but computes the model wrongly:
+``embeddinggemma`` on CoreML returns NaN or all-zero vectors without raising,
+so ``auto`` never selects CoreML for it and an explicitly requested one is
+rejected by a witness embedding at load time.
 """
 
 from __future__ import annotations
@@ -72,6 +76,24 @@ _AUTO_ORDER = [
     ("DmlExecutionProvider", "dml"),
 ]
 
+# Providers that must never be picked *automatically* for a given model,
+# keyed by model name.
+#
+# embeddinggemma × CoreML: CoreML claims only ~280 of the quantized graph's
+# 1647 nodes, split across 100+ partitions, and the result is corrupt —
+# last_hidden_state comes back all-NaN, so the pooled sentence_embedding is
+# NaN or all-zero (which one depends on how that run partitioned) — with no
+# error raised. Since embedding_device defaults to "auto" and CoreML sits
+# ahead of CPU, every Apple Silicon user running this model would otherwise
+# embed degenerate vectors silently; a `repair rebuild-index` would write them
+# over the whole palace. CoreML is also ~2x slower here when it does run
+# (7.9 vs 16.0 docs/s on an M4 Max), so nothing is lost by skipping it.
+# An explicit embedding_device=coreml is still honoured — the witness probe in
+# EmbeddinggemmaONNX._lazy_load catches it and falls back to CPU.
+_AUTO_PROVIDER_DENYLIST = {
+    "embeddinggemma": {"CoreMLExecutionProvider"},
+}
+
 _EF_CACHE: dict = {}
 # Check-then-construct on the cache must be atomic: without it, two threads
 # resolving the same key each keep their own EF instance, and each instance
@@ -80,13 +102,18 @@ _EF_CACHE_LOCK = threading.Lock()
 _WARNED: set = set()
 
 
-def _resolve_providers(device: str) -> tuple[list, str]:
+def _resolve_providers(device: str, model: Optional[str] = None) -> tuple[list, str]:
     """Return ``(provider_list, effective_device)`` for ``device``.
 
     Falls back to CPU (with a one-shot warning) when the requested
     accelerator is not compiled into the installed ``onnxruntime``.
+
+    ``model`` gates ``_AUTO_PROVIDER_DENYLIST``: a provider known to produce
+    wrong results for that model is skipped under ``auto``. Explicit device
+    requests are left alone — a user who names an accelerator gets it.
     """
     device = (device or "auto").strip().lower()
+    denied = _AUTO_PROVIDER_DENYLIST.get((model or "").strip().lower(), frozenset())
 
     try:
         import onnxruntime as ort
@@ -97,7 +124,7 @@ def _resolve_providers(device: str) -> tuple[list, str]:
 
     if device == "auto":
         for provider, name in _AUTO_ORDER:
-            if provider in available:
+            if provider in available and provider not in denied:
                 return ([provider, "CPUExecutionProvider"], name)
         return (["CPUExecutionProvider"], "cpu")
 
@@ -235,6 +262,9 @@ _EMBEDDINGGEMMA_MAX_LEN = 2048
 # a sub-batch by size rather than by arrival order (#2104), because the run
 # is priced on that padded length and not on the document count.
 _EMBEDDINGGEMMA_BATCH_SIZE = 32
+# Short document embedded once per model load to prove the execution provider
+# actually computes (see _embeddinggemma_session_is_healthy).
+_EMBEDDINGGEMMA_WITNESS = "mempalace embedding provider health check"
 
 
 def _sanitize_embeddinggemma_input_ids(tokenizer, input_ids, np):
@@ -272,6 +302,45 @@ def _sanitize_embeddinggemma_input_ids(tokenizer, input_ids, np):
     sanitized = input_ids.copy()
     sanitized[out_of_range] = unknown_token_id
     return sanitized
+
+
+def _embeddinggemma_forward(session, tokenizer, output_idx, np, texts):
+    """Run one sub-batch through the ONNX graph.
+
+    Returns the MRL-truncated, *unnormalized* ``sentence_embedding`` rows.
+    Shared by ``__call__`` and the provider witness probe so both exercise
+    exactly the same path — a probe that ran a different graph would not
+    prove anything about the vectors we hand back.
+    """
+    encs = tokenizer.encode_batch([_EMBEDDINGGEMMA_PREFIX + text for text in texts])
+    input_ids = np.asarray([e.ids for e in encs], dtype=np.int64)
+    input_ids = _sanitize_embeddinggemma_input_ids(tokenizer, input_ids, np)
+    attention_mask = np.asarray([e.attention_mask for e in encs], dtype=np.int64)
+    outputs = session.run(None, {"input_ids": input_ids, "attention_mask": attention_mask})
+    return outputs[output_idx][:, :_EMBEDDINGGEMMA_DIM]
+
+
+def _embeddinggemma_session_is_healthy(session, tokenizer, output_idx, np) -> bool:
+    """Embed a witness string and check the vector is usable.
+
+    An execution provider that only partially supports the graph can return
+    NaN or all-zero rows without raising (CoreML does exactly this on Apple
+    Silicon). Both are indistinguishable from a healthy vector once stored,
+    so the provider is checked once, at load, before anything is embedded.
+    """
+    try:
+        vectors = _embeddinggemma_forward(
+            session, tokenizer, output_idx, np, [_EMBEDDINGGEMMA_WITNESS]
+        )
+        norm = float(np.linalg.norm(vectors))
+    except Exception:
+        logger.warning(
+            "EmbeddingGemma witness embedding failed; treating the provider as unusable",
+            exc_info=True,
+        )
+        return False
+    # NaN/Inf fail the finite check; an all-zero vector fails the > 0 check.
+    return bool(np.isfinite(norm)) and norm > 0.0
 
 
 class EmbeddinggemmaONNX:
@@ -364,6 +433,39 @@ class EmbeddinggemmaONNX:
             tokenizer = Tokenizer.from_file(tok_path)
             tokenizer.enable_padding()
             tokenizer.enable_truncation(max_length=_EMBEDDINGGEMMA_MAX_LEN)
+
+            # Accelerators can compute this graph wrongly rather than refuse
+            # it, so an accelerated session has to prove itself before it
+            # embeds anything. CPU-only sessions skip the probe: CPU is the
+            # fallback, so a check there could only add a forward pass to
+            # every cold start.
+            if any(p != "CPUExecutionProvider" for p in self._providers):
+                if not _embeddinggemma_session_is_healthy(session, tokenizer, output_idx, np):
+                    logger.warning(
+                        "Embedding provider %s returned a degenerate vector (NaN or "
+                        "all-zero) for EmbeddingGemma — falling back to "
+                        "CPUExecutionProvider. Set embedding_device to 'cpu' in "
+                        "~/.mempalace/config.json to skip this check.",
+                        self._providers[0],
+                    )
+                    session = ort.InferenceSession(
+                        model_path,
+                        sess_options=_intra_op_session_options(self._intra_op_num_threads),
+                        providers=["CPUExecutionProvider"],
+                    )
+                    if not _embeddinggemma_session_is_healthy(session, tokenizer, output_idx, np):
+                        # No provider left to fall back to. Raising loses this
+                        # process's embeddings; continuing would write vectors
+                        # that are unsearchable and indistinguishable from
+                        # healthy ones once in the palace.
+                        raise RuntimeError(
+                            "EmbeddingGemma produced a degenerate vector on "
+                            "CPUExecutionProvider — refusing to embed rather than store "
+                            "unusable vectors. Reinstall onnxruntime, or switch "
+                            "embedding_model in ~/.mempalace/config.json."
+                        )
+                    self._providers = ["CPUExecutionProvider"]
+
             self._output_idx = output_idx
             self._tokenizer = tokenizer
             self._np = np
@@ -425,19 +527,13 @@ class EmbeddinggemmaONNX:
         # time (#1770).
         for start in range(0, len(order), self._batch_size):
             idxs = order[start : start + self._batch_size]
-            texts = [_EMBEDDINGGEMMA_PREFIX + input[i] for i in idxs]
-            encs = self._tokenizer.encode_batch(texts)
-            input_ids = np.asarray([e.ids for e in encs], dtype=np.int64)
-            input_ids = _sanitize_embeddinggemma_input_ids(
+            sent_emb = _embeddinggemma_forward(
+                self._session,
                 self._tokenizer,
-                input_ids,
+                self._output_idx,
                 np,
+                [input[i] for i in idxs],
             )
-            attention_mask = np.asarray([e.attention_mask for e in encs], dtype=np.int64)
-            outputs = self._session.run(
-                None, {"input_ids": input_ids, "attention_mask": attention_mask}
-            )
-            sent_emb = outputs[self._output_idx][:, :_EMBEDDINGGEMMA_DIM]
             # L2-normalize so cosine similarity == dot product (matches what the
             # MTEB methodology assumes; ChromaDB's distance is configured for it).
             norms = np.linalg.norm(sent_emb, axis=1, keepdims=True) + 1e-12
@@ -673,7 +769,7 @@ def get_embedding_function(device: Optional[str] = None, model: Optional[str] = 
         )
         return ef
 
-    providers, effective = _resolve_providers(device)
+    providers, effective = _resolve_providers(device, model)
     cache_key = (model, tuple(providers))
     cached = _EF_CACHE.get(cache_key)  # lock-free fast path; dict.get is GIL-atomic
     if cached is not None:
@@ -701,7 +797,7 @@ def get_embedding_function(device: Optional[str] = None, model: Optional[str] = 
     return ef
 
 
-def describe_device(device: Optional[str] = None) -> str:
+def describe_device(device: Optional[str] = None, model: Optional[str] = None) -> str:
     """Return a short human-readable label for the resolved embedding backend.
 
     Used by the miner CLI header / MCP status so users can see at a glance
@@ -717,7 +813,11 @@ def describe_device(device: Optional[str] = None) -> str:
             url = cfg.embedding_api_url
             return f"openai-compat ({url})" if url else "openai-compat"
         device = cfg.embedding_device
-    _, effective = _resolve_providers(device)
+        if model is None:
+            # The resolved device depends on the model (_AUTO_PROVIDER_DENYLIST),
+            # so the label would otherwise name a provider we won't use.
+            model = cfg.embedding_model
+    _, effective = _resolve_providers(device, model)
     return effective
 
 

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -27,6 +27,66 @@ def test_auto_falls_to_cpu(monkeypatch):
     assert embedding._resolve_providers("auto") == (["CPUExecutionProvider"], "cpu")
 
 
+def test_auto_skips_coreml_for_embeddinggemma(monkeypatch):
+    """auto must not hand EmbeddingGemma to CoreML.
+
+    CoreML supports only a fraction of that model's quantized graph and
+    returns an all-NaN hidden state without erroring, so a Mac user with no
+    explicit embedding_device would silently embed (and, under `repair
+    rebuild-index`, persist) degenerate vectors.
+    """
+    monkeypatch.setattr(
+        "onnxruntime.get_available_providers",
+        lambda: ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    assert embedding._resolve_providers("auto", "embeddinggemma") == (
+        ["CPUExecutionProvider"],
+        "cpu",
+    )
+
+
+def test_auto_still_picks_coreml_for_other_models(monkeypatch):
+    """The denylist is per-model — it must not disable CoreML globally."""
+    monkeypatch.setattr(
+        "onnxruntime.get_available_providers",
+        lambda: ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    assert embedding._resolve_providers("auto", "minilm") == (
+        ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+        "coreml",
+    )
+
+
+def test_auto_still_picks_cuda_for_embeddinggemma(monkeypatch):
+    """Only CoreML is implicated; CUDA stays the preferred accelerator."""
+    monkeypatch.setattr(
+        "onnxruntime.get_available_providers",
+        lambda: ["CUDAExecutionProvider", "CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    assert embedding._resolve_providers("auto", "embeddinggemma") == (
+        ["CUDAExecutionProvider", "CPUExecutionProvider"],
+        "cuda",
+    )
+
+
+def test_explicit_coreml_is_still_honored_for_embeddinggemma(monkeypatch):
+    """An explicit embedding_device=coreml is a deliberate choice, so the
+    denylist (which only guards *automatic* selection) leaves it alone. The
+    witness probe in EmbeddinggemmaONNX._lazy_load is what keeps it safe."""
+    monkeypatch.setattr(
+        "onnxruntime.get_available_providers",
+        lambda: ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    assert embedding._resolve_providers("coreml", "embeddinggemma") == (
+        ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+        "coreml",
+    )
+
+
 def test_cuda_missing_warns_with_gpu_extra(monkeypatch, caplog):
     monkeypatch.setattr("onnxruntime.get_available_providers", lambda: ["CPUExecutionProvider"])
 
@@ -78,7 +138,9 @@ def test_get_embedding_function_caches_by_resolved_provider_tuple(monkeypatch):
 
     monkeypatch.setattr(embedding, "_build_ef_class", lambda: DummyEF)
     monkeypatch.setattr(
-        embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
+        embedding,
+        "_resolve_providers",
+        lambda device, model=None: (["CPUExecutionProvider"], "cpu"),
     )
 
     first = embedding.get_embedding_function("cpu", "minilm")
@@ -108,7 +170,9 @@ def test_get_embedding_function_threads_cap_passed_to_minilm_ef(monkeypatch):
 
     monkeypatch.setattr(embedding, "_build_ef_class", lambda: DummyEF)
     monkeypatch.setattr(
-        embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
+        embedding,
+        "_resolve_providers",
+        lambda device, model=None: (["CPUExecutionProvider"], "cpu"),
     )
     monkeypatch.setattr(embedding, "_resolve_intra_op_threads", lambda: 2)
 
@@ -126,7 +190,9 @@ def test_get_embedding_function_threads_cap_passed_to_embeddinggemma(monkeypatch
 
     monkeypatch.setattr(embedding, "EmbeddinggemmaONNX", DummyGemma)
     monkeypatch.setattr(
-        embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
+        embedding,
+        "_resolve_providers",
+        lambda device, model=None: (["CPUExecutionProvider"], "cpu"),
     )
     monkeypatch.setattr(embedding, "_resolve_intra_op_threads", lambda: 4)
 
@@ -188,10 +254,23 @@ def test_describe_device_uses_resolved_effective_device(monkeypatch):
     monkeypatch.setattr(
         embedding,
         "_resolve_providers",
-        lambda device: (["CUDAExecutionProvider", "CPUExecutionProvider"], "cuda"),
+        lambda device, model=None: (["CUDAExecutionProvider", "CPUExecutionProvider"], "cuda"),
     )
 
     assert embedding.describe_device("auto") == "cuda"
+
+
+def test_describe_device_reports_the_model_aware_resolution(monkeypatch):
+    """The status header must show the device that will actually be used —
+    which now depends on the model, since CoreML is off the table for
+    embeddinggemma."""
+    monkeypatch.setattr(
+        "onnxruntime.get_available_providers",
+        lambda: ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    assert embedding.describe_device("auto", "minilm") == "coreml"
+    assert embedding.describe_device("auto", "embeddinggemma") == "cpu"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_embeddinggemma.py
+++ b/tests/test_embeddinggemma.py
@@ -514,7 +514,9 @@ def test_concurrent_get_embedding_function_single_instance(monkeypatch):
     instance and each one later loads its own copy of the model.
     """
     monkeypatch.setattr(
-        embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
+        embedding,
+        "_resolve_providers",
+        lambda device, model=None: (["CPUExecutionProvider"], "cpu"),
     )
     barrier = threading.Barrier(2)
     instances = [None, None]
@@ -536,7 +538,9 @@ def test_concurrent_get_embedding_function_single_instance(monkeypatch):
 def test_get_embedding_function_dispatches_to_embeddinggemma(monkeypatch):
     """model='embeddinggemma' must build EmbeddinggemmaONNX, not the MiniLM EF."""
     monkeypatch.setattr(
-        embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
+        embedding,
+        "_resolve_providers",
+        lambda device, model=None: (["CPUExecutionProvider"], "cpu"),
     )
     ef = embedding.get_embedding_function(device="cpu", model="embeddinggemma")
     assert isinstance(ef, embedding.EmbeddinggemmaONNX)
@@ -556,7 +560,9 @@ def test_cache_key_separates_models(monkeypatch):
 
     monkeypatch.setattr(embedding, "_build_ef_class", lambda: DummyMiniLM)
     monkeypatch.setattr(
-        embedding, "_resolve_providers", lambda device: (["CPUExecutionProvider"], "cpu")
+        embedding,
+        "_resolve_providers",
+        lambda device, model=None: (["CPUExecutionProvider"], "cpu"),
     )
 
     ml = embedding.get_embedding_function(device="cpu", model="minilm")
@@ -582,6 +588,157 @@ def test_missing_deps_raise_helpful_error(monkeypatch):
     ef = embedding.EmbeddinggemmaONNX()
     with pytest.raises(ImportError, match=r"pip install.*mempalace"):
         ef(["anything"])
+
+
+# ---------------------------------------------------------------------------
+# Provider health probe
+#
+# CoreML supports only a fraction of embeddinggemma's quantized graph (~280 of
+# 1647 nodes over 100+ partitions) and returns an all-NaN last_hidden_state
+# without raising — the pooled vector then comes back NaN or all-zero
+# depending on the partitioning. A degenerate vector written to the palace is
+# unrecoverable without a re-embed, so the loader must never hand one out.
+# ---------------------------------------------------------------------------
+
+
+class _ProviderOut:
+    def __init__(self, name):
+        self.name = name
+
+
+def _patch_provider_sensitive_session(monkeypatch, verdict):
+    """Patch InferenceSession with a session whose output depends on providers.
+
+    ``verdict(providers)`` returns ``"ok"``, ``"nan"`` or ``"zeros"``. Returns
+    ``(builds, runs)`` — the provider list of every session constructed, and
+    the provider list of every ``run`` call — so tests can assert both the
+    fallback rebuild and the cost of the probe on the healthy path.
+    """
+    import onnxruntime
+
+    builds: list[list[str]] = []
+    runs: list[list[str]] = []
+
+    class _Session:
+        def __init__(self, providers):
+            self.providers = list(providers)
+
+        def get_outputs(self):
+            return [_ProviderOut("last_hidden_state"), _ProviderOut("sentence_embedding")]
+
+        def run(self, _output_names, feed):
+            runs.append(self.providers)
+            batch, length = feed["input_ids"].shape
+            sent = np.arange(batch * 768, dtype=np.float32).reshape(batch, 768) + 1.0
+            outcome = verdict(self.providers)
+            if outcome == "nan":
+                sent[:] = np.nan
+            elif outcome == "zeros":
+                sent[:] = 0.0
+            last_hidden = np.zeros((batch, length, 768), dtype=np.float32)
+            return [last_hidden, sent]
+
+    def fake_ctor(_model_path, sess_options=None, providers=None):
+        builds.append(list(providers or []))
+        return _Session(providers or [])
+
+    monkeypatch.setattr(onnxruntime, "InferenceSession", fake_ctor)
+    return builds, runs
+
+
+def _accelerator_returns(bad):
+    return lambda providers: bad if providers != ["CPUExecutionProvider"] else "ok"
+
+
+@pytest.mark.parametrize("bad", ["nan", "zeros"])
+def test_degenerate_accelerator_output_falls_back_to_cpu(
+    patched_lazy_load, monkeypatch, caplog, bad
+):
+    """A provider returning NaN or all-zero vectors must be abandoned for CPU.
+
+    Both shapes are real CoreML behaviour on Apple Silicon — which one you get
+    depends on how the graph happens to be partitioned that run.
+    """
+    builds, _ = _patch_provider_sensitive_session(monkeypatch, _accelerator_returns(bad))
+
+    ef = embedding.EmbeddinggemmaONNX(
+        preferred_providers=["CoreMLExecutionProvider", "CPUExecutionProvider"]
+    )
+    out = np.asarray(ef(["texto de prueba"]))
+
+    assert np.isfinite(out).all(), "no NaN/Inf may reach the caller"
+    assert np.linalg.norm(out) > 0.0, "an all-zero vector is as unusable as NaN"
+    assert builds == [
+        ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+        ["CPUExecutionProvider"],
+    ], "the failed session must be rebuilt CPU-only"
+    assert ef._providers == ["CPUExecutionProvider"], "the fallback must be visible on the EF"
+    assert "CoreMLExecutionProvider" in caplog.text and "falling back" in caplog.text
+
+
+def test_healthy_accelerator_is_kept(patched_lazy_load, monkeypatch):
+    """The probe must not punish a provider that works — only reject bad ones."""
+    builds, _ = _patch_provider_sensitive_session(monkeypatch, lambda providers: "ok")
+
+    ef = embedding.EmbeddinggemmaONNX(
+        preferred_providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
+    )
+    out = np.asarray(ef(["texto de prueba"]))
+
+    assert np.isfinite(out).all()
+    assert builds == [["CUDAExecutionProvider", "CPUExecutionProvider"]], "no rebuild expected"
+    assert ef._providers == ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_cpu_only_load_skips_the_probe(patched_lazy_load, monkeypatch):
+    """The default path pays nothing: CPU is the fallback, so probing it buys
+    nothing and would add a forward pass to every cold start."""
+    builds, runs = _patch_provider_sensitive_session(monkeypatch, lambda providers: "ok")
+
+    ef = embedding.EmbeddinggemmaONNX(preferred_providers=["CPUExecutionProvider"])
+    ef(["texto de prueba"])
+
+    assert builds == [["CPUExecutionProvider"]]
+    assert len(runs) == 1, "only the caller's own forward pass"
+
+
+def test_degenerate_cpu_fallback_raises_instead_of_returning_nan(patched_lazy_load, monkeypatch):
+    """With no healthy provider left, fail loudly.
+
+    Verbatim storage is the promise; a palace quietly filled with NaN vectors
+    cannot be searched and cannot be told apart from a healthy one after the
+    fact.
+    """
+    _patch_provider_sensitive_session(monkeypatch, lambda providers: "nan")
+
+    ef = embedding.EmbeddinggemmaONNX(
+        preferred_providers=["CoreMLExecutionProvider", "CPUExecutionProvider"]
+    )
+    with pytest.raises(RuntimeError, match="degenerate"):
+        ef(["texto de prueba"])
+
+
+@pytest.mark.parametrize("device", ["auto", "coreml", "cpu"])
+def test_no_device_setting_can_produce_nan_vectors(patched_lazy_load, monkeypatch, device):
+    """End-to-end regression: no embedding_device may yield NaN for this model.
+
+    Covers both layers at once — auto never selects CoreML, and an explicit
+    coreml is caught by the probe — against a runtime that advertises CoreML
+    and poisons any accelerator session.
+    """
+    monkeypatch.setattr(
+        "onnxruntime.get_available_providers",
+        lambda: ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+    monkeypatch.setattr(embedding, "_resolve_intra_op_threads", lambda: 0)
+    _patch_provider_sensitive_session(monkeypatch, _accelerator_returns("nan"))
+
+    ef = embedding.get_embedding_function(device=device, model="embeddinggemma")
+    out = np.asarray(ef(["texto de prueba", "otro documento"]))
+
+    assert out.shape == (2, 384)
+    assert np.isfinite(out).all()
+    assert np.allclose(np.linalg.norm(out, axis=1), 1.0)
 
 
 def test_config_embedding_model_env_override(monkeypatch):


### PR DESCRIPTION
Fixes #2284.

## The bug

On Apple Silicon, `embedding_model=embeddinggemma` with the default `embedding_device=auto` silently produces degenerate vectors. ONNX Runtime warns on stderr but does not fail:

```
CoreMLExecutionProvider::GetCapability, number of partitions supported by CoreML: 123
number of nodes in the graph: 1647, number of nodes supported by CoreML: 279
```

Same model, same input, two providers:

| provider | `last_hidden_state` | `sentence_embedding` |
|---|---|---|
| CoreML | 9216 NaN, norm `nan` | 768 zeros, norm 0.0 |
| CPU | 0 NaN, norm 389.6 | norm 1.0 |

The corruption is in the hidden state; the pooled vector is the consequence. What reaches the collection is a **zero** vector — verified identical under onnxruntime 1.24.4 and 1.28.0, and under two different graph partitionings (99 partitions / 330 nodes and 123 / 279), so it does not appear to be partition-dependent. The original report described NaN vectors, which is what the raw hidden state shows.

Either way the check has to require a **finite and non-zero** norm: an all-zero vector sails through any `isnan()` test and is exactly as unusable. It also means anyone auditing an existing palace should look for zero-norm vectors, not for NaN.

`embedding_device` defaults to `"auto"` and `_AUTO_ORDER` puts CoreML ahead of CPU, so every Apple Silicon user on this model was affected without opting into anything. If it happens during `repair rebuild-index`, the whole palace is rewritten with unusable vectors — and a NaN vector is indistinguishable from a healthy one once stored.

Reproduced on a MacBook Pro M4 Max, macOS Darwin 25.6.0, onnxruntime 1.28.0, mempalace 3.7.1.

## The fix — two layers

**Selection** — `_AUTO_PROVIDER_DENYLIST` keeps `auto` from ever picking CoreML for embeddinggemma. CUDA/DirectML are untouched, and so are other models: chromadb's `ONNXMiniLM_L6_V2` already strips CoreML on its own ("not as well optimized as CPU"), so minilm never reached it. CoreML is also ~2x slower here when it does run — measured over 128 real documents:

| config | docs/s |
|---|---|
| CPU, ORT default threads | 16.0 |
| CPU, 10 threads | 15.4 |
| CPU, 14 threads | 13.7 |
| CoreML | 7.9 |

**Validation** — a witness embedding at load time makes any non-CPU provider prove it computes (finite, non-zero norm) before anything real is embedded. An explicit `embedding_device=coreml` is still honoured, but falls back to CPU with a warning instead of returning garbage. If CPU is degenerate too, it raises rather than storing unsearchable vectors.

The probe lives in `EmbeddinggemmaONNX._lazy_load`, not right after the EF is constructed: validating in `get_embedding_function` would force the ~300 MB model load on every call site that only builds an EF without embedding (status, `describe_device`), defeating the lazy load. Inside `_lazy_load` the model is already resident and the cost is one short forward pass, once per process. CPU-only sessions skip the probe entirely — CPU is the fallback, so checking it could only add a forward pass to every cold start.

`describe_device` is model-aware for the same reason: the miner header would otherwise announce a provider we will not use.

## Verification

With the real model, all three devices now return norm 1.0 and zero NaN; `auto` resolves to CPU without even building a CoreML session, and an explicit `coreml` warns and falls back:

```
WARNING Embedding provider CoreMLExecutionProvider returned a degenerate vector (NaN or all-zero)
        for EmbeddingGemma — falling back to CPUExecutionProvider.
```

11 new tests, including a parametrized regression over auto/coreml/cpu against a runtime that advertises CoreML and poisons any accelerator session. Full suite on top of `develop` @ 639c69a: **4312 passed, 31 skipped**. `ruff check` and `ruff format --check` clean.

One unrelated test, `test_mcp_server.py::TestWriteTools::test_checkpoint_added_by_accepted_via_dispatch`, fails on my machine with `Peer MCP writer active` — it fails identically on the base commit **without** this change (a MemPalace MCP writer is live on that host), and passes both in isolation and in CI.

## Not included

- `describe_device("coreml")` still reports `coreml` even though the EF ends up on CPU. The label is computed without loading the model; the load-time warning tells the truth. Changing it would mean loading 300 MB to render a header.
- With minilm + auto the label says `coreml` while chromadb runs on CPU internally — a pre-existing cosmetic mismatch, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related issues

Neither is claimed to be closed by this PR — both are the same combination (embeddinggemma × CoreML on Apple Silicon) reported through different symptoms:

- #2224 — `MEMPALACE_EMBEDDING_DEVICE=coreml` mining, 8.3% node coverage on the fp16 model and slower than CPU. Same partial-support path; that report does not mention NaN.
- #1858 — minilm→embeddinggemma re-embed that never completes on Apple Silicon CoreML.

I found no open issue reporting the NaN/zero vectors themselves.
