### PR TITLE
fix(sqlite_exact): cut remaining palace-wide read paths

### DIFF
--- a/mempalace/backends/sqlite_exact.py
+++ b/mempalace/backends/sqlite_exact.py
@@ -330,6 +330,43 @@ def sqlite_wing_room_counts(
         return None
 
 
+def sqlite_room_wing_hall_counts(palace_path: str, collection_name: str) -> Optional[list[tuple]]:
+    """Grouped (room, wing, hall, n) rows for graph_stats, or ``None``."""
+    db_path = os.path.join(palace_path, _DB_FILENAME)
+    if not os.path.isfile(db_path):
+        return None
+    try:
+        db_uri = Path(db_path).resolve().as_uri() + "?mode=ro"
+        conn = sqlite3.connect(db_uri, uri=True)
+        try:
+            conn.execute("PRAGMA busy_timeout=2000")
+            row = conn.execute(
+                "SELECT id FROM collections WHERE name = ?",
+                (collection_name,),
+            ).fetchone()
+            if row is None:
+                return None
+            collection_id = int(row[0])
+            return list(
+                conn.execute(
+                    """
+                    SELECT json_extract(metadata_json, '$.room'),
+                           json_extract(metadata_json, '$.wing'),
+                           json_extract(metadata_json, '$.hall'),
+                           COUNT(*)
+                    FROM documents
+                    WHERE collection_id = ?
+                    GROUP BY 1, 2, 3
+                    """,
+                    (collection_id,),
+                )
+            )
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+
+
 def _matches_where_document(document: str, where_document: Optional[dict]) -> bool:
     if not where_document:
         return True
@@ -664,23 +701,43 @@ class SQLiteExactCollection(BaseCollection):
                 )
                 self._replace_fts(cur, collection_id, doc_id, doc)
 
-    def _rows(self, cur, *, where=None, where_document=None, limit=None, offset=None) -> list[dict]:
+    def _rows(
+        self,
+        cur,
+        *,
+        where=None,
+        where_document=None,
+        limit=None,
+        offset=None,
+        spec: Optional[_IncludeSpec] = None,
+    ) -> list[dict]:
         _validate_where(where)
         _validate_where(where_document)
+        spec = spec or _IncludeSpec.resolve(None, default_distances=False)
         collection_id = self._collection_id(cur)
-        sql = (
-            "SELECT id, document, metadata_json, embedding\n"
-            "FROM documents\n"
-            "WHERE collection_id = ?\n"
-            "ORDER BY rowid"
-        )
-        params = [collection_id]
-        # Emit SQL LIMIT/OFFSET only on an unfiltered page. With a
-        # where/where_document the post-filter loop below drops rows *after*
-        # this scan, so a SQL LIMIT/OFFSET would cut the wrong rows; those
-        # callers scan in full and paginate in Python. SQLite requires a LIMIT
-        # before OFFSET, so an offset-only page uses "LIMIT -1" (unbounded).
-        if where is None and where_document is None and (limit is not None or offset):
+        push = None if where_document else _equality_where_sql(where)
+        python_where = where is not None and push is None
+        need_doc = spec.documents or bool(where_document)
+        need_meta = spec.metadatas or python_where
+        need_emb = spec.embeddings
+        cols = ["id"]
+        if need_doc:
+            cols.append("document")
+        if need_meta:
+            cols.append("metadata_json")
+        if need_emb:
+            cols.append("embedding")
+        sql = f"SELECT {', '.join(cols)}\nFROM documents\nWHERE collection_id = ?"
+        params: list = [collection_id]
+        if push is not None and where:
+            extra_sql, extra_params = push
+            sql += " AND " + extra_sql
+            params.extend(extra_params)
+        sql += "\nORDER BY rowid"
+        # Equality where is applied in SQL, so LIMIT/OFFSET are safe there too.
+        # Python-side filters still have to scan, then slice.
+        can_limit = (not python_where) and not where_document
+        if can_limit and (limit is not None or offset):
             if limit is not None:
                 sql += "\nLIMIT ?"
                 params.append(int(limit))
@@ -689,23 +746,80 @@ class SQLiteExactCollection(BaseCollection):
             if offset:
                 sql += "\nOFFSET ?"
                 params.append(int(offset))
-        rows = cur.execute(sql, params).fetchall()
+        raw = cur.execute(sql, params).fetchall()
         out = []
-        for doc_id, doc, meta_json, emb_blob in rows:
-            meta = _json_loads(meta_json)
-            if not _matches_where(meta, where):
+        for row in raw:
+            idx = 1
+            doc = ""
+            meta: dict = {}
+            emb_blob = None
+            if need_doc:
+                doc = row[idx] or ""
+                idx += 1
+            if need_meta:
+                meta = _json_loads(row[idx])
+                idx += 1
+            if need_emb:
+                emb_blob = row[idx]
+            if python_where and not _matches_where(meta, where):
                 continue
-            if not _matches_where_document(doc or "", where_document):
+            if where_document and not _matches_where_document(doc, where_document):
                 continue
             out.append(
                 {
-                    "id": doc_id,
-                    "document": doc or "",
+                    "id": row[0],
+                    "document": doc,
                     "metadata": meta,
                     "embedding": emb_blob,
                 }
             )
         return out
