### PR TITLE
mcp: release idle writer lease so peer sessions can write

### DIFF
--- a/deploy/server.env.example
+++ b/deploy/server.env.example
@@ -30,6 +30,12 @@ MEMPALACE_EMBEDDING_DEVICE=auto
 # /healthz traffic does not count as activity; only MCP requests reset the timer.
 MEMPALACE_MCP_IDLE_HOURS=0
 
+# A separate watchdog releases an MCP writer lease after this many minutes
+# without a completed mutating call (default 10), while leaving the server
+# running. Set 0 only when this process is the intentional sole writer and all
+# writes are routed through it.
+# MEMPALACE_MCP_WRITER_IDLE_MINUTES=10
+
 # --- Palace location (systemd / bare-metal) -------------------------------------
 # In Docker the palace lives on the mempalace-data volume by default.
 # MEMPALACE_PALACE_PATH=/var/lib/mempalace/palace

--- a/docs/write-routing-policy.md
+++ b/docs/write-routing-policy.md
@@ -182,6 +182,18 @@ that topology and the client uses its local path, where the writer lease still
 applies. Configure those clients to use the HTTP server explicitly, or run the
 server and local forwarders under the same account.
 
+Hook diary checkpoints still write directly on a server machine. `mempalace
+mine` forwards a hook-spawned transcript ingest to a live server, but the
+session-end checkpoint writes ChromaDB in process through
+`_save_diary_direct`, and the hook entry points read no server registry. Every
+session end therefore opens the server's palace from a second process. That is
+the direct hook write the routing rules above tell you not to run beside a
+writable owner. The palace lock does not observe it, because the checkpoint
+takes no writer lease. The contention appears at the SQLite layer, where a
+checkpoint that wedges mid-write holds the write lock that the server's next
+request needs. Until the checkpoint forwards the way the mine already does,
+treat a session end on a server machine as a second writer.
+
 For a filesystem-level backup of a palace owned by an always-on service, stop
 the service, capture the complete palace, then restart the service and verify
 it. Do not make the backup conditional on `pgrep` finding no process under the

--- a/docs/write-routing-policy.md
+++ b/docs/write-routing-policy.md
@@ -117,11 +117,13 @@ enough because each long-lived process can retain SQLite/WAL, FTS, or vector
 index state between calls.
 
 - A writable daemon owns the palace writer lease for its full lifetime.
-- Writable MCP HTTP acquires that lease before binding, holds it through the
-  full serving lifetime, and releases it after active requests stop.
+- Writable MCP HTTP acquires that lease before binding. It releases the lease
+  after a configurable write-idle period and reacquires it on the next
+  mutating request.
 - MCP stdio opens `sqlite_exact` read-only until it acquires the writer lease.
   It may therefore coexist for reads; mutating tools refuse while another
-  process owns the lease and reopen writable storage after that owner exits.
+  process owns the lease. A server that owns the lease releases it after the
+  same write-idle period and reacquires it when it next needs to write.
 - Read-only MCP HTTP may coexist with the writer.
 - Read-only `sqlite_exact` clients use an immutable connection for a clean
   checkpointed database, or `mode=ro` when an active writer's complete WAL
@@ -144,6 +146,48 @@ Do not delete or unlink a live palace lock to recover ownership. Stop the
 owning process cleanly; the operating system releases its lock automatically.
 If corruption is suspected, back up the palace and run integrity/repair
 operations offline, with no writable service running.
