### PR TITLE
fix(chroma): read list_drawers and tunnels from sqlite, skip HNSW

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1204,7 +1204,13 @@ def _sqlite_wing_room_counts(
 
 
 def sqlite_room_wing_hall_counts(palace_path: str, collection_name: str) -> Optional[list[tuple]]:
-    """Grouped (room, wing, hall, n) from ``chroma.sqlite3``, or ``None``."""
+    """Grouped ``(room, wing, hall, n, last_date)`` from ``chroma.sqlite3``.
+
+    ``last_date`` is the newest ``date`` metadata value in the group, so
+    ``find_tunnels`` can still report ``recent`` without paging every drawer
+    (``build_graph`` only ever uses the maximum). Returns ``None`` when sqlite
+    cannot be trusted, so the caller falls back to the client path.
+    """
     db_path = os.path.join(palace_path, "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return None
@@ -1228,13 +1234,15 @@ def sqlite_room_wing_hall_counts(palace_path: str, collection_name: str) -> Opti
                              CAST(wm.float_value AS TEXT), '') AS wing,
                     COALESCE(hm.string_value, CAST(hm.int_value AS TEXT),
                              CAST(hm.float_value AS TEXT), '') AS hall,
-                    COUNT(*) AS n
+                    COUNT(*) AS n,
+                    COALESCE(MAX(dm.string_value), '') AS last_date
                 FROM embeddings e
                 JOIN segments s ON e.segment_id = s.id AND s.scope = 'METADATA'
                 JOIN collections c ON s.collection = c.id
                 LEFT JOIN embedding_metadata rm ON rm.id = e.id AND rm.key = 'room'
                 LEFT JOIN embedding_metadata wm ON wm.id = e.id AND wm.key = 'wing'
                 LEFT JOIN embedding_metadata hm ON hm.id = e.id AND hm.key = 'hall'
+                LEFT JOIN embedding_metadata dm ON dm.id = e.id AND dm.key = 'date'
                 WHERE c.name = ?
                 GROUP BY room, wing, hall
                 """,
@@ -1246,45 +1254,68 @@ def sqlite_room_wing_hall_counts(palace_path: str, collection_name: str) -> Opti
         return None
 
 
+def _metadata_value_columns(conn) -> list[str]:
+    """Value columns actually present on ``embedding_metadata``.
+
+    Older chromadb builds predate ``bool_value``; probing keeps one reader
+    working across schema versions (same approach as the lexical path).
+    """
+    present = {row[1] for row in conn.execute("PRAGMA table_info(embedding_metadata)")}
+    return [c for c in ("string_value", "int_value", "float_value", "bool_value") if c in present]
+
+
+def _equality_filters(where: Optional[dict]) -> Optional[dict]:
+    """Flatten ``tool_list_drawers``-shaped ``where`` into ``{key: value}``.
+
+    Supports equality on ``wing``/``room`` and an ``$and`` of those. Returns
+    ``None`` for anything else so the caller falls back to ``col.get`` paging
+    rather than silently answering a filter it did not apply.
+    """
+    if not where:
+        return {}
+    if not isinstance(where, dict):
+        return None
+    clauses = []
+    if list(where.keys()) == ["$and"]:
+        for child in where["$and"] or []:
+            if not isinstance(child, dict) or len(child) != 1:
+                return None
+            clauses.append(next(iter(child.items())))
+    elif len(where) == 1 and not next(iter(where.keys())).startswith("$"):
+        clauses.append(next(iter(where.items())))
+    else:
+        return None
+    filters = {}
+    for key, val in clauses:
+        if key not in ("wing", "room"):
+            return None
+        filters[key] = val
+    return filters
+
+
 def sqlite_list_id_metadata(
     palace_path: str,
     collection_name: str,
     where: Optional[dict] = None,
-) -> Optional[tuple[list[str], list[str], list[dict]]]:
-    """All drawer ids + metadata from sqlite, without opening HNSW.
+) -> Optional[tuple[list[str], list[dict]]]:
+    """All matching drawer ids + metadata from sqlite, without opening HNSW.
+
+    Documents are deliberately excluded: ``chroma:document`` lives in the same
+    ``embedding_metadata`` table, and joining it in would materialize the whole
+    palace's verbatim text (hundreds of MB on a six-figure palace) just to
+    render one page of previews. Callers hydrate the page they display via
+    :func:`sqlite_documents_for_ids`.
 
     ``where`` supports equality on ``wing``/``room`` and ``$and`` of those,
-    matching ``tool_list_drawers``. Returns ``None`` when sqlite cannot be
-    trusted so the caller can fall back to ``col.get`` paging.
+    matching ``tool_list_drawers``; it is applied in SQL. Returns ``None`` when
+    sqlite cannot be trusted so the caller can fall back to ``col.get`` paging.
     """
     db_path = os.path.join(palace_path, "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return None
-    wing_eq = room_eq = None
-    if where:
-        if not isinstance(where, dict):
-            return None
-        if list(where.keys()) == ["$and"]:
-            for child in where["$and"] or []:
-                if not isinstance(child, dict) or len(child) != 1:
-                    return None
-                key, val = next(iter(child.items()))
-                if key == "wing":
-                    wing_eq = val
-                elif key == "room":
-                    room_eq = val
-                else:
-                    return None
-        elif len(where) == 1 and not next(iter(where.keys())).startswith("$"):
-            key, val = next(iter(where.items()))
-            if key == "wing":
-                wing_eq = val
-            elif key == "room":
-                room_eq = val
-            else:
-                return None
-        else:
-            return None
+    filters = _equality_filters(where)
+    if filters is None:
+        return None
     try:
         conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
         try:
@@ -1296,53 +1327,155 @@ def sqlite_list_id_metadata(
                 is None
             ):
                 return None
+            value_columns = _metadata_value_columns(conn)
+            if not value_columns:
+                return None
+            # Push the filter down as an inner join per key. Non-string operands
+            # cannot be matched against ``string_value``, so those stay in the
+            # Python pass below rather than silently matching nothing.
+            joins = []
+            params: list = []
+            for idx, (key, val) in enumerate(sorted(filters.items())):
+                if not isinstance(val, str):
+                    continue
+                alias = f"f{idx}"
+                joins.append(
+                    f"JOIN embedding_metadata {alias} ON {alias}.id = e.id "
+                    f"AND {alias}.key = ? AND {alias}.string_value = ?"
+                )
+                params.extend([key, val])
+            params.append(collection_name)
             rows = conn.execute(
-                """
-                SELECT e.embedding_id, m.key, m.string_value, m.int_value, m.float_value
+                f"""
+                SELECT e.embedding_id, m.key, {", ".join("m." + c for c in value_columns)}
                 FROM embeddings e
                 JOIN segments s ON e.segment_id = s.id AND s.scope = 'METADATA'
                 JOIN collections c ON s.collection = c.id
-                LEFT JOIN embedding_metadata m ON m.id = e.id
+                {" ".join(joins)}
+                LEFT JOIN embedding_metadata m
+                    ON m.id = e.id AND m.key != 'chroma:document'
                 WHERE c.name = ?
                 ORDER BY e.id
                 """,
-                (collection_name,),
+                params,
             ).fetchall()
         finally:
             conn.close()
     except sqlite3.Error:
         return None
 
+    # Column positions are resolved once: this loop runs per metadata row —
+    # millions of them on a large palace — so per-row dict building there is
+    # the difference between one second and several.
+    def _cell(name):
+        return value_columns.index(name) + 2 if name in value_columns else None
+
+    s_at, i_at, f_at, b_at = (
+        _cell(c) for c in ("string_value", "int_value", "float_value", "bool_value")
+    )
     by_id: dict[str, dict] = {}
-    docs_by_id: dict[str, str] = {}
     order: list[str] = []
-    for embedding_id, key, sval, ival, fval in rows:
-        doc_id = str(embedding_id)
-        if doc_id not in by_id:
-            by_id[doc_id] = {}
+    for row in rows:
+        doc_id = row[0]
+        meta = by_id.get(doc_id)
+        if meta is None:
+            meta = by_id[doc_id] = {}
             order.append(doc_id)
+        key = row[1]
         if not key:
             continue
-        value = sval if sval is not None else (ival if ival is not None else fval)
+        value = _metadata_cell_value(
+            row[s_at] if s_at is not None else None,
+            row[i_at] if i_at is not None else None,
+            row[f_at] if f_at is not None else None,
+            row[b_at] if b_at is not None else None,
+        )
         if value is None:
             continue
-        if str(key) == "chroma:document":
-            docs_by_id[doc_id] = str(value)
-        else:
-            by_id[doc_id][str(key)] = value
+        meta[key] = value
+
     ids: list[str] = []
     metas: list[dict] = []
-    documents: list[str] = []
     for doc_id in order:
         meta = by_id[doc_id]
-        if wing_eq is not None and meta.get("wing") != wing_eq:
-            continue
-        if room_eq is not None and meta.get("room") != room_eq:
+        if any(meta.get(key) != val for key, val in filters.items()):
             continue
         ids.append(doc_id)
         metas.append(meta)
-        documents.append(docs_by_id.get(doc_id, ""))
-    return ids, documents, metas
+    return ids, metas
+
+
+def sqlite_documents_for_ids(
+    palace_path: str,
+    collection_name: str,
+    ids: list,
+) -> Optional[dict]:
+    """``{drawer_id: document}`` for ``ids`` only, straight from sqlite.
+
+    Hydrates previews for the page being displayed without opening HNSW and
+    without reading the rest of the palace's text.
+
+    Resolved in two indexed steps rather than one join: ``embedding_id`` is
+    only indexed as part of ``UNIQUE (segment_id, embedding_id)``, so a join
+    that filters on it alone degenerates into a full scan of
+    ``embedding_metadata`` — 5.7s for a 20-row page on a 165k-drawer palace.
+    Seeking the segment first, then ``embedding_metadata``'s ``(id, key)``
+    primary key, keeps both steps on an index.
+    """
+    if not ids:
+        return {}
+    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+    wanted = [str(i) for i in ids]
+    docs: dict[str, str] = {}
+    try:
+        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        try:
+            conn.execute("PRAGMA busy_timeout = 3000")
+            segments = [
+                row[0]
+                for row in conn.execute(
+                    """
+                    SELECT s.id FROM segments s
+                    JOIN collections c ON s.collection = c.id
+                    WHERE c.name = ? AND s.scope = 'METADATA'
+                    """,
+                    (collection_name,),
+                )
+            ]
+            if not segments:
+                return None
+            seg_placeholders = ",".join("?" for _ in segments)
+            for start in range(0, len(wanted), 900):
+                chunk = wanted[start : start + 900]
+                placeholders = ",".join("?" for _ in chunk)
+                rows = conn.execute(
+                    f"""
+                    SELECT id, embedding_id FROM embeddings
+                    WHERE segment_id IN ({seg_placeholders})
+                      AND embedding_id IN ({placeholders})
+                    """,
+                    [*segments, *chunk],
+                ).fetchall()
+                if not rows:
+                    continue
+                public_by_internal = {int(row[0]): str(row[1]) for row in rows}
+                internal = list(public_by_internal)
+                internal_placeholders = ",".join("?" for _ in internal)
+                for internal_id, value in conn.execute(
+                    f"""
+                    SELECT id, string_value FROM embedding_metadata
+                    WHERE key = 'chroma:document' AND id IN ({internal_placeholders})
+                    """,
+                    internal,
+                ):
+                    docs[public_by_internal[int(internal_id)]] = str(value or "")
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+    return docs
 
 
 def _pin_hnsw_threads(collection) -> None:

--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -1203,6 +1203,148 @@ def _sqlite_wing_room_counts(
     return total, wing_rooms
 
 
+def sqlite_room_wing_hall_counts(palace_path: str, collection_name: str) -> Optional[list[tuple]]:
+    """Grouped (room, wing, hall, n) from ``chroma.sqlite3``, or ``None``."""
+    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+    try:
+        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        try:
+            conn.execute("PRAGMA busy_timeout = 3000")
+            if (
+                conn.execute(
+                    "SELECT 1 FROM collections WHERE name = ?", (collection_name,)
+                ).fetchone()
+                is None
+            ):
+                return None
+            return conn.execute(
+                """
+                SELECT
+                    COALESCE(rm.string_value, CAST(rm.int_value AS TEXT),
+                             CAST(rm.float_value AS TEXT), '') AS room,
+                    COALESCE(wm.string_value, CAST(wm.int_value AS TEXT),
+                             CAST(wm.float_value AS TEXT), '') AS wing,
+                    COALESCE(hm.string_value, CAST(hm.int_value AS TEXT),
+                             CAST(hm.float_value AS TEXT), '') AS hall,
+                    COUNT(*) AS n
+                FROM embeddings e
+                JOIN segments s ON e.segment_id = s.id AND s.scope = 'METADATA'
+                JOIN collections c ON s.collection = c.id
+                LEFT JOIN embedding_metadata rm ON rm.id = e.id AND rm.key = 'room'
+                LEFT JOIN embedding_metadata wm ON wm.id = e.id AND wm.key = 'wing'
+                LEFT JOIN embedding_metadata hm ON hm.id = e.id AND hm.key = 'hall'
+                WHERE c.name = ?
+                GROUP BY room, wing, hall
+                """,
+                (collection_name,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+
+
+def sqlite_list_id_metadata(
+    palace_path: str,
+    collection_name: str,
+    where: Optional[dict] = None,
+) -> Optional[tuple[list[str], list[str], list[dict]]]:
+    """All drawer ids + metadata from sqlite, without opening HNSW.
+
+    ``where`` supports equality on ``wing``/``room`` and ``$and`` of those,
+    matching ``tool_list_drawers``. Returns ``None`` when sqlite cannot be
+    trusted so the caller can fall back to ``col.get`` paging.
+    """
+    db_path = os.path.join(palace_path, "chroma.sqlite3")
+    if not os.path.isfile(db_path):
+        return None
+    wing_eq = room_eq = None
+    if where:
+        if not isinstance(where, dict):
+            return None
+        if list(where.keys()) == ["$and"]:
+            for child in where["$and"] or []:
+                if not isinstance(child, dict) or len(child) != 1:
+                    return None
+                key, val = next(iter(child.items()))
+                if key == "wing":
+                    wing_eq = val
+                elif key == "room":
+                    room_eq = val
+                else:
+                    return None
+        elif len(where) == 1 and not next(iter(where.keys())).startswith("$"):
+            key, val = next(iter(where.items()))
+            if key == "wing":
+                wing_eq = val
+            elif key == "room":
+                room_eq = val
+            else:
+                return None
+        else:
+            return None
+    try:
+        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        try:
+            conn.execute("PRAGMA busy_timeout = 3000")
+            if (
+                conn.execute(
+                    "SELECT 1 FROM collections WHERE name = ?", (collection_name,)
+                ).fetchone()
+                is None
+            ):
+                return None
+            rows = conn.execute(
+                """
+                SELECT e.embedding_id, m.key, m.string_value, m.int_value, m.float_value
+                FROM embeddings e
+                JOIN segments s ON e.segment_id = s.id AND s.scope = 'METADATA'
+                JOIN collections c ON s.collection = c.id
+                LEFT JOIN embedding_metadata m ON m.id = e.id
+                WHERE c.name = ?
+                ORDER BY e.id
+                """,
+                (collection_name,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+
+    by_id: dict[str, dict] = {}
+    docs_by_id: dict[str, str] = {}
+    order: list[str] = []
+    for embedding_id, key, sval, ival, fval in rows:
+        doc_id = str(embedding_id)
+        if doc_id not in by_id:
+            by_id[doc_id] = {}
+            order.append(doc_id)
+        if not key:
+            continue
+        value = sval if sval is not None else (ival if ival is not None else fval)
+        if value is None:
+            continue
+        if str(key) == "chroma:document":
+            docs_by_id[doc_id] = str(value)
+        else:
+            by_id[doc_id][str(key)] = value
+    ids: list[str] = []
+    metas: list[dict] = []
+    documents: list[str] = []
+    for doc_id in order:
+        meta = by_id[doc_id]
+        if wing_eq is not None and meta.get("wing") != wing_eq:
+            continue
+        if room_eq is not None and meta.get("room") != room_eq:
+            continue
+        ids.append(doc_id)
+        metas.append(meta)
+        documents.append(docs_by_id.get(doc_id, ""))
+    return ids, documents, metas
+
+
 def _pin_hnsw_threads(collection) -> None:
     """Best-effort retrofit: pin ``hnsw:num_threads=1`` on an existing collection.
 

--- a/mempalace/backends/sqlite_exact.py
+++ b/mempalace/backends/sqlite_exact.py
@@ -362,7 +362,11 @@ def sqlite_wing_room_counts(
 
 
 def sqlite_room_wing_hall_counts(palace_path: str, collection_name: str) -> Optional[list[tuple]]:
-    """Grouped (room, wing, hall, n) rows for graph_stats, or ``None``."""
+    """Grouped ``(room, wing, hall, n, last_date)`` rows, or ``None``.
+
+    ``last_date`` is the newest ``date`` metadata value in the group — enough
+    for ``find_tunnels``' ``recent`` field without paging every drawer.
+    """
     db_path = os.path.join(palace_path, _DB_FILENAME)
     if not os.path.isfile(db_path):
         return None
@@ -385,7 +389,8 @@ def sqlite_room_wing_hall_counts(palace_path: str, collection_name: str) -> Opti
             return list(
                 conn.execute(
                     f"""
-                    SELECT {room_expr}, {wing_expr}, {hall_expr}, COUNT(*)
+                    SELECT {room_expr}, {wing_expr}, {hall_expr}, COUNT(*),
+                           COALESCE(MAX(json_extract(metadata_json, '$.date')), '')
                     FROM documents
                     WHERE collection_id = ?
                     GROUP BY 1, 2, 3

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2006,11 +2006,16 @@ def _sqlite_graph_stats():
 
 
 def _graph_stats_from_grouped_rows(rows):
-    """Rebuild ``graph_stats`` from ``(room, wing, hall, n)`` grouped rows."""
+    """Rebuild ``graph_stats`` from ``(room, wing, hall, n)`` grouped rows.
+
+    Backends may append a fifth ``last_date`` column for ``find_tunnels``;
+    stats do not use it, so extra columns are ignored rather than unpacked.
+    """
     from collections import Counter, defaultdict
 
     room_data = defaultdict(lambda: {"wings": set(), "halls": set(), "count": 0})
-    for room, wing, hall, n in rows:
+    for row in rows:
+        room, wing, hall, n = row[0], row[1], row[2], row[3]
         if not room or room == "general" or not wing:
             continue
         node = room_data[room]
@@ -2044,6 +2049,18 @@ def _graph_stats_from_grouped_rows(rows):
         "rooms_per_wing": dict(wing_counts.most_common()),
         "top_tunnels": top_tunnels,
     }
+
+
+def _graph_sqlite_reader():
+    """The sqlite grouped-counts reader for this palace, or ``None``.
+
+    ``None`` means the graph tools must go through the collection, which is
+    what keeps a missing or broken palace reporting a diagnostic instead of
+    an empty graph.
+    """
+    from .palace_graph import sqlite_grouped_counts_reader
+
+    return sqlite_grouped_counts_reader(_config)
 
 
 def _chroma_room_wing_hall_counts():
@@ -2496,7 +2513,14 @@ def tool_get_aaak_spec():
 def tool_traverse_graph(start_room: str, max_hops: int = 2):
     """Walk the palace graph from a room. Find connected ideas across wings."""
     max_hops = max(1, min(max_hops, 10))
-    # sqlite metadata path does not open HNSW; build_graph falls back itself.
+    # sqlite metadata path does not open HNSW. When it cannot serve, open the
+    # collection here so a missing/broken palace still reports why (#1379
+    # follow-up) instead of looking like a palace with no such room.
+    if _graph_sqlite_reader() is None:
+        col = _get_collection()
+        if not col:
+            return _collection_error_or_no_palace()
+        return traverse(start_room, col=col, max_hops=max_hops)
     return traverse(start_room, max_hops=max_hops, config=_config)
 
 
@@ -2507,6 +2531,11 @@ def tool_find_tunnels(wing_a: str = None, wing_b: str = None):
         wing_b = _sanitize_optional_name(wing_b, "wing_b")
     except ValueError as e:
         return {"error": str(e)}
+    if _graph_sqlite_reader() is None:
+        col = _get_collection()
+        if not col:
+            return _collection_error_or_no_palace()
+        return find_tunnels(wing_a, wing_b, col=col)
     return find_tunnels(wing_a, wing_b, config=_config)
 
 
@@ -2807,8 +2836,8 @@ def _fetch_drawer_rows(col, where=None, page_size: int = 1000, include=None):
     return ids, documents, metadatas
 
 
-def _fill_drawer_previews(col, page: list) -> None:
-    """Hydrate ``content_preview`` for a page of logical drawers only."""
+def _page_physical_ids(page: list) -> list:
+    """The physical row ids backing one page of logical drawers."""
     physical_ids = []
     for drawer in page:
         chunk_ids = drawer.get("chunk_ids") or (drawer.get("metadata") or {}).get("chunk_ids")
@@ -2816,12 +2845,11 @@ def _fill_drawer_previews(col, page: list) -> None:
             physical_ids.extend(chunk_ids)
         else:
             physical_ids.append(drawer["drawer_id"])
-    if not physical_ids:
-        return
-    result = col.get(ids=physical_ids, include=["documents"])
-    ids = _chroma_field(result, "ids", []) or []
-    docs = _chroma_field(result, "documents", []) or []
-    docs_by_id = {doc_id: (docs[i] if i < len(docs) else "") or "" for i, doc_id in enumerate(ids)}
+    return physical_ids
+
+
+def _apply_drawer_previews(page: list, docs_by_id: dict) -> None:
+    """Set ``content_preview`` from an already-fetched ``{id: document}`` map."""
     for drawer in page:
         chunk_ids = drawer.get("chunk_ids") or (drawer.get("metadata") or {}).get("chunk_ids")
         if chunk_ids:
@@ -2829,6 +2857,41 @@ def _fill_drawer_previews(col, page: list) -> None:
         else:
             content = docs_by_id.get(drawer["drawer_id"], "")
         drawer["content_preview"] = _content_preview(content)
+
+
+def _fill_drawer_previews(col, page: list) -> None:
+    """Hydrate ``content_preview`` for a page of logical drawers only."""
+    physical_ids = _page_physical_ids(page)
+    if not physical_ids:
+        return
+    result = col.get(ids=physical_ids, include=["documents"])
+    ids = _chroma_field(result, "ids", []) or []
+    docs = _chroma_field(result, "documents", []) or []
+    docs_by_id = {doc_id: (docs[i] if i < len(docs) else "") or "" for i, doc_id in enumerate(ids)}
+    _apply_drawer_previews(page, docs_by_id)
+
+
+def _fill_drawer_previews_from_sqlite(page: list) -> None:
+    """Same, reading the page's documents straight from ``chroma.sqlite3``.
+
+    The list itself is answered from metadata only — joining documents into
+    that scan would pull the palace's entire verbatim text into memory to
+    render one page. This fetches just the rows on screen.
+    """
+    physical_ids = _page_physical_ids(page)
+    if not physical_ids:
+        return
+    from .backends.chroma import sqlite_documents_for_ids
+
+    docs_by_id = sqlite_documents_for_ids(
+        _config.palace_path, _config.collection_name, physical_ids
+    )
+    if docs_by_id is None:
+        # sqlite went unreadable between the two reads; previews are a
+        # display detail, so degrade to blank rather than fail the listing.
+        logger.debug("sqlite preview hydration failed; leaving previews empty")
+        return
+    _apply_drawer_previews(page, docs_by_id)
 
 
 def _collapse_drawer_rows(ids, documents, metadatas):
@@ -3600,7 +3663,6 @@ def tool_list_drawers(
         elif len(conditions) > 1:
             where = {"$and": conditions}
 
-        ids = documents = metadatas = None
         listed = None
         if _is_chroma_backend() and _config.palace_path:
             from .backends.chroma import sqlite_list_id_metadata
@@ -3609,7 +3671,9 @@ def tool_list_drawers(
                 _config.palace_path, _config.collection_name, where=where
             )
         if listed is not None:
-            ids, documents, metadatas = listed
+            # Documents are fetched for the displayed page only, below.
+            ids, metadatas = listed
+            documents = []
         else:
             col = _get_collection()
             if not col:
@@ -3625,7 +3689,9 @@ def tool_list_drawers(
             ]
 
         page = drawers[offset : offset + limit]
-        if listed is None:
+        if listed is not None:
+            _fill_drawer_previews_from_sqlite(page)
+        else:
             col = _get_collection()
             if col:
                 _fill_drawer_previews(col, page)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -2047,45 +2047,11 @@ def _graph_stats_from_grouped_rows(rows):
 
 
 def _chroma_room_wing_hall_counts():
-    import sqlite3 as _sqlite3
-
     if not _config.palace_path:
         return None
-    db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
-    if not os.path.isfile(db_path):
-        return None
-    collection_name = _config.collection_name
-    conn = _sqlite3.connect(sqlite_read_uri(db_path), uri=True)
-    try:
-        conn.execute("PRAGMA busy_timeout = 3000")
-        if (
-            conn.execute("SELECT 1 FROM collections WHERE name = ?", (collection_name,)).fetchone()
-            is None
-        ):
-            return None
-        return conn.execute(
-            """
-            SELECT
-                COALESCE(rm.string_value, CAST(rm.int_value AS TEXT),
-                         CAST(rm.float_value AS TEXT), '') AS room,
-                COALESCE(wm.string_value, CAST(wm.int_value AS TEXT),
-                         CAST(wm.float_value AS TEXT), '') AS wing,
-                COALESCE(hm.string_value, CAST(hm.int_value AS TEXT),
-                         CAST(hm.float_value AS TEXT), '') AS hall,
-                COUNT(*) AS n
-            FROM embeddings e
-            JOIN segments s ON e.segment_id = s.id AND s.scope = 'METADATA'
-            JOIN collections c ON s.collection = c.id
-            LEFT JOIN embedding_metadata rm ON rm.id = e.id AND rm.key = 'room'
-            LEFT JOIN embedding_metadata wm ON wm.id = e.id AND wm.key = 'wing'
-            LEFT JOIN embedding_metadata hm ON hm.id = e.id AND hm.key = 'hall'
-            WHERE c.name = ?
-            GROUP BY room, wing, hall
-            """,
-            (collection_name,),
-        ).fetchall()
-    finally:
-        conn.close()
+    from .backends.chroma import sqlite_room_wing_hall_counts
+
+    return sqlite_room_wing_hall_counts(_config.palace_path, _config.collection_name)
 
 
 def tool_status():
@@ -2530,10 +2496,8 @@ def tool_get_aaak_spec():
 def tool_traverse_graph(start_room: str, max_hops: int = 2):
     """Walk the palace graph from a room. Find connected ideas across wings."""
     max_hops = max(1, min(max_hops, 10))
-    col = _get_collection()
-    if not col:
-        return _collection_error_or_no_palace()
-    return traverse(start_room, col=col, max_hops=max_hops)
+    # sqlite metadata path does not open HNSW; build_graph falls back itself.
+    return traverse(start_room, max_hops=max_hops, config=_config)
 
 
 def tool_find_tunnels(wing_a: str = None, wing_b: str = None):
@@ -2543,10 +2507,7 @@ def tool_find_tunnels(wing_a: str = None, wing_b: str = None):
         wing_b = _sanitize_optional_name(wing_b, "wing_b")
     except ValueError as e:
         return {"error": str(e)}
-    col = _get_collection()
-    if not col:
-        return _collection_error_or_no_palace()
-    return find_tunnels(wing_a, wing_b, col=col)
+    return find_tunnels(wing_a, wing_b, config=_config)
 
 
 def tool_graph_stats():
@@ -3625,10 +3586,6 @@ def tool_list_drawers(
     except ValueError as e:
         return {"error": str(e)}
 
-    col = _get_collection()
-    if not col:
-        return _collection_error_or_no_palace()
-
     try:
         where = None
         conditions = []
@@ -3643,7 +3600,21 @@ def tool_list_drawers(
         elif len(conditions) > 1:
             where = {"$and": conditions}
 
-        ids, documents, metadatas = _fetch_drawer_rows(col, where=where, include=["metadatas"])
+        ids = documents = metadatas = None
+        listed = None
+        if _is_chroma_backend() and _config.palace_path:
+            from .backends.chroma import sqlite_list_id_metadata
+
+            listed = sqlite_list_id_metadata(
+                _config.palace_path, _config.collection_name, where=where
+            )
+        if listed is not None:
+            ids, documents, metadatas = listed
+        else:
+            col = _get_collection()
+            if not col:
+                return _collection_error_or_no_palace()
+            ids, documents, metadatas = _fetch_drawer_rows(col, where=where, include=["metadatas"])
         drawers = _collapse_drawer_rows(ids, documents, metadatas)
 
         if since_dt is not None or before_dt is not None:
@@ -3654,7 +3625,10 @@ def tool_list_drawers(
             ]
 
         page = drawers[offset : offset + limit]
-        _fill_drawer_previews(col, page)
+        if listed is None:
+            col = _get_collection()
+            if col:
+                _fill_drawer_previews(col, page)
 
         return {
             "drawers": page,

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -66,30 +66,56 @@ _graph_cache_time = 0.0
 _GRAPH_CACHE_TTL = 60.0  # seconds — graph changes less often than metadata
 
 
+def sqlite_grouped_counts_reader(config=None):
+    """Return the backend's grouped-counts function, or ``None``.
+
+    ``None`` means the sqlite path cannot serve this palace and the caller
+    should use the collection — which is also how a missing or unreadable
+    palace keeps reporting a real diagnostic instead of an empty graph.
+
+    The backend is resolved from *configuration*, not by sniffing the palace
+    directory for db files: a directory holding artifacts for two backends is
+    a ``BackendMismatchError`` on every normal path, and sniffing would quietly
+    pick one instead of surfacing that.
+    """
+    config = config or MempalaceConfig()
+    if not config.palace_path:
+        return None
+    try:
+        from .palace import resolve_backend_name
+
+        backend = resolve_backend_name(
+            config.palace_path, explicit=os.environ.get("MEMPALACE_BACKEND_EXPLICIT")
+        )
+        if backend == "chroma":
+            from .backends.chroma import sqlite_room_wing_hall_counts
+
+            db_name = "chroma.sqlite3"
+        elif backend == "sqlite_exact":
+            from .backends.sqlite_exact import _DB_FILENAME as db_name
+            from .backends.sqlite_exact import sqlite_room_wing_hall_counts
+        else:
+            return None
+        if not os.path.isfile(os.path.join(config.palace_path, db_name)):
+            return None
+        return sqlite_room_wing_hall_counts
+    except Exception:
+        logger.debug("backend resolution for the sqlite graph path failed", exc_info=True)
+    return None
+
+
 def _try_sqlite_nodes_edges(config=None):
     """Build graph nodes/edges from backend sqlite metadata, no HNSW.
 
     Returns ``(nodes, edges)`` or ``None`` when the palace is not a sqlite
-    backend we know how to read. Dates are omitted (empty lists) — tunnel
-    ``recent`` stays blank on this path.
+    backend we know how to read, so the caller falls back to client paging.
     """
     config = config or MempalaceConfig()
-    palace = config.palace_path
-    name = config.collection_name
-    if not palace:
+    reader = sqlite_grouped_counts_reader(config)
+    if reader is None:
         return None
-    rows = None
-    chroma_db = os.path.join(palace, "chroma.sqlite3")
-    exact_db = os.path.join(palace, "sqlite_exact.sqlite3")
     try:
-        if os.path.isfile(chroma_db):
-            from .backends.chroma import sqlite_room_wing_hall_counts
-
-            rows = sqlite_room_wing_hall_counts(palace, name)
-        elif os.path.isfile(exact_db):
-            from .backends.sqlite_exact import sqlite_room_wing_hall_counts
-
-            rows = sqlite_room_wing_hall_counts(palace, name)
+        rows = reader(config.palace_path, config.collection_name)
     except Exception:
         logger.debug("sqlite graph path failed; falling back to client paging", exc_info=True)
         return None
@@ -99,15 +125,24 @@ def _try_sqlite_nodes_edges(config=None):
 
 
 def _nodes_edges_from_grouped_rows(rows):
-    """Mirror ``build_graph``'s per-drawer filter from ``(room, wing, hall, n)``."""
-    room_data = defaultdict(lambda: {"wings": set(), "halls": set(), "count": 0})
-    for room, wing, hall, n in rows:
+    """Mirror ``build_graph``'s per-drawer filter from grouped rows.
+
+    Rows are ``(room, wing, hall, n)`` with an optional fifth ``last_date``
+    column — backends that cannot supply a date still work, they just leave
+    ``dates`` empty as the client path does for undated drawers.
+    """
+    room_data = defaultdict(lambda: {"wings": set(), "halls": set(), "count": 0, "dates": set()})
+    for row in rows:
+        room, wing, hall, n = row[0], row[1], row[2], row[3]
+        last_date = row[4] if len(row) > 4 else ""
         if not room or room == "general" or not wing:
             continue
         node = room_data[str(room)]
         node["wings"].add(str(wing))
         if hall:
             node["halls"].add(str(hall))
+        if last_date:
+            node["dates"].add(str(last_date))
         node["count"] += int(n)
     edges = []
     nodes = {}
@@ -118,7 +153,7 @@ def _nodes_edges_from_grouped_rows(rows):
             "wings": wings,
             "halls": halls,
             "count": data["count"],
-            "dates": [],
+            "dates": sorted(data["dates"])[-5:] if data["dates"] else [],
         }
         if len(wings) >= 2:
             for i, wa in enumerate(wings):

--- a/mempalace/palace_graph.py
+++ b/mempalace/palace_graph.py
@@ -66,6 +66,76 @@ _graph_cache_time = 0.0
 _GRAPH_CACHE_TTL = 60.0  # seconds — graph changes less often than metadata
 
 
+def _try_sqlite_nodes_edges(config=None):
+    """Build graph nodes/edges from backend sqlite metadata, no HNSW.
+
+    Returns ``(nodes, edges)`` or ``None`` when the palace is not a sqlite
+    backend we know how to read. Dates are omitted (empty lists) — tunnel
+    ``recent`` stays blank on this path.
+    """
+    config = config or MempalaceConfig()
+    palace = config.palace_path
+    name = config.collection_name
+    if not palace:
+        return None
+    rows = None
+    chroma_db = os.path.join(palace, "chroma.sqlite3")
+    exact_db = os.path.join(palace, "sqlite_exact.sqlite3")
+    try:
+        if os.path.isfile(chroma_db):
+            from .backends.chroma import sqlite_room_wing_hall_counts
+
+            rows = sqlite_room_wing_hall_counts(palace, name)
+        elif os.path.isfile(exact_db):
+            from .backends.sqlite_exact import sqlite_room_wing_hall_counts
+
+            rows = sqlite_room_wing_hall_counts(palace, name)
+    except Exception:
+        logger.debug("sqlite graph path failed; falling back to client paging", exc_info=True)
+        return None
+    if rows is None:
+        return None
+    return _nodes_edges_from_grouped_rows(rows)
+
+
+def _nodes_edges_from_grouped_rows(rows):
+    """Mirror ``build_graph``'s per-drawer filter from ``(room, wing, hall, n)``."""
+    room_data = defaultdict(lambda: {"wings": set(), "halls": set(), "count": 0})
+    for room, wing, hall, n in rows:
+        if not room or room == "general" or not wing:
+            continue
+        node = room_data[str(room)]
+        node["wings"].add(str(wing))
+        if hall:
+            node["halls"].add(str(hall))
+        node["count"] += int(n)
+    edges = []
+    nodes = {}
+    for room, data in room_data.items():
+        wings = sorted(data["wings"])
+        halls = sorted(data["halls"])
+        nodes[room] = {
+            "wings": wings,
+            "halls": halls,
+            "count": data["count"],
+            "dates": [],
+        }
+        if len(wings) >= 2:
+            for i, wa in enumerate(wings):
+                for wb in wings[i + 1 :]:
+                    for hall in halls:
+                        edges.append(
+                            {
+                                "room": room,
+                                "wing_a": wa,
+                                "wing_b": wb,
+                                "hall": hall,
+                                "count": data["count"],
+                            }
+                        )
+    return nodes, edges
+
+
 def invalidate_graph_cache():
     """Clear the graph cache. Called from mcp_server.py on writes."""
     global _graph_cache_nodes, _graph_cache_edges, _graph_cache_time
@@ -110,7 +180,18 @@ def build_graph(col=None, config=None):
         if _graph_cache_nodes is not None and (now - _graph_cache_time) < _GRAPH_CACHE_TTL:
             return _graph_cache_nodes, _graph_cache_edges
 
+    # Only when the caller did not pass a collection: MCP tools. Tests that
+    # inject ``col=`` keep the client paging path against that collection.
     if col is None:
+        sqlite_graph = _try_sqlite_nodes_edges(config)
+        if sqlite_graph is not None:
+            nodes, edges = sqlite_graph
+            if nodes:
+                with _graph_cache_lock:
+                    _graph_cache_nodes = nodes
+                    _graph_cache_edges = edges
+                    _graph_cache_time = time.time()
+            return nodes, edges
         col = _get_collection(config)
     if not col:
         return {}, []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -126,6 +126,11 @@ def _patch_mcp_server(monkeypatch, config, kg):
     invalidate_graph_cache()
 
 
+def _unexpected_client_read(*_a, **_k):
+    """Tripwire for paths that must stay off the chroma client (and HNSW)."""
+    raise AssertionError("chroma collection opened — this path must read sqlite")
+
+
 def _get_collection(palace_path, create=False):
     """Helper to get collection from test palace.
 
@@ -1412,6 +1417,97 @@ with mine_palace_lock(sys.argv[1]):
         assert result["total"] == 1
         assert result["drawers"][0]["drawer_id"] == "keep"
         assert "keep me" in result["drawers"][0]["content_preview"]
+
+    def test_list_drawers_scan_filters_in_sql_and_skips_documents(
+        self, monkeypatch, config, palace_path, collection, kg
+    ):
+        """The listing scan must not drag the palace's text through memory.
+
+        ``chroma:document`` lives in ``embedding_metadata`` alongside the
+        loci, so an unqualified join pulls every drawer's verbatim content in
+        to render one page — on a six-figure palace that is hundreds of MB and
+        seconds of wall clock. The wing/room filter belongs in SQL for the same
+        reason: filtering in Python means scanning the whole collection first.
+        """
+        collection.add(
+            ids=["keep", "drop"],
+            documents=["keep me", "drop me"],
+            metadatas=[
+                {"wing": "mempalace", "room": "notes"},
+                {"wing": "other", "room": "notes"},
+            ],
+        )
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+        from mempalace.backends import chroma as chroma_backend
+
+        statements = []
+        real_connect = chroma_backend.sqlite3.connect
+
+        def _tracing_connect(*a, **kw):
+            conn = real_connect(*a, **kw)
+            conn.set_trace_callback(statements.append)
+            return conn
+
+        monkeypatch.setattr(chroma_backend.sqlite3, "connect", _tracing_connect)
+        monkeypatch.setattr(mcp_server, "_fetch_drawer_rows", _unexpected_client_read)
+        monkeypatch.setattr(mcp_server, "_get_collection", _unexpected_client_read)
+
+        result = mcp_server.tool_list_drawers(wing="mempalace", limit=20)
+        assert result["total"] == 1
+        assert "keep me" in result["drawers"][0]["content_preview"]
+
+        scans = [s for s in statements if "FROM embeddings" in s and "ORDER BY e.id" in s]
+        assert scans, f"no listing scan observed in {statements}"
+        scan = scans[0]
+        # Documents are excluded from the scan and the filter is pushed down.
+        assert "chroma:document" in scan and "!=" in scan
+        assert scan.count("JOIN embedding_metadata") >= 2, scan
+        assert "string_value = " in scan or "string_value = ?" in scan
+
+        # The page's documents are fetched by id, not by re-reading everything.
+        doc_reads = [
+            s
+            for s in statements
+            if "chroma:document" in s and "FROM embedding_metadata" in s and " id IN " in s
+        ]
+        assert doc_reads, f"page previews did not use an id-scoped read: {statements}"
+
+    def test_find_tunnels_reports_recent_from_sqlite(
+        self, monkeypatch, config, palace_path, collection, kg
+    ):
+        """``recent`` survives the sqlite path — it is part of the tool's output."""
+        collection.add(
+            ids=["d_old", "d_new"],
+            documents=["chromadb in code", "chromadb in project"],
+            metadatas=[
+                {"room": "chromadb", "wing": "wing_code", "hall": "db", "date": "2026-01-02"},
+                {"room": "chromadb", "wing": "wing_project", "hall": "db", "date": "2026-03-04"},
+            ],
+        )
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        monkeypatch.setattr(mcp_server, "_get_collection", _unexpected_client_read)
+        tunnels = mcp_server.tool_find_tunnels()
+        assert tunnels[0]["recent"] == "2026-03-04"
+
+    def test_graph_tools_report_a_missing_palace(self, monkeypatch, config, palace_path, kg):
+        """A palace with no database must diagnose, not look empty.
+
+        ``find_tunnels`` returning ``[]`` and ``traverse`` returning "room not
+        found" would tell the user their palace has no tunnels when in fact it
+        could not be opened at all.
+        """
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        tunnels = mcp_server.tool_find_tunnels()
+        assert isinstance(tunnels, dict) and tunnels.get("error")
+
+        walked = mcp_server.tool_traverse_graph("anything")
+        assert isinstance(walked, dict) and walked.get("error")
+        assert "not found" not in walked["error"].lower()
 
     def test_no_palace_returns_error(self, monkeypatch, config, kg):
         _patch_mcp_server(monkeypatch, config, kg)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -121,6 +121,9 @@ def _patch_mcp_server(monkeypatch, config, kg):
     monkeypatch.setattr(mcp_server, "_get_kg", lambda *a, **kw: kg)
     monkeypatch.setattr(mcp_server, "_taxonomy_cache", None)
     monkeypatch.setattr(mcp_server, "_taxonomy_cache_time", 0.0)
+    from mempalace.palace_graph import invalidate_graph_cache
+
+    invalidate_graph_cache()
 
 
 def _get_collection(palace_path, create=False):
@@ -1363,6 +1366,52 @@ with mine_palace_lock(sys.argv[1]):
         assert stats["top_tunnels"] == [
             {"room": "chromadb", "wings": ["wing_code", "wing_project"], "count": 2}
         ]
+
+    def test_find_tunnels_uses_sqlite_fast_path(
+        self, monkeypatch, config, palace_path, collection, kg
+    ):
+        collection.add(
+            ids=["d_db_code", "d_db_proj"],
+            documents=["chromadb in code", "chromadb in project"],
+            metadatas=[
+                {"room": "chromadb", "wing": "wing_code", "hall": "db"},
+                {"room": "chromadb", "wing": "wing_project", "hall": "db"},
+            ],
+        )
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        def _no_client_open(*_a, **_k):
+            raise AssertionError("chroma collection opened — find_tunnels must use sqlite")
+
+        monkeypatch.setattr(mcp_server, "_get_collection", _no_client_open)
+        tunnels = mcp_server.tool_find_tunnels()
+        assert tunnels[0]["room"] == "chromadb"
+        assert set(tunnels[0]["wings"]) == {"wing_code", "wing_project"}
+
+    def test_list_drawers_uses_chroma_sqlite_metadata(
+        self, monkeypatch, config, palace_path, collection, kg
+    ):
+        collection.add(
+            ids=["keep", "drop"],
+            documents=["keep me", "drop me"],
+            metadatas=[
+                {"wing": "mempalace", "room": "notes"},
+                {"wing": "other", "room": "notes"},
+            ],
+        )
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        def _boom(*_a, **_k):
+            raise AssertionError("list_drawers paged col.get instead of chroma sqlite")
+
+        monkeypatch.setattr(mcp_server, "_fetch_drawer_rows", _boom)
+        monkeypatch.setattr(mcp_server, "_get_collection", _boom)
+        result = mcp_server.tool_list_drawers(wing="mempalace", limit=20)
+        assert result["total"] == 1
+        assert result["drawers"][0]["drawer_id"] == "keep"
+        assert "keep me" in result["drawers"][0]["content_preview"]
 
     def test_no_palace_returns_error(self, monkeypatch, config, kg):
         _patch_mcp_server(monkeypatch, config, kg)

--- a/tests/test_palace_graph.py
+++ b/tests/test_palace_graph.py
@@ -3,6 +3,8 @@
 All ChromaDB access is mocked — no real database needed.
 """
 
+import json
+import os
 from unittest.mock import MagicMock, patch
 
 
@@ -305,3 +307,52 @@ class TestFuzzyMatch:
         nodes = {f"room-{i}": {} for i in range(20)}
         result = _fuzzy_match("room", nodes, n=3)
         assert len(result) <= 3
+
+
+# --- sqlite fast path backend gating ---
+
+
+class TestSqliteGroupedCountsReader:
+    """The sqlite graph path must follow configuration, not the filesystem."""
+
+    MAGIC = b"SQLite format 3\x00"
+
+    def _config(self, palace_path):
+        from mempalace.config import MempalaceConfig
+
+        cfg_dir = os.path.join(os.path.dirname(palace_path), "config")
+        os.makedirs(cfg_dir, exist_ok=True)
+        with open(os.path.join(cfg_dir, "config.json"), "w") as f:
+            json.dump({"palace_path": palace_path}, f)
+        return MempalaceConfig(config_dir=cfg_dir)
+
+    def test_chroma_palace_resolves_a_reader(self, tmp_path):
+        from mempalace.backends.chroma import sqlite_room_wing_hall_counts
+        from mempalace.palace_graph import sqlite_grouped_counts_reader
+
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        (palace / "chroma.sqlite3").write_bytes(self.MAGIC)
+        assert (
+            sqlite_grouped_counts_reader(self._config(str(palace))) is sqlite_room_wing_hall_counts
+        )
+
+    def test_missing_database_falls_back_to_the_client(self, tmp_path):
+        """No db file means no fast path — that is how a broken palace still
+        reports a diagnostic instead of an empty graph."""
+        from mempalace.palace_graph import sqlite_grouped_counts_reader
+
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        assert sqlite_grouped_counts_reader(self._config(str(palace))) is None
+
+    def test_mixed_backend_artifacts_do_not_get_sniffed(self, tmp_path):
+        """Two backends' files in one directory is a ``BackendMismatchError``
+        on every normal path; picking one by file order would hide that."""
+        from mempalace.palace_graph import sqlite_grouped_counts_reader
+
+        palace = tmp_path / "palace"
+        palace.mkdir()
+        (palace / "chroma.sqlite3").write_bytes(self.MAGIC)
+        (palace / "sqlite_exact.sqlite3").write_bytes(self.MAGIC)
+        assert sqlite_grouped_counts_reader(self._config(str(palace))) is None

--- a/tests/test_sqlite_exact_backend.py
+++ b/tests/test_sqlite_exact_backend.py
@@ -1256,17 +1256,17 @@ def test_sqlite_exact_room_wing_hall_counts(tmp_path):
         ids=["1", "2", "3"],
         documents=["a", "b", "c"],
         metadatas=[
-            {"room": "chromadb", "wing": "wing_code", "hall": "db"},
+            {"room": "chromadb", "wing": "wing_code", "hall": "db", "date": "2026-01-02"},
             {"room": "chromadb", "wing": "wing_project", "hall": "db"},
             {"room": "auth", "wing": "wing_code", "hall": "security"},
         ],
         embeddings=[[1, 0], [1, 0], [1, 0]],
     )
     rows = sqlite_room_wing_hall_counts(str(tmp_path), "mempalace_drawers")
-    grouped = {(room, wing, hall): n for room, wing, hall, n in rows}
-    assert grouped[("chromadb", "wing_code", "db")] == 1
-    assert grouped[("chromadb", "wing_project", "db")] == 1
-    assert grouped[("auth", "wing_code", "security")] == 1
+    grouped = {(room, wing, hall): (n, last) for room, wing, hall, n, last in rows}
+    assert grouped[("chromadb", "wing_code", "db")] == (1, "2026-01-02")
+    assert grouped[("chromadb", "wing_project", "db")] == (1, "")
+    assert grouped[("auth", "wing_code", "security")] == (1, "")
 
 
 def test_sqlite_exact_locus_columns_and_index(tmp_path):


### PR DESCRIPTION
Yes — chroma can take the same shortcut sqlite_exact did: **read loci from `chroma.sqlite3`, do not page `col.get()` / HNSW.**

Measured on `igorls-blade-15` (i7-8750H, chroma 1.7 GB, 165k drawers, develop 3.7.1):

| Call | Before |
|---|---|
| `list_drawers` no filter, limit=20 | **36.6 s** |
| `find_tunnels` | **29.7 s then Internal tool error** |
| `graph_stats` | 1.2 s (already had sqlite GROUP BY) |
| warm search | 111–373 ms (HNSW is fine once loaded) |

## Changes

- `chroma.sqlite_list_id_metadata` — ids + metadata + `chroma:document` from `embedding_metadata`, no vector index
- `chroma.sqlite_room_wing_hall_counts` — shared grouped read for graph_stats and `build_graph`
- `build_graph()` uses that path when MCP does not inject a collection (tests that pass `col=` keep paging)
- `find_tunnels` / `traverse` no longer open the collection first

`list_drawers` and tunnels become sqlite scans; search still uses HNSW (that's the right tool).

Tests: `TestReadTools` graph_stats / find_tunnels / list_drawers sqlite tripwires + `test_palace_graph.py`.
