### PR TITLE
fix(graph): report complete palace graph stats

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -94,6 +94,7 @@ from .palace_graph import (  # noqa: E402
     list_tunnels,
     delete_tunnel,
     follow_tunnels,
+    _load_tunnels as _load_graph_tunnels,
 )
 from .hallways import (  # noqa: E402
     list_hallways,
@@ -1980,7 +1981,7 @@ def _sqlite_graph_stats():
     (non-chroma backend, missing/unbootstrapped palace, sqlite error). The
     reconstruction mirrors ``palace_graph.build_graph`` /
     ``palace_graph.graph_stats`` exactly: a node is a room with a non-empty
-    wing and a usable room name (the catch-all ``"general"`` is excluded), and
+    wing and a usable room name (including the catch-all ``"general"``), and
     edges are the per-hall cross-wing crossings of multi-wing rooms.
     """
     rows = None
@@ -2006,25 +2007,30 @@ def _sqlite_graph_stats():
 
 
 def _graph_stats_from_grouped_rows(rows):
-    """Rebuild ``graph_stats`` from ``(room, wing, hall, n)`` grouped rows.
+    """Rebuild ``graph_stats`` from grouped sqlite metadata rows.
 
-    Backends may append a fifth ``last_date`` column for ``find_tunnels``;
-    stats do not use it, so extra columns are ignored rather than unpacked.
+    Rows are ``(room, wing, hall, n)`` with an optional fifth ``last_date``
+    column. Because grouping includes ``hall``, one room placement can occupy
+    multiple SQL rows; room instances therefore use a distinct ``(wing, room)`` set.
     """
     from collections import Counter, defaultdict
 
     room_data = defaultdict(lambda: {"wings": set(), "halls": set(), "count": 0})
+    room_instances = set()
     for row in rows:
         room, wing, hall, n = row[0], row[1], row[2], row[3]
-        if not room or room == "general" or not wing:
+        if not room or not wing:
             continue
-        node = room_data[room]
-        node["wings"].add(str(wing))
+        room_key = str(room)
+        wing_key = str(wing)
+        room_instances.add((wing_key, room_key))
+        node = room_data[room_key]
+        node["wings"].add(wing_key)
         if hall:
             node["halls"].add(str(hall))
         node["count"] += int(n)
 
-    tunnel_rooms = 0
+    passive_tunnel_rooms = 0
     total_edges = 0
     wing_counts = Counter()
     for data in room_data.values():
@@ -2032,20 +2038,25 @@ def _graph_stats_from_grouped_rows(rows):
         for wing in data["wings"]:
             wing_counts[wing] += 1
         if n_wings >= 2:
-            tunnel_rooms += 1
+            passive_tunnel_rooms += 1
             total_edges += (n_wings * (n_wings - 1) // 2) * len(data["halls"])
 
     top_tunnels = [
         {"room": room, "wings": sorted(data["wings"]), "count": data["count"]}
-        for room, data in sorted(room_data.items(), key=lambda kv: (-len(kv[1]["wings"]), kv[0]))[
-            :10
-        ]
+        for room, data in sorted(
+            room_data.items(), key=lambda item: (-len(item[1]["wings"]), item[0])
+        )[:10]
         if len(data["wings"]) >= 2
     ]
+    explicit_tunnel_count = len(_load_graph_tunnels(_config))
     return {
         "total_rooms": len(room_data),
-        "tunnel_rooms": tunnel_rooms,
+        "total_room_instances": len(room_instances),
+        "tunnel_rooms": passive_tunnel_rooms,
+        "passive_tunnel_rooms": passive_tunnel_rooms,
+        "explicit_tunnels": explicit_tunnel_count,
         "total_edges": total_edges,
+        "total_connections": total_edges + explicit_tunnel_count,
         "rooms_per_wing": dict(wing_counts.most_common()),
         "top_tunnels": top_tunnels,
     }

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -135,7 +135,7 @@ def _nodes_edges_from_grouped_rows(rows):
     for row in rows:
         room, wing, hall, n = row[0], row[1], row[2], row[3]
         last_date = row[4] if len(row) > 4 else ""
-        if not room or room == "general" or not wing:
+        if not room or not wing:
             continue
         node = room_data[str(room)]
         node["wings"].add(str(wing))
@@ -252,7 +252,7 @@ def build_graph(col=None, config=None):
             wing = meta.get("wing", "")
             hall = meta.get("hall", "")
             date = meta.get("date", "")
-            if room and room != "general" and wing:
+            if room and wing:
                 room_data[room]["wings"].add(wing)
                 if hall:
                     room_data[room]["halls"].add(hall)
@@ -409,24 +409,37 @@ def find_tunnels(wing_a: str = None, wing_b: str = None, col=None, config=None):
 
 
 def graph_stats(col=None, config=None):
-    """Summary statistics about the palace graph."""
+    """Summary statistics about the palace graph.
+
+    ``total_rooms`` keeps its historical meaning: unique room-name nodes in
+    the passive graph. ``total_room_instances`` counts distinct (wing, room)
+    placements, which is the number users naturally compare with ``status``.
+    Explicit tunnel records are reported separately so the overview does not
+    silently omit agent-created graph connections.
+    """
     nodes, edges = build_graph(col, config)
 
-    tunnel_rooms = sum(1 for n in nodes.values() if len(n["wings"]) >= 2)
+    passive_tunnel_rooms = sum(1 for n in nodes.values() if len(n["wings"]) >= 2)
+    total_room_instances = sum(len(n["wings"]) for n in nodes.values())
+    explicit_tunnel_count = len(_load_tunnels(config))
     wing_counts = Counter()
     for data in nodes.values():
-        for w in data["wings"]:
-            wing_counts[w] += 1
+        for wing in data["wings"]:
+            wing_counts[wing] += 1
 
     return {
         "total_rooms": len(nodes),
-        "tunnel_rooms": tunnel_rooms,
+        "total_room_instances": total_room_instances,
+        "tunnel_rooms": passive_tunnel_rooms,
+        "passive_tunnel_rooms": passive_tunnel_rooms,
+        "explicit_tunnels": explicit_tunnel_count,
         "total_edges": len(edges),
+        "total_connections": len(edges) + explicit_tunnel_count,
         "rooms_per_wing": dict(wing_counts.most_common()),
         "top_tunnels": [
-            {"room": r, "wings": d["wings"], "count": d["count"]}
-            for r, d in sorted(nodes.items(), key=lambda x: -len(x[1]["wings"]))[:10]
-            if len(d["wings"]) >= 2
+            {"room": room, "wings": data["wings"], "count": data["count"]}
+            for room, data in sorted(nodes.items(), key=lambda item: -len(item[1]["wings"]))[:10]
+            if len(data["wings"]) >= 2
         ],
     }
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1362,12 +1362,12 @@ with mine_palace_lock(sys.argv[1]):
         monkeypatch.setattr(mcp_server, "_get_collection", _no_client_open)
 
         stats = mcp_server.tool_graph_stats()
-        # "general" room and the wing-less drawer are excluded, matching
-        # build_graph's per-drawer filter.
-        assert stats["total_rooms"] == 2
+        # "general" is a real room; the wing-less drawer is still excluded.
+        # Existing tripwires above guarantee the collection/HNSW path stays unopened.
+        assert stats["total_rooms"] == 3
         assert stats["tunnel_rooms"] == 1
         assert stats["total_edges"] == 1
-        assert stats["rooms_per_wing"] == {"wing_code": 2, "wing_project": 1}
+        assert stats["rooms_per_wing"] == {"wing_code": 3, "wing_project": 1}
         assert stats["top_tunnels"] == [
             {"room": "chromadb", "wings": ["wing_code", "wing_project"], "count": 2}
         ]
@@ -7921,3 +7921,40 @@ class TestSearchDateFilters:
         assert "before" in schema["properties"]
         assert schema["properties"]["since"]["type"] == "string"
         assert schema["properties"]["before"]["type"] == "string"
+
+
+def test_2288_grouped_graph_stats_count_distinct_room_instances(monkeypatch):
+    from mempalace import mcp_server
+
+    monkeypatch.setattr(
+        mcp_server,
+        "_load_graph_tunnels",
+        lambda config=None: [{"id": "t1"}, {"id": "t2"}],
+    )
+    rows = [
+        ("fact", "desercion", "facts", 1, "2026-01-01"),
+        ("general", "desercion-pascual", "misc", 1, "2026-01-01"),
+        ("general", "desertion", "misc", 2, "2026-01-02"),
+        # Same placement, different hall: this must not add a room instance.
+        ("general", "desertion", "other", 3, "2026-01-03"),
+        ("heatstgnn-model-selection", "desertion", "models", 1, "2026-01-01"),
+        ("diary", "desertion", "journal", 1, "2026-01-01"),
+        ("general", "matlab-drive", "misc", 1, "2026-01-01"),
+        ("documentation", "octopus", "docs", 1, "2026-01-01"),
+        ("plans", "octopus", "plans", 1, "2026-01-01"),
+        ("controller", "octopus", "control", 1, "2026-01-01"),
+    ]
+    stats = mcp_server._graph_stats_from_grouped_rows(rows)
+
+    assert stats["total_rooms"] == 7
+    assert stats["total_room_instances"] == 9
+    assert stats["tunnel_rooms"] == stats["passive_tunnel_rooms"] == 1
+    assert stats["explicit_tunnels"] == 2
+    assert stats["total_connections"] == stats["total_edges"] + 2
+    assert set(stats["rooms_per_wing"]) == {
+        "desercion",
+        "desercion-pascual",
+        "desertion",
+        "matlab-drive",
+        "octopus",
+    }

--- a/tests/test_palace_graph.py
+++ b/tests/test_palace_graph.py
@@ -113,14 +113,15 @@ class TestBuildGraph:
         assert edges[0]["wing_b"] == "wing_project"
         assert edges[0]["hall"] == "databases"
 
-    def test_general_room_excluded(self):
+    def test_general_room_included(self):
         col = _make_fake_collection(
             [
                 {"room": "general", "wing": "wing_code", "hall": "misc", "date": ""},
             ]
         )
         nodes, edges = build_graph(col=col)
-        assert "general" not in nodes
+        assert "general" in nodes
+        assert nodes["general"]["wings"] == ["wing_code"]
 
     def test_missing_wing_excluded(self):
         col = _make_fake_collection(
@@ -356,3 +357,54 @@ class TestSqliteGroupedCountsReader:
         (palace / "chroma.sqlite3").write_bytes(self.MAGIC)
         (palace / "sqlite_exact.sqlite3").write_bytes(self.MAGIC)
         assert sqlite_grouped_counts_reader(self._config(str(palace))) is None
+
+
+def test_2288_grouped_general_room_is_not_filtered():
+    from mempalace.palace_graph import _nodes_edges_from_grouped_rows
+
+    nodes, edges = _nodes_edges_from_grouped_rows(
+        [
+            ("general", "wing_a", "hall_one", 2, "2026-01-01"),
+            ("general", "wing_a", "hall_two", 3, "2026-01-02"),
+            ("general", "wing_b", "hall_one", 1, "2026-01-03"),
+        ]
+    )
+    assert nodes["general"]["wings"] == ["wing_a", "wing_b"]
+    assert nodes["general"]["halls"] == ["hall_one", "hall_two"]
+    assert nodes["general"]["count"] == 6
+    assert len(edges) == 2
+
+
+def test_2288_graph_stats_preserve_room_names_and_count_room_instances():
+    invalidate_graph_cache()
+    col = _make_fake_collection(
+        [
+            {"room": "fact", "wing": "desercion"},
+            {"room": "general", "wing": "desercion-pascual"},
+            {"room": "general", "wing": "desertion"},
+            {"room": "heatstgnn-model-selection", "wing": "desertion"},
+            {"room": "diary", "wing": "desertion"},
+            {"room": "general", "wing": "matlab-drive"},
+            {"room": "documentation", "wing": "octopus"},
+            {"room": "plans", "wing": "octopus"},
+            {"room": "controller", "wing": "octopus"},
+        ]
+    )
+    with patch.dict(
+        graph_stats.__globals__,
+        {"_load_tunnels": lambda config=None: [{"id": "t1"}, {"id": "t2"}]},
+    ):
+        stats = graph_stats(col=col)
+
+    assert stats["total_rooms"] == 7
+    assert stats["total_room_instances"] == 9
+    assert stats["tunnel_rooms"] == stats["passive_tunnel_rooms"] == 1
+    assert stats["explicit_tunnels"] == 2
+    assert stats["total_connections"] == stats["total_edges"] + 2
+    assert set(stats["rooms_per_wing"]) == {
+        "desercion",
+        "desercion-pascual",
+        "desertion",
+        "matlab-drive",
+        "octopus",
+    }


### PR DESCRIPTION
Closes #2260.

`build_graph()` and the newer grouped-SQL graph fast paths were discarding every drawer/group whose room was named `general`. That makes wings represented only by `general` disappear from graph reporting and under-counts mixed wings.

This rework follows the maintainer guidance on the current read-path architecture and applies the same room-preservation rule in all three places:

- `mempalace/palace_graph.py` — client-paging `build_graph()` path;
- `mempalace/palace_graph.py` — grouped `_nodes_edges_from_grouped_rows()` path used by sqlite-backed graph reads;
- `mempalace/mcp_server.py` — grouped `_graph_stats_from_grouped_rows()` MCP fast path.

The reporting contract stays backwards-compatible while making placement counts explicit:

- include `general` as a real room node instead of discarding it;
- keep `total_rooms` as the historical count of unique room-name nodes;
- add `total_room_instances` for distinct `(wing, room)` placements;
- count grouped-SQL room instances with an actual distinct `(wing, room)` set, so the same placement appearing under multiple halls is not over-counted;
- keep `tunnel_rooms` and `total_edges` semantics intact;
- add `passive_tunnel_rooms` as the clearer alias;
- report `explicit_tunnels` from the existing tunnel sidecar;
- add `total_connections = total_edges + explicit_tunnels`.

The sqlite fast-path contract is preserved: existing tripwire coverage still fails if graph stats open the collection/HNSW path. Regression tests cover both the client path and grouped path, including a repeated `(wing, room)` across different halls.

Validation of the four feature/test files:

- `python -m pytest -q tests/test_palace_graph.py tests/test_palace_graph_tunnels.py` — **82 passed**
- `python -m pytest -q tests/test_mcp_server.py -k 'graph_stats or tunnel or 2288'` — **7 passed, 367 deselected**
- `ruff check mempalace/palace_graph.py mempalace/mcp_server.py tests/test_palace_graph.py tests/test_mcp_server.py` — **passed**
- `ruff format --check ...` — **4 files already formatted**
- `python -m compileall -q ...` — **passed**

Those tests ran on `develop` at `fe8e748`. While validation was running, `develop` advanced to `3e56979` for the 3.8.0 release. The intervening commits modify only release/version/workflow/docs files and do not touch any of the four files in this PR, so the validated blobs were transplanted unchanged onto `3e56979`.

Final branch shape:

- one clean commit on current `develop`;
- 1 ahead / 0 behind at rebase time;
- only four changed files:
  - `mempalace/palace_graph.py`
  - `mempalace/mcp_server.py`
  - `tests/test_palace_graph.py`
  - `tests/test_mcp_server.py`
