### PR TITLE
fix(mcp): default diary agent_name; report bad args as -32602 not -32000

### DIFF
--- a/FWFG.md
+++ b/FWFG.md
@@ -1,0 +1,43 @@
+# FWFG fork — operating notes
+
+This is the FWFG-owned fork of the public `mempalace/mempalace`, carrying the
+multi-model provenance / wing-registry / bootstrap / adapter work. Upstream
+tracking is kept clean (see `docs`/the design spec); this file is FWFG-only and
+is **not** meant to go upstream.
+
+## Which MemPalace Is Which
+
+There are two related repos and (historically) more than one Python install. Keep
+them straight:
+
+| Thing | What it is |
+|---|---|
+| **`mempalace`** (this repo) | The **runtime package fork** — MCP server, provenance stamping, wing registry/canonicalization, `mempalace_bootstrap`, the OpenAI adapter, local migration/backfill. |
+| **`mempalace-bq`** | The **BigQuery sync/mirror** companion — DDL, the push/pull sync, forced-resync. It is *not* a MemPalace package; it never becomes the fork. |
+
+### Rules that prevent old/new confusion
+
+- **Never use bare `python -m mempalace`.** With multiple interpreters on a machine
+  (3.12, 3.14, uv, Store stub…), bare `python` is ambiguous and may hit a stale
+  global install or one with no `mempalace` at all.
+- **Every configured host points at the explicit fork interpreter:**
+  `C:\dev\mempalace\.venv\Scripts\python.exe`
+  This applies to every MCP server entry and every hook command (Claude Code's
+  `.mcp.json` / `~/.claude.json` / `~/.claude/settings.json`, and Codex's
+  `~/.codex/config.toml` / `~/.codex/hooks.json`).
+- **Stale global installs should fail loudly.** Do not leave an old `mempalace`
+  installed in a global/user-site interpreter. `pip uninstall` it (by exact
+  interpreter) so a stray bare `python -m mempalace` errors instead of silently
+  running old code.
+
+### How to tell which one you're running
+
+```
+C:\dev\mempalace\.venv\Scripts\python.exe -m mempalace doctor
+```
+
+`mempalace doctor` prints the executable path, package import path, package
+version, palace path, registry path, env-derived provenance
+(`harness`/`account`/`model`/`machine`/`session`), and whether the
+`mempalace_bootstrap` tool exists. The fork reports a `+fwfg` version and
+`bootstrap_tool_available: true`; a stale global install will not.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Restart Claude Code, then type `/skills` to verify "mempalace" appears.
 claude mcp add mempalace -- python -m mempalace.mcp_server
 ```
 
-Now your AI has 29 tools available through MCP. Ask it anything:
+Now your AI has 31 tools available through MCP. Ask it anything:
 
 > *"What did we decide about auth last month?"*
 
@@ -470,12 +470,13 @@ claude plugin install --scope user mempalace
 claude mcp add mempalace -- python -m mempalace.mcp_server
 ```
 
-### 29 Tools
+### 31 Tools
 
 **Palace (read)**
 
 | Tool | What |
 |------|------|
+| `mempalace_bootstrap` | Startup discovery: protocol, AAAK, account-scoped wings, filing rules, provenance context |
 | `mempalace_status` | Palace overview + AAAK spec + memory protocol |
 | `mempalace_list_wings` | Wings with counts |
 | `mempalace_list_rooms` | Rooms within a wing |
@@ -490,6 +491,7 @@ claude mcp add mempalace -- python -m mempalace.mcp_server
 |------|------|
 | `mempalace_add_drawer` | File verbatim content |
 | `mempalace_delete_drawer` | Remove by ID |
+| `mempalace_register_wing` | Promote a provisional wing to canonical or merge a near-duplicate as an alias |
 
 **Knowledge Graph**
 
@@ -665,7 +667,7 @@ Plain text. Becomes Layer 0 — loaded every session.
 | `cli.py` | CLI entry point |
 | `config.py` | Configuration loading and defaults |
 | `normalize.py` | Converts 5 chat formats to standard transcript |
-| `mcp_server.py` | MCP server — 29 tools, AAAK auto-teach, memory protocol |
+| `mcp_server.py` | MCP server — 31 tools, AAAK auto-teach, memory protocol |
 | `miner.py` | Project file ingest |
 | `convo_miner.py` | Conversation ingest — chunks by exchange pair |
 | `searcher.py` | Semantic search via ChromaDB |
@@ -689,7 +691,7 @@ mempalace/
 ├── README.md                  ← you are here
 ├── mempalace/                 ← core package (README)
 │   ├── cli.py                 ← CLI entry point
-│   ├── mcp_server.py          ← MCP server (29 tools)
+│   ├── mcp_server.py          ← MCP server (31 tools)
 │   ├── knowledge_graph.py     ← temporal entity graph
 │   ├── palace_graph.py        ← room navigation graph
 │   ├── dialect.py             ← AAAK compression

--- a/mempalace/adapters/openai.py
+++ b/mempalace/adapters/openai.py
@@ -64,3 +64,28 @@ def with_memory_instructions(base: str | None) -> str:
     if not base:
         return BOOTSTRAP_INSTRUCTIONS
     return f"{BOOTSTRAP_INSTRUCTIONS}\n\n{base}"
+
+
+class SaveCadence:
+    """Counts agent turns; signals a save every `interval` turns.
+
+    Deterministic and SDK-free so the auto-save policy is unit-testable.
+    """
+
+    def __init__(self, interval: int = 15):
+        if interval < 1:
+            raise ValueError("interval must be >= 1")
+        self.interval = interval
+        self.count = 0
+
+    def tick(self) -> bool:
+        """Record one completed turn; return True when a save is due."""
+        self.count += 1
+        return self.count % self.interval == 0
+
+    def pending(self) -> bool:
+        """True if a save is currently due (interval boundary reached)."""
+        return self.count % self.interval == 0
+
+    def reset(self) -> None:
+        self.count = 0

--- a/mempalace/adapters/openai.py
+++ b/mempalace/adapters/openai.py
@@ -1,0 +1,49 @@
+"""OpenAI Agents SDK adapter for MemPalace.
+
+Pure helpers (no SDK import) so they're testable without the OpenAI API:
+  mcp_server_params()   - build the MCPServerStdio params (provenance env)
+  BOOTSTRAP_INSTRUCTIONS / with_memory_instructions()
+  SaveCadence           - deterministic turn-count auto-save trigger
+  saved_in_result()     - verify a run actually wrote to the palace
+
+SDK-coupled helpers import `agents` lazily (optional dependency):
+  build_mcp_server(), MemPalaceRunHooks
+"""
+from __future__ import annotations
+
+import os
+import platform
+import socket
+import sys
+
+HARNESS = "openai-agents-sdk"
+
+
+def _hostname() -> str:
+    return (os.environ.get("MEMPALACE_MACHINE") or platform.node()
+            or socket.gethostname() or "unknown").lower()
+
+
+def mcp_server_params(*, account: str | None, model: str | None = None,
+                      palace_path: str | None = None, registry_path: str | None = None,
+                      session: str | None = None) -> dict:
+    """Build the params dict for agents.mcp.MCPServerStdio.
+
+    The MCP stdio transport REPLACES the subprocess environment with `env`, so we
+    merge os.environ first (preserving PATH etc.) and then layer provenance on top.
+    harness is fixed to this adapter; account/model/session/paths are optional.
+    """
+    env = dict(os.environ)
+    env["MEMPALACE_HARNESS"] = HARNESS
+    env["MEMPALACE_MACHINE"] = _hostname()
+    if account:
+        env["MEMPALACE_ACCOUNT"] = account
+    if model:
+        env["MEMPALACE_MODEL"] = model
+    if session:
+        env["MEMPALACE_SESSION"] = session
+    if palace_path:
+        env["MEMPALACE_PALACE_PATH"] = palace_path
+    if registry_path:
+        env["MEMPALACE_REGISTRY_PATH"] = registry_path
+    return {"command": sys.executable, "args": ["-m", "mempalace.mcp_server"], "env": env}