+
+### Idle MCP writer lease release
+
+The stdio and HTTP MCP transports start a writer-idle watchdog. When no
+mutating tool has completed for 10 minutes, and no storage-touching request is
+in flight, the watchdog closes this process's storage handles and releases its
+writer lease. The next mutating request tries to acquire the lease again. It
+continues normally if the lease is free, or returns the peer-writer refusal if
+another process acquired it during the idle gap.
+
+Configure the threshold with `MEMPALACE_MCP_WRITER_IDLE_MINUTES`. The default
+is `10`; `0` disables idle release and restores hold-until-exit behavior. An
+unparseable value uses the 10-minute default, and a negative value is treated
+as `0`.
+
+This watchdog is independent of `MEMPALACE_MCP_IDLE_HOURS`. Setting the
+process idle timeout to `0` keeps an MCP server running, but does not disable
+writer-lease release. This separation lets an always-on server remain
+available without keeping local peers read-only while it is not writing.
+
+### Prefer one server where you control the deployment
+
+Where every client can use HTTP, prefer one `mempalace serve` process as the
+palace's writer. Concurrent client requests then serialize inside one process
+instead of moving the writer lease between processes. The systemd template is
+[`deploy/mempalace-server.service`](../deploy/mempalace-server.service).
+
+Local stdio clients and compatible CLI operations can discover that server
+through the per-palace registry in `~/.mempalace/server/<key>/`. The registry
+and its bearer token live under the current operating-system user's home. A
+server running under a dedicated service account therefore does not publish a
+registry that a human user's local clients can see. Discovery fails quietly in
+that topology and the client uses its local path, where the writer lease still
+applies. Configure those clients to use the HTTP server explicitly, or run the
+server and local forwarders under the same account.
+
+For a filesystem-level backup of a palace owned by an always-on service, stop
+the service, capture the complete palace, then restart the service and verify
+it. Do not make the backup conditional on `pgrep` finding no process under the
+service account: an always-on server makes that condition permanently false,
+so the backup would be skipped every time. Networked backends should use their
+backend-native snapshot procedure.
 
 ## Follow-up PRs
 

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -615,12 +615,13 @@ def _mine_args_forwardable(args, include_ignored) -> bool:
 def _forward_mine_to_hub(args, palace_path: str) -> bool:
     """Run this mine inside the palace's HTTP hub, if one is alive.
 
-    A long-lived hub (``mempalace serve``) holds the MCP writer lease for
-    its whole lifetime, so a direct mine from this process — including the
-    background save hooks, which spawn exactly this CLI — would be refused
-    and transcript capture would silently stop on the hub machine. The hub
-    itself may mine (the palace lock is process-re-entrant there, #1859),
-    so the fix is to hand it the job over HTTP.
+    A live hub (``mempalace serve``) is the intended writer for its palace. A
+    direct mine from this process — including the background save hooks, which
+    spawn exactly this CLI — would either be refused while the hub owns the
+    lease or take ownership after the hub releases an idle lease. Forwarding
+    keeps one process authoritative and avoids making the hub reacquire on its
+    next write. The hub itself may mine (the palace lock is process-re-entrant
+    there, #1859), so the job is handed to it over HTTP.
 
     Returns True when the hub handled the mine (this function has already
     printed the outcome and exited non-zero on failure). Returns False when

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -406,9 +406,11 @@ _STARTUP_INTEGRITY_MAX_MB_DEFAULT = 512.0
 #
 # The existing per-operation palace lock serializes individual writes, but it
 # cannot make another long-lived Chroma PersistentClient forget stale in-memory
-# HNSW/FTS state. Hold the same per-palace mine lock for this MCP process
-# lifetime. A peer MCP process can still serve read tools, but mutating tools
-# refuse before touching Chroma or the knowledge graph.
+# HNSW/FTS state. Acquire the same per-palace mine lock as a process-scoped
+# lease. The idle-release watchdog may drop it after a write-idle gap, and the
+# next mutating call reacquires it. While the lease is held, a peer MCP process
+# can still serve read tools, but mutating tools refuse before touching Chroma
+# or the knowledge graph.
 _MCP_WRITER_LOCK_CM = None
 _MCP_WRITER_READ_ONLY = False
 _MCP_WRITER_LOCK_FAILED = False
@@ -418,9 +420,9 @@ _MCP_ALLOW_PEER_WRITER_ENV = "MEMPALACE_MCP_ALLOW_PEER_WRITER"
 
 # Writer-lease idle release (fork patch 2026-08-19; upstream candidate).
 #
-# The lease above is otherwise held for the life of the process, so an
-# orphaned-but-alive stdio server (client machine rebooted; tailscale SSH
-# never delivered EOF) keeps every peer session read-only for hours
+# Without the watchdog, the lease above is held for the life of the process,
+# so an orphaned-but-alive stdio server (client machine rebooted; tailscale
+# SSH never delivered EOF) keeps every peer session read-only for hours
 # (observed twice on 2026-08-19). Acquisition is already self-healing per
 # mutating call, so the lease can be dropped whenever this process has not
 # written for a while: the next mutating call transparently re-acquires.

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -416,6 +416,22 @@ _MCP_WRITER_LOCK_ERROR = ""
 _MCP_WRITER_ATEXIT_REGISTERED = False
 _MCP_ALLOW_PEER_WRITER_ENV = "MEMPALACE_MCP_ALLOW_PEER_WRITER"
 
+# Writer-lease idle release (fork patch 2026-08-19; upstream candidate).
+#
+# The lease above is otherwise held for the life of the process, so an
+# orphaned-but-alive stdio server (client machine rebooted; tailscale SSH
+# never delivered EOF) keeps every peer session read-only for hours
+# (observed twice on 2026-08-19). Acquisition is already self-healing per
+# mutating call, so the lease can be dropped whenever this process has not
+# written for a while: the next mutating call transparently re-acquires.
+# The in-flight counter stops the watchdog from releasing (and closing
+# storage handles) under a running chroma-touching request.
+_MCP_WRITER_IDLE_MINUTES_ENV = "MEMPALACE_MCP_WRITER_IDLE_MINUTES"
+_MCP_WRITER_IDLE_MINUTES_DEFAULT = 10.0
+_MCP_WRITER_STATE_LOCK = threading.RLock()
+_MCP_WRITER_INFLIGHT = 0
+_last_mutating_time: float = time.monotonic()
+
 _MUTATING_TOOLS = frozenset(
     {
         "mempalace_kg_add",
@@ -690,6 +706,12 @@ def _discard_mcp_storage_handles() -> None:
 
 
 def _release_mcp_writer_lock() -> None:
+    """Thread-safe wrapper: release under _MCP_WRITER_STATE_LOCK."""
+    with _MCP_WRITER_STATE_LOCK:
+        _release_mcp_writer_lock_unlocked()
+
+
+def _release_mcp_writer_lock_unlocked() -> None:
     """Close writable handles and release this process's palace lease."""
 
     global _MCP_WRITER_LOCK_CM, _MCP_WRITER_READ_ONLY