+
+    def _rows_by_ids(self, cur, collection_id: int, ids: list[str], spec: _IncludeSpec) -> dict:
+        """Fetch requested columns for ``ids`` via ``IN``, keyed by id."""
+        unique = []
+        seen = set()
+        for doc_id in ids:
+            if doc_id not in seen:
+                seen.add(doc_id)
+                unique.append(doc_id)
+        if not unique:
+            return {}
+        cols = ["id"]
+        if spec.documents:
+            cols.append("document")
+        if spec.metadatas:
+            cols.append("metadata_json")
+        if spec.embeddings:
+            cols.append("embedding")
+        by_id: dict = {}
+        for start in range(0, len(unique), 900):
+            chunk = unique[start : start + 900]
+            placeholders = ",".join("?" for _ in chunk)
+            for row in cur.execute(
+                f"SELECT {', '.join(cols)} FROM documents "
+                f"WHERE collection_id = ? AND id IN ({placeholders})",
+                (collection_id, *chunk),
+            ):
+                idx = 1
+                doc = ""
+                meta: dict = {}
+                emb_blob = None
+                if spec.documents:
+                    doc = row[idx] or ""
+                    idx += 1
+                if spec.metadatas:
+                    meta = _json_loads(row[idx])
+                    idx += 1
+                if spec.embeddings:
+                    emb_blob = row[idx]
+                by_id[row[0]] = {
+                    "id": row[0],
+                    "document": doc,
+                    "metadata": meta,
+                    "embedding": emb_blob,
+                }
+        return by_id
 
     def query(
         self,
@@ -904,33 +1018,51 @@ class SQLiteExactCollection(BaseCollection):
         include=None,
     ) -> GetResult:
         spec = _IncludeSpec.resolve(include, default_distances=False)
-        # Fast path for the common unfiltered page (e.g. the prefetch_mined_set
-        # and status sweeps): push LIMIT/OFFSET into the scan instead of
-        # materializing the whole collection and slicing in Python. Safe only
-        # with no post-filter (ids/where/where_document drop rows after the
-        # scan) and non-negative bounds: SQLite does not honor a negative LIMIT
-        # or OFFSET the way a Python slice does, so those keep the slice path.
+        # get(ids=...) must not scan the collection: look up by primary key.
+        if ids is not None and where is None and where_document is None:
+            with self._cursor() as cur:
+                collection_id = self._collection_id(cur)
+                by_id = self._rows_by_ids(cur, collection_id, list(ids), spec)
+            rows = [by_id[doc_id] for doc_id in ids if doc_id in by_id]
+            if offset:
+                rows = rows[offset:]
+            if limit is not None:
+                rows = rows[:limit]
+            return self._get_result(rows, spec)
+
+        # Unfiltered (or SQL-pushable equality) pages: LIMIT/OFFSET in SQL.
+        # Negative bounds stay on the Python slice path — SQLite does not
+        # honor a negative LIMIT/OFFSET the way a Python slice does.
+        python_where = bool(where_document) or (
+            where is not None and _equality_where_sql(where) is None
+        )
         push_page = (
-            ids is None
-            and where is None
-            and where_document is None
+            not python_where
             and (limit is None or limit >= 0)
             and (offset is None or offset >= 0)
             and (limit is not None or offset)
         )
         with self._cursor() as cur:
             if push_page:
-                rows = self._rows(cur, limit=limit, offset=offset)
+                rows = self._rows(
+                    cur,
+                    where=where,
+                    where_document=where_document,
+                    limit=limit,
+                    offset=offset,
+                    spec=spec,
+                )
             else:
-                rows = self._rows(cur, where=where, where_document=where_document)
+                rows = self._rows(cur, where=where, where_document=where_document, spec=spec)
         if not push_page:
-            if ids is not None:
-                by_id = {row["id"]: row for row in rows}
-                rows = [by_id[doc_id] for doc_id in ids if doc_id in by_id]
             if offset:
                 rows = rows[offset:]
             if limit is not None:
                 rows = rows[:limit]