--- a/mempalace/adapters/openai.py
+++ b/mempalace/adapters/openai.py
@@ -132,6 +132,30 @@ def build_mcp_server(*, account: str | None, model: str | None = None,
     return MCPServerStdio(name=name, params=params)
 
 
+def make_run_hooks(cadence: "SaveCadence"):
+    """Build an agents.RunHooks that ticks `cadence` once per completed turn
+    (on_agent_end). Raises ImportError with an install hint if the SDK is absent.
+    The boolean 'due' is read from cadence.tick()'s effect via cadence.pending()
+    after each turn by the chat loop; the hook only advances the counter."""
+    try:
+        from agents import RunHooks
+    except ImportError as e:  # pragma: no cover - exercised only when SDK absent
+        raise ImportError(
+            "The OpenAI Agents SDK is required for make_run_hooks. "
+            "Install it with: pip install 'mempalace[openai]' (or pip install openai-agents)."
+        ) from e
+
+    class _MemPalaceRunHooks(RunHooks):
+        def __init__(self, cadence):
+            self._cadence = cadence
+            self.last_due = False
+
+        async def on_agent_end(self, context, agent, output):
+            self.last_due = self._cadence.tick()
+
+    return _MemPalaceRunHooks(cadence)
+
+
 SAVE_PROMPT = (
     "MemPalace checkpoint: save this session's key content now. Call "
     "mempalace_diary_write with an AAAK-compressed summary, and mempalace_add_drawer "

--- a/mempalace/adapters/openai.py
+++ b/mempalace/adapters/openai.py
@@ -109,3 +109,25 @@ def saved_in_result(run_result) -> bool:
         if name in WRITE_TOOLS:
             return True
     return False
+
+
+SAVE_PROMPT = (
+    "MemPalace checkpoint: save this session's key content now. Call "
+    "mempalace_diary_write with an AAAK-compressed summary, and mempalace_add_drawer "
+    "for any verbatim decisions/quotes/code. File into an existing wing. Then continue."
+)
+
+
+class FlushError(RuntimeError):
+    """Raised when a save flush ran but no MemPalace write tool was called."""
+
+
+def flush_due(run, *, max_attempts: int = 2) -> None:
+    """Drive a verified save. `run` is a callable taking a prompt string and
+    returning a run result (duck-typed for saved_in_result). Retries up to
+    max_attempts; raises FlushError if no write tool was called (fails visibly)."""
+    for _ in range(max_attempts):
+        result = run(SAVE_PROMPT)
+        if saved_in_result(result):
+            return
+    raise FlushError("save flush did not produce a MemPalace write tool call")

--- a/mempalace/adapters/openai.py
+++ b/mempalace/adapters/openai.py
@@ -84,8 +84,9 @@ class SaveCadence:
         return self.count % self.interval == 0
 
     def pending(self) -> bool:
-        """True if a save is currently due (interval boundary reached)."""
-        return self.count % self.interval == 0
+        """True if there are turns recorded since the last reset that an interval
+        flush has not yet covered (drives the session-end flush)."""
+        return self.count % self.interval != 0
 
     def reset(self) -> None:
         self.count = 0

--- a/mempalace/adapters/openai.py
+++ b/mempalace/adapters/openai.py
@@ -112,6 +112,26 @@ def saved_in_result(run_result) -> bool:
     return False
 
 
+def build_mcp_server(*, account: str | None, model: str | None = None,
+                     palace_path: str | None = None, registry_path: str | None = None,
+                     session: str | None = None, name: str = "mempalace"):
+    """Create an agents.mcp.MCPServerStdio wired with provenance env.
+
+    Returns an async-context-manager server to pass to Agent(mcp_servers=[...]).
+    Raises ImportError with an install hint if the OpenAI Agents SDK is absent.
+    """
+    try:
+        from agents.mcp import MCPServerStdio
+    except ImportError as e:  # pragma: no cover - exercised only when SDK absent
+        raise ImportError(
+            "The OpenAI Agents SDK is required for build_mcp_server. "
+            "Install it with: pip install 'mempalace[openai]' (or pip install openai-agents)."
+        ) from e
+    params = mcp_server_params(account=account, model=model, palace_path=palace_path,
+                               registry_path=registry_path, session=session)
+    return MCPServerStdio(name=name, params=params)
+
+
 SAVE_PROMPT = (
     "MemPalace checkpoint: save this session's key content now. Call "
     "mempalace_diary_write with an AAAK-compressed summary, and mempalace_add_drawer "

--- a/mempalace/adapters/openai.py
+++ b/mempalace/adapters/openai.py
@@ -47,3 +47,20 @@ def mcp_server_params(*, account: str | None, model: str | None = None,
     if registry_path:
         env["MEMPALACE_REGISTRY_PATH"] = registry_path
     return {"command": sys.executable, "args": ["-m", "mempalace.mcp_server"], "env": env}
+
+
+BOOTSTRAP_INSTRUCTIONS = (
+    "You have persistent memory via the MemPalace MCP tools. "
+    "On startup, call mempalace_bootstrap once and follow its protocol and filing "
+    "rules exactly. Before answering about any past work, person, or decision, "
+    "search the palace (mempalace_search / mempalace_kg_query) — never guess. "
+    "File new memories into an existing wing from the bootstrap list; do not invent "
+    "near-duplicate wings. Provenance is set by the environment — never fabricate it."
+)
+
+
+def with_memory_instructions(base: str | None) -> str:
+    """Prepend the MemPalace bootstrap stub to an agent's instructions."""
+    if not base:
+        return BOOTSTRAP_INSTRUCTIONS
+    return f"{BOOTSTRAP_INSTRUCTIONS}\n\n{base}"

--- a/mempalace/adapters/openai.py
+++ b/mempalace/adapters/openai.py
@@ -89,3 +89,23 @@ class SaveCadence:
 
     def reset(self) -> None:
         self.count = 0
+
+
+WRITE_TOOLS = ("mempalace_diary_write", "mempalace_add_drawer")
+
+
+def saved_in_result(run_result) -> bool:
+    """True if the run made at least one MemPalace write-tool call.
+
+    Duck-typed against the Agents SDK RunResult (`.new_items`, each item a
+    tool_call_item whose `.raw_item.name` is the tool name) so it is testable
+    without the SDK.
+    """
+    items = getattr(run_result, "new_items", None) or []
+    for item in items:
+        if getattr(item, "type", None) != "tool_call_item":
+            continue
+        name = getattr(getattr(item, "raw_item", None), "name", None)
+        if name in WRITE_TOOLS:
+            return True
+    return False

--- a/mempalace/adapters/openai.py
+++ b/mempalace/adapters/openai.py
@@ -7,7 +7,44 @@ Pure helpers (no SDK import) so they're testable without the OpenAI API:
   saved_in_result()     - verify a run actually wrote to the palace
 
 SDK-coupled helpers import `agents` lazily (optional dependency):
-  build_mcp_server(), MemPalaceRunHooks
+  build_mcp_server(), make_run_hooks()
+
+Example (chat loop with deterministic auto-save)::
+
+    import asyncio
+    from agents import Agent, Runner
+    from mempalace.adapters import openai as mp
+
+    async def main():
+        cadence = mp.SaveCadence(interval=15)
+        hooks = mp.make_run_hooks(cadence)
+        async with mp.build_mcp_server(account="alan@fwfg.com", model="gpt-4o") as server:
+            agent = Agent(
+                name="CFO",
+                instructions=mp.with_memory_instructions("You are Alan's analyst."),
+                model="gpt-4o",
+                mcp_servers=[server],
+            )
+
+            async def run(text):
+                return await Runner.run(agent, text, hooks=hooks)
+
+            while (user := input("> ")) not in ("exit", "quit"):
+                result = await run(user)
+                print(result.final_output)
+                if hooks.last_due:                 # interval reached this turn
+                    await _flush(run)
+                    cadence.reset()
+            if cadence.pending():                  # session-end: save leftover turns
+                await _flush(run)
+
+    async def _flush(run):
+        # flush_due wants a sync callable; await the save run, then verify it wrote.
+        result = await run(mp.SAVE_PROMPT)
+        if not mp.saved_in_result(result):
+            raise mp.FlushError("model did not write to the palace")
+
+    asyncio.run(main())
 """
 from __future__ import annotations
 

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -461,6 +461,7 @@ def cmd_compress(args):
 def doctor_report() -> dict:
     """Diagnostic snapshot: which MemPalace is running, plus its config and
     env-derived provenance. Read-only; touches no palace data."""
+    import os as _os
     from pathlib import Path
 
     from .version import __version__, FWFG_VERSION
@@ -472,6 +473,9 @@ def doctor_report() -> dict:
         bootstrap = "mempalace_bootstrap" in TOOLS
     except Exception:
         bootstrap = None  # could not import the MCP layer
+
+    acct, source, _matched = cfg.resolve_account()
+    tree_acct, tree_matched = cfg.tree_account_for_cwd()
     return {
         "executable": sys.executable,
         "package_path": str(Path(__file__).resolve().parent),
@@ -479,6 +483,11 @@ def doctor_report() -> dict:
         "base_version": __version__,
         "palace_path": cfg.palace_path,
         "registry_path": cfg.registry_path,
+        "cwd": _os.getcwd(),
+        "account_source": source,
+        "resolved_account": acct,
+        "matched_tree": tree_matched,
+        "tree_account": tree_acct,
         "provenance": {
             "harness": cfg.harness,
             "account": cfg.account,

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -260,6 +260,41 @@ def cmd_repair(args):
     print(f"\n{'=' * 55}\n")
 
 
+def cmd_seed_registry(args):
+    """Seed wing_registry.yaml from the palace's existing wings."""
+    from .normalization import seed_registry_from_palace
+
+    cfg = MempalaceConfig()
+    palace = os.path.expanduser(args.palace) if args.palace else cfg.palace_path
+    registry_path = args.registry or cfg.registry_path
+    entries = seed_registry_from_palace(palace, registry_path=registry_path, dry_run=args.dry_run)
+    review = [e for e in entries if e.status == "review"]
+    print(f"  {len(entries)} wings; {len(review)} need account review.")
+    for e in review:
+        print(f"    REVIEW: {e.slug} (account unassigned)")
+    print("  DRY RUN — not written." if args.dry_run else f"  Wrote {registry_path}")
+
+
+def cmd_backfill_provenance(args):
+    """Backfill harness/model/account/machine onto existing drawers."""
+    from .normalization import backfill_provenance
+
+    cfg = MempalaceConfig()
+    palace = os.path.expanduser(args.palace) if args.palace else cfg.palace_path
+    registry_path = args.registry or cfg.registry_path
+    n = backfill_provenance(
+        palace,
+        registry_path=registry_path,
+        dry_run=args.dry_run,
+        backup=not args.no_backup,
+        rewrite=args.rewrite,
+    )
+    verb = "would change" if args.dry_run else "changed"
+    print(f"  Backfill {verb} {n} drawer(s).")
+    if args.dry_run:
+        print("  DRY RUN — re-run with --yes to apply (a backup is taken first).")
+
+
 def cmd_hook(args):
     """Run hook logic: reads JSON from stdin, outputs JSON to stdout."""
     from .hooks_cli import run_hook
@@ -558,6 +593,32 @@ def main():
     for instr_name in ["init", "search", "mine", "help", "status"]:
         instructions_sub.add_parser(instr_name, help=f"Output {instr_name} instructions")
 
+    # seed-registry
+    sp_seed = sub.add_parser("seed-registry", help="Seed wing_registry.yaml from existing wings")
+    sp_seed.add_argument("--palace", help="Palace path (default: configured)")
+    sp_seed.add_argument(
+        "--registry", help="Registry YAML path (default: ~/.mempalace/wing_registry.yaml)"
+    )
+    sp_seed.add_argument("--dry-run", action="store_true", help="Show without writing")
+
+    # backfill-provenance
+    sp_bf = sub.add_parser(
+        "backfill-provenance", help="Backfill provenance onto existing drawers"
+    )
+    sp_bf.add_argument("--palace", help="Palace path (default: configured)")
+    sp_bf.add_argument("--registry", help="Registry YAML path")
+    sp_bf.add_argument(
+        "--yes",
+        dest="dry_run",
+        action="store_false",
+        help="Apply changes (default is dry-run)",
+    )
+    sp_bf.add_argument("--no-backup", action="store_true", help="Skip the pre-write palace backup")
+    sp_bf.add_argument(
+        "--rewrite", action="store_true", help="Also rewrite wing to canonical slug"
+    )
+    sp_bf.set_defaults(dry_run=True)
+
     # repair
     sub.add_parser(
         "repair",
@@ -621,6 +682,8 @@ def main():
         "repair": cmd_repair,
         "migrate": cmd_migrate,
         "status": cmd_status,
+        "seed-registry": cmd_seed_registry,
+        "backfill-provenance": cmd_backfill_provenance,
     }
     dispatch[args.command](args)
 

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -458,6 +458,50 @@ def cmd_compress(args):
         print("  (dry run -- nothing stored)")
 
 
+def doctor_report() -> dict:
+    """Diagnostic snapshot: which MemPalace is running, plus its config and
+    env-derived provenance. Read-only; touches no palace data."""
+    from pathlib import Path
+
+    from .version import __version__, FWFG_VERSION
+
+    cfg = MempalaceConfig()
+    try:
+        from .mcp_server import TOOLS
+
+        bootstrap = "mempalace_bootstrap" in TOOLS
+    except Exception:
+        bootstrap = None  # could not import the MCP layer
+    return {
+        "executable": sys.executable,
+        "package_path": str(Path(__file__).resolve().parent),
+        "version": FWFG_VERSION,
+        "base_version": __version__,
+        "palace_path": cfg.palace_path,
+        "registry_path": cfg.registry_path,
+        "provenance": {
+            "harness": cfg.harness,
+            "account": cfg.account,
+            "model": cfg.model,
+            "machine": cfg.machine,
+            "session": cfg.session,
+        },
+        "bootstrap_tool_available": bootstrap,
+    }
+
+
+def cmd_doctor(args):
+    """Print which MemPalace is running (path/version) + config + provenance.
+
+    Use this to tell the FWFG fork apart from a stale global install when a host
+    misbehaves. If `version` lacks `+fwfg` or `bootstrap_tool_available` is false,
+    the caller is running the wrong (old) package.
+    """
+    import json
+
+    print(json.dumps(doctor_report(), indent=2))
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="MemPalace — Give your AI a memory. No API key required.",
@@ -648,6 +692,11 @@ def main():
 
     sub.add_parser("status", help="Show what's been filed")
 
+    sub.add_parser(
+        "doctor",
+        help="Diagnose which MemPalace is running (path/version/provenance/config)",
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -684,6 +733,7 @@ def main():
         "status": cmd_status,
         "seed-registry": cmd_seed_registry,
         "backfill-provenance": cmd_backfill_provenance,
+        "doctor": cmd_doctor,
     }
     dispatch[args.command](args)
 

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -240,6 +240,27 @@ class MempalaceConfig:
             return env
         return str(self._config_dir / "wing_registry.yaml")
 
+    @property
+    def trees_path(self):
+        env = os.environ.get("MEMPALACE_TREES_PATH")
+        if env:
+            return env
+        return str(self._config_dir / "trees.yaml")
+
+    def load_trees(self) -> list[dict]:
+        """Read the tree-map (list of {path, account}). Fail open: missing or
+        corrupt file -> []. Non-dict entries are dropped."""
+        import yaml
+
+        p = Path(self.trees_path)
+        if not p.is_file():
+            return []
+        try:
+            data = yaml.safe_load(p.read_text(encoding="utf-8")) or []
+        except Exception:
+            return []
+        return [e for e in data if isinstance(e, dict)]
+
     def provenance(self) -> dict:
         """Provenance metadata for a write. Omits keys with no value, because
         ChromaDB metadata rejects None. harness/machine always present."""

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -59,6 +59,24 @@ def sanitize_content(value: str, max_length: int = 100_000) -> str:
     return value
 
 
+def match_tree(cwd: str, trees: list[dict]) -> tuple[str | None, str | None]:
+    """Longest-prefix, case-insensitive, path-boundary-aware match of `cwd`
+    against tree entries (each {"path","account"}). Returns (account, matched_path)
+    or (None, None). Malformed entries (missing path/account) are skipped."""
+    norm_cwd = os.path.normcase(os.path.normpath(cwd))
+    best = None  # (prefix_len, account, original_path)
+    for entry in trees:
+        path = entry.get("path")
+        account = entry.get("account")
+        if not path or not account:
+            continue
+        norm_p = os.path.normcase(os.path.normpath(path))
+        if norm_cwd == norm_p or norm_cwd.startswith(norm_p + os.sep):
+            if best is None or len(norm_p) > best[0]:
+                best = (len(norm_p), account, path)
+    return (best[1], best[2]) if best else (None, None)
+
+
 DEFAULT_PALACE_PATH = os.path.expanduser("~/.mempalace/palace")
 DEFAULT_COLLECTION_NAME = "mempalace_drawers"
 

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -6,6 +6,7 @@ Priority: env vars > config file (~/.mempalace/config.json) > defaults
 
 import json
 import os
+import platform
 import re
 from pathlib import Path
 
@@ -193,6 +194,38 @@ class MempalaceConfig:
                 json.dump(self._file_config, f, indent=2, ensure_ascii=False)
         except OSError:
             pass
+
+    @property
+    def harness(self):
+        return os.environ.get("MEMPALACE_HARNESS") or "unknown"
+
+    @property
+    def model(self):
+        return os.environ.get("MEMPALACE_MODEL") or None
+
+    @property
+    def account(self):
+        return os.environ.get("MEMPALACE_ACCOUNT") or None
+
+    @property
+    def machine(self):
+        return os.environ.get("MEMPALACE_MACHINE") or (platform.node() or "").lower() or "unknown"
+
+    @property
+    def session(self):
+        return os.environ.get("MEMPALACE_SESSION") or None
+
+    def provenance(self) -> dict:
+        """Provenance metadata for a write. Omits keys with no value, because
+        ChromaDB metadata rejects None. harness/machine always present."""
+        prov = {"harness": self.harness, "machine": self.machine}
+        if self.model:
+            prov["model"] = self.model
+        if self.account:
+            prov["account"] = self.account
+        if self.session:
+            prov["session"] = self.session
+        return prov
 
     def init(self):
         """Create config directory and write default config.json if it doesn't exist."""

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -223,7 +223,23 @@ class MempalaceConfig:
 
     @property
     def account(self):
-        return os.environ.get("MEMPALACE_ACCOUNT") or None
+        return self.resolve_account()[0]
+
+    def resolve_account(self) -> tuple[str | None, str, str | None]:
+        """(account, source, matched_tree). Precedence: MEMPALACE_ACCOUNT env wins;
+        else longest-prefix CWD tree-map match; else (None, 'none', None)."""
+        env = os.environ.get("MEMPALACE_ACCOUNT")
+        if env:
+            return env, "env", None
+        account, matched = match_tree(os.getcwd(), self.load_trees())
+        if account:
+            return account, "tree", matched
+        return None, "none", None
+
+    def tree_account_for_cwd(self) -> tuple[str | None, str | None]:
+        """What the current CWD resolves to via the tree-map, IGNORING any env
+        override. Lets `doctor` show tree-derivation before a pin is stripped."""
+        return match_tree(os.getcwd(), self.load_trees())
 
     @property
     def machine(self):

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -215,6 +215,13 @@ class MempalaceConfig:
     def session(self):
         return os.environ.get("MEMPALACE_SESSION") or None
 
+    @property
+    def registry_path(self):
+        env = os.environ.get("MEMPALACE_REGISTRY_PATH")
+        if env:
+            return env
+        return str(self._config_dir / "wing_registry.yaml")
+
     def provenance(self) -> dict:
         """Provenance metadata for a write. Omits keys with no value, because
         ChromaDB metadata rejects None. harness/machine always present."""

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -9,6 +9,7 @@ correct), honors dry_run (compute + report, write nothing).
 """
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
@@ -346,3 +347,101 @@ def ensure_agents_section(path: Path, dry_run: bool) -> bool:
     sep = "" if text.endswith("\n") else "\n"
     path.write_text(text + sep + AGENTS_SECTION, encoding="utf-8")
     return True
+
+
+GLOBAL_DIRS = [Path.home() / ".mempalace", Path.home() / ".codex", Path.home() / ".claude"]
+HOME_CLAUDE_JSON = Path.home() / ".claude.json"
+CLAUDE_SETTINGS = Path.home() / ".claude" / "settings.json"
+CODEX_CONFIG = Path.home() / ".codex" / "config.toml"
+CODEX_HOOKS = Path.home() / ".codex" / "hooks.json"
+DEFAULT_TREES = [
+    {"path": r"C:\dev", "account": "alan@fwfg.com"},
+    {"path": r"C:\pdev", "account": "ja.powell@gmail.com"},
+]
+
+
+def agents_targets_for_tree(tree_root: Path, known_trees: list[Path]) -> list[Path]:
+    """AGENTS.md paths the installer may write for THIS run = only the current
+    tree's. Other trees are out of bounds (printed as a follow-up by run_install)."""
+    return [Path(tree_root) / "AGENTS.md"]
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(prog="mempalace.host_install")
+    p.add_argument("--tree-root", default=os.getcwd())
+    p.add_argument("--venv-python", default="")
+    p.add_argument("--tree", action="append", default=[], help="PATH=ACCOUNT (repeatable)")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--yes", action="store_true")
+    p.add_argument("--strip-account", action="store_true")
+    p.add_argument("--strip-all-account-overrides", action="store_true")
+    return p.parse_args(argv)
+
+
+def _tree_entries(extra: list[str]) -> list[dict]:
+    entries = list(DEFAULT_TREES)
+    for spec in extra:
+        if "=" in spec:
+            path, acct = spec.split("=", 1)
+            entries.append({"path": path.strip(), "account": acct.strip()})
+    return entries
+
+
+def run_install(args) -> int:
+    tree_root = Path(args.tree_root)
+    trees_path = Path.home() / ".mempalace" / "trees.yaml"
+    print(f"== MemPalace host install (tree-root={tree_root}, dry_run={args.dry_run}) ==")
+    write_trees_yaml(trees_path, _tree_entries(args.tree), args.dry_run)         # global
+    repoint_json_mcp(tree_root / ".mcp.json", "mempalace", args.venv_python, "claude-code", args.dry_run)
+    repoint_json_mcp(HOME_CLAUDE_JSON, "mempalace", args.venv_python, "claude-code", args.dry_run)
+    repoint_hook_commands(CLAUDE_SETTINGS, args.venv_python, "claude-code", args.dry_run)
+    repoint_codex_toml(CODEX_CONFIG, args.venv_python, "codex", args.dry_run)
+    repoint_hook_commands(CODEX_HOOKS, args.venv_python, "codex", args.dry_run)
+    for agents in agents_targets_for_tree(tree_root, [Path(e["path"]) for e in DEFAULT_TREES]):
+        if within_tree(agents, tree_root, GLOBAL_DIRS):
+            ensure_agents_section(agents, args.dry_run)
+    # boundary follow-up: other known trees are NOT written here
+    for e in DEFAULT_TREES:
+        other = Path(e["path"])
+        if not within_tree(other, tree_root, GLOBAL_DIRS) and other.exists():
+            print(f"  NOTE: run `python -m mempalace.host_install` from {other} to configure its AGENTS.md")
+    stale = uninstall_stale(_discover_interpreters(args.venv_python), args.venv_python, args.yes, args.dry_run)
+    if stale:
+        print(f"  stale mempalace interpreters: {stale}")
+    print("  VERIFY-THEN-STRIP: open a session in this tree, run `mempalace doctor`,")
+    print("  confirm tree_account is correct, THEN run with --strip-account.")
+    return 0
+
+
+def run_strip(args) -> int:
+    scope = "all" if args.strip_all_account_overrides else "host"
+    host = [HOME_CLAUDE_JSON, CLAUDE_SETTINGS, CODEX_CONFIG, CODEX_HOOKS]
+    project = [Path(args.tree_root) / ".mcp.json"]
+    print(f"== strip account (scope={scope}, dry_run={args.dry_run}) ==")
+    removed = strip_account(host, project, scope, args.dry_run)
+    print(f"  {'would remove' if args.dry_run else 'removed'} MEMPALACE_ACCOUNT from: {removed or 'nothing'}")
+    return 0
+
+
+def _discover_interpreters(venv_python: str) -> list[str]:
+    found = []
+    found += _default_runner(["where", "python"]).splitlines()
+    found += parse_py_launcher(_default_runner(["py", "-0p"]))
+    seen, out = set(), []
+    for p in (x.strip() for x in found if x.strip()):
+        k = os.path.normcase(os.path.normpath(p))
+        if k not in seen:
+            seen.add(k)
+            out.append(p)
+    return out
+
+
+def main(argv=None):
+    args = parse_args(argv if argv is not None else __import__("sys").argv[1:])
+    if args.strip_account or args.strip_all_account_overrides:
+        return run_strip(args)
+    return run_install(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -10,6 +10,7 @@ correct), honors dry_run (compute + report, write nothing).
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -105,5 +106,52 @@ def repoint_json_mcp(path: Path, server: str, venv_python: str, harness: str,
     srv["args"] = desired_args
     env["MEMPALACE_HARNESS"] = harness
     srv["env"] = env
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+_HOOK_RE = re.compile(
+    r"^(?P<py>.+?)\s+-m\s+mempalace\s+hook\s+run\s+--hook\s+(?P<hook>\S+)\s+"
+    r"--harness\s+(?P<harness>\S+)\s*$"
+)
+
+
+def repoint_hook_commands(path: Path, venv_python: str, harness: str, dry_run: bool) -> bool:
+    """Rewrite any 'mempalace hook run' command in a hooks JSON to use the explicit
+    venv python (QUOTED, so paths with spaces like C:\\Program Files\\... work as a
+    single shell token) and the given harness. Leaves non-mempalace commands alone.
+    Idempotent; backs up; returns changed."""
+    path = Path(path)
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    changed = False
+
+    def fix(node):
+        nonlocal changed
+        if isinstance(node, dict):
+            cmd = node.get("command")
+            if isinstance(cmd, str):
+                m = _HOOK_RE.match(cmd.strip())
+                if m:
+                    new = f'"{venv_python}" -m mempalace hook run --hook {m["hook"]} --harness {harness}'
+                    if new != cmd:
+                        node["command"] = new
+                        changed = True
+            for v in node.values():
+                fix(v)
+        elif isinstance(node, list):
+            for v in node:
+                fix(v)
+
+    fix(data)
+    if not changed:
+        return False
+    if dry_run:
+        return True
+    backup_file(path)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return True

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -222,6 +222,58 @@ def repoint_codex_toml(path: Path, venv_python: str, harness: str, dry_run: bool
     return True
 
 
+def _strip_account_json(path: Path, dry_run: bool) -> bool:
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    found = False
+    for srv in (data.get("mcpServers") or {}).values():
+        env = srv.get("env") if isinstance(srv, dict) else None
+        if isinstance(env, dict) and "MEMPALACE_ACCOUNT" in env:
+            found = True
+            if not dry_run:
+                del env["MEMPALACE_ACCOUNT"]
+    if found and not dry_run:
+        backup_file(path)
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return found
+
+
+def _strip_account_toml(path: Path, dry_run: bool) -> bool:
+    if not path.is_file():
+        return False
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    kept = [ln for ln in lines if ln.strip().split("=")[0].strip() != "MEMPALACE_ACCOUNT"]
+    if len(kept) == len(lines):
+        return False
+    if not dry_run:
+        backup_file(path)
+        path.write_text("\n".join(kept) + "\n", encoding="utf-8")
+    return True
+
+
+def strip_account(host_paths: list[Path], project_paths: list[Path], scope: str,
+                  dry_run: bool) -> list[str]:
+    """Remove MEMPALACE_ACCOUNT from host-level configs (always) and, when
+    scope=='all', from project-scoped configs too. JSON + TOML. Returns the list
+    of files changed (or that would change, when dry_run). DEC-G: default keeps
+    project/user overrides — the escape hatch for unreliable-CWD harnesses."""
+    targets = list(host_paths)
+    if scope == "all":
+        targets += list(project_paths)
+    removed: list[str] = []
+    for p in targets:
+        p = Path(p)
+        hit = _strip_account_toml(p, dry_run) if p.suffix == ".toml" else _strip_account_json(p, dry_run)
+        if hit:
+            removed.append(str(p))
+    return removed
+
+
 AGENTS_SECTION = """
 ## MemPalace memory (required)
 

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -10,8 +10,10 @@ correct), honors dry_run (compute + report, write nothing).
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -220,6 +222,43 @@ def repoint_codex_toml(path: Path, venv_python: str, harness: str, dry_run: bool
     backup_file(path)
     path.write_text(new_text, encoding="utf-8")
     return True
+
+
+def parse_py_launcher(text: str) -> list[str]:
+    """Extract interpreter paths from `py -0p` output."""
+    paths = []
+    for line in text.splitlines():
+        idx = line.find(":\\")
+        if idx >= 1:
+            paths.append(line[idx - 1:].strip())
+    return paths
+
+
+def _default_runner(cmd: list[str]) -> str:
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=120).stdout
+    except Exception:
+        return ""
+
+
+def uninstall_stale(interpreters: list[str], venv_python: str, yes: bool, dry_run: bool,
+                    _runner=None) -> list[str]:
+    """For each interpreter (exact path) that is NOT the venv and HAS mempalace,
+    uninstall via that exact interpreter (`<py> -m pip uninstall -y mempalace`).
+    Never uses bare python/pip. Returns interpreters uninstalled (or would be)."""
+    if _runner is None:
+        _runner = _default_runner
+    removed = []
+    venv_n = os.path.normcase(os.path.normpath(venv_python))
+    for py in interpreters:
+        if os.path.normcase(os.path.normpath(py)) == venv_n:
+            continue
+        if "Name: mempalace" not in _runner([py, "-m", "pip", "show", "mempalace"]):
+            continue
+        removed.append(py)
+        if not dry_run and yes:
+            _runner([py, "-m", "pip", "uninstall", "-y", "mempalace"])
+    return removed
 
 
 def _strip_account_json(path: Path, dry_run: bool) -> bool:

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -388,6 +388,9 @@ def _tree_entries(extra: list[str]) -> list[dict]:
 
 
 def run_install(args) -> int:
+    if not args.venv_python or not Path(args.venv_python).is_file():
+        print(f"ERROR: --venv-python must be an existing interpreter; got {args.venv_python!r}")
+        return 1
     tree_root = Path(args.tree_root)
     trees_path = Path.home() / ".mempalace" / "trees.yaml"
     print(f"== MemPalace host install (tree-root={tree_root}, dry_run={args.dry_run}) ==")

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -387,6 +387,134 @@ def _tree_entries(extra: list[str]) -> list[dict]:
     return entries
 
 
+def ensure_json_mcp_server(path: Path, server: str, venv_python: str, harness: str,
+                           dry_run: bool) -> bool:
+    """Register mcpServers[server] in a JSON config that EXISTS but lacks the entry.
+    The installer otherwise only REPOINTS an already-registered server; on a
+    never-onboarded host that block is absent and repoint_json_mcp silently no-ops,
+    leaving hooks wired but no server to call. Creates the entry in the shape
+    repoint_json_mcp expects (venv command, mempalace.mcp_server args, env with
+    MEMPALACE_HARNESS, NO account — account is tree-derived). No-op if the file is
+    absent or the server already present (repoint handles that). Never clobbers a
+    malformed mcpServers. Backs up; honors dry_run; returns changed."""
+    path = Path(path)
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    servers = data.get("mcpServers")
+    if servers is not None and not isinstance(servers, dict):
+        return False                                  # malformed — never clobber
+    if isinstance(servers, dict) and isinstance(servers.get(server), dict):
+        return False                                  # already registered
+    if dry_run:
+        return True
+    if not isinstance(servers, dict):
+        servers = {}
+        data["mcpServers"] = servers
+    servers[server] = {
+        "command": venv_python,
+        "args": ["-m", "mempalace.mcp_server"],
+        "env": {"MEMPALACE_HARNESS": harness},
+    }
+    backup_file(path)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+def ensure_codex_mempalace_server(path: Path, venv_python: str, harness: str,
+                                  dry_run: bool) -> bool:
+    """Append a [mcp_servers.mempalace] block to a Codex config.toml that EXISTS but
+    lacks it — the Codex counterpart to ensure_json_mcp_server. repoint_codex_toml
+    no-ops on an absent block, so a fresh host ends up with mempalace hooks wired and
+    no server registered. Shape mirrors repoint_codex_toml's contract (venv command
+    as a single-quoted TOML literal, mempalace.mcp_server args, an env table with
+    MEMPALACE_HARNESS, NO account). No-op if the file is absent or the block present.
+    Verifies the result parses (tomllib) before writing; backs up; honors dry_run."""
+    import tomllib
+    path = Path(path)
+    if not path.is_file():
+        return False
+    text = path.read_text(encoding="utf-8")
+    try:
+        cur = tomllib.loads(text)
+    except Exception:
+        return False
+    if isinstance((cur.get("mcp_servers") or {}).get("mempalace"), dict):
+        return False                                  # already present — repoint handles it
+    block = (
+        "[mcp_servers.mempalace]\n"
+        f"command = '{venv_python}'\n"               # single-quoted TOML literal (no escaping)
+        'args = ["-m", "mempalace.mcp_server"]\n\n'
+        "[mcp_servers.mempalace.env]\n"
+        f'MEMPALACE_HARNESS = "{harness}"\n'
+    )
+    sep = "" if text.endswith("\n") else "\n"
+    new_text = text + sep + "\n" + block
+    try:
+        tomllib.loads(new_text)                       # never write unparseable TOML
+    except Exception:
+        return False
+    if dry_run:
+        return True
+    backup_file(path)
+    path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+def _hooks_reference_mempalace(path: Path) -> bool:
+    path = Path(path)
+    if not path.is_file():
+        return False
+    try:
+        return "mempalace hook run" in path.read_text(encoding="utf-8")
+    except Exception:
+        return False
+
+
+def _json_has_mempalace_server(path: Path) -> bool:
+    path = Path(path)
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    return isinstance(data, dict) and isinstance((data.get("mcpServers") or {}).get("mempalace"), dict)
+
+
+def _toml_has_mempalace_server(path: Path) -> bool:
+    import tomllib
+    path = Path(path)
+    if not path.is_file():
+        return False
+    try:
+        cur = tomllib.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    return isinstance((cur.get("mcp_servers") or {}).get("mempalace"), dict)
+
+
+def _warn_half_configured(tree_root: Path) -> None:
+    """Loud guard for the case ensure_* can't fix: a harness whose hooks call
+    mempalace but with no server block registered (e.g. the config file doesn't
+    exist yet) will fire auto-save with no MCP tools to call. Warn, don't hide it."""
+    if _hooks_reference_mempalace(CODEX_HOOKS) and not _toml_has_mempalace_server(CODEX_CONFIG):
+        print(f"  WARNING: {CODEX_HOOKS} runs mempalace hooks but {CODEX_CONFIG} has no "
+              f"[mcp_servers.mempalace] block — Codex auto-save will fire with no MCP server "
+              f"to call. Create/register the Codex config, then re-run.")
+    claude_ok = (_json_has_mempalace_server(HOME_CLAUDE_JSON)
+                 or _json_has_mempalace_server(Path(tree_root) / ".mcp.json"))
+    if _hooks_reference_mempalace(CLAUDE_SETTINGS) and not claude_ok:
+        print(f"  WARNING: {CLAUDE_SETTINGS} runs mempalace hooks but no mcpServers.mempalace "
+              f"in {HOME_CLAUDE_JSON} or {Path(tree_root) / '.mcp.json'} — Claude auto-save will "
+              f"fire with no MCP server to call.")
+
+
 def run_install(args) -> int:
     if not args.venv_python or not Path(args.venv_python).is_file():
         print(f"ERROR: --venv-python must be an existing interpreter; got {args.venv_python!r}")
@@ -395,9 +523,13 @@ def run_install(args) -> int:
     trees_path = Path.home() / ".mempalace" / "trees.yaml"
     print(f"== MemPalace host install (tree-root={tree_root}, dry_run={args.dry_run}) ==")
     write_trees_yaml(trees_path, _tree_entries(args.tree), args.dry_run)         # global
-    repoint_json_mcp(tree_root / ".mcp.json", "mempalace", args.venv_python, "claude-code", args.dry_run)
+    proj_mcp = tree_root / ".mcp.json"
+    ensure_json_mcp_server(proj_mcp, "mempalace", args.venv_python, "claude-code", args.dry_run)
+    repoint_json_mcp(proj_mcp, "mempalace", args.venv_python, "claude-code", args.dry_run)
+    ensure_json_mcp_server(HOME_CLAUDE_JSON, "mempalace", args.venv_python, "claude-code", args.dry_run)
     repoint_json_mcp(HOME_CLAUDE_JSON, "mempalace", args.venv_python, "claude-code", args.dry_run)
     repoint_hook_commands(CLAUDE_SETTINGS, args.venv_python, "claude-code", args.dry_run)
+    ensure_codex_mempalace_server(CODEX_CONFIG, args.venv_python, "codex", args.dry_run)
     repoint_codex_toml(CODEX_CONFIG, args.venv_python, "codex", args.dry_run)
     repoint_hook_commands(CODEX_HOOKS, args.venv_python, "codex", args.dry_run)
     for agents in agents_targets_for_tree(tree_root, [Path(e["path"]) for e in DEFAULT_TREES]):
@@ -411,6 +543,7 @@ def run_install(args) -> int:
     stale = uninstall_stale(_discover_interpreters(args.venv_python), args.venv_python, args.yes, args.dry_run)
     if stale:
         print(f"  stale mempalace interpreters: {stale}")
+    _warn_half_configured(tree_root)
     print("  VERIFY-THEN-STRIP: open a session in this tree, run `mempalace doctor`,")
     print("  confirm tree_account is correct, THEN run with --strip-account.")
     return 0

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -9,6 +9,7 @@ correct), honors dry_run (compute + report, write nothing).
 """
 from __future__ import annotations
 
+import json
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -71,4 +72,38 @@ def write_trees_yaml(path: Path, entries: list[dict], dry_run: bool) -> bool:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
                     encoding="utf-8")
+    return True
+
+
+def repoint_json_mcp(path: Path, server: str, venv_python: str, harness: str,
+                     dry_run: bool) -> bool:
+    """Point a JSON mcpServers[server] at the venv python + set HARNESS env.
+    PRESERVES any existing MEMPALACE_ACCOUNT and never adds one — account is
+    tree-derived; removal is strip_account's job (verify-before-strip). No-op if
+    file/server absent or already correct. Backs up before writing. Returns changed."""
+    path = Path(path)
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    srv = (data.get("mcpServers") or {}).get(server)
+    if not isinstance(srv, dict):
+        return False
+    desired_cmd = venv_python
+    desired_args = ["-m", "mempalace.mcp_server"]
+    env = dict(srv.get("env") or {})
+    changed = (srv.get("command") != desired_cmd or srv.get("args") != desired_args
+               or env.get("MEMPALACE_HARNESS") != harness)
+    if not changed:
+        return False
+    if dry_run:
+        return True
+    backup_file(path)
+    srv["command"] = desired_cmd
+    srv["args"] = desired_args
+    env["MEMPALACE_HARNESS"] = harness
+    srv["env"] = env
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return True

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -13,6 +13,8 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 
+import yaml
+
 
 def backup_file(path: Path) -> Path | None:
     """Copy `path` to `<path>.bak.<ts>` before it is edited. None if absent."""
@@ -37,3 +39,36 @@ def within_tree(target: Path, tree_root: Path, allowed_globals: list[Path]) -> b
         except ValueError:
             continue
     return False
+
+
+def _load_yaml_list(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+    except Exception:
+        return []
+    return [e for e in data if isinstance(e, dict)]
+
+
+def write_trees_yaml(path: Path, entries: list[dict], dry_run: bool) -> bool:
+    """Merge `entries` (keyed by path; account overrides) into the tree-map and
+    write it with yaml.safe_dump. Idempotent; backs up before overwrite; returns
+    True iff content changed (or would change, when dry_run)."""
+    path = Path(path)
+    merged: dict[str, str] = {e["path"]: e["account"] for e in _load_yaml_list(path)
+                             if e.get("path") and e.get("account")}
+    before = dict(merged)
+    for e in entries:
+        if e.get("path") and e.get("account"):
+            merged[e["path"]] = e["account"]
+    if merged == before and path.is_file():
+        return False
+    if dry_run:
+        return True
+    payload = [{"path": p, "account": a} for p, a in merged.items()]
+    backup_file(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
+                    encoding="utf-8")
+    return True

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -1,0 +1,39 @@
+"""Portable host installer for the FWFG MemPalace fork.
+
+Pure, testable config-edit helpers + orchestration. Runs under the fork venv
+(has pyyaml + mempalace). The stdlib bootstrap scripts/install_host.py creates
+the venv and delegates here via `python -m mempalace.host_install`.
+
+Every edit helper: backs up first, is idempotent (returns False when already
+correct), honors dry_run (compute + report, write nothing).
+"""
+from __future__ import annotations
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+
+def backup_file(path: Path) -> Path | None:
+    """Copy `path` to `<path>.bak.<ts>` before it is edited. None if absent."""
+    path = Path(path)
+    if not path.is_file():
+        return None
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    bak = path.with_name(f"{path.name}.bak.{ts}")
+    shutil.copy2(path, bak)
+    return bak
+
+
+def within_tree(target: Path, tree_root: Path, allowed_globals: list[Path]) -> bool:
+    """True iff `target` is under `tree_root` or under one of `allowed_globals`.
+    The identity-boundary guard: a C:\\dev run must never write a C:\\pdev path."""
+    target = Path(target).resolve()
+    roots = [Path(tree_root).resolve(), *[Path(g).resolve() for g in allowed_globals]]
+    for r in roots:
+        try:
+            target.relative_to(r)
+            return True
+        except ValueError:
+            continue
+    return False

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -155,3 +155,68 @@ def repoint_hook_commands(path: Path, venv_python: str, harness: str, dry_run: b
     backup_file(path)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return True
+
+
+def repoint_codex_toml(path: Path, venv_python: str, harness: str, dry_run: bool) -> bool:
+    """Targeted edit of the [mcp_servers.mempalace] block in a Codex config.toml:
+    set command to the venv python and ensure an env table with MEMPALACE_HARNESS.
+    PRESERVES any existing MEMPALACE_ACCOUNT and never adds one (removal is
+    strip_account's job — verify-before-strip). Preserves comments/other tables.
+    Idempotent; backs up; returns changed. Verifies the result parses (tomllib)
+    before writing."""
+    import tomllib
+    path = Path(path)
+    if not path.is_file():
+        return False
+    text = path.read_text(encoding="utf-8")
+    try:
+        cur = tomllib.loads(text)
+    except Exception:
+        return False
+    mp = (cur.get("mcp_servers") or {}).get("mempalace")
+    if not isinstance(mp, dict):
+        return False
+    cmd_ok = mp.get("command") == venv_python
+    env_ok = (mp.get("env") or {}).get("MEMPALACE_HARNESS") == harness
+    if cmd_ok and env_ok:
+        return False
+    lines = text.splitlines()
+    out, i, n = [], 0, len(lines)
+    while i < n:
+        line = lines[i]
+        if line.strip() == "[mcp_servers.mempalace]":
+            out.append(line)
+            i += 1
+            # rewrite keys until the next table header or EOF
+            while i < n and not lines[i].lstrip().startswith("["):
+                stripped = lines[i].lstrip()
+                if stripped.startswith("command"):
+                    out.append(f"command = '{venv_python}'")   # single-quoted TOML literal (no escaping)
+                else:
+                    out.append(lines[i])
+                i += 1
+            # ensure an env table follows with the harness
+            out.append("")
+            out.append("[mcp_servers.mempalace.env]")
+            out.append(f'MEMPALACE_HARNESS = "{harness}"')
+            # skip an existing env table (we just rewrote it) to avoid duplication
+            if i < n and lines[i].strip() == "[mcp_servers.mempalace.env]":
+                i += 1
+                while i < n and not lines[i].lstrip().startswith("["):
+                    s = lines[i].lstrip()
+                    if s and not s.startswith("MEMPALACE_HARNESS") and not s.startswith("#"):
+                        out.append(lines[i])   # preserve other env keys
+                    i += 1
+            continue
+        out.append(line)
+        i += 1
+    new_text = "\n".join(out) + "\n"
+    try:
+        tomllib.loads(new_text)              # never write unparseable TOML
+    except Exception:
+        return False
+    if dry_run:
+        return True
+    backup_file(path)
+    path.write_text(new_text, encoding="utf-8")
+    return True

--- a/mempalace/host_install.py
+++ b/mempalace/host_install.py
@@ -220,3 +220,38 @@ def repoint_codex_toml(path: Path, venv_python: str, harness: str, dry_run: bool
     backup_file(path)
     path.write_text(new_text, encoding="utf-8")
     return True
+
+
+AGENTS_SECTION = """
+## MemPalace memory (required)
+
+You have persistent memory via the **MemPalace MCP tools**. Provenance (harness,
+account, machine) is set by the environment / tree-map — never fabricate it.
+
+1. **On startup:** call `mempalace_bootstrap` once and follow its protocol + filing
+   rules. File into an existing wing from the list it returns; don't spawn
+   near-duplicates (use `mempalace_register_wing` for a genuinely new one).
+2. **Before answering** about any past person, project, decision, or event: call
+   `mempalace_search` or `mempalace_kg_query` first. Never guess — verify.
+3. **At session end** (or after a meaningful chunk of work): call
+   `mempalace_diary_write` (AAAK summary) + `mempalace_add_drawer` (verbatim
+   decisions/quotes/code).
+"""
+
+
+def ensure_agents_section(path: Path, dry_run: bool) -> bool:
+    """Append the MemPalace memory protocol to an existing AGENTS.md if absent.
+    Idempotent (keyed on the section header); backs up; returns changed. No-op if
+    the file does not exist (the installer never creates a tree's AGENTS.md)."""
+    path = Path(path)
+    if not path.is_file():
+        return False
+    text = path.read_text(encoding="utf-8")
+    if "## MemPalace memory (required)" in text:
+        return False
+    if dry_run:
+        return True
+    backup_file(path)
+    sep = "" if text.endswith("\n") else "\n"
+    path.write_text(text + sep + AGENTS_SECTION, encoding="utf-8")
+    return True

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -40,6 +40,7 @@ import json
 import os
 import sqlite3
 import threading
+import uuid
 from datetime import date, datetime
 from pathlib import Path
 
@@ -164,7 +165,7 @@ class KnowledgeGraph:
                 if existing:
                     return existing["id"]  # Already exists and still valid
 
-                triple_id = f"t_{sub_id}_{pred}_{obj_id}_{hashlib.sha256(f'{valid_from}{datetime.now().isoformat()}'.encode()).hexdigest()[:12]}"
+                triple_id = f"t_{sub_id}_{pred}_{obj_id}_{hashlib.sha256(f'{valid_from}{datetime.now().isoformat()}{uuid.uuid4()}'.encode()).hexdigest()[:12]}"
 
                 conn.execute(
                     """INSERT INTO triples (id, subject, predicate, object, valid_from, valid_to, confidence, source_closet, source_file)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -568,7 +568,8 @@ def tool_follow_tunnels(wing: str, room: str):
 
 
 def tool_add_drawer(
-    wing: str, room: str, content: str, source_file: str = None, added_by: str = "mcp"
+    wing: str, room: str, content: str, source_file: str = None,
+    added_by: str = "mcp", model: str = None
 ):
     """File verbatim content into a wing/room. Checks for duplicates first."""
     global _metadata_cache
@@ -608,19 +609,22 @@ def tool_add_drawer(
         pass
 
     try:
+        meta = {
+            "wing": wing,
+            "room": room,
+            "source_file": source_file or "",
+            "chunk_index": 0,
+            "added_by": added_by,
+            "filed_at": datetime.now().isoformat(),
+        }
+        prov = _config.provenance()
+        if model:
+            prov["model"] = model
+        meta.update(prov)
         col.upsert(
             ids=[drawer_id],
             documents=[content],
-            metadatas=[
-                {
-                    "wing": wing,
-                    "room": room,
-                    "source_file": source_file or "",
-                    "chunk_index": 0,
-                    "added_by": added_by,
-                    "filed_at": datetime.now().isoformat(),
-                }
-            ],
+            metadatas=[meta],
         )
         _metadata_cache = None
         logger.info(f"Filed drawer: {drawer_id} → {wing}/{room}")
@@ -1373,6 +1377,7 @@ TOOLS = {
                 },
                 "source_file": {"type": "string", "description": "Where this came from (optional)"},
                 "added_by": {"type": "string", "description": "Who is filing this (default: mcp)"},
+                "model": {"type": "string", "description": "Override the model for this write (default: server env)"},
             },
             "required": ["wing", "room", "content"],
         },

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -887,7 +887,7 @@ def tool_kg_stats():
 # ==================== AGENT DIARY ====================
 
 
-def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
+def tool_diary_write(agent_name: str, entry: str, topic: str = "general", model: str = None):
     """
     Write a diary entry for this agent. Each agent gets its own wing
     with a diary room. Entries are timestamped and accumulate over time.
@@ -928,21 +928,24 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general"):
         # semantic search quality. For now, store raw AAAK in metadata so it's
         # preserved, and keep the document as-is for embedding (even though
         # compressed AAAK degrades embedding quality).
+        meta = {
+            "wing": wing,
+            "room": room,
+            "hall": "hall_diary",
+            "topic": topic,
+            "type": "diary_entry",
+            "agent": agent_name,
+            "filed_at": now.isoformat(),
+            "date": now.strftime("%Y-%m-%d"),
+        }
+        prov = _config.provenance()
+        if model:
+            prov["model"] = model
+        meta.update(prov)
         col.add(
             ids=[entry_id],
             documents=[entry],
-            metadatas=[
-                {
-                    "wing": wing,
-                    "room": room,
-                    "hall": "hall_diary",
-                    "topic": topic,
-                    "type": "diary_entry",
-                    "agent": agent_name,
-                    "filed_at": now.isoformat(),
-                    "date": now.strftime("%Y-%m-%d"),
-                }
-            ],
+            metadatas=[meta],
         )
         logger.info(f"Diary entry: {entry_id} → {wing}/diary/{topic}")
         return {
@@ -1467,6 +1470,7 @@ TOOLS = {
                     "type": "string",
                     "description": "Topic tag (optional, default: general)",
                 },
+                "model": {"type": "string", "description": "Override the model for this entry (default: server env)"},
             },
             "required": ["agent_name", "entry"],
         },

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -328,6 +328,41 @@ EXAMPLE:
 Read AAAK naturally — expand codes mentally, treat *markers* as emotional context.
 When WRITING AAAK: use entity codes, mark emotions, keep structure tight."""
 
+FILING_RULES = (
+    "Search before you write. File into an existing wing from the list below. "
+    "Propose a new wing only with create_wing=true on add_drawer (it will be flagged "
+    "provisional) or via mempalace_register_wing. Provenance (harness/model/account/"
+    "machine) is set by the environment — do not fabricate it."
+)
+
+
+def tool_bootstrap():
+    """One-call discovery payload for a fresh model: protocol, AAAK, account-scoped
+    wing lists, config warnings, and the server's provenance context."""
+    account = _config.account
+    reg = _wr.load_registry(_config.registry_path)
+    scoped = [e for e in reg.entries if (e.account or None) == (account or None)]
+    wings = [{"slug": e.slug, "kind": e.kind, "description": e.description}
+             for e in scoped if e.status == "active"]
+
+    warnings = []
+    if not account:
+        warnings.append("MEMPALACE_ACCOUNT is not set — writes will be unattributed to an account.")
+    if _config.harness == "unknown":
+        warnings.append("MEMPALACE_HARNESS is not set — harness will be recorded as 'unknown'.")
+    if not reg.entries:
+        warnings.append("Wing registry is empty or missing — wings will be stored as 'unverified'.")
+
+    return {
+        "protocol": PALACE_PROTOCOL,
+        "aaak_dialect": AAAK_SPEC,
+        "filing_rules": FILING_RULES,
+        "account": account,
+        "wings": wings,
+        "provenance": _config.provenance(),
+        "warnings": warnings,
+    }
+
 
 def tool_list_wings():
     col = _get_collection()
@@ -1137,6 +1172,11 @@ def tool_reconnect():
 # ==================== MCP PROTOCOL ====================
 
 TOOLS = {
+    "mempalace_bootstrap": {
+        "description": "Startup discovery: returns the MemPalace protocol, AAAK spec, account-scoped wing list, filing rules, config warnings, and this server's provenance context. Call once at session start and follow it.",
+        "input_schema": {"type": "object", "properties": {}},
+        "handler": tool_bootstrap,
+    },
     "mempalace_status": {
         "description": "Palace overview — total drawers, wing and room counts",
         "input_schema": {"type": "object", "properties": {}},

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -639,6 +639,21 @@ def tool_add_drawer(
         return {"success": False, "error": str(e)}
 
 
+def tool_register_wing(slug: str, display: str = "", description: str = "",
+                       kind: str = "project", merge_alias: str = None):
+    """Promote a provisional wing to canonical, or merge an alias into an existing slug.
+    Account comes from the server env (MEMPALACE_ACCOUNT)."""
+    try:
+        slug = sanitize_name(slug, "slug")
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+    reg = _wr.load_registry(_config.registry_path)
+    out = _wr.register_wing(reg, slug=slug, account=_config.account, kind=kind,
+                            display=display, description=description, merge_alias=merge_alias)
+    _wr.save_registry(reg, _config.registry_path)
+    return {"success": True, "slug": out.slug, "status": out.status}
+
+
 def tool_delete_drawer(drawer_id: str):
     """Delete a single drawer by ID."""
     global _metadata_cache
@@ -1393,6 +1408,21 @@ TOOLS = {
             "required": ["wing", "room", "content"],
         },
         "handler": tool_add_drawer,
+    },
+    "mempalace_register_wing": {
+        "description": "Promote a provisional wing to canonical, or merge a near-duplicate name into an existing wing as an alias. Account-scoped to the server env.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "slug": {"type": "string", "description": "Canonical wing slug to create or target"},
+                "display": {"type": "string", "description": "Human-readable name (optional)"},
+                "description": {"type": "string", "description": "One-line description (optional)"},
+                "kind": {"type": "string", "description": "project | diary (default project)"},
+                "merge_alias": {"type": "string", "description": "A near-duplicate name to record as an alias of slug (optional)"},
+            },
+            "required": ["slug"],
+        },
+        "handler": tool_register_wing,
     },
     "mempalace_delete_drawer": {
         "description": "Delete a drawer by ID. Irreversible.",

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -680,6 +680,8 @@ def tool_register_wing(slug: str, display: str = "", description: str = "",
     Account comes from the server env (MEMPALACE_ACCOUNT)."""
     try:
         slug = sanitize_name(slug, "slug")
+        if merge_alias is not None:
+            merge_alias = sanitize_name(merge_alias, "merge_alias")
     except ValueError as e:
         return {"success": False, "error": str(e)}
     reg = _wr.load_registry(_config.registry_path)
@@ -994,7 +996,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", model:
             "agent": agent_name,
             "filed_at": now.isoformat(),
             "date": now.strftime("%Y-%m-%d"),
-            "wing_status": "canonical",
+            "wing_status": "canonical",  # diary wings are deterministic per-agent, not registry-resolved
         }
         prov = _config.provenance()
         if model:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from .config import MempalaceConfig, sanitize_name, sanitize_content
 from .version import __version__
+from . import wing_registry as _wr
 import chromadb
 from .query_sanitizer import sanitize_query
 from .searcher import search_memories
@@ -580,6 +581,10 @@ def tool_add_drawer(
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
+    _reg = _wr.load_registry(_config.registry_path)
+    _canon = _wr.canonicalize_wing(wing, account=_config.account, kind="project", registry=_reg)
+    wing = _canon.slug
+
     col = _get_collection(create=True)
     if not col:
         return _no_palace()
@@ -616,6 +621,7 @@ def tool_add_drawer(
             "chunk_index": 0,
             "added_by": added_by,
             "filed_at": datetime.now().isoformat(),
+            "wing_status": _canon.status,
         }
         prov = _config.provenance()
         if model:
@@ -901,7 +907,8 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", model:
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
-    wing = f"wing_{agent_name.lower().replace(' ', '_')}"
+    agent_slug = _wr.canonicalize_agent(agent_name)
+    wing = f"wing_{agent_slug}"
     room = "diary"
     col = _get_collection(create=True)
     if not col:
@@ -937,6 +944,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", model:
             "agent": agent_name,
             "filed_at": now.isoformat(),
             "date": now.strftime("%Y-%m-%d"),
+            "wing_status": "canonical",
         }
         prov = _config.provenance()
         if model:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -945,14 +945,29 @@ def tool_kg_stats():
 # ==================== AGENT DIARY ====================
 
 
-def tool_diary_write(agent_name: str, entry: str, topic: str = "general", model: str = None):
+def _default_agent_name() -> str:
+    """Fall back to the writer's identity from the environment when the caller
+    omits agent_name. MEMPALACE_MODEL is only set by the OpenAI adapter, so the
+    harness (set by every host install) is the practical default."""
+    return _config.model or _config.harness or "unknown"
+
+
+def tool_diary_write(
+    agent_name: str = None, entry: str = None, topic: str = "general", model: str = None
+):
     """
     Write a diary entry for this agent. Each agent gets its own wing
     with a diary room. Entries are timestamped and accumulate over time.
 
     This is the agent's personal journal — observations, thoughts,
     what it worked on, what it noticed, what it thinks matters.
+
+    agent_name defaults to the environment's model/harness identity.
     """
+    if entry is None:
+        return {"success": False, "error": "entry is required"}
+    if agent_name is None:
+        agent_name = _default_agent_name()
     try:
         agent_name = sanitize_name(agent_name, "agent_name")
         entry = sanitize_content(entry)
@@ -1019,17 +1034,24 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", model:
         return {"success": False, "error": str(e)}
 
 
-def tool_diary_read(agent_name: str, last_n: int = 10):
+def tool_diary_read(agent_name: str = None, last_n: int = 10):
     """
     Read an agent's recent diary entries. Returns the last N entries
     in chronological order — the agent's personal journal.
+
+    agent_name defaults to the environment's model/harness identity.
     """
+    if agent_name is None:
+        agent_name = _default_agent_name()
     try:
         agent_name = sanitize_name(agent_name, "agent_name")
     except ValueError as e:
         return {"error": str(e)}
     last_n = max(1, min(last_n, 100))
-    wing = f"wing_{agent_name.lower().replace(' ', '_')}"
+    # Must match tool_diary_write's wing derivation exactly, or the reader looks
+    # in a wing the writer never wrote to (e.g. "Claude Opus 5" -> wing_claude_opus_5
+    # on read vs wing_claude-opus-5 on write).
+    wing = f"wing_{_wr.canonicalize_agent(agent_name)}"
     col = _get_collection()
     if not col:
         return _no_palace()
@@ -1540,7 +1562,7 @@ TOOLS = {
             "properties": {
                 "agent_name": {
                     "type": "string",
-                    "description": "Your name — each agent gets their own diary wing",
+                    "description": "Your name — each agent gets their own diary wing (optional; defaults to the server's model/harness identity)",
                 },
                 "entry": {
                     "type": "string",
@@ -1552,7 +1574,7 @@ TOOLS = {
                 },
                 "model": {"type": "string", "description": "Override the model for this entry (default: server env)"},
             },
-            "required": ["agent_name", "entry"],
+            "required": ["entry"],
         },
         "handler": tool_diary_write,
     },
@@ -1563,14 +1585,14 @@ TOOLS = {
             "properties": {
                 "agent_name": {
                     "type": "string",
-                    "description": "Your name — each agent gets their own diary wing",
+                    "description": "Your name — each agent gets their own diary wing (optional; defaults to the server's model/harness identity)",
                 },
                 "last_n": {
                     "type": "integer",
                     "description": "Number of recent entries to read (default: 10)",
                 },
             },
-            "required": ["agent_name"],
+            "required": [],
         },
         "handler": tool_diary_read,
     },
@@ -1675,6 +1697,7 @@ def handle_request(request):
         import inspect
 
         schema_props = TOOLS[tool_name]["input_schema"].get("properties", {})
+        sig = None
         try:
             handler = TOOLS[tool_name]["handler"]
             sig = inspect.signature(handler)
@@ -1702,8 +1725,22 @@ def handle_request(request):
                     "id": req_id,
                     "error": {"code": -32602, "message": f"Invalid value for parameter '{key}'"},
                 }
+        tool_args.pop("wait_for_previous", None)
+        # Validate argument binding BEFORE calling, so a caller's mistake returns a
+        # legible -32602 instead of being flattened into an opaque -32000 whose only
+        # traceback goes to stderr (which MCP hosts discard). Binding is checked here
+        # rather than by catching TypeError around the call, so a genuine TypeError
+        # raised inside a handler body is still reported as an internal error.
+        if sig is not None:
+            try:
+                sig.bind(**tool_args)
+            except TypeError as e:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32602, "message": f"Invalid arguments for {tool_name}: {e}"},
+                }
         try:
-            tool_args.pop("wait_for_previous", None)
             result = TOOLS[tool_name]["handler"](**tool_args)
             return {
                 "jsonrpc": "2.0",

--- a/mempalace/normalization.py
+++ b/mempalace/normalization.py
@@ -7,7 +7,9 @@ documents are never modified; writes back up first and merge metadata.
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
+from . import wing_registry as wr
 
 
 # Legacy `agent` string -> (harness, model). Order matters: most specific first.
@@ -65,3 +67,54 @@ def account_for_wing(wing: str) -> tuple[str | None, bool]:
     if any(p.search(w) for p in _WORK_PATTERNS):
         return ("alan@fwfg.com", False)
     return (None, True)
+
+
+def _read_wing_counts(palace_path: str) -> dict[str, int]:
+    """Distinct wings -> drawer count, read via the ChromaDB API (read-only)."""
+    import chromadb
+    client = chromadb.PersistentClient(path=str(Path(palace_path).expanduser()))
+    col = client.get_collection("mempalace_drawers")
+    counts: dict[str, int] = {}
+    total = col.count()
+    offset = 0
+    while offset < total:
+        batch = col.get(include=["metadatas"], limit=1000, offset=offset)
+        metas = batch["metadatas"] or []
+        if not metas:
+            break
+        for m in metas:
+            w = (m or {}).get("wing", "__unknown__")
+            counts[w] = counts.get(w, 0) + 1
+        offset += len(metas)
+    del col, client
+    return counts
+
+
+def seed_registry_from_palace(palace_path: str, *, registry_path=None, dry_run: bool = True) -> list:
+    """Build wing_registry entries from the palace's wings, collapsing dupes by
+    normalized slug and assigning accounts (unknowns flagged status='review').
+    Returns the entries; writes the YAML unless dry_run."""
+    counts = _read_wing_counts(palace_path)
+    by_slug: dict[str, wr.WingEntry] = {}
+    for raw_wing, n in sorted(counts.items()):
+        slug = wr.normalize(raw_wing)
+        kind = "diary" if raw_wing.startswith("wing_") and slug.startswith("wing-") else "project"
+        account, needs_review = account_for_wing(raw_wing)
+        if slug in by_slug:
+            entry = by_slug[slug]
+            if raw_wing != entry.slug and wr.normalize(raw_wing) != entry.slug:
+                pass
+            if raw_wing not in entry.aliases and raw_wing != slug:
+                entry.aliases.append(raw_wing)
+            continue
+        entry = wr.WingEntry(
+            slug=slug, display=raw_wing, kind=kind, account=account,
+            aliases=[raw_wing] if raw_wing != slug else [],
+            status="review" if needs_review else "active",
+            description=f"{n} drawers (seeded)",
+        )
+        by_slug[slug] = entry
+    entries = list(by_slug.values())
+    if not dry_run:
+        wr.save_registry(wr.Registry(entries=entries), registry_path)
+    return entries

--- a/mempalace/normalization.py
+++ b/mempalace/normalization.py
@@ -7,6 +7,8 @@ documents are never modified; writes back up first and merge metadata.
 from __future__ import annotations
 
 import re
+import shutil
+from datetime import datetime
 from pathlib import Path
 
 from . import wing_registry as wr
@@ -118,3 +120,78 @@ def seed_registry_from_palace(palace_path: str, *, registry_path=None, dry_run: 
     if not dry_run:
         wr.save_registry(wr.Registry(entries=entries), registry_path)
     return entries
+
+
+def backfill_provenance(palace_path: str, *, registry_path=None, dry_run: bool = True,
+                        backup: bool = True, rewrite: bool = False, batch_size: int = 500) -> int:
+    """Add harness/model/account/machine (and wing_status) to existing drawers.
+
+    Additive + crash-safe: documents are never touched; existing metadata keys are
+    preserved (read-merge-write); a copytree backup is taken before the first write
+    unless backup=False. Idempotent. Returns the number of drawers changed (or that
+    WOULD change, when dry_run). rewrite=True also overwrites `wing` with its
+    canonical slug; default leaves the stored wing and relies on registry aliases.
+    """
+    import chromadb
+    palace_path = str(Path(palace_path).expanduser())
+    reg = wr.load_registry(registry_path)
+    wing_account = {e.slug: e.account for e in reg.entries}
+    for e in reg.entries:                                   # aliases also map to the account
+        for a in e.aliases:
+            wing_account.setdefault(wr.normalize(a), e.account)
+
+    client = chromadb.PersistentClient(path=palace_path)
+    col = client.get_collection("mempalace_drawers")
+    total = col.count()
+
+    pending_ids, pending_metas, changed = [], [], 0
+    offset = 0
+    backed_up = not backup
+    while offset < total:
+        batch = col.get(include=["metadatas"], limit=batch_size, offset=offset)
+        ids, metas = batch["ids"], (batch["metadatas"] or [])
+        if not ids:
+            break
+        for did, meta in zip(ids, metas):
+            meta = dict(meta or {})
+            new = _provenance_for(meta, wing_account, reg, rewrite)
+            updates = {k: v for k, v in new.items() if meta.get(k) != v}
+            if not updates:
+                continue
+            changed += 1
+            if not dry_run:
+                meta.update(updates)
+                pending_ids.append(did)
+                pending_metas.append(meta)
+        offset += len(ids)
+
+    if not dry_run and pending_ids:
+        if not backed_up:
+            ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+            shutil.copytree(palace_path, f"{palace_path}.pre-backfill.{ts}")
+            backed_up = True
+        for i in range(0, len(pending_ids), batch_size):
+            col.update(ids=pending_ids[i:i + batch_size], metadatas=pending_metas[i:i + batch_size])
+    del col, client
+    return changed
+
+
+def _provenance_for(meta: dict, wing_account: dict, reg, rewrite: bool) -> dict:
+    """Compute the provenance fields a drawer SHOULD have (without mutating meta)."""
+    harness, model = classify_agent(meta.get("agent"))
+    canon = wr.normalize(meta.get("wing", ""))
+    account = wing_account.get(canon)
+    out = {}
+    if harness:
+        out["harness"] = harness
+    if model:
+        out["model"] = model
+    if account:
+        out["account"] = account
+    synced = meta.get("_synced_from")
+    if synced:
+        out["machine"] = str(synced)
+    out["wing_status"] = "canonical" if canon in {e.slug for e in reg.entries} else "provisional"
+    if rewrite and canon and meta.get("wing") != canon:
+        out["wing"] = canon
+    return out

--- a/mempalace/normalization.py
+++ b/mempalace/normalization.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 
+
+
 # Legacy `agent` string -> (harness, model). Order matters: most specific first.
 # Unknown -> (None, None); we never guess.
 _OPUS_47 = re.compile(r"opus[-.]?4[-.]?7|opus47")
@@ -31,3 +33,35 @@ def classify_agent(agent: str | None) -> tuple[str | None, str | None]:
     if a == "claude-code" or _CLAUDE_HARNESS.match(a):
         return ("claude-code", None)
     return (None, None)
+
+
+# Explicit account classification for historical wings. Unknowns are flagged
+# for review, never defaulted to work (spec §7).
+_PERSONAL_PATTERNS = (re.compile(r"^pdev($|[-_])"),)
+_WORK_PATTERNS = (
+    re.compile(r"^wing[-_]"),       # agent diaries (claude-*, opus-*) are work on this machine
+    re.compile(r"^fwfg([-_]|$)"),
+    re.compile(r"^dev$"),
+    re.compile(r"^apple([-_]|$)"),
+    re.compile(r"^gizmo"),
+    re.compile(r"^klaviyo"),
+    re.compile(r"^uscreen"),
+    re.compile(r"^inbox([-_]|$)"),
+    re.compile(r"^support([-_]|$)"),
+    re.compile(r"^mempalace([-_]|$)"),
+    re.compile(r"^md-file"),
+    re.compile(r"^filenamer"),
+    re.compile(r"^claude-skills"),
+    re.compile(r"^user-preferences$"),
+)
+
+
+def account_for_wing(wing: str) -> tuple[str | None, bool]:
+    """Return (account, needs_review). Personal -> ja.powell@gmail.com;
+    recognized work -> alan@fwfg.com; unrecognized -> (None, True) for review."""
+    w = (wing or "").strip().lower()
+    if any(p.search(w) for p in _PERSONAL_PATTERNS):
+        return ("ja.powell@gmail.com", False)
+    if any(p.search(w) for p in _WORK_PATTERNS):
+        return ("alan@fwfg.com", False)
+    return (None, True)

--- a/mempalace/normalization.py
+++ b/mempalace/normalization.py
@@ -1,0 +1,33 @@
+"""Historical normalization: backfill provenance + seed the wing registry.
+
+Pure classifiers (classify_agent, account_for_wing) + palace operations
+(seed_registry_from_palace, backfill_provenance). Additive and crash-safe:
+documents are never modified; writes back up first and merge metadata.
+"""
+from __future__ import annotations
+
+import re
+
+# Legacy `agent` string -> (harness, model). Order matters: most specific first.
+# Unknown -> (None, None); we never guess.
+_OPUS_47 = re.compile(r"opus[-.]?4[-.]?7|opus47")
+_OPUS_48 = re.compile(r"opus[-.]?4[-.]?8|opus48")
+_CLAUDE_HARNESS = re.compile(r"^(claude|opus-fwfg|wing[-_]?claude)")
+
+
+def classify_agent(agent: str | None) -> tuple[str | None, str | None]:
+    """Map a legacy `agent` metadata string to (harness, model). Never guesses."""
+    if not agent:
+        return (None, None)
+    a = agent.strip().lower()
+    if _OPUS_48.search(a):
+        return ("claude-code", "claude-opus-4.8")
+    if _OPUS_47.search(a):
+        return ("claude-code", "claude-opus-4.7")
+    if "fable-5" in a or "fable5" in a:
+        return ("claude-code", "claude-fable-5")
+    if a == "codex" or a.startswith("codex"):
+        return ("codex", None)
+    if a == "claude-code" or _CLAUDE_HARNESS.match(a):
+        return ("claude-code", None)
+    return (None, None)

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,10 @@
 """Single source of truth for the MemPalace package version."""
 
+# Upstream baseline — kept exactly aligned so upstream version/README
+# consistency checks stay green and the fork diff stays clean.
 __version__ = "3.3.0"
+
+# FWFG fork build marker — identifies this as the FWFG fork (vs a stale
+# upstream/global install). Surfaced by `mempalace doctor`.
+FWFG_BUILD = "fwfg.20260614"
+FWFG_VERSION = f"{__version__}+{FWFG_BUILD}"

--- a/mempalace/wing_registry.py
+++ b/mempalace/wing_registry.py
@@ -72,10 +72,11 @@ class CanonResult:
 
 def canonicalize_agent(name: str) -> str:
     """Return a bare writer slug. Strips any number of leading 'wing-'/'wing_'
-    segments so the storage layer can add the 'wing_' prefix exactly once."""
+    segments (including a trailing bare 'wing') so the storage layer can add the
+    'wing_' prefix exactly once."""
     slug = normalize(name)
-    while slug.startswith("wing-"):
-        slug = slug[len("wing-"):]
+    while slug == "wing" or slug.startswith("wing-"):
+        slug = "" if slug == "wing" else slug[len("wing-"):]
     return slug or "unknown"
 
 

--- a/mempalace/wing_registry.py
+++ b/mempalace/wing_registry.py
@@ -111,3 +111,22 @@ def canonicalize_wing(name: str, account: str | None, kind: str, registry: Regis
                 return CanonResult(slug=best_slug, status="canonical", matched=True)
 
     return CanonResult(slug=norm, status="provisional")
+
+
+def register_wing(registry: Registry, slug: str, account: str | None, kind: str = "project",
+                  display: str = "", description: str = "", merge_alias: str | None = None) -> CanonResult:
+    """Promote a wing to canonical, or merge `merge_alias` into an existing slug.
+    Mutates `registry` in place; caller persists with save_registry()."""
+    slug = normalize(slug)
+    existing = next((e for e in registry.entries
+                     if e.slug == slug and (e.account or None) == (account or None)
+                     and e.kind == kind), None)
+    if existing is None:
+        existing = WingEntry(slug=slug, display=display or slug, kind=kind,
+                             account=account, description=description, status="active")
+        registry.entries.append(existing)
+    if merge_alias:
+        alias = normalize(merge_alias)
+        if alias != existing.slug and alias not in existing.aliases:
+            existing.aliases.append(alias)
+    return CanonResult(slug=existing.slug, status="canonical", matched=True)

--- a/mempalace/wing_registry.py
+++ b/mempalace/wing_registry.py
@@ -90,7 +90,7 @@ def canonicalize_wing(name: str, account: str | None, kind: str, registry: Regis
     """
     norm = normalize(name)
     if not registry.entries:
-        return CanonResult(slug=norm, status="unverified")
+        return CanonResult(slug=name, status="unverified")
 
     scoped = [e for e in registry.entries
               if e.kind == kind and (e.account or None) == (account or None)]
@@ -110,7 +110,7 @@ def canonicalize_wing(name: str, account: str | None, kind: str, registry: Regis
             if best_score >= FUZZY_THRESHOLD and (best_score - runner) >= FUZZY_MARGIN:
                 return CanonResult(slug=best_slug, status="canonical", matched=True)
 
-    return CanonResult(slug=norm, status="provisional")
+    return CanonResult(slug=name, status="provisional")
 
 
 def register_wing(registry: Registry, slug: str, account: str | None, kind: str = "project",

--- a/mempalace/wing_registry.py
+++ b/mempalace/wing_registry.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
 import yaml
+from rapidfuzz import fuzz, process
 
 DEFAULT_REGISTRY_PATH = Path(os.path.expanduser("~/.mempalace/wing_registry.yaml"))
 _SEP_RE = re.compile(r"[\s_]+")
@@ -56,3 +57,47 @@ def save_registry(reg: Registry, path: Path | None = None) -> None:
         yaml.safe_dump([asdict(e) for e in reg.entries], sort_keys=False, allow_unicode=True),
         encoding="utf-8",
     )
+
+
+FUZZY_THRESHOLD = 90      # token_set_ratio score required to accept
+FUZZY_MARGIN = 8          # winner must beat runner-up by this much
+
+
+@dataclass
+class CanonResult:
+    slug: str
+    status: str           # canonical | provisional | unverified
+    matched: bool = False
+
+
+def canonicalize_wing(name: str, account: str | None, kind: str, registry: Registry) -> CanonResult:
+    """Resolve `name` to a canonical wing slug, scoped to account+kind.
+
+    - empty registry              -> unverified (fail open, store as requested)
+    - exact slug/alias match      -> canonical
+    - high-confidence fuzzy match -> canonical (no alias learning here)
+    - otherwise (incl. account mismatch) -> provisional
+    """
+    norm = normalize(name)
+    if not registry.entries:
+        return CanonResult(slug=norm, status="unverified")
+
+    scoped = [e for e in registry.entries
+              if e.kind == kind and (e.account or None) == (account or None)]
+
+    # exact slug/alias
+    for e in scoped:
+        if norm == e.slug or norm in {normalize(a) for a in e.aliases}:
+            return CanonResult(slug=e.slug, status="canonical", matched=True)
+
+    # high-confidence fuzzy, with runner-up margin
+    if scoped:
+        choices = {e.slug: e.slug for e in scoped}
+        ranked = process.extract(norm, choices, scorer=fuzz.token_set_ratio, limit=2)
+        if ranked:
+            best_slug, best_score = ranked[0][0], ranked[0][1]
+            runner = ranked[1][1] if len(ranked) > 1 else 0
+            if best_score >= FUZZY_THRESHOLD and (best_score - runner) >= FUZZY_MARGIN:
+                return CanonResult(slug=best_slug, status="canonical", matched=True)
+
+    return CanonResult(slug=norm, status="provisional")

--- a/mempalace/wing_registry.py
+++ b/mempalace/wing_registry.py
@@ -1,0 +1,58 @@
+"""Wing registry + canonicalization. Pure logic; no MCP/Chroma imports."""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+import yaml
+
+DEFAULT_REGISTRY_PATH = Path(os.path.expanduser("~/.mempalace/wing_registry.yaml"))
+_SEP_RE = re.compile(r"[\s_]+")
+_DEDUP_DASH_RE = re.compile(r"-{2,}")
+
+
+def normalize(name: str) -> str:
+    """Lowercase, trim, unify separators to single '-'."""
+    s = (name or "").strip().lower()
+    s = _SEP_RE.sub("-", s)
+    s = _DEDUP_DASH_RE.sub("-", s)
+    return s.strip("-")
+
+
+@dataclass
+class WingEntry:
+    slug: str
+    display: str = ""
+    kind: str = "project"          # project | diary
+    account: str | None = None
+    aliases: list[str] = field(default_factory=list)
+    status: str = "active"         # active | archived
+    description: str = ""
+
+
+@dataclass
+class Registry:
+    entries: list[WingEntry] = field(default_factory=list)
+
+
+def load_registry(path: Path | None = None) -> Registry:
+    """Read the registry YAML. Fail open: missing/corrupt -> empty Registry."""
+    path = Path(path) if path else DEFAULT_REGISTRY_PATH
+    if not path.is_file():
+        return Registry()
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+        return Registry(entries=[WingEntry(**e) for e in raw])
+    except Exception:
+        return Registry()
+
+
+def save_registry(reg: Registry, path: Path | None = None) -> None:
+    path = Path(path) if path else DEFAULT_REGISTRY_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump([asdict(e) for e in reg.entries], sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )

--- a/mempalace/wing_registry.py
+++ b/mempalace/wing_registry.py
@@ -70,6 +70,15 @@ class CanonResult:
     matched: bool = False
 
 
+def canonicalize_agent(name: str) -> str:
+    """Return a bare writer slug. Strips any number of leading 'wing-'/'wing_'
+    segments so the storage layer can add the 'wing_' prefix exactly once."""
+    slug = normalize(name)
+    while slug.startswith("wing-"):
+        slug = slug[len("wing-"):]
+    return slug or "unknown"
+
+
 def canonicalize_wing(name: str, account: str | None, kind: str, registry: Registry) -> CanonResult:
     """Resolve `name` to a canonical wing slug, scoped to account+kind.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "chromadb>=0.5.0",
     "pyyaml>=6.0,<7",
+    "rapidfuzz>=3.0,<4",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ mempalace = "mempalace.cli:main"
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]
 spellcheck = ["autocorrect>=2.0"]
+openai = ["openai-agents>=0.1"]
 
 [dependency-groups]
 dev = ["pytest>=7.0", "pytest-cov>=4.0", "ruff>=0.4.0", "psutil>=5.9"]

--- a/scripts/install_host.py
+++ b/scripts/install_host.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Bootstrap the FWFG MemPalace fork on a host, then delegate to the venv module.
+
+Stdlib only (runs before the package/venv exist). Steps: ensure repo (you ran
+this from a clone), create the venv, editable-install, then hand off to
+`<venv>/python -m mempalace.host_install` for all config work. Forwards flags.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent          # the fork clone
+VENV = REPO / ".venv"
+VENV_PY = VENV / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def run(cmd):
+    print("  $", " ".join(str(c) for c in cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main():
+    base = sys.executable
+    run(["git", "-C", str(REPO), "pull", "--ff-only"])
+    if not VENV_PY.exists():
+        run([base, "-m", "venv", str(VENV)])
+    run([str(VENV_PY), "-m", "pip", "install", "-e", str(REPO)])
+    if "--with-openai" in sys.argv:
+        run([str(VENV_PY), "-m", "pip", "install", "openai-agents"])
+    forwarded = [a for a in sys.argv[1:] if a != "--with-openai"]
+    run([str(VENV_PY), "-m", "mempalace.host_install", "--venv-python", str(VENV_PY), *forwarded])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_adapter_openai.py
+++ b/tests/test_adapter_openai.py
@@ -172,3 +172,18 @@ def test_build_mcp_server_requires_sdk_or_returns_server(monkeypatch):
         srv = adapter.build_mcp_server(account="alan@fwfg.com", model="gpt-4o")
         # It's an MCPServerStdio configured with our provenance params.
         assert srv is not None
+
+
+def test_make_run_hooks_requires_sdk_or_ticks(monkeypatch):
+    import importlib.util
+    cadence = adapter.SaveCadence(interval=2)
+    if importlib.util.find_spec("agents") is None:
+        with pytest.raises(ImportError) as ei:
+            adapter.make_run_hooks(cadence)
+        assert "openai-agents" in str(ei.value)
+    else:
+        import asyncio
+        hooks = adapter.make_run_hooks(cadence)
+        # on_agent_end ticks the cadence
+        asyncio.run(hooks.on_agent_end(None, None, "out"))
+        assert cadence.count == 1

--- a/tests/test_adapter_openai.py
+++ b/tests/test_adapter_openai.py
@@ -47,3 +47,26 @@ def test_with_memory_instructions_prepends_bootstrap():
 def test_with_memory_instructions_handles_empty_base():
     assert adapter.with_memory_instructions("") == adapter.BOOTSTRAP_INSTRUCTIONS
     assert adapter.with_memory_instructions(None) == adapter.BOOTSTRAP_INSTRUCTIONS
+
+
+def test_save_cadence_fires_every_interval():
+    cadence = adapter.SaveCadence(interval=3)
+    results = [cadence.tick() for _ in range(7)]
+    # fires on the 3rd and 6th tick only
+    assert results == [False, False, True, False, False, True, False]
+
+
+def test_save_cadence_due_and_reset():
+    cadence = adapter.SaveCadence(interval=2)
+    cadence.tick()           # count 1
+    assert cadence.pending() is False
+    cadence.tick()           # count 2 -> due
+    # tick() already returned True at the boundary; pending tracks "unsaved turns exist"
+    cadence.reset()
+    assert cadence.count == 0
+
+
+def test_save_cadence_rejects_bad_interval():
+    import pytest
+    with pytest.raises(ValueError):
+        adapter.SaveCadence(interval=0)

--- a/tests/test_adapter_openai.py
+++ b/tests/test_adapter_openai.py
@@ -32,3 +32,18 @@ def test_mcp_server_params_omits_unset_optionals(monkeypatch):
     assert "MEMPALACE_MODEL" not in env
     assert "MEMPALACE_ACCOUNT" not in env
     assert "MEMPALACE_SESSION" not in env
+
+
+def test_with_memory_instructions_prepends_bootstrap():
+    base = "You are a helpful CFO assistant."
+    out = adapter.with_memory_instructions(base)
+    assert adapter.BOOTSTRAP_INSTRUCTIONS in out
+    assert base in out
+    assert out.startswith(adapter.BOOTSTRAP_INSTRUCTIONS)  # memory protocol first
+    # mentions the bootstrap tool by name so the model calls it
+    assert "mempalace_bootstrap" in adapter.BOOTSTRAP_INSTRUCTIONS
+
+
+def test_with_memory_instructions_handles_empty_base():
+    assert adapter.with_memory_instructions("") == adapter.BOOTSTRAP_INSTRUCTIONS
+    assert adapter.with_memory_instructions(None) == adapter.BOOTSTRAP_INSTRUCTIONS

--- a/tests/test_adapter_openai.py
+++ b/tests/test_adapter_openai.py
@@ -58,14 +58,22 @@ def test_save_cadence_fires_every_interval():
     assert results == [False, False, True, False, False, True, False]
 
 
-def test_save_cadence_due_and_reset():
-    cadence = adapter.SaveCadence(interval=2)
-    cadence.tick()           # count 1
-    assert cadence.pending() is False
-    cadence.tick()           # count 2 -> due
-    # tick() already returned True at the boundary; pending tracks "unsaved turns exist"
-    cadence.reset()
-    assert cadence.count == 0
+def test_save_cadence_pending_tracks_unsaved_turns():
+    c = adapter.SaveCadence(interval=15)
+    assert c.pending() is False            # nothing recorded yet
+    for _ in range(7):
+        c.tick()
+    assert c.pending() is True             # 7 unsaved turns -> session-end must flush
+    c.reset()
+    assert c.pending() is False and c.count == 0
+
+
+def test_save_cadence_pending_false_at_interval_boundary():
+    c = adapter.SaveCadence(interval=2)
+    assert c.tick() is False               # count 1
+    assert c.pending() is True             # one unsaved turn pending
+    assert c.tick() is True                # count 2 -> due (boundary)
+    assert c.pending() is False            # boundary reached; the due-flush covers it
 
 
 def test_save_cadence_rejects_bad_interval():

--- a/tests/test_adapter_openai.py
+++ b/tests/test_adapter_openai.py
@@ -158,3 +158,17 @@ def test_flush_due_second_attempt_succeeds():
 
     adapter.flush_due(saves_on_retry)  # no raise
     assert state["n"] == 2
+
+
+def test_build_mcp_server_requires_sdk_or_returns_server(monkeypatch):
+    # If the SDK is absent, build_mcp_server raises a clear, actionable error.
+    import importlib.util
+    have_sdk = importlib.util.find_spec("agents") is not None
+    if not have_sdk:
+        with pytest.raises(ImportError) as ei:
+            adapter.build_mcp_server(account="alan@fwfg.com")
+        assert "openai-agents" in str(ei.value)
+    else:
+        srv = adapter.build_mcp_server(account="alan@fwfg.com", model="gpt-4o")
+        # It's an MCPServerStdio configured with our provenance params.
+        assert srv is not None

--- a/tests/test_adapter_openai.py
+++ b/tests/test_adapter_openai.py
@@ -70,3 +70,45 @@ def test_save_cadence_rejects_bad_interval():
     import pytest
     with pytest.raises(ValueError):
         adapter.SaveCadence(interval=0)
+
+
+class _FakeRaw:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeItem:
+    def __init__(self, type_, name=None):
+        self.type = type_
+        self.raw_item = _FakeRaw(name) if name else object()
+
+
+class _FakeResult:
+    def __init__(self, items):
+        self.new_items = items
+
+
+def test_saved_in_result_detects_diary_write():
+    res = _FakeResult([
+        _FakeItem("message_output_item"),
+        _FakeItem("tool_call_item", "mempalace_diary_write"),
+    ])
+    assert adapter.saved_in_result(res) is True
+
+
+def test_saved_in_result_detects_add_drawer():
+    res = _FakeResult([_FakeItem("tool_call_item", "mempalace_add_drawer")])
+    assert adapter.saved_in_result(res) is True
+
+
+def test_saved_in_result_false_when_no_write_tool():
+    res = _FakeResult([
+        _FakeItem("tool_call_item", "mempalace_search"),
+        _FakeItem("message_output_item"),
+    ])
+    assert adapter.saved_in_result(res) is False
+
+
+def test_saved_in_result_handles_missing_attrs():
+    assert adapter.saved_in_result(object()) is False
+    assert adapter.saved_in_result(_FakeResult([])) is False

--- a/tests/test_adapter_openai.py
+++ b/tests/test_adapter_openai.py
@@ -1,4 +1,6 @@
 import sys
+
+import pytest
 from mempalace.adapters import openai as adapter
 
 
@@ -67,7 +69,6 @@ def test_save_cadence_due_and_reset():
 
 
 def test_save_cadence_rejects_bad_interval():
-    import pytest
     with pytest.raises(ValueError):
         adapter.SaveCadence(interval=0)
 
@@ -112,3 +113,40 @@ def test_saved_in_result_false_when_no_write_tool():
 def test_saved_in_result_handles_missing_attrs():
     assert adapter.saved_in_result(object()) is False
     assert adapter.saved_in_result(_FakeResult([])) is False
+
+
+def test_flush_due_runs_save_prompt_and_verifies():
+    calls = []
+
+    def fake_run(prompt):
+        calls.append(prompt)
+        return _FakeResult([_FakeItem("tool_call_item", "mempalace_diary_write")])
+
+    adapter.flush_due(fake_run)
+    assert len(calls) == 1
+    assert "save" in calls[0].lower() or "diary" in calls[0].lower()
+
+
+def test_flush_due_retries_once_then_raises():
+    calls = []
+
+    def never_saves(prompt):
+        calls.append(prompt)
+        return _FakeResult([_FakeItem("message_output_item")])
+
+    with pytest.raises(adapter.FlushError):
+        adapter.flush_due(never_saves)
+    assert len(calls) == 2  # initial + one retry
+
+
+def test_flush_due_second_attempt_succeeds():
+    state = {"n": 0}
+
+    def saves_on_retry(prompt):
+        state["n"] += 1
+        if state["n"] == 1:
+            return _FakeResult([])
+        return _FakeResult([_FakeItem("tool_call_item", "mempalace_add_drawer")])
+
+    adapter.flush_due(saves_on_retry)  # no raise
+    assert state["n"] == 2

--- a/tests/test_adapter_openai.py
+++ b/tests/test_adapter_openai.py
@@ -1,0 +1,34 @@
+import sys
+from mempalace.adapters import openai as adapter
+
+
+def test_mcp_server_params_sets_provenance_env_and_merges_os_environ(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")  # representative existing env var
+    params = adapter.mcp_server_params(
+        account="alan@fwfg.com", model="gpt-4o",
+        palace_path="/p/palace", registry_path="/p/registry.yaml", session="run-1",
+    )
+    assert params["command"] == sys.executable
+    assert params["args"] == ["-m", "mempalace.mcp_server"]
+    env = params["env"]
+    # provenance is set, harness is fixed for this adapter
+    assert env["MEMPALACE_HARNESS"] == "openai-agents-sdk"
+    assert env["MEMPALACE_ACCOUNT"] == "alan@fwfg.com"
+    assert env["MEMPALACE_MODEL"] == "gpt-4o"
+    assert env["MEMPALACE_SESSION"] == "run-1"
+    assert env["MEMPALACE_PALACE_PATH"] == "/p/palace"
+    assert env["MEMPALACE_REGISTRY_PATH"] == "/p/registry.yaml"
+    assert env["MEMPALACE_MACHINE"]  # defaulted to hostname
+    # os.environ is merged (PATH preserved) so the subprocess can spawn python
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_mcp_server_params_omits_unset_optionals(monkeypatch):
+    for k in ("MEMPALACE_MODEL", "MEMPALACE_ACCOUNT", "MEMPALACE_SESSION"):
+        monkeypatch.delenv(k, raising=False)
+    params = adapter.mcp_server_params(account=None)
+    env = params["env"]
+    assert env["MEMPALACE_HARNESS"] == "openai-agents-sdk"
+    assert "MEMPALACE_MODEL" not in env
+    assert "MEMPALACE_ACCOUNT" not in env
+    assert "MEMPALACE_SESSION" not in env

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,37 @@
+import importlib
+
+
+def _reload(monkeypatch, tmp_path, account="alan@fwfg.com", harness="openai-agents-sdk"):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path / "palace"))
+    monkeypatch.setenv("MEMPALACE_REGISTRY_PATH", str(tmp_path / "wing_registry.yaml"))
+    if account is None:
+        monkeypatch.delenv("MEMPALACE_ACCOUNT", raising=False)
+    else:
+        monkeypatch.setenv("MEMPALACE_ACCOUNT", account)
+    monkeypatch.setenv("MEMPALACE_HARNESS", harness)
+    import mempalace.config as config
+    import mempalace.mcp_server as srv
+    importlib.reload(config)
+    importlib.reload(srv)
+    return srv
+
+
+def test_bootstrap_account_scopes_wings(monkeypatch, tmp_path):
+    from mempalace import wing_registry as wr
+    wr.save_registry(wr.Registry(entries=[
+        wr.WingEntry(slug="fwfg-deploy", kind="project", account="alan@fwfg.com", description="work"),
+        wr.WingEntry(slug="pdev-foundation", kind="project", account="ja.powell@gmail.com", description="personal"),
+    ]), tmp_path / "wing_registry.yaml")
+    srv = _reload(monkeypatch, tmp_path)
+    out = srv.tool_bootstrap()
+    slugs = [w["slug"] for w in out["wings"]]
+    assert "fwfg-deploy" in slugs
+    assert "pdev-foundation" not in slugs            # personal hidden from work caller
+    assert out["provenance"]["harness"] == "openai-agents-sdk"
+    assert "protocol" in out and "aaak_dialect" in out and "filing_rules" in out
+
+
+def test_bootstrap_warns_on_missing_account(monkeypatch, tmp_path):
+    srv = _reload(monkeypatch, tmp_path, account=None)
+    out = srv.tool_bootstrap()
+    assert any("account" in w.lower() for w in out["warnings"])

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,26 @@
+from mempalace import cli
+
+
+def test_doctor_report_keys_and_provenance(monkeypatch):
+    monkeypatch.setenv("MEMPALACE_HARNESS", "codex")
+    monkeypatch.setenv("MEMPALACE_ACCOUNT", "alan@fwfg.com")
+    monkeypatch.delenv("MEMPALACE_MODEL", raising=False)
+    r = cli.doctor_report()
+    for k in ("executable", "package_path", "version", "base_version", "palace_path",
+              "registry_path", "provenance", "bootstrap_tool_available"):
+        assert k in r
+    assert "fwfg" in r["version"] and r["version"].startswith("3.3.0")  # fork marker
+    assert r["base_version"] == "3.3.0"                # upstream baseline preserved
+    assert set(r["provenance"]) == {"harness", "account", "model", "machine", "session"}
+    assert r["provenance"]["harness"] == "codex"
+    assert r["provenance"]["account"] == "alan@fwfg.com"
+    assert r["provenance"]["model"] is None
+    assert r["provenance"]["machine"]                 # hostname default, non-empty
+    assert r["bootstrap_tool_available"] is True       # this is the fork
+
+
+def test_doctor_version_is_fwfg_marked():
+    from mempalace.version import __version__, FWFG_VERSION
+    assert __version__ == "3.3.0"                       # upstream baseline untouched
+    assert FWFG_VERSION.startswith("3.3.0")
+    assert "fwfg" in FWFG_VERSION

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -24,3 +24,31 @@ def test_doctor_version_is_fwfg_marked():
     assert __version__ == "3.3.0"                       # upstream baseline untouched
     assert FWFG_VERSION.startswith("3.3.0")
     assert "fwfg" in FWFG_VERSION
+
+
+def test_doctor_shows_tree_resolution(tmp_path, monkeypatch):
+    p = tmp_path / "trees.yaml"
+    p.write_text(f"- path: '{tmp_path}'\n  account: 'alan@fwfg.com'\n", encoding="utf-8")
+    monkeypatch.setenv("MEMPALACE_TREES_PATH", str(p))
+    monkeypatch.delenv("MEMPALACE_ACCOUNT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    from mempalace import cli
+    r = cli.doctor_report()
+    assert r["account_source"] == "tree"
+    assert r["resolved_account"] == "alan@fwfg.com"
+    assert r["tree_account"] == "alan@fwfg.com"
+    assert r["matched_tree"] == str(tmp_path)
+
+
+def test_doctor_env_override_still_shows_tree(tmp_path, monkeypatch):
+    p = tmp_path / "trees.yaml"
+    p.write_text(f"- path: '{tmp_path}'\n  account: 'alan@fwfg.com'\n", encoding="utf-8")
+    monkeypatch.setenv("MEMPALACE_TREES_PATH", str(p))
+    monkeypatch.setenv("MEMPALACE_ACCOUNT", "pinned@x")
+    monkeypatch.chdir(tmp_path)
+    from mempalace import cli
+    r = cli.doctor_report()
+    assert r["account_source"] == "env" and r["resolved_account"] == "pinned@x"
+    # the CWD-derived value is still visible -> safe to verify before stripping
+    assert r["tree_account"] == "alan@fwfg.com"
+    assert r["matched_tree"] == str(tmp_path)

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -260,3 +260,35 @@ def test_strip_account_idempotent_and_dry_run(tmp_path):
     assert "MEMPALACE_ACCOUNT" in json.loads(host.read_text())["mcpServers"]["mempalace"]["env"]  # dry-run wrote nothing
     hi.strip_account([host], [], "host", dry_run=False)
     assert hi.strip_account([host], [], "host", dry_run=False) == []     # idempotent
+
+
+def test_parse_py_launcher_extracts_paths():
+    text = (" -V:3.14 *        C:\\Users\\a\\pythoncore-3.14-64\\python.exe\n"
+            " -V:3.12          C:\\Users\\a\\Programs\\Python\\Python312\\python.exe\n")
+    paths = hi.parse_py_launcher(text)
+    assert r"C:\Users\a\pythoncore-3.14-64\python.exe" in paths
+    assert r"C:\Users\a\Programs\Python\Python312\python.exe" in paths
+
+
+def test_uninstall_stale_uses_exact_interpreter_never_bare(tmp_path):
+    calls = []
+    def fake_run(cmd):
+        calls.append(cmd)
+        # report mempalace present only for the first interpreter
+        return "Name: mempalace" if cmd[:2] == [r"C:\py1.exe", "-m"] and "show" in cmd else ""
+    removed = hi.uninstall_stale(
+        interpreters=[r"C:\py1.exe", r"C:\py2.exe"],
+        venv_python=r"C:\dev\mempalace\.venv\Scripts\python.exe",
+        yes=True, dry_run=False, _runner=fake_run)
+    # every command starts with an explicit interpreter path (has drive letter colon), never bare "python"/"pip"
+    assert all(":" in c[0] for c in calls)
+    assert r"C:\py1.exe" in removed and r"C:\py2.exe" not in removed
+    # the uninstall for py1 was issued by exact interpreter
+    assert [r"C:\py1.exe", "-m", "pip", "uninstall", "-y", "mempalace"] in calls
+
+
+def test_uninstall_stale_skips_venv(tmp_path):
+    venv = r"C:\dev\mempalace\.venv\Scripts\python.exe"
+    calls = []
+    hi.uninstall_stale([venv], venv, yes=True, dry_run=False, _runner=lambda c: (calls.append(c), "")[1])
+    assert calls == []     # the venv interpreter is never touched

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -1,4 +1,5 @@
 # tests/test_host_install.py
+import yaml
 from mempalace import host_install as hi
 
 
@@ -31,3 +32,37 @@ def test_within_tree_refuses_sibling_tree(tmp_path):
     pdev.mkdir()
     # a C:\dev run must NOT target a C:\pdev path
     assert hi.within_tree(pdev / "AGENTS.md", dev, []) is False
+
+
+def test_write_trees_yaml_safe_dump_roundtrips_windows_paths(tmp_path):
+    p = tmp_path / "trees.yaml"
+    entries = [
+        {"path": r"C:\dev", "account": "alan@fwfg.com"},
+        {"path": r"C:\pdev", "account": "ja.powell@gmail.com"},
+    ]
+    assert hi.write_trees_yaml(p, entries, dry_run=False) is True
+    loaded = yaml.safe_load(p.read_text(encoding="utf-8"))   # must parse cleanly
+    assert {e["path"] for e in loaded} == {r"C:\dev", r"C:\pdev"}
+    assert {e["account"] for e in loaded} == {"alan@fwfg.com", "ja.powell@gmail.com"}
+
+
+def test_write_trees_yaml_idempotent(tmp_path):
+    p = tmp_path / "trees.yaml"
+    entries = [{"path": r"C:\dev", "account": "alan@fwfg.com"}]
+    hi.write_trees_yaml(p, entries, dry_run=False)
+    assert hi.write_trees_yaml(p, entries, dry_run=False) is False   # no change
+
+
+def test_write_trees_yaml_merges_and_overrides(tmp_path):
+    p = tmp_path / "trees.yaml"
+    hi.write_trees_yaml(p, [{"path": r"C:\dev", "account": "old@x"}], dry_run=False)
+    hi.write_trees_yaml(p, [{"path": r"C:\dev", "account": "alan@fwfg.com"},
+                            {"path": r"C:\pdev", "account": "ja.powell@gmail.com"}], dry_run=False)
+    loaded = {e["path"]: e["account"] for e in yaml.safe_load(p.read_text(encoding="utf-8"))}
+    assert loaded == {r"C:\dev": "alan@fwfg.com", r"C:\pdev": "ja.powell@gmail.com"}
+
+
+def test_write_trees_yaml_dry_run_writes_nothing(tmp_path):
+    p = tmp_path / "trees.yaml"
+    assert hi.write_trees_yaml(p, [{"path": r"C:\dev", "account": "a@x"}], dry_run=True) is True
+    assert not p.exists()

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -151,3 +151,58 @@ def test_repoint_hooks_ignores_non_mempalace_commands(tmp_path):
     p.write_text(json.dumps({"hooks": {"SessionStart": [{"hooks": [
         {"type": "command", "command": "powershell.exe -File x.ps1"}]}]}}), encoding="utf-8")
     assert hi.repoint_hook_commands(p, VENV, "claude-code", dry_run=False) is False
+
+
+def _codex_fixture(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "model = 'gpt-5.5'\n\n"
+        "[mcp_servers.mempalace]\n"
+        "command = 'C:\\\\Users\\\\x\\\\python.exe'\n"
+        "args = [\"-m\", \"mempalace.mcp_server\"]\n\n"
+        "[mcp_servers.other]\n"
+        "command = 'node.exe'\n",
+        encoding="utf-8")
+    return p
+
+
+def test_repoint_codex_toml_sets_command_and_env(tmp_path):
+    import tomllib
+    p = _codex_fixture(tmp_path)
+    assert hi.repoint_codex_toml(p, VENV, "codex", dry_run=False) is True
+    c = tomllib.load(open(p, "rb"))
+    mp = c["mcp_servers"]["mempalace"]
+    assert mp["command"] == VENV
+    assert mp["env"]["MEMPALACE_HARNESS"] == "codex"
+    assert c["mcp_servers"]["other"]["command"] == "node.exe"   # untouched
+
+
+def test_repoint_codex_toml_idempotent(tmp_path):
+    p = _codex_fixture(tmp_path)
+    hi.repoint_codex_toml(p, VENV, "codex", dry_run=False)
+    assert hi.repoint_codex_toml(p, VENV, "codex", dry_run=False) is False
+
+
+def test_repoint_codex_toml_preserves_existing_account(tmp_path):
+    import tomllib
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[mcp_servers.mempalace]\n"
+        "command = 'old.exe'\n"
+        'args = ["-m", "mempalace.mcp_server"]\n\n'
+        "[mcp_servers.mempalace.env]\n"
+        'MEMPALACE_HARNESS = "claude-code"\n'
+        'MEMPALACE_ACCOUNT = "alan@fwfg.com"\n',
+        encoding="utf-8")
+    hi.repoint_codex_toml(p, VENV, "codex", dry_run=False)
+    env = tomllib.load(open(p, "rb"))["mcp_servers"]["mempalace"]["env"]
+    assert env["MEMPALACE_ACCOUNT"] == "alan@fwfg.com"   # PRESERVED until --strip-account
+    assert env["MEMPALACE_HARNESS"] == "codex"
+
+
+def test_repoint_codex_toml_does_not_add_account_when_absent(tmp_path):
+    import tomllib
+    p = _codex_fixture(tmp_path)   # fixture has no account
+    hi.repoint_codex_toml(p, VENV, "codex", dry_run=False)
+    env = tomllib.load(open(p, "rb"))["mcp_servers"]["mempalace"].get("env", {})
+    assert "MEMPALACE_ACCOUNT" not in env

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -228,3 +228,35 @@ def test_ensure_agents_section_idempotent(tmp_path):
 
 def test_ensure_agents_section_missing_file_is_noop(tmp_path):
     assert hi.ensure_agents_section(tmp_path / "absent.md", dry_run=False) is False
+
+
+def test_strip_account_host_only_leaves_project(tmp_path):
+    host = tmp_path / "claude.json"
+    host.write_text(json.dumps({"mcpServers": {"mempalace": {"command": "p",
+        "env": {"MEMPALACE_HARNESS": "claude-code", "MEMPALACE_ACCOUNT": "alan@fwfg.com"}}}}), encoding="utf-8")
+    proj = tmp_path / ".mcp.json"
+    proj.write_text(json.dumps({"mcpServers": {"mempalace": {"command": "p",
+        "env": {"MEMPALACE_HARNESS": "claude-code", "MEMPALACE_ACCOUNT": "alan@fwfg.com"}}}}), encoding="utf-8")
+    removed = hi.strip_account(host_paths=[host], project_paths=[proj], scope="host", dry_run=False)
+    assert any("claude.json" in str(r) for r in removed)
+    assert "MEMPALACE_ACCOUNT" not in json.loads(host.read_text())["mcpServers"]["mempalace"]["env"]
+    # project-scoped pin preserved (the escape hatch)
+    assert "MEMPALACE_ACCOUNT" in json.loads(proj.read_text())["mcpServers"]["mempalace"]["env"]
+
+
+def test_strip_account_all_removes_project_too(tmp_path):
+    proj = tmp_path / ".mcp.json"
+    proj.write_text(json.dumps({"mcpServers": {"mempalace": {"command": "p",
+        "env": {"MEMPALACE_ACCOUNT": "alan@fwfg.com"}}}}), encoding="utf-8")
+    hi.strip_account(host_paths=[], project_paths=[proj], scope="all", dry_run=False)
+    assert "MEMPALACE_ACCOUNT" not in json.loads(proj.read_text())["mcpServers"]["mempalace"]["env"]
+
+
+def test_strip_account_idempotent_and_dry_run(tmp_path):
+    host = tmp_path / "claude.json"
+    host.write_text(json.dumps({"mcpServers": {"mempalace": {"command": "p",
+        "env": {"MEMPALACE_ACCOUNT": "a@x"}}}}), encoding="utf-8")
+    assert hi.strip_account([host], [], "host", dry_run=True)            # would remove
+    assert "MEMPALACE_ACCOUNT" in json.loads(host.read_text())["mcpServers"]["mempalace"]["env"]  # dry-run wrote nothing
+    hi.strip_account([host], [], "host", dry_run=False)
+    assert hi.strip_account([host], [], "host", dry_run=False) == []     # idempotent

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -1,5 +1,7 @@
 # tests/test_host_install.py
 import json
+from pathlib import Path
+
 import yaml
 from mempalace import host_install as hi
 
@@ -292,3 +294,25 @@ def test_uninstall_stale_skips_venv(tmp_path):
     calls = []
     hi.uninstall_stale([venv], venv, yes=True, dry_run=False, _runner=lambda c: (calls.append(c), "")[1])
     assert calls == []     # the venv interpreter is never touched
+
+
+def test_run_install_refuses_pdev_target_from_dev_run(tmp_path, monkeypatch):
+    dev = tmp_path / "dev"
+    pdev = tmp_path / "pdev"
+    dev.mkdir()
+    pdev.mkdir()
+    (pdev / "AGENTS.md").write_text("# personal\n", encoding="utf-8")
+    # a dev run must not touch pdev's AGENTS.md
+    assert hi.within_tree(pdev / "AGENTS.md", dev, []) is False
+    # ensure run_install only ever calls ensure_agents_section on within-tree paths:
+    targeted = hi.agents_targets_for_tree(tree_root=dev, known_trees=[dev, pdev])
+    assert all(hi.within_tree(t, dev, []) for t in targeted)
+    assert (pdev / "AGENTS.md") not in [Path(t) for t in targeted]
+
+
+def test_main_default_run_does_not_strip(monkeypatch):
+    # argparse: default run has strip_account False
+    args = hi.parse_args(["--dry-run"])
+    assert args.strip_account is False and args.strip_all_account_overrides is False
+    args2 = hi.parse_args(["--strip-account"])
+    assert args2.strip_account is True

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -1,6 +1,9 @@
 # tests/test_host_install.py
+import json
 import yaml
 from mempalace import host_install as hi
+
+VENV = r"C:\dev\mempalace\.venv\Scripts\python.exe"
 
 
 def test_backup_file_copies_with_timestamp(tmp_path):
@@ -66,3 +69,47 @@ def test_write_trees_yaml_dry_run_writes_nothing(tmp_path):
     p = tmp_path / "trees.yaml"
     assert hi.write_trees_yaml(p, [{"path": r"C:\dev", "account": "a@x"}], dry_run=True) is True
     assert not p.exists()
+
+
+def _mcp_fixture(tmp_path):
+    p = tmp_path / ".mcp.json"
+    p.write_text(json.dumps({"mcpServers": {"mempalace": {
+        "command": r"C:\Users\x\AppData\Local\Programs\Python\Python312\python.exe",
+        "args": ["-m", "mempalace.mcp_server"]}}}), encoding="utf-8")
+    return p
+
+
+def test_repoint_json_mcp_sets_command_harness_no_account(tmp_path):
+    p = _mcp_fixture(tmp_path)
+    assert hi.repoint_json_mcp(p, "mempalace", VENV, "claude-code", dry_run=False) is True
+    s = json.loads(p.read_text(encoding="utf-8"))["mcpServers"]["mempalace"]
+    assert s["command"] == VENV
+    assert s["args"] == ["-m", "mempalace.mcp_server"]
+    assert s["env"]["MEMPALACE_HARNESS"] == "claude-code"
+    assert "MEMPALACE_ACCOUNT" not in s["env"]            # does NOT add when absent
+
+
+def test_repoint_json_mcp_preserves_existing_account(tmp_path):
+    p = tmp_path / ".mcp.json"
+    p.write_text(json.dumps({"mcpServers": {"mempalace": {
+        "command": "old.exe", "args": ["-m", "mempalace.mcp_server"],
+        "env": {"MEMPALACE_HARNESS": "claude-code",
+                "MEMPALACE_ACCOUNT": "alan@fwfg.com"}}}}), encoding="utf-8")
+    hi.repoint_json_mcp(p, "mempalace", VENV, "claude-code", dry_run=False)
+    env = json.loads(p.read_text(encoding="utf-8"))["mcpServers"]["mempalace"]["env"]
+    assert env["MEMPALACE_ACCOUNT"] == "alan@fwfg.com"    # pin PRESERVED until --strip-account
+    assert env["MEMPALACE_HARNESS"] == "claude-code"
+
+
+def test_repoint_json_mcp_idempotent_and_backs_up(tmp_path):
+    p = _mcp_fixture(tmp_path)
+    hi.repoint_json_mcp(p, "mempalace", VENV, "claude-code", dry_run=False)
+    assert any(".bak." in f.name for f in tmp_path.iterdir())   # backup made
+    assert hi.repoint_json_mcp(p, "mempalace", VENV, "claude-code", dry_run=False) is False
+
+
+def test_repoint_json_mcp_missing_server_or_file_is_noop(tmp_path):
+    assert hi.repoint_json_mcp(tmp_path / "absent.json", "mempalace", VENV, "claude-code", False) is False
+    p = tmp_path / "x.json"
+    p.write_text('{"mcpServers": {}}', encoding="utf-8")
+    assert hi.repoint_json_mcp(p, "mempalace", VENV, "claude-code", False) is False

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -206,3 +206,25 @@ def test_repoint_codex_toml_does_not_add_account_when_absent(tmp_path):
     hi.repoint_codex_toml(p, VENV, "codex", dry_run=False)
     env = tomllib.load(open(p, "rb"))["mcp_servers"]["mempalace"].get("env", {})
     assert "MEMPALACE_ACCOUNT" not in env
+
+
+AGENTS_MARKER = "## MemPalace memory (required)"
+
+
+def test_ensure_agents_section_appends_when_absent(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    p.write_text("# Tree\n\nsome rules\n", encoding="utf-8")
+    assert hi.ensure_agents_section(p, dry_run=False) is True
+    assert AGENTS_MARKER in p.read_text(encoding="utf-8")
+    assert "mempalace_bootstrap" in p.read_text(encoding="utf-8")
+
+
+def test_ensure_agents_section_idempotent(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    p.write_text("# Tree\n", encoding="utf-8")
+    hi.ensure_agents_section(p, dry_run=False)
+    assert hi.ensure_agents_section(p, dry_run=False) is False
+
+
+def test_ensure_agents_section_missing_file_is_noop(tmp_path):
+    assert hi.ensure_agents_section(tmp_path / "absent.md", dry_run=False) is False

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -332,3 +332,161 @@ def test_run_install_refuses_empty_or_missing_venv_python(tmp_path, monkeypatch)
     assert rc == 1                                   # refused
     # the project .mcp.json command was NOT corrupted to ""
     assert json.loads(proj.read_text(encoding="utf-8"))["mcpServers"]["mempalace"]["command"] == "OLD"
+
+
+# --- registering a MISSING server block (fresh-host onboarding gap) ---
+
+def test_ensure_json_mcp_creates_when_absent(tmp_path):
+    p = tmp_path / ".mcp.json"
+    p.write_text('{"mcpServers": {"other": {"command": "node.exe"}}}', encoding="utf-8")
+    assert hi.ensure_json_mcp_server(p, "mempalace", VENV, "claude-code", dry_run=False) is True
+    s = json.loads(p.read_text(encoding="utf-8"))["mcpServers"]["mempalace"]
+    assert s["command"] == VENV
+    assert s["args"] == ["-m", "mempalace.mcp_server"]
+    assert s["env"]["MEMPALACE_HARNESS"] == "claude-code"
+    assert "MEMPALACE_ACCOUNT" not in s["env"]            # tree-derived, never pinned on create
+    assert json.loads(p.read_text())["mcpServers"]["other"]["command"] == "node.exe"   # sibling kept
+
+
+def test_ensure_json_mcp_creates_mcpservers_key_when_missing(tmp_path):
+    p = tmp_path / ".mcp.json"
+    p.write_text('{"someOtherTopLevel": 1}', encoding="utf-8")
+    assert hi.ensure_json_mcp_server(p, "mempalace", VENV, "claude-code", dry_run=False) is True
+    d = json.loads(p.read_text(encoding="utf-8"))
+    assert d["mcpServers"]["mempalace"]["command"] == VENV
+    assert d["someOtherTopLevel"] == 1                    # unrelated top-level keys preserved
+
+
+def test_ensure_json_mcp_noop_when_present(tmp_path):
+    p = _mcp_fixture(tmp_path)                            # already has mempalace
+    assert hi.ensure_json_mcp_server(p, "mempalace", VENV, "claude-code", dry_run=False) is False
+
+
+def test_ensure_json_mcp_noop_when_file_absent(tmp_path):
+    assert hi.ensure_json_mcp_server(tmp_path / "absent.json", "mempalace", VENV, "claude-code", False) is False
+
+
+def test_ensure_json_mcp_dry_run_writes_nothing(tmp_path):
+    p = tmp_path / ".mcp.json"
+    p.write_text('{"mcpServers": {}}', encoding="utf-8")
+    assert hi.ensure_json_mcp_server(p, "mempalace", VENV, "claude-code", dry_run=True) is True
+    assert json.loads(p.read_text(encoding="utf-8")) == {"mcpServers": {}}    # untouched
+
+
+def test_ensure_json_mcp_backs_up_and_idempotent(tmp_path):
+    p = tmp_path / ".mcp.json"
+    p.write_text('{"mcpServers": {}}', encoding="utf-8")
+    hi.ensure_json_mcp_server(p, "mempalace", VENV, "claude-code", dry_run=False)
+    assert any(".bak." in f.name for f in tmp_path.iterdir())
+    assert hi.ensure_json_mcp_server(p, "mempalace", VENV, "claude-code", dry_run=False) is False
+
+
+def test_ensure_json_mcp_refuses_malformed_mcpservers(tmp_path):
+    p = tmp_path / ".mcp.json"
+    p.write_text('{"mcpServers": [1, 2, 3]}', encoding="utf-8")       # wrong type
+    assert hi.ensure_json_mcp_server(p, "mempalace", VENV, "claude-code", dry_run=False) is False
+    assert json.loads(p.read_text(encoding="utf-8")) == {"mcpServers": [1, 2, 3]}   # never clobbered
+
+
+def test_ensure_then_repoint_json_is_stable(tmp_path):
+    p = tmp_path / ".mcp.json"
+    p.write_text('{"mcpServers": {}}', encoding="utf-8")
+    hi.ensure_json_mcp_server(p, "mempalace", VENV, "claude-code", dry_run=False)
+    # the freshly-created block is already correct, so repoint must no-op
+    assert hi.repoint_json_mcp(p, "mempalace", VENV, "claude-code", dry_run=False) is False
+
+
+def test_ensure_codex_creates_block_when_absent(tmp_path):
+    import tomllib
+    p = tmp_path / "config.toml"
+    p.write_text("model = 'gpt-5.5'\n\n[mcp_servers.node_repl]\ncommand = 'node.exe'\n", encoding="utf-8")
+    assert hi.ensure_codex_mempalace_server(p, VENV, "codex", dry_run=False) is True
+    c = tomllib.load(open(p, "rb"))
+    mp = c["mcp_servers"]["mempalace"]
+    assert mp["command"] == VENV
+    assert mp["args"] == ["-m", "mempalace.mcp_server"]
+    assert mp["env"]["MEMPALACE_HARNESS"] == "codex"
+    assert "MEMPALACE_ACCOUNT" not in mp.get("env", {})
+    assert c["mcp_servers"]["node_repl"]["command"] == "node.exe"   # sibling server preserved
+    assert c["model"] == "gpt-5.5"                                  # top-level preserved
+
+
+def test_ensure_codex_noop_when_present(tmp_path):
+    p = _codex_fixture(tmp_path)                          # already has mempalace
+    assert hi.ensure_codex_mempalace_server(p, VENV, "codex", dry_run=False) is False
+
+
+def test_ensure_codex_noop_when_file_absent(tmp_path):
+    assert hi.ensure_codex_mempalace_server(tmp_path / "absent.toml", VENV, "codex", False) is False
+
+
+def test_ensure_codex_dry_run_writes_nothing(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text("[mcp_servers.node_repl]\ncommand = 'node.exe'\n", encoding="utf-8")
+    before = p.read_text(encoding="utf-8")
+    assert hi.ensure_codex_mempalace_server(p, VENV, "codex", dry_run=True) is True
+    assert p.read_text(encoding="utf-8") == before
+
+
+def test_ensure_codex_backs_up_idempotent_then_repoint_stable(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text("[mcp_servers.node_repl]\ncommand = 'node.exe'\n", encoding="utf-8")
+    hi.ensure_codex_mempalace_server(p, VENV, "codex", dry_run=False)
+    assert any(".bak." in f.name for f in tmp_path.iterdir())
+    assert hi.ensure_codex_mempalace_server(p, VENV, "codex", dry_run=False) is False
+    # repoint sees the freshly-created block as already correct
+    assert hi.repoint_codex_toml(p, VENV, "codex", dry_run=False) is False
+
+
+def _run_install_args(venv_python, tree_root):
+    import types
+    return types.SimpleNamespace(
+        venv_python=venv_python, tree_root=str(tree_root), tree=[],
+        dry_run=False, yes=False, strip_account=False, strip_all_account_overrides=False)
+
+
+def _stub_home(tmp_path, monkeypatch):
+    """Point Path.home() and the module HOME-rooted config constants into tmp,
+    and neuter interpreter discovery (no subprocess). Returns the fake home dir."""
+    home = tmp_path / "home"
+    (home / ".mempalace").mkdir(parents=True)
+    (home / ".codex").mkdir(parents=True)
+    monkeypatch.setattr(hi.Path, "home", lambda: home)
+    monkeypatch.setattr(hi, "CODEX_CONFIG", home / ".codex" / "config.toml")
+    monkeypatch.setattr(hi, "CODEX_HOOKS", home / ".codex" / "hooks.json")
+    monkeypatch.setattr(hi, "HOME_CLAUDE_JSON", home / ".claude.json")
+    monkeypatch.setattr(hi, "CLAUDE_SETTINGS", home / ".claude" / "settings.json")
+    monkeypatch.setattr(hi, "_discover_interpreters", lambda venv: [])
+    return home
+
+
+def test_run_install_registers_missing_codex_block(tmp_path, monkeypatch):
+    # regression for the home-desktop gap: config.toml has another server but no mempalace
+    import tomllib
+    home = _stub_home(tmp_path, monkeypatch)
+    (home / ".codex" / "config.toml").write_text(
+        "[mcp_servers.node_repl]\ncommand = 'node.exe'\n", encoding="utf-8")
+    venvpy = tmp_path / "python.exe"
+    venvpy.write_text("", encoding="utf-8")
+    dev = tmp_path / "dev"
+    dev.mkdir()
+    assert hi.run_install(_run_install_args(str(venvpy), dev)) == 0
+    c = tomllib.load(open(home / ".codex" / "config.toml", "rb"))
+    assert c["mcp_servers"]["mempalace"]["command"] == str(venvpy)
+    assert c["mcp_servers"]["mempalace"]["env"]["MEMPALACE_HARNESS"] == "codex"
+    assert c["mcp_servers"]["node_repl"]["command"] == "node.exe"   # sibling untouched
+
+
+def test_run_install_warns_when_codex_hooks_wired_but_no_config(tmp_path, monkeypatch, capsys):
+    home = _stub_home(tmp_path, monkeypatch)
+    (home / ".codex" / "hooks.json").write_text(json.dumps({"hooks": {"Stop": [{"hooks": [
+        {"type": "command",
+         "command": '"x.exe" -m mempalace hook run --hook stop --harness codex'}]}]}}), encoding="utf-8")
+    # NOTE: no config.toml created -> ensure_* can't register, so run_install must WARN
+    venvpy = tmp_path / "python.exe"
+    venvpy.write_text("", encoding="utf-8")
+    dev = tmp_path / "dev"
+    dev.mkdir()
+    hi.run_install(_run_install_args(str(venvpy), dev))
+    out = capsys.readouterr().out
+    assert "WARNING" in out and "config.toml" in out

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -113,3 +113,41 @@ def test_repoint_json_mcp_missing_server_or_file_is_noop(tmp_path):
     p = tmp_path / "x.json"
     p.write_text('{"mcpServers": {}}', encoding="utf-8")
     assert hi.repoint_json_mcp(p, "mempalace", VENV, "claude-code", False) is False
+
+
+def _hooks_fixture(tmp_path, harness_in_cmd):
+    p = tmp_path / "hooks.json"
+    cmd = f"python -m mempalace hook run --hook stop --harness {harness_in_cmd}"
+    p.write_text(json.dumps({"hooks": {"Stop": [{"hooks": [
+        {"type": "command", "command": cmd}]}]}}), encoding="utf-8")
+    return p
+
+
+def test_repoint_hooks_explicit_python_and_harness(tmp_path):
+    p = _hooks_fixture(tmp_path, "claude-code")          # codex file had wrong harness
+    assert hi.repoint_hook_commands(p, VENV, "codex", dry_run=False) is True
+    cmd = json.loads(p.read_text(encoding="utf-8"))["hooks"]["Stop"][0]["hooks"][0]["command"]
+    assert cmd == f'"{VENV}" -m mempalace hook run --hook stop --harness codex'
+
+
+def test_repoint_hooks_quotes_python_with_spaces(tmp_path):
+    p = _hooks_fixture(tmp_path, "claude-code")
+    spaced = r"C:\Program Files\mp\.venv\Scripts\python.exe"
+    assert hi.repoint_hook_commands(p, spaced, "claude-code", dry_run=False) is True
+    cmd = json.loads(p.read_text(encoding="utf-8"))["hooks"]["Stop"][0]["hooks"][0]["command"]
+    assert cmd == f'"{spaced}" -m mempalace hook run --hook stop --harness claude-code'
+    # idempotent even with the quoted, space-containing path
+    assert hi.repoint_hook_commands(p, spaced, "claude-code", dry_run=False) is False
+
+
+def test_repoint_hooks_idempotent(tmp_path):
+    p = _hooks_fixture(tmp_path, "claude-code")
+    hi.repoint_hook_commands(p, VENV, "claude-code", dry_run=False)
+    assert hi.repoint_hook_commands(p, VENV, "claude-code", dry_run=False) is False
+
+
+def test_repoint_hooks_ignores_non_mempalace_commands(tmp_path):
+    p = tmp_path / "h.json"
+    p.write_text(json.dumps({"hooks": {"SessionStart": [{"hooks": [
+        {"type": "command", "command": "powershell.exe -File x.ps1"}]}]}}), encoding="utf-8")
+    assert hi.repoint_hook_commands(p, VENV, "claude-code", dry_run=False) is False

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -1,0 +1,33 @@
+# tests/test_host_install.py
+from mempalace import host_install as hi
+
+
+def test_backup_file_copies_with_timestamp(tmp_path):
+    f = tmp_path / "c.json"
+    f.write_text("original", encoding="utf-8")
+    bak = hi.backup_file(f)
+    assert bak is not None and bak.exists()
+    assert bak.read_text(encoding="utf-8") == "original"
+    assert ".bak." in bak.name
+
+
+def test_backup_file_absent_returns_none(tmp_path):
+    assert hi.backup_file(tmp_path / "nope.json") is None
+
+
+def test_within_tree_allows_under_root_and_globals(tmp_path):
+    root = tmp_path / "dev"
+    glob = tmp_path / "home" / ".mempalace"
+    (root).mkdir()
+    (glob).mkdir(parents=True)
+    assert hi.within_tree(root / "AGENTS.md", root, [glob]) is True
+    assert hi.within_tree(glob / "trees.yaml", root, [glob]) is True
+
+
+def test_within_tree_refuses_sibling_tree(tmp_path):
+    dev = tmp_path / "dev"
+    pdev = tmp_path / "pdev"
+    dev.mkdir()
+    pdev.mkdir()
+    # a C:\dev run must NOT target a C:\pdev path
+    assert hi.within_tree(pdev / "AGENTS.md", dev, []) is False

--- a/tests/test_host_install.py
+++ b/tests/test_host_install.py
@@ -316,3 +316,19 @@ def test_main_default_run_does_not_strip(monkeypatch):
     assert args.strip_account is False and args.strip_all_account_overrides is False
     args2 = hi.parse_args(["--strip-account"])
     assert args2.strip_account is True
+
+
+def test_run_install_refuses_empty_or_missing_venv_python(tmp_path, monkeypatch):
+    import types
+    # point HOME-ish writes nowhere dangerous: we only assert it refuses + writes nothing
+    proj = tmp_path / ".mcp.json"
+    proj.write_text(json.dumps({"mcpServers": {"mempalace": {
+        "command": "OLD", "args": ["-m", "mempalace.mcp_server"]}}}), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    args = types.SimpleNamespace(
+        venv_python="", tree_root=str(tmp_path), tree=[], dry_run=False, yes=False,
+        strip_account=False, strip_all_account_overrides=False)
+    rc = hi.run_install(args)
+    assert rc == 1                                   # refused
+    # the project .mcp.json command was NOT corrupted to ""
+    assert json.loads(proj.read_text(encoding="utf-8"))["mcpServers"]["mempalace"]["command"] == "OLD"

--- a/tests/test_kg_triple_id_unique.py
+++ b/tests/test_kg_triple_id_unique.py
@@ -1,0 +1,20 @@
+"""Regression: add_triple ids must not collide on rapid invalidate -> re-add,
+even when the wall clock returns the same instant for both adds."""
+import datetime as _dt
+
+import mempalace.knowledge_graph as kgmod
+
+
+class _FrozenDateTime:
+    @staticmethod
+    def now():
+        return _dt.datetime(2026, 1, 1, 0, 0, 0)
+
+
+def test_rapid_invalidate_re_add_no_id_collision(kg, monkeypatch):
+    # Freeze the clock so both add_triple calls hash an identical timestamp.
+    monkeypatch.setattr(kgmod, "datetime", _FrozenDateTime)
+    t1 = kg.add_triple("Alice", "works_at", "Acme")
+    kg.invalidate("Alice", "works_at", "Acme", ended="2025-01-01")
+    t2 = kg.add_triple("Alice", "works_at", "Acme")  # same frozen instant
+    assert t1 != t2  # must be a distinct id, no IntegrityError

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -42,6 +42,44 @@ def _get_collection(palace_path, create=False):
 
 
 class TestHandleRequest:
+    def test_bad_arguments_return_invalid_params_not_internal_error(self):
+        """A caller's argument mistake must be legible over the wire.
+
+        Regression: unbindable args raised TypeError inside the call, which the
+        blanket handler flattened to -32000 'Internal tool error' while the real
+        traceback went to stderr (which MCP hosts discard). Undiagnosable.
+        """
+        from mempalace.mcp_server import handle_request
+
+        resp = handle_request(
+            {
+                "method": "tools/call",
+                "id": 1,
+                "params": {"name": "mempalace_search", "arguments": {}},
+            }
+        )
+        assert resp["error"]["code"] == -32602
+        assert "mempalace_search" in resp["error"]["message"]
+        # the actual missing parameter is named, not swallowed
+        assert "query" in resp["error"]["message"]
+
+    def test_handler_internal_typeerror_still_reports_internal_error(self, monkeypatch):
+        """Only *binding* failures become -32602; bugs inside a handler stay -32000."""
+        import mempalace.mcp_server as srv
+
+        def boom(query: str = "x", **kwargs):
+            raise TypeError("exploded inside the body")
+
+        monkeypatch.setitem(srv.TOOLS["mempalace_search"], "handler", boom)
+        resp = srv.handle_request(
+            {
+                "method": "tools/call",
+                "id": 1,
+                "params": {"name": "mempalace_search", "arguments": {"query": "q"}},
+            }
+        )
+        assert resp["error"]["code"] == -32000
+
     def test_initialize(self):
         from mempalace.mcp_server import handle_request
 
@@ -637,6 +675,69 @@ class TestDiaryTools:
         assert r["total"] == 1
         assert r["entries"][0]["topic"] == "architecture"
         assert "authentication" in r["entries"][0]["content"]
+
+    def test_diary_write_defaults_agent_name_to_harness(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        """Omitting agent_name must not fail — it falls back to the env identity.
+
+        Regression: agent_name was required, so omitting it raised TypeError in the
+        dispatcher and surfaced as an opaque -32000 'Internal tool error'.
+        """
+        monkeypatch.delenv("MEMPALACE_MODEL", raising=False)
+        monkeypatch.setenv("MEMPALACE_HARNESS", "claude-code")
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_diary_write, tool_diary_read
+
+        w = tool_diary_write(entry="No agent_name supplied.")
+        assert w["success"] is True
+        assert w["agent"] == "claude-code"
+
+        # and the reader defaults to the same identity, so it finds that entry
+        r = tool_diary_read()
+        assert r["total"] == 1
+        assert "No agent_name supplied." in r["entries"][0]["content"]
+
+    def test_diary_write_prefers_model_over_harness(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        monkeypatch.setenv("MEMPALACE_MODEL", "claude-opus-5")
+        monkeypatch.setenv("MEMPALACE_HARNESS", "claude-code")
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_diary_write
+
+        assert tool_diary_write(entry="x")["agent"] == "claude-opus-5"
+
+    def test_diary_write_requires_entry(self, monkeypatch, config, palace_path, kg):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_diary_write
+
+        w = tool_diary_write(agent_name="TestAgent")
+        assert w["success"] is False
+        assert "entry" in w["error"]
+
+    def test_diary_read_finds_wing_written_by_spaced_agent_name(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        """Reader and writer must derive the same wing.
+
+        Writer canonicalizes ("Claude Opus 5" -> claude-opus-5); the reader used to
+        do its own ad-hoc lower/underscore mangling (-> claude_opus_5) and so read
+        from a wing the writer never wrote to.
+        """
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, _col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_diary_write, tool_diary_read
+
+        tool_diary_write(agent_name="Claude Opus 5", entry="spaced name entry")
+        r = tool_diary_read(agent_name="Claude Opus 5")
+        assert r["total"] == 1
+        assert "spaced name entry" in r["entries"][0]["content"]
 
     def test_diary_read_empty(self, monkeypatch, config, palace_path, kg):
         _patch_mcp_server(monkeypatch, config, kg)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -27,3 +27,20 @@ def test_classify_agent_unknown_stays_null():
     assert norm.classify_agent("") == (None, None)
     assert norm.classify_agent(None) == (None, None)
     assert norm.classify_agent("some-future-harness") == (None, None)
+
+
+def test_account_for_wing_personal():
+    assert norm.account_for_wing("pdev-foundation") == ("ja.powell@gmail.com", False)
+    assert norm.account_for_wing("pdev-anything") == ("ja.powell@gmail.com", False)
+
+
+def test_account_for_wing_work():
+    for w in ("fwfg-deploy", "fwfg-data-warehouse", "dev", "wing_claude-opus-4-8",
+              "apple-revenue-economics", "mempalace-bq", "inbox-triage"):
+        account, review = norm.account_for_wing(w)
+        assert account == "alan@fwfg.com" and review is False
+
+
+def test_account_for_wing_unknown_is_flagged_not_defaulted():
+    account, review = norm.account_for_wing("totally-unrecognized-thing")
+    assert account is None and review is True

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,4 +1,6 @@
+import chromadb
 from mempalace import normalization as norm
+from mempalace import wing_registry as wr
 
 
 def test_classify_agent_claude_code():
@@ -44,3 +46,40 @@ def test_account_for_wing_work():
 def test_account_for_wing_unknown_is_flagged_not_defaulted():
     account, review = norm.account_for_wing("totally-unrecognized-thing")
     assert account is None and review is True
+
+
+def _make_palace(tmp_path, drawers):
+    """drawers: list of (id, document, metadata). Returns palace dir path."""
+    p = tmp_path / "palace"
+    client = chromadb.PersistentClient(path=str(p))
+    col = client.get_or_create_collection("mempalace_drawers", metadata={"hnsw:space": "cosine"})
+    col.add(ids=[d[0] for d in drawers], documents=[d[1] for d in drawers],
+            metadatas=[d[2] for d in drawers])
+    del col, client
+    return str(p)
+
+
+def test_seed_registry_assigns_accounts_and_flags_unknown(tmp_path):
+    palace = _make_palace(tmp_path, [
+        ("d1", "x", {"wing": "fwfg-deploy", "room": "decisions"}),
+        ("d2", "y", {"wing": "pdev-foundation", "room": "decisions"}),
+        ("d3", "z", {"wing": "mystery-wing", "room": "r"}),
+        ("d4", "w", {"wing": "wing_claude-opus-4-8", "room": "diary"}),
+    ])
+    out = tmp_path / "wing_registry.yaml"
+    norm.seed_registry_from_palace(palace, registry_path=out, dry_run=False)
+    reg = wr.load_registry(out)
+    by_slug = {e.slug: e for e in reg.entries}
+    assert by_slug["fwfg-deploy"].account == "alan@fwfg.com"
+    assert by_slug["pdev-foundation"].account == "ja.powell@gmail.com"
+    assert by_slug["wing-claude-opus-4-8"].account == "alan@fwfg.com"
+    # unknown wing is present but flagged (account None, status review)
+    assert by_slug["mystery-wing"].account is None
+    assert by_slug["mystery-wing"].status == "review"
+
+
+def test_seed_registry_dry_run_writes_nothing(tmp_path):
+    palace = _make_palace(tmp_path, [("d1", "x", {"wing": "fwfg-deploy", "room": "r"})])
+    out = tmp_path / "wing_registry.yaml"
+    norm.seed_registry_from_palace(palace, registry_path=out, dry_run=True)
+    assert not out.exists()

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,29 @@
+from mempalace import normalization as norm
+
+
+def test_classify_agent_claude_code():
+    assert norm.classify_agent("claude-code") == ("claude-code", None)
+
+
+def test_classify_agent_opus_models_all_spellings():
+    for a in ("claude-opus-4-7", "claude-opus-4.7", "claude-opus-4-7-1m", "claude-code-opus47"):
+        harness, model = norm.classify_agent(a)
+        assert harness == "claude-code"
+        assert model == "claude-opus-4.7"
+    assert norm.classify_agent("claude-opus-4-8") == ("claude-code", "claude-opus-4.8")
+
+
+def test_classify_agent_fable():
+    assert norm.classify_agent("claude-fable-5") == ("claude-code", "claude-fable-5")
+
+
+def test_classify_agent_bare_claude_is_harness_only():
+    # 'claude' / project-nickname agents: harness known-ish, model unknown -> None (never guessed)
+    assert norm.classify_agent("claude") == ("claude-code", None)
+    assert norm.classify_agent("opus-fwfg-deploy") == ("claude-code", None)
+
+
+def test_classify_agent_unknown_stays_null():
+    assert norm.classify_agent("") == (None, None)
+    assert norm.classify_agent(None) == (None, None)
+    assert norm.classify_agent("some-future-harness") == (None, None)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -83,3 +83,51 @@ def test_seed_registry_dry_run_writes_nothing(tmp_path):
     out = tmp_path / "wing_registry.yaml"
     norm.seed_registry_from_palace(palace, registry_path=out, dry_run=True)
     assert not out.exists()
+
+
+def test_backfill_adds_provenance_preserves_existing_meta(tmp_path):
+    palace = _make_palace(tmp_path, [
+        ("d1", "doc one", {"wing": "fwfg-deploy", "room": "decisions",
+                            "agent": "claude-opus-4-8", "filed_at": "2026-05-01T00:00:00"}),
+        ("d2", "doc two", {"wing": "pdev-foundation", "room": "diary",
+                           "agent": "claude-code", "_synced_from": "home-pc"}),
+    ])
+    reg = tmp_path / "wing_registry.yaml"
+    norm.seed_registry_from_palace(palace, registry_path=reg, dry_run=False)
+    changed = norm.backfill_provenance(palace, registry_path=reg, dry_run=False, backup=False)
+    assert changed == 2
+
+    client = chromadb.PersistentClient(path=palace)
+    col = client.get_collection("mempalace_drawers")
+    g = col.get(ids=["d1", "d2"], include=["documents", "metadatas"])
+    m = {i: meta for i, meta in zip(g["ids"], g["metadatas"])}
+    # provenance added
+    assert m["d1"]["harness"] == "claude-code" and m["d1"]["model"] == "claude-opus-4.8"
+    assert m["d1"]["account"] == "alan@fwfg.com"
+    assert m["d2"]["account"] == "ja.powell@gmail.com"
+    assert m["d2"]["machine"] == "home-pc"        # from _synced_from
+    # existing metadata preserved; document untouched (verbatim)
+    assert m["d1"]["room"] == "decisions" and m["d1"]["filed_at"] == "2026-05-01T00:00:00"
+    assert g["documents"][g["ids"].index("d1")] == "doc one"
+
+
+def test_backfill_is_idempotent(tmp_path):
+    palace = _make_palace(tmp_path, [
+        ("d1", "x", {"wing": "fwfg-deploy", "room": "r", "agent": "claude-code"})])
+    reg = tmp_path / "wing_registry.yaml"
+    norm.seed_registry_from_palace(palace, registry_path=reg, dry_run=False)
+    norm.backfill_provenance(palace, registry_path=reg, dry_run=False, backup=False)
+    second = norm.backfill_provenance(palace, registry_path=reg, dry_run=False, backup=False)
+    assert second == 0          # nothing left to change
+
+
+def test_backfill_dry_run_changes_nothing(tmp_path):
+    palace = _make_palace(tmp_path, [
+        ("d1", "x", {"wing": "fwfg-deploy", "room": "r", "agent": "claude-code"})])
+    reg = tmp_path / "wing_registry.yaml"
+    norm.seed_registry_from_palace(palace, registry_path=reg, dry_run=False)
+    would = norm.backfill_provenance(palace, registry_path=reg, dry_run=True, backup=False)
+    assert would == 1
+    client = chromadb.PersistentClient(path=palace)
+    col = client.get_collection("mempalace_drawers")
+    assert "harness" not in (col.get(ids=["d1"], include=["metadatas"])["metadatas"][0])

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -45,3 +45,23 @@ def test_add_drawer_stamps_provenance(monkeypatch, tmp_path):
     assert meta["account"] == "alan@fwfg.com"
     assert meta["model"] == "gpt-4o"          # per-call override wins over (unset) env
     assert meta["machine"]
+
+
+def test_diary_write_stamps_provenance(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path / "palace2"))
+    monkeypatch.setenv("MEMPALACE_HARNESS", "claude-code")
+    monkeypatch.setenv("MEMPALACE_MODEL", "claude-opus-4-8")
+    monkeypatch.setenv("MEMPALACE_ACCOUNT", "alan@fwfg.com")
+    import mempalace.config as config
+    import mempalace.mcp_server as srv
+    importlib.reload(config)
+    importlib.reload(srv)
+
+    res = srv.tool_diary_write(agent_name="claude-code", entry="SESSION:x|done|★")
+    assert res["success"]
+    got = srv._get_collection().get(ids=[res["entry_id"]], include=["metadatas"])
+    meta = got["metadatas"][0]
+    assert meta["type"] == "diary_entry"
+    assert meta["harness"] == "claude-code"
+    assert meta["model"] == "claude-opus-4-8"
+    assert meta["account"] == "alan@fwfg.com"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,3 +1,5 @@
+import importlib
+
 from mempalace.config import MempalaceConfig
 
 
@@ -23,3 +25,23 @@ def test_provenance_from_env(monkeypatch, tmp_path):
         "harness": "openai-agents-sdk", "model": "gpt-4o",
         "account": "alan@fwfg.com", "machine": "laptop-7", "session": "run-123",
     }
+
+
+def test_add_drawer_stamps_provenance(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path / "palace"))
+    monkeypatch.setenv("MEMPALACE_HARNESS", "openai-agents-sdk")
+    monkeypatch.setenv("MEMPALACE_ACCOUNT", "alan@fwfg.com")
+    monkeypatch.delenv("MEMPALACE_MODEL", raising=False)
+    import mempalace.config as config
+    import mempalace.mcp_server as srv
+    importlib.reload(config)
+    importlib.reload(srv)
+
+    res = srv.tool_add_drawer(wing="provtest", room="r", content="hello world", model="gpt-4o")
+    assert res["success"]
+    got = srv._get_collection().get(ids=[res["drawer_id"]], include=["metadatas"])
+    meta = got["metadatas"][0]
+    assert meta["harness"] == "openai-agents-sdk"
+    assert meta["account"] == "alan@fwfg.com"
+    assert meta["model"] == "gpt-4o"          # per-call override wins over (unset) env
+    assert meta["machine"]

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -65,3 +65,26 @@ def test_diary_write_stamps_provenance(monkeypatch, tmp_path):
     assert meta["harness"] == "claude-code"
     assert meta["model"] == "claude-opus-4-8"
     assert meta["account"] == "alan@fwfg.com"
+
+
+def test_add_drawer_canonicalizes_wing_via_registry(monkeypatch, tmp_path):
+    palace = tmp_path / "palace3"
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace))
+    monkeypatch.setenv("MEMPALACE_HARNESS", "openai-agents-sdk")
+    monkeypatch.setenv("MEMPALACE_ACCOUNT", "alan@fwfg.com")
+    from mempalace import wing_registry as wr
+    reg_path = tmp_path / "wing_registry.yaml"
+    wr.save_registry(wr.Registry(entries=[wr.WingEntry(
+        slug="fwfg-deploy", kind="project", account="alan@fwfg.com", aliases=["fwfg_deploy"])]), reg_path)
+    monkeypatch.setenv("MEMPALACE_REGISTRY_PATH", str(reg_path))
+
+    import mempalace.config as config
+    import mempalace.mcp_server as srv
+    importlib.reload(config)
+    importlib.reload(srv)
+
+    res = srv.tool_add_drawer(wing="fwfg_deploy", room="decisions", content="x y z")
+    assert res["wing"] == "fwfg-deploy"          # canonicalized
+    meta = srv._get_collection().get(ids=[res["drawer_id"]], include=["metadatas"])["metadatas"][0]
+    assert meta["wing"] == "fwfg-deploy"
+    assert meta["wing_status"] == "canonical"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,25 @@
+from mempalace.config import MempalaceConfig
+
+
+def test_provenance_defaults(monkeypatch, tmp_path):
+    for k in ("MEMPALACE_HARNESS", "MEMPALACE_MODEL", "MEMPALACE_ACCOUNT",
+              "MEMPALACE_MACHINE", "MEMPALACE_SESSION"):
+        monkeypatch.delenv(k, raising=False)
+    cfg = MempalaceConfig(config_dir=tmp_path)
+    prov = cfg.provenance()
+    assert prov["harness"] == "unknown"
+    assert prov["machine"]  # hostname, non-empty
+    assert "model" not in prov and "account" not in prov and "session" not in prov
+
+
+def test_provenance_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("MEMPALACE_HARNESS", "openai-agents-sdk")
+    monkeypatch.setenv("MEMPALACE_MODEL", "gpt-4o")
+    monkeypatch.setenv("MEMPALACE_ACCOUNT", "alan@fwfg.com")
+    monkeypatch.setenv("MEMPALACE_MACHINE", "laptop-7")
+    monkeypatch.setenv("MEMPALACE_SESSION", "run-123")
+    cfg = MempalaceConfig(config_dir=tmp_path)
+    assert cfg.provenance() == {
+        "harness": "openai-agents-sdk", "model": "gpt-4o",
+        "account": "alan@fwfg.com", "machine": "laptop-7", "session": "run-123",
+    }

--- a/tests/test_tree_account.py
+++ b/tests/test_tree_account.py
@@ -60,3 +60,55 @@ def test_load_trees_corrupt_is_empty(tmp_path, monkeypatch):
     p.write_text("{ this: is: not: valid", encoding="utf-8")
     monkeypatch.setenv("MEMPALACE_TREES_PATH", str(p))
     assert MempalaceConfig(config_dir=tmp_path).load_trees() == []
+
+
+def _trees_file(tmp_path, monkeypatch, here):
+    p = tmp_path / "trees.yaml"
+    # Use single-quoted YAML scalars so Windows backslashes are not treated as
+    # escape sequences (YAML double-quoted strings process \U, \a, etc.).
+    p.write_text(f"- path: '{here}'\n  account: 'alan@fwfg.com'\n", encoding="utf-8")
+    monkeypatch.setenv("MEMPALACE_TREES_PATH", str(p))
+    return MempalaceConfig(config_dir=tmp_path)
+
+
+def test_resolve_account_env_wins(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MEMPALACE_ACCOUNT", "override@x")
+    cfg = _trees_file(tmp_path, monkeypatch, str(tmp_path))
+    assert cfg.resolve_account() == ("override@x", "env", None)
+
+
+def test_resolve_account_tree_when_no_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("MEMPALACE_ACCOUNT", raising=False)
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+    cfg = _trees_file(tmp_path, monkeypatch, str(tmp_path))   # tmp_path is a prefix of work
+    acct, source, matched = cfg.resolve_account()
+    assert acct == "alan@fwfg.com" and source == "tree"
+    assert matched == str(tmp_path)
+
+
+def test_resolve_account_none_when_no_match(tmp_path, monkeypatch):
+    monkeypatch.delenv("MEMPALACE_ACCOUNT", raising=False)
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    cfg = MempalaceConfig(config_dir=tmp_path)
+    monkeypatch.setenv("MEMPALACE_TREES_PATH", str(tmp_path / "absent.yaml"))
+    assert cfg.resolve_account() == (None, "none", None)
+
+
+def test_tree_account_for_cwd_ignores_env(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MEMPALACE_ACCOUNT", "override@x")   # env set, but ignored here
+    cfg = _trees_file(tmp_path, monkeypatch, str(tmp_path))
+    acct, matched = cfg.tree_account_for_cwd()
+    assert acct == "alan@fwfg.com"            # from CWD, not env
+
+
+def test_account_property_uses_resolution(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MEMPALACE_ACCOUNT", raising=False)
+    cfg = _trees_file(tmp_path, monkeypatch, str(tmp_path))
+    assert cfg.account == "alan@fwfg.com"

--- a/tests/test_tree_account.py
+++ b/tests/test_tree_account.py
@@ -1,4 +1,4 @@
-from mempalace.config import match_tree
+from mempalace.config import match_tree, MempalaceConfig
 
 TREES = [
     {"path": r"C:\dev", "account": "alan@fwfg.com"},
@@ -36,3 +36,27 @@ def test_longest_prefix_wins():
 def test_skips_malformed_entries():
     trees = [{"path": r"C:\dev"}, {"account": "x"}, {"path": r"C:\dev", "account": "ok@x"}]
     assert match_tree(r"C:\dev\x", trees) == ("ok@x", r"C:\dev")
+
+
+def test_load_trees_missing_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("MEMPALACE_TREES_PATH", str(tmp_path / "nope.yaml"))
+    assert MempalaceConfig(config_dir=tmp_path).load_trees() == []
+
+
+def test_load_trees_reads_entries(tmp_path, monkeypatch):
+    p = tmp_path / "trees.yaml"
+    p.write_text(
+        '- path: "C:\\\\dev"\n  account: "alan@fwfg.com"\n'
+        '- path: "C:\\\\pdev"\n  account: "ja.powell@gmail.com"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MEMPALACE_TREES_PATH", str(p))
+    trees = MempalaceConfig(config_dir=tmp_path).load_trees()
+    assert {e["account"] for e in trees} == {"alan@fwfg.com", "ja.powell@gmail.com"}
+
+
+def test_load_trees_corrupt_is_empty(tmp_path, monkeypatch):
+    p = tmp_path / "trees.yaml"
+    p.write_text("{ this: is: not: valid", encoding="utf-8")
+    monkeypatch.setenv("MEMPALACE_TREES_PATH", str(p))
+    assert MempalaceConfig(config_dir=tmp_path).load_trees() == []

--- a/tests/test_tree_account.py
+++ b/tests/test_tree_account.py
@@ -1,0 +1,38 @@
+from mempalace.config import match_tree
+
+TREES = [
+    {"path": r"C:\dev", "account": "alan@fwfg.com"},
+    {"path": r"C:\pdev", "account": "ja.powell@gmail.com"},
+]
+
+
+def test_exact_and_nested_match():
+    assert match_tree(r"C:\dev", TREES) == ("alan@fwfg.com", r"C:\dev")
+    assert match_tree(r"C:\dev\mempalace", TREES) == ("alan@fwfg.com", r"C:\dev")
+    assert match_tree(r"C:\pdev\foo\bar", TREES) == ("ja.powell@gmail.com", r"C:\pdev")
+
+
+def test_no_match_returns_none():
+    assert match_tree(r"C:\Users\alan", TREES) == (None, None)
+
+
+def test_boundary_not_substring():
+    # C:\developer must NOT match C:\dev
+    assert match_tree(r"C:\developer\x", TREES) == (None, None)
+
+
+def test_case_insensitive():
+    assert match_tree(r"c:\DEV\Mempalace", TREES) == ("alan@fwfg.com", r"C:\dev")
+
+
+def test_longest_prefix_wins():
+    trees = [
+        {"path": r"C:\dev", "account": "work@x"},
+        {"path": r"C:\dev\personal-sub", "account": "personal@x"},
+    ]
+    assert match_tree(r"C:\dev\personal-sub\proj", trees) == ("personal@x", r"C:\dev\personal-sub")
+
+
+def test_skips_malformed_entries():
+    trees = [{"path": r"C:\dev"}, {"account": "x"}, {"path": r"C:\dev", "account": "ok@x"}]
+    assert match_tree(r"C:\dev\x", trees) == ("ok@x", r"C:\dev")

--- a/tests/test_wing_registry.py
+++ b/tests/test_wing_registry.py
@@ -75,3 +75,18 @@ def test_canonicalize_agent_all_prefix_becomes_unknown():
     assert wr.canonicalize_agent("wing_") == "unknown"
     assert wr.canonicalize_agent("wing_wing_") == "unknown"
     assert wr.canonicalize_agent("WING_") == "unknown"
+
+
+def test_register_wing_creates_new(reg):
+    out = wr.register_wing(reg, slug="new-thing", account="alan@fwfg.com", kind="project",
+                           display="New Thing", description="d")
+    assert out.status == "canonical"
+    assert any(e.slug == "new-thing" for e in reg.entries)
+
+
+def test_register_wing_merge_adds_alias(reg):
+    out = wr.register_wing(reg, slug="fwfg-deploy", account="alan@fwfg.com", kind="project",
+                           merge_alias="fwfgdeploy")
+    assert out.status == "canonical" and out.slug == "fwfg-deploy"
+    entry = next(e for e in reg.entries if e.slug == "fwfg-deploy")
+    assert "fwfgdeploy" in entry.aliases

--- a/tests/test_wing_registry.py
+++ b/tests/test_wing_registry.py
@@ -62,3 +62,10 @@ def test_missing_registry_is_unverified(tmp_path):
     r = wr.canonicalize_wing("whatever", account="alan@fwfg.com", kind="project",
                              registry=wr.load_registry(tmp_path / "absent.yaml"))
     assert r.status == "unverified" and r.slug == "whatever"
+
+
+def test_canonicalize_agent_strips_wing_prefix_and_normalizes():
+    assert wr.canonicalize_agent("wing_claude-code") == "claude-code"
+    assert wr.canonicalize_agent("Claude Code") == "claude-code"
+    assert wr.canonicalize_agent("wing_wing_claude-code") == "claude-code"
+    assert wr.canonicalize_agent("openai-agents-sdk") == "openai-agents-sdk"

--- a/tests/test_wing_registry.py
+++ b/tests/test_wing_registry.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mempalace import wing_registry as wr
 
 
@@ -22,3 +24,41 @@ def test_save_then_load_roundtrip(tmp_path):
     reloaded = wr.load_registry(p)
     assert reloaded.entries[0].slug == "fwfg-deploy"
     assert "fwfg_deploy" in reloaded.entries[0].aliases
+
+
+@pytest.fixture
+def reg():
+    return wr.Registry(entries=[
+        wr.WingEntry(slug="fwfg-deploy", kind="project", account="alan@fwfg.com",
+                     aliases=["fwfg_deploy"]),
+        wr.WingEntry(slug="fwfg-data-warehouse", kind="project", account="alan@fwfg.com"),
+        wr.WingEntry(slug="pdev-foundation", kind="project", account="ja.powell@gmail.com"),
+    ])
+
+
+def test_exact_alias_match_is_canonical(reg):
+    r = wr.canonicalize_wing("fwfg_deploy", account="alan@fwfg.com", kind="project", registry=reg)
+    assert r.slug == "fwfg-deploy" and r.status == "canonical"
+
+
+def test_high_confidence_fuzzy_is_canonical_no_alias_learn(reg):
+    r = wr.canonicalize_wing("fwfg-data-warehous", account="alan@fwfg.com", kind="project", registry=reg)
+    assert r.slug == "fwfg-data-warehouse" and r.status == "canonical"
+    # no auto-learn: alias list unchanged
+    assert "fwfg-data-warehous" not in [a for e in reg.entries for a in e.aliases]
+
+
+def test_no_match_is_provisional(reg):
+    r = wr.canonicalize_wing("brand-new-thing", account="alan@fwfg.com", kind="project", registry=reg)
+    assert r.slug == "brand-new-thing" and r.status == "provisional"
+
+
+def test_other_account_wing_never_canonicalizes(reg):
+    r = wr.canonicalize_wing("pdev-foundation", account="alan@fwfg.com", kind="project", registry=reg)
+    assert r.status == "provisional" and r.slug == "pdev-foundation"
+
+
+def test_missing_registry_is_unverified(tmp_path):
+    r = wr.canonicalize_wing("whatever", account="alan@fwfg.com", kind="project",
+                             registry=wr.load_registry(tmp_path / "absent.yaml"))
+    assert r.status == "unverified" and r.slug == "whatever"

--- a/tests/test_wing_registry.py
+++ b/tests/test_wing_registry.py
@@ -90,3 +90,13 @@ def test_register_wing_merge_adds_alias(reg):
     assert out.status == "canonical" and out.slug == "fwfg-deploy"
     entry = next(e for e in reg.entries if e.slug == "fwfg-deploy")
     assert "fwfgdeploy" in entry.aliases
+
+
+def test_fallback_paths_preserve_input_name():
+    # empty registry -> unverified, name preserved (underscores NOT dashed)
+    r = wr.canonicalize_wing("test_wing", account=None, kind="project", registry=wr.Registry())
+    assert r.status == "unverified" and r.slug == "test_wing"
+    # registry present but no match -> provisional, name preserved
+    reg = wr.Registry(entries=[wr.WingEntry(slug="fwfg-deploy", kind="project", account="alan@fwfg.com")])
+    r2 = wr.canonicalize_wing("my_new_proj", account="alan@fwfg.com", kind="project", registry=reg)
+    assert r2.status == "provisional" and r2.slug == "my_new_proj"

--- a/tests/test_wing_registry.py
+++ b/tests/test_wing_registry.py
@@ -1,0 +1,24 @@
+from mempalace import wing_registry as wr
+
+
+def test_normalize():
+    assert wr.normalize("  FWFG Deploy ") == "fwfg-deploy"
+    assert wr.normalize("fwfg_data_warehouse") == "fwfg-data-warehouse"
+    assert wr.normalize("wing__claude__code") == "wing-claude-code"
+
+
+def test_load_missing_returns_empty(tmp_path):
+    reg = wr.load_registry(tmp_path / "nope.yaml")
+    assert reg.entries == []
+
+
+def test_save_then_load_roundtrip(tmp_path):
+    p = tmp_path / "reg.yaml"
+    reg = wr.Registry(entries=[wr.WingEntry(
+        slug="fwfg-deploy", display="FWFG Deploy", kind="project",
+        account="alan@fwfg.com", aliases=["fwfg_deploy"], status="active",
+        description="deploy repo")])
+    wr.save_registry(reg, p)
+    reloaded = wr.load_registry(p)
+    assert reloaded.entries[0].slug == "fwfg-deploy"
+    assert "fwfg_deploy" in reloaded.entries[0].aliases

--- a/tests/test_wing_registry.py
+++ b/tests/test_wing_registry.py
@@ -69,3 +69,9 @@ def test_canonicalize_agent_strips_wing_prefix_and_normalizes():
     assert wr.canonicalize_agent("Claude Code") == "claude-code"
     assert wr.canonicalize_agent("wing_wing_claude-code") == "claude-code"
     assert wr.canonicalize_agent("openai-agents-sdk") == "openai-agents-sdk"
+
+
+def test_canonicalize_agent_all_prefix_becomes_unknown():
+    assert wr.canonicalize_agent("wing_") == "unknown"
+    assert wr.canonicalize_agent("wing_wing_") == "unknown"
+    assert wr.canonicalize_agent("WING_") == "unknown"

--- a/tests/test_wing_registry.py
+++ b/tests/test_wing_registry.py
@@ -116,3 +116,16 @@ def test_tool_register_wing_persists(monkeypatch, tmp_path):
     assert out["success"] and out["slug"] == "brand-new-thing"
     reloaded = wr.load_registry(reg_path)
     assert any(e.slug == "brand-new-thing" for e in reloaded.entries)
+
+
+def test_tool_register_wing_rejects_unsafe_merge_alias(monkeypatch, tmp_path):
+    reg_path = tmp_path / "wing_registry.yaml"
+    monkeypatch.setenv("MEMPALACE_REGISTRY_PATH", str(reg_path))
+    monkeypatch.setenv("MEMPALACE_ACCOUNT", "alan@fwfg.com")
+    import importlib
+    import mempalace.config as config
+    import mempalace.mcp_server as srv
+    importlib.reload(config)
+    importlib.reload(srv)
+    out = srv.tool_register_wing(slug="ok-wing", merge_alias="../../etc/passwd")
+    assert out["success"] is False and "error" in out

--- a/tests/test_wing_registry.py
+++ b/tests/test_wing_registry.py
@@ -100,3 +100,19 @@ def test_fallback_paths_preserve_input_name():
     reg = wr.Registry(entries=[wr.WingEntry(slug="fwfg-deploy", kind="project", account="alan@fwfg.com")])
     r2 = wr.canonicalize_wing("my_new_proj", account="alan@fwfg.com", kind="project", registry=reg)
     assert r2.status == "provisional" and r2.slug == "my_new_proj"
+
+
+def test_tool_register_wing_persists(monkeypatch, tmp_path):
+    reg_path = tmp_path / "wing_registry.yaml"
+    monkeypatch.setenv("MEMPALACE_REGISTRY_PATH", str(reg_path))
+    monkeypatch.setenv("MEMPALACE_ACCOUNT", "alan@fwfg.com")
+    import importlib
+    import mempalace.config as config
+    import mempalace.mcp_server as srv
+    importlib.reload(config)
+    importlib.reload(srv)
+
+    out = srv.tool_register_wing(slug="brand-new-thing", display="Brand New", description="d")
+    assert out["success"] and out["slug"] == "brand-new-thing"
+    reloaded = wr.load_registry(reg_path)
+    assert any(e.slug == "brand-new-thing" for e in reloaded.entries)


### PR DESCRIPTION
## The bug

`mempalace_diary_write` and `mempalace_diary_read` failed with `MCP error -32000: Internal tool error` on **every** call, for months.

Both declared `agent_name` as `required`. The dispatcher calls `handler(**tool_args)`, so omitting it raised `TypeError` *before the handler body ran*, and the blanket `except Exception` flattened it into an opaque `-32000`. `logger.exception` writes the traceback to **stderr**, which MCP hosts discard — so the client saw a bare error code with no way to diagnose it.

Reproduced in-process against the module the server actually runs:

| call | result |
|---|---|
| `tool_diary_read(agent_name=...)` direct | success |
| dispatch **with** `agent_name` | success |
| dispatch **without** `agent_name` | `TypeError` → `-32000` |

This explains every symptom that had been recorded against it: payload size never mattered (190 B and 4 KB both failed — binding precedes the body), encoding never mattered, `diary_read` failed too (the only other tool whose sole required arg is `agent_name`), and `add_drawer` / `kg_add` / `search` / `status` never failed because none of them require it. Months of speculation about payload size and unicode encoding; neither was ever involved.

## Changes

1. **`agent_name` defaults** to `MEMPALACE_MODEL`, else `MEMPALACE_HARNESS`, else `"unknown"`. Only `adapters/openai.py` sets `MEMPALACE_MODEL`, so under other harnesses the harness name is the practical default. Both schemas drop `agent_name` from `required` so the declared contract matches the code.

2. **Legible argument errors, for every tool.** `handle_request` validates binding with `inspect.Signature.bind` before dispatch and returns `-32602` with the real message. Binding is checked up front rather than by wrapping the call in `except TypeError` — the latter would misreport a genuine `TypeError` raised *inside* a handler body as a caller argument error. A test pins that distinction.

3. **`diary_read` now derives its wing via `canonicalize_agent`**, matching `diary_write`. It previously did its own `lower().replace(' ', '_')`, so `"Claude Opus 5"` wrote to `wing_claude-opus-5` and read from `wing_claude_opus_5`. Latent while neither side had a default — but once both default to the same env string, read and write must agree, so this is required for (1) to be correct. (`normalize()` collapses only `[\s_]+`, so dotted slugs like `claude-opus-4.8` round-trip fine; only spaces and underscores diverged.)

## Verification

- Full suite: **985 passed, 1 skipped**.
- 6 new tests. **5 of 6 fail against the old source**; the 6th (`test_handler_internal_typeerror_still_reports_internal_error`) passes both ways by design — it is the guard that `-32602` did not widen to swallow real handler bugs.
- `ruff check` clean.
- `ruff format --check` still flags both files. This is **pre-existing on `main`** (verified by stashing) and deliberately not addressed here, to avoid burying a 53-line fix in an unrelated whitespace diff.

## Note for anyone running this

A live MCP server keeps the old module loaded — `-32000` persists until the server restarts. Until then, pass `agent_name` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
