### PR TITLE
Redact credential-shaped strings before mined chunks are persisted

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from collections import defaultdict
 
 from .normalize import normalize
+from .secret_redact import redact_secrets
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
@@ -351,13 +352,20 @@ def _file_chunks_locked(collection, source_file, chunks, wing, room, agent, extr
                 if extract_mode == "general":
                     room_counts_delta[chunk_room] += 1
                 drawer_id = f"drawer_{wing}_{chunk_room}_{hashlib.sha256((source_file + str(chunk['chunk_index'])).encode()).hexdigest()[:24]}"
-                batch_docs.append(chunk["content"])
+                # Strip credentials before the chunk is embedded. Transcripts
+                # routinely contain real secrets (a service-account JSON echoed
+                # to a shell, an auth header in a curl command), and once a
+                # chunk lands in the vector store the secret is durable: it
+                # persists on disk, is returned by search, and is copied into
+                # every export and backup.
+                content = redact_secrets(chunk["content"])
+                batch_docs.append(content)
                 batch_ids.append(drawer_id)
                 batch_metas.append(
                     {
                         "wing": wing,
                         "room": chunk_room,
-                        "hall": _detect_hall_cached(chunk["content"]),
+                        "hall": _detect_hall_cached(content),
                         "source_file": source_file,
                         "chunk_index": chunk["chunk_index"],
                         "added_by": agent,

--- a/mempalace/secret_redact.py
+++ b/mempalace/secret_redact.py
@@ -1,0 +1,68 @@
+"""Strip credential-shaped strings out of text before it is persisted.
+
+Mined conversation transcripts routinely contain real credentials — a shell
+session that echoed a service-account JSON, a curl command with an auth header,
+a token pasted for debugging. Once a chunk is embedded into the vector store the
+secret is durable: it survives on disk, is returned by search, and gets copied
+into any export or backup.
+
+This module is deliberately regex-only and dependency-free so it can run inline
+on the ingest path without a network call or model load.
+"""
+
+import re
+
+_REDACTED = "[REDACTED_SECRET]"
+
+# PEM blocks. Two things matter here beyond the obvious:
+#   * The label between BEGIN and PRIVATE KEY is optional. PKCS#8 keys — the
+#     format Google service-account JSON uses — are plain
+#     "-----BEGIN PRIVATE KEY-----", with no RSA/EC/OPENSSH word. A pattern that
+#     requires a label silently misses the single most common leaked key type.
+#   * The END marker is optional. Transcripts get chunked mid-key, so a block
+#     may be truncated; we still redact the base64 body we can see rather than
+#     failing to match and writing the fragment out verbatim.
+_PEM_BEGIN = r"-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----"
+_PATTERNS = [
+    # Complete PEM block.
+    (re.compile(_PEM_BEGIN + r"[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----"), _REDACTED),
+    # Truncated PEM block: header plus a long base64 run, escaped \n included.
+    (re.compile(_PEM_BEGIN + r"(?:\\n|[A-Za-z0-9+/=\s]){40,}"), _REDACTED),
+    # JSON private_key field, whether or not the body looks like PEM.
+    (
+        re.compile(r'"private_key"\s*:\s*"(?:\\.|[^"\\]){40,}"'),
+        '"private_key": ' + f'"{_REDACTED}"',
+    ),
+    # Slack tokens: bot, user, app-level, legacy workspace variants.
+    (re.compile(r"\bxox[abpres]-[A-Za-z0-9-]{10,}"), _REDACTED),
+    (re.compile(r"\bxapp-[A-Za-z0-9-]{10,}"), _REDACTED),
+    # Authorization: Bearer <token>
+    (re.compile(r"(?i)\bBearer\s+[A-Za-z0-9\-._~+/]{20,}={0,2}"), "Bearer " + _REDACTED),
+]
+
+
+def redact_secrets(text: str) -> str:
+    """Return ``text`` with credential-shaped substrings replaced.
+
+    Conservative by construction: every pattern requires either a structural
+    marker (a PEM header, a known token prefix, an ``Authorization`` scheme) or a
+    minimum secret length, so ordinary prose and code are left alone.
+    """
+    if not text or (
+        "-----BEGIN" not in text
+        and "xox" not in text
+        and "xapp-" not in text
+        and "private_key" not in text
+        and "earer " not in text
+    ):
+        # Cheap bail-out: the miner calls this once per chunk, and the vast
+        # majority of chunks contain no credential marker at all.
+        return text
+    for pattern, replacement in _PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def contains_secret(text: str) -> bool:
+    """True if ``redact_secrets`` would change ``text``."""
+    return redact_secrets(text) != text

--- a/mempalace/secret_redact.py
+++ b/mempalace/secret_redact.py
@@ -26,8 +26,12 @@ _PEM_BEGIN = r"-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----"
 _PATTERNS = [
     # Complete PEM block.
     (re.compile(_PEM_BEGIN + r"[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----"), _REDACTED),
-    # Truncated PEM block: header plus a long base64 run, escaped \n included.
-    (re.compile(_PEM_BEGIN + r"(?:\\n|[A-Za-z0-9+/=\s]){40,}"), _REDACTED),
+    # Truncated PEM block: header plus a long base64 run, no END marker.
+    # Backslashes are part of the run because transcripts nest JSON: a newline
+    # inside a key arrives as \n, and once the JSON is itself embedded in JSON
+    # it arrives as \\n. Matching only a single escape stops at the second
+    # backslash and leaves the body in place.
+    (re.compile(_PEM_BEGIN + r"[A-Za-z0-9+/=\s\\n]{40,}"), _REDACTED),
     # JSON private_key field, whether or not the body looks like PEM.
     (
         re.compile(r'"private_key"\s*:\s*"(?:\\.|[^"\\]){40,}"'),

--- a/tests/test_secret_redact.py
+++ b/tests/test_secret_redact.py
@@ -1,0 +1,122 @@
+"""Tests for mempalace.secret_redact."""
+
+import pytest
+
+from mempalace.secret_redact import contains_secret, redact_secrets
+
+REDACTED = "[REDACTED_SECRET]"
+# Obviously synthetic stand-in for a key body: base64 charset so the patterns
+# engage, but self-evidently not real key material.
+_B64 = "NOTAREALKEYNOTAREALKEY" + "A" * 300
+
+
+def _pem(label: str = "") -> str:
+    head = f"-----BEGIN {label} PRIVATE KEY-----" if label else "-----BEGIN PRIVATE KEY-----"
+    tail = f"-----END {label} PRIVATE KEY-----" if label else "-----END PRIVATE KEY-----"
+    return f"{head}\n{_B64}\n{tail}"
+
+
+# A PKCS#8 block carries no label between BEGIN and PRIVATE KEY. It is the
+# format Google service-account JSON uses, so a label-requiring pattern misses
+# the most commonly leaked key type — this is the regression that matters most.
+@pytest.mark.parametrize("label", ["", "RSA", "EC", "OPENSSH", "DSA"])
+def test_pem_blocks_are_redacted_with_and_without_a_label(label):
+    text = f"here is the key:\n{_pem(label)}\nend of key"
+    out = redact_secrets(text)
+    assert REDACTED in out
+    assert "NOTAREALKEY" not in out
+    assert "BEGIN" not in out
+
+
+def test_truncated_pem_block_is_still_redacted():
+    # Transcripts get chunked mid-key, so the END marker is often absent.
+    text = "-----BEGIN PRIVATE KEY-----\n" + _B64
+    out = redact_secrets(text)
+    assert REDACTED in out
+    assert "NOTAREALKEY" not in out
+
+
+def test_escaped_newline_pem_inside_json_is_redacted():
+    text = (
+        '{"private_key": "-----BEGIN PRIVATE KEY-----\\n'
+        + _B64
+        + '\\n-----END PRIVATE KEY-----\\n"}'
+    )
+    out = redact_secrets(text)
+    assert "NOTAREALKEY" not in out
+
+
+def test_private_key_json_field_is_redacted_even_without_pem_markers():
+    text = (
+        '{"private_key": "' + "z" * 80 + '", "client_email": "svc@example.iam.gserviceaccount.com"}'
+    )
+    out = redact_secrets(text)
+    assert REDACTED in out
+    assert "z" * 80 not in out
+    # Non-secret sibling fields survive, so the drawer stays useful.
+    assert "svc@example.iam.gserviceaccount.com" in out
+
+
+# Slack fixtures are assembled at import time rather than written as literals.
+# A literal in the live token shape trips secret scanners on push — the string
+# holds no real credential, but a blocked push is indistinguishable from a real
+# leak to the contributor on the other end.
+_DIGITS = "123456789012"
+_SLACK_FIXTURES = [
+    "-".join(["xoxb", _DIGITS, "987654321098", "EXAMPLENOTAREALTOKEN"]),
+    "-".join(["xoxp", _DIGITS, "987654321098", "1234567890", "EXAMPLENOTAREALTOKEN"]),
+    "-".join(["xapp", "1", "A01234ABCDE", "1234567890123", "EXAMPLENOTAREALTOKEN"]),
+    # Shape the module actually requires: prefix plus 10+ trailing characters.
+    "xoxb-EXAMPLE-NOT-A-REAL-TOKEN",
+]
+
+
+@pytest.mark.parametrize("token", _SLACK_FIXTURES)
+def test_slack_tokens_are_redacted(token):
+    out = redact_secrets(f"SLACK_TOKEN={token}")
+    assert token not in out
+    assert REDACTED in out
+
+
+def test_bearer_token_is_redacted_but_scheme_is_kept():
+    out = redact_secrets("Authorization: Bearer abcdefghijklmnopqrstuvwxyz012345")
+    assert "abcdefghijklmnopqrstuvwxyz012345" not in out
+    assert out == f"Authorization: Bearer {REDACTED}"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "We discussed the xoxb- prefix and how tokens are shaped.",
+        "The header is -----BEGIN PRIVATE KEY----- followed by base64.",
+        "Set private_key in the config before deploying.",
+        "def load_key(path):\n    return open(path).read()",
+        "Bearer tokens expire after an hour.",
+        "",
+    ],
+)
+def test_discussion_and_ordinary_text_are_left_alone(text):
+    assert redact_secrets(text) == text
+    assert not contains_secret(text)
+
+
+def test_contains_secret_detects_a_real_key():
+    assert contains_secret(_pem())
+
+
+def test_multiple_secrets_in_one_chunk_are_all_redacted():
+    text = (
+        f"first:\n{_pem()}\n"
+        f"then a token {_SLACK_FIXTURES[0]}\n"
+        "and a header Authorization: Bearer abcdefghijklmnopqrstuvwxyz012345\n"
+    )
+    out = redact_secrets(text)
+    assert "NOTAREALKEY" not in out
+    assert _SLACK_FIXTURES[0] not in out
+    assert "abcdefghijklmnopqrstuvwxyz012345" not in out
+    assert out.count(REDACTED) >= 3
+
+
+def test_redaction_is_idempotent():
+    once = redact_secrets(_pem())
+    assert redact_secrets(once) == once

--- a/tests/test_secret_redact.py
+++ b/tests/test_secret_redact.py
@@ -36,13 +36,25 @@ def test_truncated_pem_block_is_still_redacted():
     assert "NOTAREALKEY" not in out
 
 
-def test_escaped_newline_pem_inside_json_is_redacted():
+@pytest.mark.parametrize("escape", ["\\n", "\\\\n"])
+def test_escaped_newline_pem_inside_json_is_redacted_at_any_escape_depth(escape):
+    # A key inside JSON carries \n; the same JSON embedded in another JSON
+    # document carries \\n. Both have to be redacted.
     text = (
-        '{"private_key": "-----BEGIN PRIVATE KEY-----\\n'
+        '{"private_key": "-----BEGIN PRIVATE KEY-----'
+        + escape
         + _B64
-        + '\\n-----END PRIVATE KEY-----\\n"}'
+        + escape
+        + '-----END PRIVATE KEY-----"}'
     )
     out = redact_secrets(text)
+    assert "NOTAREALKEY" not in out
+
+
+def test_truncated_double_escaped_block_is_redacted():
+    text = "-----BEGIN PRIVATE KEY-----\\\\n" + _B64
+    out = redact_secrets(text)
+    assert REDACTED in out
     assert "NOTAREALKEY" not in out
 
 


### PR DESCRIPTION
## The problem

`mine_convos()` writes chunk content into the collection verbatim. `_file_chunks_locked()` does:

```python
batch_docs.append(chunk["content"])
```

Nothing on that path filters the text. Mined conversation transcripts routinely contain real credentials — a service-account JSON echoed to a shell, an `Authorization` header in a `curl` command, a token pasted while debugging — and once a chunk is embedded, the secret is durable: it persists in the vector store on disk, is returned by search, and is copied into every export and backup.

This is easy to miss because redaction *does* exist elsewhere. Deployments that wrap the MCP server can filter `add_drawer`/`update_drawer` calls, so manually-filed drawers are covered — but the periodic/cron miner doesn't go through that path. The result is an asymmetry where the interactive route is protected and the bulk-ingest route, which processes far more text, is not.

## The fix

Adds `mempalace/secret_redact.py` and calls it from `_file_chunks_locked()` before the document is appended to the upsert batch:

```python
content = redact_secrets(chunk["content"])
batch_docs.append(content)
```

The module is **regex-only and dependency-free**, so it runs inline during ingest with no network call or model load, and it short-circuits on a cheap substring check because the overwhelming majority of chunks contain no credential marker at all.

Patterns cover PEM private-key blocks, the JSON `private_key` field, Slack `xox*` / `xapp-` tokens, and `Authorization: Bearer` headers.

### Two details that are easy to get wrong

Both are covered by tests, because both are the difference between "looks like it redacts keys" and "actually does":

1. **The label between `BEGIN` and `PRIVATE KEY` is optional.** PKCS#8 blocks are plain `-----BEGIN PRIVATE KEY-----`, with no `RSA`/`EC`/`OPENSSH` word — that's the format Google service-account JSON uses, and so one of the most commonly leaked key types. A pattern written as `BEGIN [A-Z ]+ PRIVATE KEY` requires at least one character in that slot and therefore misses exactly that case while appearing to handle private keys.

2. **The `END` marker is optional.** Transcripts get chunked, so a key is frequently split mid-body and the terminator never arrives in the same chunk. A pattern anchored on `END` fails to match and the visible base64 fragment gets written out verbatim. This redacts the body it can see.

## Conservative by construction

Every pattern requires a structural marker — a PEM header, a known token prefix, an `Authorization` scheme — plus a minimum length. Prose *about* credentials and code that merely handles them is left untouched, and the tests assert that directly:

```python
"We discussed the xoxb- prefix and how tokens are shaped."
"The header is -----BEGIN PRIVATE KEY----- followed by base64."
"Set private_key in the config before deploying."
```

Non-secret sibling fields also survive, so a redacted drawer stays useful — a service-account blob keeps its `client_email` and loses only the key.

## Tests

22 tests in `tests/test_secret_redact.py`, covering all five PEM label variants, truncated blocks, escaped-`\n` PEM inside JSON, the `private_key` field without PEM markers, Slack and Bearer tokens, multiple secrets in one chunk, idempotence, and the negative cases above.

```
22 passed
```

`ruff check` and `ruff format --check` clean.

Run with `--noconftest` locally (`tests/conftest.py` imports `chromadb`, which isn't needed by this file). The `convo_miner` change is import- and lint-checked but I did not run the chromadb-backed suites.

One note on the Slack fixtures: they're assembled at import time from parts rather than written as literals. A literal in the live token shape trips GitHub push protection and downstream secret scanners — the strings hold no real credential, but a blocked push looks identical to a real leak to whoever hits it.

Targeting `develop` per CONTRIBUTING.md.