@@ -709,6 +731,12 @@ def _release_mcp_writer_lock() -> None:
 
 
 def _acquire_mcp_writer_lock() -> tuple[bool, str]:
+    """Thread-safe wrapper: acquire under _MCP_WRITER_STATE_LOCK."""
+    with _MCP_WRITER_STATE_LOCK:
+        return _acquire_mcp_writer_lock_unlocked()
+
+
+def _acquire_mcp_writer_lock_unlocked() -> tuple[bool, str]:
     """Acquire this process's per-palace MCP writer lease.
 
     Returns (True, "") when this process may write. Returns (False, reason)
@@ -788,6 +816,8 @@ def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     _MCP_WRITER_READ_ONLY = False
     _MCP_WRITER_LOCK_FAILED = False
     _MCP_WRITER_LOCK_ERROR = ""
+    global _last_mutating_time
+    _last_mutating_time = time.monotonic()
     return True, ""
 
 
@@ -804,7 +834,10 @@ def _mcp_peer_writer_refusal(req_id, tool_name: str):
         "id": req_id,
         "error": {
             "code": -32001,
-            "message": "Peer MCP writer active; this server is read-only for mutating tools",
+            "message": (
+                "Peer MCP writer active; this server is read-only for mutating tools"
+                + (f" [{reason}]" if reason else "")
+            ),
             "data": {
                 "tool": tool_name,
                 "palace": _config.palace_path,
@@ -6630,7 +6663,7 @@ def handle_request(request):
             if "entry" not in tool_args or tool_args["entry"] is None:
                 tool_args["entry"] = content_val
         try:
-            with _write_stall_watch(tool_name):
+            with _writer_inflight(tool_name), _write_stall_watch(tool_name):
                 result = _decorate_mcp_tool_result(
                     tool_name, TOOLS[tool_name]["handler"](**tool_args)
                 )
@@ -6980,6 +7013,81 @@ def _start_write_stall_watchdog() -> None:
                 os._exit(_WRITE_STALL_EXIT_CODE)
 
     t = threading.Thread(target=_watchdog, name="mcp-write-stall-watchdog", daemon=True)
+    t.start()
+
+
+def _writer_idle_release_secs() -> float:
+    """Writer-lease idle-release threshold in seconds (0 = disabled)."""
+    raw = os.environ.get(_MCP_WRITER_IDLE_MINUTES_ENV, "")
+    if raw:
+        try:
+            minutes = float(raw)
+        except ValueError:
+            return _MCP_WRITER_IDLE_MINUTES_DEFAULT * 60
+        return max(0.0, minutes) * 60
+    return _MCP_WRITER_IDLE_MINUTES_DEFAULT * 60
+
+
+@contextlib.contextmanager
+def _writer_inflight(tool_name: str):
+    """Track chroma-touching tool calls so the idle-release watchdog never
+    drops the writer lease (and its storage handles) under a running call.
+
+    Counts every tool except the logstream set (own sqlite database, exempt
+    from the lease); only completed calls to _MUTATING_TOOLS refresh the
+    write-idle clock."""
+    global _MCP_WRITER_INFLIGHT, _last_mutating_time
+    if tool_name in _HTTP_LOCK_FREE_TOOLS:
+        yield
+        return
+    with _MCP_WRITER_STATE_LOCK:
+        _MCP_WRITER_INFLIGHT += 1
+    try:
+        yield
+    finally:
+        with _MCP_WRITER_STATE_LOCK:
+            _MCP_WRITER_INFLIGHT -= 1
+            if tool_name in _MUTATING_TOOLS:
+                _last_mutating_time = time.monotonic()
+
+
+def _maybe_release_idle_writer(idle_secs: float) -> bool:
+    """Release the writer lease if held, write-idle past idle_secs, and no
+    chroma-touching call is in flight. Returns True when released."""
+    with _MCP_WRITER_STATE_LOCK:
+        if _MCP_WRITER_LOCK_CM is None or _MCP_WRITER_INFLIGHT > 0:
+            return False
+        idle = time.monotonic() - _last_mutating_time
+        if idle < idle_secs:
+            return False
+        logger.info(
+            "writer lease idle for %.1f min (limit %.1f min); releasing so "
+            "peer sessions can write.",
+            idle / 60,
+            idle_secs / 60,
+        )
+        _release_mcp_writer_lock_unlocked()
+        return True
+
+
+def _start_writer_idle_release_watchdog() -> None:
+    """Drop an idle writer lease so peer sessions stop seeing read-only
+    refusals. Set MEMPALACE_MCP_WRITER_IDLE_MINUTES=0 to disable (pre-patch
+    behavior: lease held until process exit)."""
+    timeout = _writer_idle_release_secs()
+    if timeout <= 0:
+        return
+    check_interval = min(30.0, timeout / 4)
+
+    def _watchdog() -> None:
+        while True:
+            time.sleep(check_interval)
+            try:
+                _maybe_release_idle_writer(timeout)
+            except Exception:
+                logger.exception("writer idle-release check failed")
+
+    t = threading.Thread(target=_watchdog, name="mcp-writer-idle-release", daemon=True)
     t.start()
 
 
@@ -8243,6 +8351,7 @@ def _run_stdio_loop() -> None:
     # Idle auto-exit: release ChromaDB file handles from stale servers
     # that outlived their Claude Code session (#1552).
     _start_idle_exit_watchdog()
+    _start_writer_idle_release_watchdog()
 
     # Say so when a chromadb write stops coming back, from a thread the stuck
     # call is not blocking.
@@ -8321,6 +8430,7 @@ def _run_http_loop() -> None:
         # soon as the process is alive.
         _refresh_vector_disabled_flag()
         _start_idle_exit_watchdog()
+        _start_writer_idle_release_watchdog()
         _start_write_stall_watchdog()
 
         raw_warmup = os.environ.get("MEMPALACE_EAGER_WARMUP", "").strip().lower()

--- a/mempalace/server_registry.py
+++ b/mempalace/server_registry.py
@@ -1,13 +1,13 @@
 """Per-palace discovery registry for the MemPalace HTTP MCP hub.
 
 ``mempalace serve`` (and ``mempalace-mcp --transport http``) is meant to be