+        return self._get_result(rows, spec)
+
+    @staticmethod
+    def _get_result(rows: list[dict], spec: _IncludeSpec) -> GetResult:
         return GetResult(
             ids=[row["id"] for row in rows],
             documents=[row["document"] for row in rows] if spec.documents else [],

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -678,8 +678,7 @@ def _discard_mcp_storage_handles() -> None:
     _collection_open_error = None
     _palace_db_inode = 0
     _palace_db_mtime = 0.0
-    _metadata_cache = None
-    _metadata_cache_time = 0
+    _invalidate_overview_caches()
 
 
 def _release_mcp_writer_lock() -> None:
@@ -1214,8 +1213,7 @@ def _force_chroma_cache_reset() -> None:
     _collection_open_error = None
     _palace_db_inode = 0
     _palace_db_mtime = 0.0
-    _metadata_cache = None
-    _metadata_cache_time = 0
+    _invalidate_overview_caches()
     # This runs on the #1315 retry path, which drops caches precisely to
     # re-observe the palace after a transient index error. The capacity verdict
     # is another cached view of that same palace, so it must be dropped too, or
@@ -1385,8 +1383,7 @@ def _get_client():
         _collection_cache_backend = None
         _collection_cache_palace = None
         _collection_open_error = None
-        _metadata_cache = None
-        _metadata_cache_time = 0
+        _invalidate_overview_caches()
         _palace_db_inode = current_inode
         _palace_db_mtime = current_mtime
     return _client_cache
@@ -1473,8 +1470,7 @@ def _get_collection(create=False):
                     _collection_cache_backend = backend_name
                     _collection_cache_palace = _config.palace_path
                     _collection_open_error = None
-                    _metadata_cache = None
-                    _metadata_cache_time = 0
+                    _invalidate_overview_caches()
                 return _collection_cache
             except (BackendMismatchError, KeyError) as exc:
                 logger.warning("backend open failed for %s: %s", _config.palace_path, exc)
@@ -1488,8 +1484,7 @@ def _get_collection(create=False):
                 _collection_cache = None
                 _collection_cache_backend = None
                 _collection_cache_palace = None
-                _metadata_cache = None
-                _metadata_cache_time = 0
+                _invalidate_overview_caches()
                 return None
             except Exception:
                 logger.exception(
@@ -1501,8 +1496,7 @@ def _get_collection(create=False):
                 _collection_cache = None
                 _collection_cache_backend = None
                 _collection_cache_palace = None
-                _metadata_cache = None
-                _metadata_cache_time = 0
+                _invalidate_overview_caches()
                 _collection_open_error = {
                     "error": "Backend open failed",
                     "details": "Could not open the selected backend collection.",
@@ -1578,8 +1572,7 @@ def _get_collection(create=False):
                 _collection_cache_backend = "chroma"
                 _collection_cache_palace = _config.palace_path
                 _collection_open_error = None
-                _metadata_cache = None
-                _metadata_cache_time = 0
+                _invalidate_overview_caches()
             elif _collection_cache is None:
                 ef = ChromaBackend._resolve_embedding_function()
                 ef_kwargs = {"embedding_function": ef} if ef is not None else {}
@@ -1589,8 +1582,7 @@ def _get_collection(create=False):
                 _collection_cache_backend = "chroma"
                 _collection_cache_palace = _config.palace_path
                 _collection_open_error = None
-                _metadata_cache = None
-                _metadata_cache_time = 0
+                _invalidate_overview_caches()
             return _collection_cache
         except (BackendMismatchError, KeyError) as exc:
             _collection_open_error = {
@@ -1606,8 +1598,7 @@ def _get_collection(create=False):
             _collection_cache_palace = None
             _palace_db_inode = 0
             _palace_db_mtime = 0.0
-            _metadata_cache = None
-            _metadata_cache_time = 0
+            _invalidate_overview_caches()
             return None
         except Exception:
             logger.exception(
@@ -1627,8 +1618,7 @@ def _get_collection(create=False):
                 _collection_cache_palace = None
                 _palace_db_inode = 0
                 _palace_db_mtime = 0.0
-                _metadata_cache = None
-                _metadata_cache_time = 0
+                _invalidate_overview_caches()
                 _collection_open_error = {
                     "error": "Backend open failed",
                     "details": "Could not open the Chroma collection.",
@@ -1640,8 +1630,7 @@ def _get_collection(create=False):
     _collection_cache_palace = None
     _palace_db_inode = 0
     _palace_db_mtime = 0.0
-    _metadata_cache = None
-    _metadata_cache_time = 0
+    _invalidate_overview_caches()
     _collection_open_error = _collection_open_error or {
         "error": "Backend open failed",
         "details": "Could not open the selected backend collection.",
@@ -1762,7 +1751,19 @@ def _supports_metadata_facets(col) -> bool:
 _metadata_cache = None
 _metadata_cache_time = 0
 _METADATA_CACHE_TTL = 5.0  # seconds
+_taxonomy_cache = None
+_taxonomy_cache_time = 0.0
+_TAXONOMY_CACHE_TTL = 5.0  # seconds — same idea as the palace-graph cache
 _MAX_RESULTS = 100  # upper bound for search/list limit params
+
+
+def _invalidate_overview_caches():
+    """Drop status/list_wings taxonomy and metadata page caches after writes."""
+    global _metadata_cache, _metadata_cache_time, _taxonomy_cache, _taxonomy_cache_time
+    _metadata_cache = None
+    _metadata_cache_time = 0
+    _taxonomy_cache = None
+    _taxonomy_cache_time = 0.0
 
 
 def _get_cached_metadata(col, where=None):
@@ -1918,6 +1919,15 @@ def _sqlite_taxonomy():
     sqlite_exact reads ``sqlite_exact.sqlite3`` with one ``json_extract``
     GROUP BY so status does not page every metadata row.
     """
+    global _taxonomy_cache, _taxonomy_cache_time
+    now = time.time()
+    cache_key = (_config.palace_path, _config.collection_name)
+    if (
+        _taxonomy_cache is not None
+        and _taxonomy_cache[0] == cache_key
+        and (now - _taxonomy_cache_time) < _TAXONOMY_CACHE_TTL
+    ):
+        return _taxonomy_cache[1]
     counts = None
     try:
         if _is_chroma_backend():
@@ -1950,7 +1960,10 @@ def _sqlite_taxonomy():
         for room, n in room_counts.items():
             rkey = _norm(room)
             dest[rkey] = dest.get(rkey, 0) + n
-    return total, normalized
+    result = total, normalized
+    _taxonomy_cache = (cache_key, result)
+    _taxonomy_cache_time = now
+    return result
 
 
 def _sqlite_graph_stats():
@@ -1970,10 +1983,71 @@ def _sqlite_graph_stats():
     wing and a usable room name (the catch-all ``"general"`` is excluded), and
     edges are the per-hall cross-wing crossings of multi-wing rooms.
     """
-    if not _is_chroma_backend():
+    rows = None
+    try:
+        if _is_chroma_backend():
+            rows = _chroma_room_wing_hall_counts()
+        elif _selected_backend_name() == "sqlite_exact":
+            from .backends.sqlite_exact import sqlite_room_wing_hall_counts
+
+            rows = sqlite_room_wing_hall_counts(_config.palace_path, _config.collection_name)
+        else:
+            return None
+    except Exception:
+        logger.debug("sqlite graph_stats fast path failed; falling back", exc_info=True)
         return None
-    import sqlite3 as _sqlite3
+    if rows is None:
+        return None
+    try:
+        return _graph_stats_from_grouped_rows(rows)
+    except Exception:
+        logger.debug("sqlite graph_stats reconstruction failed; falling back", exc_info=True)
+        return None
+
+
+def _graph_stats_from_grouped_rows(rows):
+    """Rebuild ``graph_stats`` from ``(room, wing, hall, n)`` grouped rows."""
     from collections import Counter, defaultdict
+
+    room_data = defaultdict(lambda: {"wings": set(), "halls": set(), "count": 0})
+    for room, wing, hall, n in rows:
+        if not room or room == "general" or not wing:
+            continue
+        node = room_data[room]
+        node["wings"].add(str(wing))
+        if hall:
+            node["halls"].add(str(hall))
+        node["count"] += int(n)
+
+    tunnel_rooms = 0
+    total_edges = 0
+    wing_counts = Counter()
+    for data in room_data.values():
+        n_wings = len(data["wings"])
+        for wing in data["wings"]:
+            wing_counts[wing] += 1
+        if n_wings >= 2:
+            tunnel_rooms += 1
+            total_edges += (n_wings * (n_wings - 1) // 2) * len(data["halls"])
+
+    top_tunnels = [
+        {"room": room, "wings": sorted(data["wings"]), "count": data["count"]}
+        for room, data in sorted(room_data.items(), key=lambda kv: (-len(kv[1]["wings"]), kv[0]))[
+            :10
+        ]
+        if len(data["wings"]) >= 2
+    ]
+    return {
+        "total_rooms": len(room_data),
+        "tunnel_rooms": tunnel_rooms,
+        "total_edges": total_edges,
+        "rooms_per_wing": dict(wing_counts.most_common()),
+        "top_tunnels": top_tunnels,
+    }
+
+
+def _chroma_room_wing_hall_counts():
+    import sqlite3 as _sqlite3
 
     if not _config.palace_path:
         return None
@@ -1981,94 +2055,37 @@ def _sqlite_graph_stats():
     if not os.path.isfile(db_path):
         return None
     collection_name = _config.collection_name
-    # Treat any failure as a soft fallback to the client path (sqlite errors,
-    # but also an unexpected schema shape tripping the reconstruction) so
-    # graph_stats degrades to build_graph() rather than raising — mirroring the
-    # sibling sqlite fast paths (_sqlite_taxonomy / _sqlite_wing_room_counts).
+    conn = _sqlite3.connect(sqlite_read_uri(db_path), uri=True)
     try:
-        conn = _sqlite3.connect(sqlite_read_uri(db_path), uri=True)
-        try:
-            conn.execute("PRAGMA busy_timeout = 3000")
-            if (
-                conn.execute(
-                    "SELECT 1 FROM collections WHERE name = ?", (collection_name,)
-                ).fetchone()
-                is None
-            ):
-                return None
-            rows = conn.execute(
-                """
-                SELECT
-                    COALESCE(rm.string_value, CAST(rm.int_value AS TEXT),
-                             CAST(rm.float_value AS TEXT), '') AS room,
-                    COALESCE(wm.string_value, CAST(wm.int_value AS TEXT),
-                             CAST(wm.float_value AS TEXT), '') AS wing,
-                    COALESCE(hm.string_value, CAST(hm.int_value AS TEXT),
-                             CAST(hm.float_value AS TEXT), '') AS hall,
-                    COUNT(*) AS n
-                FROM embeddings e
-                JOIN segments s ON e.segment_id = s.id AND s.scope = 'METADATA'
-                JOIN collections c ON s.collection = c.id
-                LEFT JOIN embedding_metadata rm ON rm.id = e.id AND rm.key = 'room'
-                LEFT JOIN embedding_metadata wm ON wm.id = e.id AND wm.key = 'wing'
-                LEFT JOIN embedding_metadata hm ON hm.id = e.id AND hm.key = 'hall'
-                WHERE c.name = ?
-                GROUP BY room, wing, hall
-                """,
-                (collection_name,),
-            ).fetchall()
-        finally:
-            conn.close()
-
-        # Reconstruct build_graph()'s room_data, applying its per-drawer filter
-        # (`if room and room != "general" and wing`).
-        room_data = defaultdict(lambda: {"wings": set(), "halls": set(), "count": 0})
-        for room, wing, hall, n in rows:
-            if not room or room == "general" or not wing:
-                continue
-            node = room_data[room]
-            node["wings"].add(wing)
-            if hall:
-                node["halls"].add(hall)
-            node["count"] += int(n)
-
-        tunnel_rooms = 0
-        total_edges = 0
-        wing_counts = Counter()
-        for data in room_data.values():
-            n_wings = len(data["wings"])
-            for wing in data["wings"]:
-                wing_counts[wing] += 1
-            if n_wings >= 2:
-                tunnel_rooms += 1
-                # Edges per multi-wing room: one per wing-pair per hall, matching
-                # build_graph's nested wa<wb × hall expansion.
-                total_edges += (n_wings * (n_wings - 1) // 2) * len(data["halls"])
-
-        top_tunnels = [
-            {"room": room, "wings": sorted(data["wings"]), "count": data["count"]}
-            # build_graph's graph_stats slices the top 10 by wing-count first,
-            # then keeps the multi-wing ones. An explicit room-name tiebreaker
-            # keeps the fast path deterministic across runs — preferable to
-            # leaning on SQLite's unspecified GROUP BY order. (Exact membership
-            # parity with the client path is unattainable anyway; the two never
-            # run on the same palace, since the backend picks one.)
-            for room, data in sorted(
-                room_data.items(), key=lambda kv: (-len(kv[1]["wings"]), kv[0])
-            )[:10]
-            if len(data["wings"]) >= 2
-        ]
-
-        return {
-            "total_rooms": len(room_data),
-            "tunnel_rooms": tunnel_rooms,
-            "total_edges": total_edges,
-            "rooms_per_wing": dict(wing_counts.most_common()),
-            "top_tunnels": top_tunnels,
-        }
-    except Exception:
-        logger.debug("sqlite graph_stats fast path failed; falling back", exc_info=True)
-        return None
+        conn.execute("PRAGMA busy_timeout = 3000")
+        if (
+            conn.execute("SELECT 1 FROM collections WHERE name = ?", (collection_name,)).fetchone()
+            is None
+        ):
+            return None
+        return conn.execute(
+            """
+            SELECT
+                COALESCE(rm.string_value, CAST(rm.int_value AS TEXT),
+                         CAST(rm.float_value AS TEXT), '') AS room,
+                COALESCE(wm.string_value, CAST(wm.int_value AS TEXT),
+                         CAST(wm.float_value AS TEXT), '') AS wing,
+                COALESCE(hm.string_value, CAST(hm.int_value AS TEXT),
+                         CAST(hm.float_value AS TEXT), '') AS hall,
+                COUNT(*) AS n
+            FROM embeddings e
+            JOIN segments s ON e.segment_id = s.id AND s.scope = 'METADATA'
+            JOIN collections c ON s.collection = c.id
+            LEFT JOIN embedding_metadata rm ON rm.id = e.id AND rm.key = 'room'
+            LEFT JOIN embedding_metadata wm ON wm.id = e.id AND wm.key = 'wing'
+            LEFT JOIN embedding_metadata hm ON hm.id = e.id AND hm.key = 'hall'
+            WHERE c.name = ?
+            GROUP BY room, wing, hall
+            """,
+            (collection_name,),
+        ).fetchall()
+    finally:
+        conn.close()
 
 
 def tool_status():
@@ -2790,15 +2807,18 @@ def _drawer_payload(record):
     return payload
 
 
-def _fetch_drawer_rows(col, where=None, page_size: int = 1000):
+def _fetch_drawer_rows(col, where=None, page_size: int = 1000, include=None):
+    include = include or ["documents", "metadatas"]
     ids = []
     documents = []
     metadatas = []
     offset = 0
+    want_docs = "documents" in include
+    want_meta = "metadatas" in include
 
     while True:
         kwargs = {
-            "include": ["documents", "metadatas"],
+            "include": include,
             "limit": page_size,
             "offset": offset,
         }
@@ -2816,14 +2836,38 @@ def _fetch_drawer_rows(col, where=None, page_size: int = 1000):
         ids.extend(batch_ids)
 
         for idx in range(len(batch_ids)):
-            documents.append(batch_docs[idx] if idx < len(batch_docs) else "")
-            metadatas.append(batch_metas[idx] if idx < len(batch_metas) else {})
+            documents.append(batch_docs[idx] if want_docs and idx < len(batch_docs) else "")
+            metadatas.append(batch_metas[idx] if want_meta and idx < len(batch_metas) else {})
 
         offset += len(batch_ids)
         if len(batch_ids) < page_size:
             break
 
     return ids, documents, metadatas
+
+
+def _fill_drawer_previews(col, page: list) -> None:
+    """Hydrate ``content_preview`` for a page of logical drawers only."""
+    physical_ids = []
+    for drawer in page:
+        chunk_ids = drawer.get("chunk_ids") or (drawer.get("metadata") or {}).get("chunk_ids")
+        if chunk_ids:
+            physical_ids.extend(chunk_ids)
+        else:
+            physical_ids.append(drawer["drawer_id"])
+    if not physical_ids:
+        return
+    result = col.get(ids=physical_ids, include=["documents"])
+    ids = _chroma_field(result, "ids", []) or []
+    docs = _chroma_field(result, "documents", []) or []
+    docs_by_id = {doc_id: (docs[i] if i < len(docs) else "") or "" for i, doc_id in enumerate(ids)}
+    for drawer in page:
+        chunk_ids = drawer.get("chunk_ids") or (drawer.get("metadata") or {}).get("chunk_ids")
+        if chunk_ids:
+            content = "".join(docs_by_id.get(cid, "") for cid in chunk_ids)
+        else:
+            content = docs_by_id.get(drawer["drawer_id"], "")
+        drawer["content_preview"] = _content_preview(content)
 
 
 def _collapse_drawer_rows(ids, documents, metadatas):
@@ -3007,7 +3051,7 @@ def tool_add_drawer(
                     "Drawer write was acknowledged but the new ID is not readable. "
                     "The palace index may be stale; run reconnect or repair."
                 )
-            _metadata_cache = None
+            _invalidate_overview_caches()
             logger.info(f"Filed drawer: {drawer_id} -> {wing}/{room}")
             return {
                 "success": True,
@@ -3042,7 +3086,7 @@ def tool_add_drawer(
                 "Drawer write was acknowledged but the new ID is not readable. "
                 "The palace index may be stale; run reconnect or repair."
             )
-        _metadata_cache = None
+        _invalidate_overview_caches()
         logger.info(f"Filed drawer: {drawer_id} -> {wing}/{room} ({len(chunk_ids)} chunks)")
         return {
             "success": True,
@@ -3080,7 +3124,7 @@ def tool_delete_drawer(drawer_id: str):
         )
 
         col.delete(ids=record["ids"])
-        _metadata_cache = None
+        _invalidate_overview_caches()
 
         logger.info("Deleted drawer: %s (%s rows)", drawer_id, len(record["ids"]))
 
@@ -3341,7 +3385,7 @@ def tool_mine(
         return payload
     finally:
         if not dry_run:
-            _metadata_cache = None
+            _invalidate_overview_caches()
 
 
 def _purge_source_closets(source_file: str, *, commit: bool) -> int:
@@ -3472,7 +3516,7 @@ def tool_delete_by_source(source_file: str, dry_run: bool = True):
     )
     try:
         col.delete(where=where)
-        _metadata_cache = None
+        _invalidate_overview_caches()
         # Purge the matching closets too so the AAAK index doesn't keep stale
         # pointers at the now-deleted drawers (#1722). Done after the drawer
         # delete and intentionally best-effort: the drawers are already gone,
@@ -3532,7 +3576,7 @@ def tool_sync(project_dir: str = None, wing: str = None, apply: bool = False):
             return {"success": False, "error": f"sync failed: {exc}"}
     finally:
         if apply:
-            _metadata_cache = None
+            _invalidate_overview_caches()
 
 
 def tool_get_drawer(drawer_id: str):
@@ -3599,7 +3643,7 @@ def tool_list_drawers(
         elif len(conditions) > 1:
             where = {"$and": conditions}
 
-        ids, documents, metadatas = _fetch_drawer_rows(col, where=where)
+        ids, documents, metadatas = _fetch_drawer_rows(col, where=where, include=["metadatas"])
         drawers = _collapse_drawer_rows(ids, documents, metadatas)
 
         if since_dt is not None or before_dt is not None:
@@ -3610,6 +3654,7 @@ def tool_list_drawers(
             ]
 
         page = drawers[offset : offset + limit]
+        _fill_drawer_previews(col, page)
 
         return {
             "drawers": page,
@@ -3698,7 +3743,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
             if stale_ids:
                 col.delete(ids=stale_ids)
 
-            _metadata_cache = None
+            _invalidate_overview_caches()
 
             logger.info("Updated drawer: %s (%s rows)", drawer_id, len(chunk_ids))
 
@@ -3717,7 +3762,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
         update_kwargs["metadatas"] = [new_meta]
 
         col.update(**update_kwargs)
-        _metadata_cache = None
+        _invalidate_overview_caches()
 
         logger.info("Updated drawer: %s", drawer_id)
 

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -1598,6 +1598,57 @@ def _query_drawers_with_filter_fallback(
         }
 
 
+def _backend_capabilities(col) -> frozenset:
+    backend = getattr(col, "_backend", None)
+    if backend is None:
+        inner = getattr(col, "_inner", None)
+        backend = getattr(inner, "_backend", None) if inner is not None else None
+    caps = getattr(backend, "capabilities", None) if backend is not None else None
+    return caps if isinstance(caps, (set, frozenset)) else frozenset()
+
+
+def _closet_boosts(closets_col, *, query: str, n_results: int, where: dict) -> dict:
+    """Best-per-source closet hits used as a rank boost, never a gate.
+
+    sqlite_exact (and any lexical backend) uses FTS instead of a second
+    exact-cosine scan over the closet collection — closets are pointer
+    lines, so BM25 is the better signal anyway.
+    """
+    boosts: dict = {}
+    n_hits = max(1, n_results * 2)
+    if "supports_lexical_search" in _backend_capabilities(closets_col):
+        result = closets_col.lexical_search(query=query, n_results=n_hits, where=where or None)
+        hits = getattr(result, "hits", None) or []
+        for rank, hit in enumerate(hits):
+            meta = hit.metadata or {}
+            source = meta.get("source_file", "")
+            if source and source not in boosts:
+                preview = (hit.document or "")[:200]
+                boosts[source] = (rank, 0.0, preview)
+        return boosts
+
+    ckwargs = {
+        "query_texts": [query],
+        "n_results": n_hits,
+        "include": ["documents", "metadatas", "distances"],
+    }
+    if where:
+        ckwargs["where"] = where
+    closet_results = closets_col.query(**ckwargs)
+    for rank, (cdoc, cmeta, cdist) in enumerate(
+        zip(
+            _first_or_empty(closet_results, "documents"),
+            _first_or_empty(closet_results, "metadatas"),
+            _first_or_empty(closet_results, "distances"),
+        )
+    ):
+        cmeta = cmeta or {}
+        source = cmeta.get("source_file", "")
+        if source and source not in boosts:
+            boosts[source] = (rank, cdist, (cdoc or "")[:200])
+    return boosts
+
+
 def search_memories(
     query: str,
     palace_path: str,
@@ -1725,25 +1776,9 @@ def search_memories(
     closet_boost_by_source: dict = {}  # source_file -> (rank, closet_dist, preview)
     try:
         closets_col = get_closets_collection(palace_path, create=False)
-        ckwargs = {
-            "query_texts": [query],
-            "n_results": n_results * 2,
-            "include": ["documents", "metadatas", "distances"],
-        }
-        if where:
-            ckwargs["where"] = where
-        closet_results = closets_col.query(**ckwargs)
-        for rank, (cdoc, cmeta, cdist) in enumerate(
-            zip(
-                _first_or_empty(closet_results, "documents"),
-                _first_or_empty(closet_results, "metadatas"),
-                _first_or_empty(closet_results, "distances"),
-            )
-        ):
-            cmeta = cmeta or {}
-            source = cmeta.get("source_file", "")
-            if source and source not in closet_boost_by_source:
-                closet_boost_by_source[source] = (rank, cdist, cdoc[:200])
+        closet_boost_by_source = _closet_boosts(
+            closets_col, query=query, n_results=n_results, where=where
+        )
     except Exception:
         # No closets yet — hybrid degrades to pure drawer search.
         logger.debug("Closet collection unavailable; using drawer-only search", exc_info=True)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -119,6 +119,8 @@ def _patch_mcp_server(monkeypatch, config, kg):
     # Accept varargs because production ``_get_kg`` now takes an optional
     # canonical_path; ``_call_kg`` passes the captured key through.
     monkeypatch.setattr(mcp_server, "_get_kg", lambda *a, **kw: kg)
+    monkeypatch.setattr(mcp_server, "_taxonomy_cache", None)
+    monkeypatch.setattr(mcp_server, "_taxonomy_cache_time", 0.0)
 
 
 def _get_collection(palace_path, create=False):

--- a/tests/test_sqlite_exact_backend.py
+++ b/tests/test_sqlite_exact_backend.py
@@ -187,12 +187,10 @@ def test_sqlite_exact_get_unfiltered_page_pushes_limit_offset(tmp_path):
     assert "OFFSET" in selects[0]
 
 
-def test_sqlite_exact_get_filtered_page_stays_on_full_scan(tmp_path):
+def test_sqlite_exact_get_equality_filter_pushes_limit(tmp_path):
     _backend, col = _collection(tmp_path)
     _seed(col, 6)
 
-    # With a filter the rows are dropped after the scan, so LIMIT/OFFSET must
-    # not reach SQL; the page is taken in Python over the filtered rows.
     result, selects = _doc_select_sql(
         col,
         lambda: col.get(where={"wing": "w"}, limit=2, offset=1, include=["metadatas"]),
@@ -200,8 +198,10 @@ def test_sqlite_exact_get_filtered_page_stays_on_full_scan(tmp_path):
 
     assert result.ids == ["d1", "d2"]
     assert len(selects) == 1
-    assert "LIMIT" not in selects[0]
-    assert "OFFSET" not in selects[0]
+    assert "LIMIT" in selects[0]
+    assert "OFFSET" in selects[0]
+    assert "embedding" not in selects[0].split("FROM documents")[0]
+    assert "document" not in selects[0].split("FROM documents")[0]
 
 
 def test_sqlite_exact_get_offset_only_and_limit_only_push(tmp_path):
@@ -283,19 +283,22 @@ def test_sqlite_exact_get_offset_zero_is_a_full_scan(tmp_path):
     assert "OFFSET" not in selects[0]
 
 
-def test_sqlite_exact_get_ids_with_page_slices_in_python(tmp_path):
+def test_sqlite_exact_get_ids_looks_up_by_primary_key(tmp_path):
     _backend, col = _collection(tmp_path)
     _seed(col, 5)
 
-    # ids force the Python path even with a page: the requested order is kept,
-    # then offset/limit slice the reordered list with no SQL LIMIT/OFFSET.
-    result, selects = _doc_select_sql(
-        col, lambda: col.get(ids=["d4", "d3", "d2", "d1"], offset=1, limit=2)
-    )
+    statements = []
+    conn = col._handle.conn
+    conn.set_trace_callback(statements.append)
+    try:
+        result = col.get(ids=["d4", "d3", "d2", "d1"], offset=1, limit=2)
+    finally:
+        conn.set_trace_callback(None)
+
     assert result.ids == ["d3", "d2"]
-    assert len(selects) == 1
-    assert "LIMIT" not in selects[0]
-    assert "OFFSET" not in selects[0]
+    in_selects = [s for s in statements if "FROM documents" in s and "IN (" in s]
+    assert in_selects
+    assert all("ORDER BY rowid" not in s for s in in_selects)
 
 
 def test_sqlite_exact_upsert_delete_and_multi_collection_isolation(tmp_path):
@@ -891,6 +894,53 @@ def test_search_union_uses_sqlite_exact_lexical_search(tmp_path, monkeypatch):
     assert result["results"][0]["matched_via"] == "bm25_backend"
 
 
+def test_search_closets_use_lexical_not_vector_on_sqlite_exact(tmp_path, monkeypatch):
+    import mempalace.backends.embedding_wrapper as embedding_wrapper
+    from mempalace.backends.sqlite_exact import SQLiteExactCollection
+    from mempalace.palace import get_collection, get_closets_collection
+    from mempalace.searcher import search_memories
+
+    monkeypatch.setenv("MEMPALACE_BACKEND_EXPLICIT", "sqlite_exact")
+    monkeypatch.setattr(
+        embedding_wrapper, "_embed_texts", lambda texts: [[1.0, 0.0] for _ in texts]
+    )
+
+    drawers = get_collection(str(tmp_path), create=True)
+    closets = get_closets_collection(str(tmp_path), create=True)
+    drawers.add(
+        ids=["d1"],
+        documents=["meshguard trust path"],
+        metadatas=[{"source_file": "a.md", "wing": "w", "room": "r", "chunk_index": 0}],
+    )
+    closets.add(
+        ids=["c1"],
+        documents=["topic|meshguard|→d1"],
+        metadatas=[{"source_file": "a.md", "wing": "w"}],
+    )
+
+    called = {"query": 0, "lex": 0}
+    orig_query = SQLiteExactCollection.query
+    orig_lex = SQLiteExactCollection.lexical_search
+
+    def wrapped_query(self, *args, **kwargs):
+        if self._collection_name == "mempalace_closets":
+            called["query"] += 1
+        return orig_query(self, *args, **kwargs)
+
+    def wrapped_lex(self, *args, **kwargs):
+        if self._collection_name == "mempalace_closets":
+            called["lex"] += 1
+        return orig_lex(self, *args, **kwargs)
+
+    monkeypatch.setattr(SQLiteExactCollection, "query", wrapped_query)
+    monkeypatch.setattr(SQLiteExactCollection, "lexical_search", wrapped_lex)
+
+    result = search_memories("meshguard", str(tmp_path), n_results=1)
+    assert "error" not in result
+    assert called["lex"] == 1
+    assert called["query"] == 0
+
+
 def test_search_union_reports_unsupported_lexical_capability(monkeypatch, tmp_path):
     import mempalace.searcher as searcher
 
@@ -1181,3 +1231,39 @@ def test_sqlite_exact_wing_room_counts(tmp_path):
     assert wing_rooms["alpha"]["notes"] == 1
     assert wing_rooms["alpha"]["code"] == 1
     assert wing_rooms["beta"]["notes"] == 1
+
+
+def test_sqlite_exact_get_metadatas_skips_document_and_embedding(tmp_path):
+    _backend, col = _collection(tmp_path)
+    _seed(col, 3)
+
+    result, selects = _doc_select_sql(col, lambda: col.get(limit=2, include=["metadatas"]))
+    assert result.ids == ["d0", "d1"]
+    assert result.documents == []
+    assert result.embeddings is None
+    assert len(selects) == 1
+    select_list = selects[0].split("FROM documents")[0]
+    assert "metadata_json" in select_list
+    assert re.search(r"\bdocument\b", select_list) is None
+    assert "embedding" not in select_list
+
+
+def test_sqlite_exact_room_wing_hall_counts(tmp_path):
+    from mempalace.backends.sqlite_exact import sqlite_room_wing_hall_counts
+
+    _backend, col = _collection(tmp_path)
+    col.add(
+        ids=["1", "2", "3"],
+        documents=["a", "b", "c"],
+        metadatas=[
+            {"room": "chromadb", "wing": "wing_code", "hall": "db"},
+            {"room": "chromadb", "wing": "wing_project", "hall": "db"},
+            {"room": "auth", "wing": "wing_code", "hall": "security"},
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+    rows = sqlite_room_wing_hall_counts(str(tmp_path), "mempalace_drawers")
+    grouped = {(room, wing, hall): n for room, wing, hall, n in rows}
+    assert grouped[("chromadb", "wing_code", "db")] == 1
+    assert grouped[("chromadb", "wing_project", "db")] == 1
+    assert grouped[("auth", "wing_code", "security")] == 1


### PR DESCRIPTION
Follow-up to #2308. Search/status cosine and metadata paging are better; these were the next palace-wide reads on the live 167k-drawer `sqlite_exact` hub.

Does not touch `chroma.py`.

## Changes

1. **`get()` no longer loads the whole palace**
   - `get(ids=...)` uses `WHERE id IN (...)` (was: scan every row, then dict lookup).
   - `include=["metadatas"]` does not SELECT `document` or `embedding`.
   - Equality `where` (`wing`/`room`/`source_file`) plus `LIMIT`/`OFFSET` go to SQL.

2. **`list_drawers` paginates for real**
   - Walk metadata only to collapse logical drawers and compute `total`.
   - Hydrate `content_preview` for the page via `get(ids=...)`.
   - Live: unfiltered `limit=20` was 2752 ms because it loaded every document.

3. **Taxonomy cache (5s TTL)**
   - `status` / `list_wings` / `list_rooms` / `get_taxonomy` share one GROUP BY result.
   - Dropped on writes (`_invalidate_overview_caches`).

4. **`graph_stats` sqlite_exact fast path**
   - Same reconstruction as chroma, from `json_extract` room/wing/hall GROUP BY.
   - First call was 1647 ms paging metadata.

5. **Closet boost is FTS, not a second cosine**
   - Closets are pointer lines; BM25 is the better signal.
   - Avoids loading the 166k-closet embedding matrix on every search.

## Isolated SQL on this palace (167k drawers)

| Scan | Time |
|---|---|
| `id, document, metadata_json, embedding` | 806 ms |
| `id, metadata_json` | 591 ms |
| `LIMIT 20` / `IN 20` | 0 ms |
| taxonomy GROUP BY | 974 ms (then cached) |

## Tests

`uv run pytest tests/test_sqlite_exact_backend.py tests/test_mcp_server.py tests/test_searcher.py tests/test_closets.py` — 586 passed.