-the single long-lived writer for a shared palace: once it performs its first
-mutating tool call it holds the per-palace MCP writer lease (#1818) for its
-whole lifetime, and every other process is refused palace writes. That is
-correct for agents — they talk to the hub — but the background save hooks
-and the plain CLI still spawn short-lived ``mempalace mine`` processes,
-which would be refused while a hub is up and silently stop transcript
-capture on the hub machine.
+the single long-lived writer for a shared palace. It acquires the per-palace
+MCP writer lease (#1818), may release it after a configured write-idle gap,
+and reacquires it on the next mutating call. Agents talk to the hub, but the
+background save hooks and the plain CLI still spawn short-lived
+``mempalace mine`` processes. Without forwarding, those processes are refused
+while the hub owns the lease or may take an idle lease and force the hub to
+reacquire later.
 
 This module gives those local processes a way to find the hub instead of
 fighting it: the HTTP transport records ``{pid, host, port, scheme,

--- a/tests/test_mcp_writer_idle_release.py
+++ b/tests/test_mcp_writer_idle_release.py
@@ -1,0 +1,100 @@
+"""Writer-lease idle release (fork patch 2026-08-19).
+
+The lease is dropped by a watchdog after a period with no completed mutating
+call, so an orphaned-but-alive stdio server cannot keep peer sessions
+read-only. These tests exercise the release decision and the in-flight
+guard directly; the acquire path's self-healing retry is covered by the
+existing peer-writer tests.
+"""
+
+import time
+
+import mempalace.mcp_server as m
+
+
+class _FakeLockCM:
+    def __init__(self):
+        self.exited = False
+
+    def __exit__(self, *args):
+        self.exited = True
+
+
+def _hold_lease(monkeypatch):
+    cm = _FakeLockCM()
+    monkeypatch.setattr(m, "_MCP_WRITER_LOCK_CM", cm)
+    monkeypatch.setattr(m, "_MCP_WRITER_INFLIGHT", 0)
+    monkeypatch.setattr(m, "_discard_mcp_storage_handles", lambda: None)
+    return cm
+
+
+def test_releases_lease_idle_past_threshold(monkeypatch):
+    cm = _hold_lease(monkeypatch)
+    monkeypatch.setattr(m, "_last_mutating_time", time.monotonic() - 3600)
+    assert m._maybe_release_idle_writer(600) is True
+    assert m._MCP_WRITER_LOCK_CM is None
+    assert cm.exited
+
+
+def test_keeps_lease_within_threshold(monkeypatch):
+    cm = _hold_lease(monkeypatch)
+    monkeypatch.setattr(m, "_last_mutating_time", time.monotonic())
+    assert m._maybe_release_idle_writer(600) is False
+    assert m._MCP_WRITER_LOCK_CM is cm
+    assert not cm.exited
+
+
+def test_keeps_lease_with_inflight_call(monkeypatch):
+    cm = _hold_lease(monkeypatch)
+    monkeypatch.setattr(m, "_last_mutating_time", time.monotonic() - 3600)
+    monkeypatch.setattr(m, "_MCP_WRITER_INFLIGHT", 1)
+    assert m._maybe_release_idle_writer(600) is False
+    assert m._MCP_WRITER_LOCK_CM is cm
+    assert not cm.exited
+
+
+def test_noop_without_lease(monkeypatch):
+    monkeypatch.setattr(m, "_MCP_WRITER_LOCK_CM", None)
+    monkeypatch.setattr(m, "_MCP_WRITER_INFLIGHT", 0)
+    assert m._maybe_release_idle_writer(600) is False
+
+
+def test_inflight_counter_and_mutating_clock(monkeypatch):
+    monkeypatch.setattr(m, "_MCP_WRITER_INFLIGHT", 0)
+    before = time.monotonic() - 999
+    monkeypatch.setattr(m, "_last_mutating_time", before)
+    mutating = sorted(m._MUTATING_TOOLS - m._HTTP_LOCK_FREE_TOOLS)[0]
+    with m._writer_inflight(mutating):
+        assert m._MCP_WRITER_INFLIGHT == 1
+    assert m._MCP_WRITER_INFLIGHT == 0
+    assert m._last_mutating_time > before
+
+
+def test_read_tool_counts_inflight_but_not_clock(monkeypatch):
+    monkeypatch.setattr(m, "_MCP_WRITER_INFLIGHT", 0)
+    before = time.monotonic() - 999
+    monkeypatch.setattr(m, "_last_mutating_time", before)
+    read_tool = "mempalace_search"
+    assert read_tool not in m._MUTATING_TOOLS
+    with m._writer_inflight(read_tool):
+        assert m._MCP_WRITER_INFLIGHT == 1
+    assert m._MCP_WRITER_INFLIGHT == 0
+    assert m._last_mutating_time == before
+
+
+def test_lock_free_tool_skips_counter(monkeypatch):
+    monkeypatch.setattr(m, "_MCP_WRITER_INFLIGHT", 0)
+    tool = sorted(m._HTTP_LOCK_FREE_TOOLS)[0]
+    with m._writer_inflight(tool):
+        assert m._MCP_WRITER_INFLIGHT == 0
+
+
+def test_idle_secs_env_parsing(monkeypatch):
+    monkeypatch.setenv(m._MCP_WRITER_IDLE_MINUTES_ENV, "5")
+    assert m._writer_idle_release_secs() == 300
+    monkeypatch.setenv(m._MCP_WRITER_IDLE_MINUTES_ENV, "0")
+    assert m._writer_idle_release_secs() == 0
+    monkeypatch.setenv(m._MCP_WRITER_IDLE_MINUTES_ENV, "lixo")
+    assert m._writer_idle_release_secs() == m._MCP_WRITER_IDLE_MINUTES_DEFAULT * 60
+    monkeypatch.delenv(m._MCP_WRITER_IDLE_MINUTES_ENV)
+    assert m._writer_idle_release_secs() == m._MCP_WRITER_IDLE_MINUTES_DEFAULT * 60


### PR DESCRIPTION
## Problem

The per-palace MCP writer lease (#1818) is acquired on the first mutating call and held for the life of the process. A stdio server whose client died without delivering EOF (client machine reboot; the SSH transport kept the connection half-open) keeps the lease indefinitely, so every peer session gets `-32001 Peer MCP writer active` for hours; the idle-exit watchdog (#1552) only reaps it after 8 h by default. Observed twice in one day on a multi-session deployment sharing one palace over SSH stdio.

## Change

- A new watchdog releases the writer lease after `MEMPALACE_MCP_WRITER_IDLE_MINUTES` (default 10, `0` disables) without a completed mutating call. `_acquire_mcp_writer_lock` already re-attempts the non-blocking flock on every mutating call, so the next write from any process (this one included) re-acquires transparently — no restart, no reconnect.
- An in-flight counter over chroma-touching tool calls (everything except the logstream set) guarantees the release never closes storage handles under a running request. Only completed mutating calls refresh the write-idle clock; lease promotion also refreshes it, so a lease cannot be dropped between preflight and dispatch.
- Acquire/release now run under one shared RLock, since release can now fire from the watchdog thread.
- The `-32001` refusal message now includes the holder identity (`data.reason` already carried it; most MCP clients only surface `message`).

## Testing

- 8 new unit tests (`tests/test_mcp_writer_idle_release.py`): release decision, in-flight guard, clock semantics, env parsing.
- Existing `test_palace_locks.py`, `test_vector_write_gate.py`, `test_mcp_http_transport.py` pass (84 total).
- Live integration on a scratch palace: two real stdio servers with a 3 s threshold — A writes and holds; B is refused while A holds (negative control); after A idles, B writes fine; A is refused while B holds; after B idles, A re-acquires. 5/5.
