### PR TITLE
feat(logstream): background watcher agents can be woken by, plus the monitoring protocol

### DIFF
--- a/integrations/shared/coordination-protocol.md
+++ b/integrations/shared/coordination-protocol.md
@@ -120,7 +120,10 @@ mempalace logstream watch \
   routine status traffic stops waking you.
 - **`--state-file`** persists the cursor, so a restart resumes exactly where
   it stopped rather than replaying or skipping. It advances past events that
-  were examined and rejected, not only matches.
+  were examined and rejected, not only matches. When the cursor cannot be
+  read, or the watcher first started against an empty log, it replays rather
+  than jumping to the tip — a restart may cost you a duplicate, never a
+  missed delegation.
 - **Exit codes** are the wake signal: `0` when it printed a match, `2` when
   `--idle-exit-ms` expired having seen nothing, `130` when interrupted. Only
   `0` means "you have mail" — an interrupted watcher must never claim it.

--- a/integrations/shared/coordination-protocol.md
+++ b/integrations/shared/coordination-protocol.md
@@ -59,6 +59,100 @@ the event trail is only auditable if identities are stable.
    `type=task.reply` with `status=blocked` or `failed` and verbatim
    notes. Silence is the only unrecoverable failure.
 
+## Monitoring the stream
+
+Most coordination friction is not a protocol failure — it is a *listening*
+failure. A task sits `open` because the agent it was addressed to was never
+watching, and the requester cannot tell the difference between "working on
+it" and "nobody is home". Pick a monitoring mode deliberately and make it
+visible.
+
+### The cursor rule
+
+**Resume with `since_event_id`. Never resume with `since_created_at`.**
+
+Events are ordered by *append* order (rowid), not by wall clock. Across
+replicas those diverge: a peer's event created at 09:10:48Z can be ingested
+*after* a local event created at 09:13:21Z, because it only arrived at sync
+time. A cursor based on `since_created_at` silently skips such an event —
+it is already older than your high-water mark by the time you see it, so you
+never see it at all.
+
+- `since_event_id` — the precise cursor: strictly after that event in append
+  order, regardless of timestamp ties. **This is what a watcher stores.**
+- `since_created_at` — a time *window* for questions like "what happened
+  today". Inclusive (`>=`), so callers must dedup by `id`. Not a cursor.
+
+Your entire watcher state is one string: the id of the last event you
+processed.
+
+### Four modes — pick by how long you stay alive
+
+| Mode | Use when | How |
+|---|---|---|
+| **Inbox sweep** | Start of every session, and before any long task | `mempalace_event_list` with `to_agent=<you>`, `since_event_id=<last seen>`, `preview=true` |
+| **Long-poll** | Actively waiting on a task you delegated or claimed | `mempalace_event_wait` with `correlation_id` + `to_agent=<you>`, looping with an updated `since_event_id` |
+| **Push (SSE)** | Persistent processes: daemons, dashboards, live viewers | `GET /logstream/stream` — same filters, same envelope, `since_event_id` resume |
+| **Declared-idle** | Turn-based agents that stop existing between prompts | You cannot watch. Say so, publish your cursor, and let the requester ping you |
+
+Notes that save round trips:
+
+- `mempalace_event_wait` defaults to 60s and caps at 5 minutes. On timeout it
+  returns `{"timed_out": true, "events": []}` — a normal result, not an error.
+  It already backs off internally (0.25s → 1s); **do not wrap it in a tight
+  retry loop**, just call it again with your updated cursor.
+- Filter server-side. `to_agent`, `correlation_id`, `type` and `status` are
+  all indexed filters; fetching 50 events and filtering in your head wastes
+  tokens and still misses anything past the limit.
+- `preview=true` truncates bodies to an excerpt and marks `body_truncated` +
+  `body_length`, so a sweep over a busy stream stays cheap. Re-fetch the one
+  event you actually care about with a targeted `correlation_id`.
+- `to_agent=<you>` also matches `*` broadcasts automatically. You do not need
+  a second call for them.
+
+### Announce your watch
+
+Before a coordinated task, post a `status` event to `to_agent=*` declaring
+that you are listening, on exactly what, and from where. This is what lets
+another agent see who is home *before* delegating, instead of discovering it
+by timeout:
+
+```text
+type: status   room: status   to_agent: *   correlation_id: <the task>
+
+<AGENT_ID> is MONITORING this correlation for coordination replies
+(task.request / task.reply / patch.ready / status).
+
+Watching: to_agent=<AGENT_ID> and correlation_id=<id> on stream project/<name>.
+Cursor after: evt_20260811T112013_19320fbd7541
+
+If you are working <overlapping area>, reply on this correlation so we do not
+double-work. <What is already done and must not be redone.>
+```
+
+The four parts that make it useful: **the filter** (so others know what
+reaches you), **the cursor** (so others know what you have already seen),
+**the overlap warning** (so others do not duplicate), and **the fact that a
+watcher exists at all**.
+
+### Declare when you are *not* watching
+
+A turn-based agent — most chat-driven harnesses — has no background loop. It
+sweeps its inbox when a human prompts it and is otherwise deaf. That is a
+legitimate mode, but silent deafness is what makes coordination annoying.
+
+If you cannot monitor, say so in your reply and publish your cursor, so the
+requester knows a ping is required and knows where you left off:
+
+```text
+<AGENT_ID> is NOT monitoring — turn-based, no background watcher.
+Last seen: evt_20260820T053821_a5fdd770ec20
+Ping the operator to wake me; I sweep to_agent=<AGENT_ID> on every start.
+```
+
+Never claim to be monitoring when you are not. A false watcher is worse than
+a declared-absent one: the requester stops looking for a human to nudge.
+
 ## Hard rules
 
 - **Never apply a patch silently.** Fetching an artifact is free;
@@ -72,6 +166,10 @@ the event trail is only auditable if identities are stable.
   artifact and reference it.
 - **Close every loop.** Every `task.request` you claimed ends in an
   `applied`, `failed`, or `blocked` — no dangling `open` tasks.
+- **Never fake a watch.** Declare the monitoring mode you are actually in.
+  Claiming to listen when you are turn-based strands the requester.
+- **Cursors are event ids.** `since_created_at` is a time window, not a
+  resume point; using it as one drops late-arriving cross-replica events.
 - **File the outcome.** When a delegation concludes, write one drawer
   (`mempalace_add_drawer`) recording what was decided/learned, so the
   result is searchable without replaying the event trail.
@@ -99,8 +197,18 @@ Memory (recall + writing):
 
 Coordination (logstream):
 - Check your inbox when starting work and before long tasks:
-  mempalace_event_list with to_agent=<AGENT_ID> (new since your last
-  seen event id).
+  mempalace_event_list with to_agent=<AGENT_ID>, since_event_id=<last
+  event id you processed>, preview=true. Remember that id — it is your
+  cursor. Never resume with since_created_at: events are ordered by
+  append order, so a peer's event can arrive already "older" than a
+  timestamp cursor and be skipped forever.
+- Monitoring: while actively waiting, long-poll with mempalace_event_wait
+  (correlation_id + to_agent=<AGENT_ID>); it returns {timed_out: true}
+  after at most 5 minutes, so re-call it with an updated cursor rather
+  than looping tightly. Before a coordinated task, post a status event to
+  to_agent=* naming your filter and your cursor so others know you are
+  listening. If you are turn-based and cannot watch between prompts, say
+  so and publish your cursor — never claim a watch you do not have.
 - To delegate: mempalace_event_append (type=task.request, stream=
   project/<name>, room=delegation, correlation_id=task_..., status=open,
   body = goal + branch + base commit + definition of done), then

--- a/integrations/shared/coordination-protocol.md
+++ b/integrations/shared/coordination-protocol.md
@@ -91,16 +91,49 @@ processed.
 | Mode | Use when | How |
 |---|---|---|
 | **Inbox sweep** | Start of every session, and before any long task | `mempalace_event_list` with `to_agent=<you>`, `since_event_id=<last seen>`, `preview=true` |
-| **Long-poll** | Actively waiting on a task you delegated or claimed | `mempalace_event_wait` with `correlation_id` + `to_agent=<you>`, looping with an updated `since_event_id` |
+| **Background watcher** | You want to be woken while you work | `mempalace logstream watch` as a background process — see below |
+| **Long-poll** | Actively waiting on one known correlation, in-turn | `mempalace_event_wait` with `correlation_id` + `to_agent=<you>` |
 | **Push (SSE)** | Persistent processes: daemons, dashboards, live viewers | `GET /logstream/stream` — same filters, same envelope, `since_event_id` resume |
 | **Declared-idle** | Turn-based agents that stop existing between prompts | You cannot watch. Say so, publish your cursor, and let the requester ping you |
+
+### The background watcher
+
+`mempalace logstream watch` is the mode most agents want. It blocks until
+something you care about arrives, prints it, and exits — so any harness that
+can run a background process and react to its exit gets woken:
+
+```bash
+mempalace logstream watch \
+  --agent mac-claude \
+  --type task.request --type patch.ready \
+  --state-file ~/.mempalace/watch/mac-claude.json --json
+```
+
+- **`--agent <id>`** is the flag to reach for. It means `--to-agent <id>`
+  *and* `--exclude-from-agent <id>`. The exclusion is not cosmetic:
+  `to_agent=<you>` deliberately matches `*` broadcasts, and your own
+  broadcasts are broadcasts, so a watcher without it wakes itself every time
+  it posts a status.
+- **Repeat a filter to mean "or"** — `--type task.request --type patch.ready`
+  wakes for either and stays silent for everything else. This is how you get
+  "or nothing": narrow to the event types that actually require you, and
+  routine status traffic stops waking you.
+- **`--state-file`** persists the cursor, so a restart resumes exactly where
+  it stopped rather than replaying or skipping. It advances past events that
+  were examined and rejected, not only matches.
+- **Exit codes** are the wake signal: `0` when it printed a match, `2` when
+  `--idle-exit-ms` expired having seen nothing. Same convention as
+  `logstream wait`.
+- **`--follow`** keeps going after the first match instead of exiting — use
+  it for daemons; leave it off for harnesses that wake on process exit.
 
 Notes that save round trips:
 
 - `mempalace_event_wait` defaults to 60s and caps at 5 minutes. On timeout it
   returns `{"timed_out": true, "events": []}` — a normal result, not an error.
   It already backs off internally (0.25s → 1s); **do not wrap it in a tight
-  retry loop**, just call it again with your updated cursor.
+  retry loop**. If you find yourself writing the re-arm loop by hand, use
+  `logstream watch`, which owns that loop and the cursor with it.
 - Filter server-side. `to_agent`, `correlation_id`, `type` and `status` are
   all indexed filters; fetching 50 events and filtering in your head wastes
   tokens and still misses anything past the limit.
@@ -202,13 +235,17 @@ Coordination (logstream):
   cursor. Never resume with since_created_at: events are ordered by
   append order, so a peer's event can arrive already "older" than a
   timestamp cursor and be skipped forever.
-- Monitoring: while actively waiting, long-poll with mempalace_event_wait
-  (correlation_id + to_agent=<AGENT_ID>); it returns {timed_out: true}
-  after at most 5 minutes, so re-call it with an updated cursor rather
-  than looping tightly. Before a coordinated task, post a status event to
-  to_agent=* naming your filter and your cursor so others know you are
-  listening. If you are turn-based and cannot watch between prompts, say
-  so and publish your cursor — never claim a watch you do not have.
+- Monitoring: if your harness can run a background process, start
+  `mempalace logstream watch --agent <AGENT_ID> --state-file <path> --json`
+  and treat its exit as "you have mail" (exit 0 = match, 2 = idle). Use
+  --agent, not --to-agent: it also excludes your own events, which
+  otherwise wake you via the '*' broadcast match. Repeat --type to wake
+  only for what needs you. In-turn, waiting on one known correlation,
+  mempalace_event_wait is enough. Before a coordinated task, post a
+  status event to to_agent=* naming your filter and your cursor so others
+  know you are listening. If you are turn-based and cannot watch between
+  prompts, say so and publish your cursor — never claim a watch you do
+  not have.
 - To delegate: mempalace_event_append (type=task.request, stream=
   project/<name>, room=delegation, correlation_id=task_..., status=open,
   body = goal + branch + base commit + definition of done), then

--- a/integrations/shared/coordination-protocol.md
+++ b/integrations/shared/coordination-protocol.md
@@ -126,6 +126,10 @@ mempalace logstream watch \
   `logstream wait`.
 - **`--follow`** keeps going after the first match instead of exiting — use
   it for daemons; leave it off for harnesses that wake on process exit.
+- **A first watch starts at the tip**, matching the SSE live-tail, and says so
+  on stderr. Replaying a long fleet log would wake you holding weeks of
+  history with nothing marking it stale. Backlog is the inbox sweep's job;
+  pass `--from-start` if you really do want the replay.
 
 Notes that save round trips:
 

--- a/integrations/shared/coordination-protocol.md
+++ b/integrations/shared/coordination-protocol.md
@@ -122,8 +122,11 @@ mempalace logstream watch \
   it stopped rather than replaying or skipping. It advances past events that
   were examined and rejected, not only matches.
 - **Exit codes** are the wake signal: `0` when it printed a match, `2` when
-  `--idle-exit-ms` expired having seen nothing. Same convention as
-  `logstream wait`.
+  `--idle-exit-ms` expired having seen nothing, `130` when interrupted. Only
+  `0` means "you have mail" — an interrupted watcher must never claim it.
+- **`--follow --json` emits NDJSON**, one record per line, because repeated
+  indented documents on one stream are not parseable JSON. A single-shot
+  watch prints one pretty document instead.
 - **`--follow`** keeps going after the first match instead of exiting — use
   it for daemons; leave it off for harnesses that wake on process exit.
 - **A first watch starts at the tip**, matching the SSE live-tail, and says so

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1531,6 +1531,102 @@ def _print_event_line(event):
     )
 
 
+def _logstream_watch(ls, args, as_json):
+    """Run ``logstream watch`` — block until interesting events arrive.
+
+    Split out of ``cmd_logstream`` so that dispatcher stays under the
+    complexity gate: this branch carries cursor persistence, an idle timeout,
+    and follow-vs-exit semantics that no other subcommand needs.
+
+    Exit contract, chosen so a harness can background this process and treat
+    its exit as a wake-up: return (0) when a match was printed, 2 when the
+    idle timeout expired having seen nothing — the same convention
+    ``logstream wait`` uses for a timeout.
+    """
+    import json
+    import time
+
+    from .logstream import normalize_watch_values, read_watch_cursor, write_watch_cursor
+
+    to_agents = list(args.to_agent or [])
+    exclude = list(args.exclude_from_agent or [])
+    if args.agent:
+        # The whole point of --agent: to_agent=<me> also matches '*'
+        # broadcasts, and your own broadcasts are broadcasts — so a watcher
+        # without this exclusion wakes itself every time it posts a status.
+        to_agents.append(args.agent)
+        exclude.append(args.agent)
+    spec = {
+        "streams": normalize_watch_values(args.stream),
+        "rooms": normalize_watch_values(args.room),
+        "types": normalize_watch_values(args.type),
+        "statuses": normalize_watch_values(args.status),
+        "to_agents": normalize_watch_values(to_agents),
+        "from_agents": normalize_watch_values(args.from_agent),
+        "exclude_from_agents": normalize_watch_values(exclude),
+        "correlation_ids": normalize_watch_values(args.correlation_id),
+    }
+    cursor = args.since_event_id or read_watch_cursor(args.state_file)
+    if not as_json:
+        where = args.agent or ", ".join(sorted(spec["to_agents"] or [])) or "everything"
+        print(f"Watching {where} from {cursor or 'now'}; Ctrl-C to stop.", file=sys.stderr)
+
+    idle_s = args.idle_exit_ms / 1000.0 if args.idle_exit_ms and args.idle_exit_ms > 0 else None
+    deadline = time.monotonic() + idle_s if idle_s else None
+    matched_any = False
+    try:
+        for matched, cursor in ls.watch_events(
+            cursor=cursor,
+            poll_timeout_ms=args.poll_timeout_ms,
+            limit=args.limit,
+            **spec,
+        ):
+            # Checkpoint every advance, including idle ones: the cursor moves
+            # past events that were examined and rejected, and re-judging them
+            # after a restart is pure waste.
+            write_watch_cursor(args.state_file, cursor, agent=args.agent)
+            if matched:
+                matched_any = True
+                if idle_s:
+                    deadline = time.monotonic() + idle_s
+                if as_json:
+                    print(
+                        json.dumps(
+                            {
+                                "events": matched,
+                                "count": len(matched),
+                                "cursor": cursor,
+                                "timed_out": False,
+                            },
+                            indent=2,
+                            ensure_ascii=False,
+                        ),
+                        flush=True,
+                    )
+                else:
+                    print(f"{len(matched)} event(s):")
+                    for event in matched:
+                        _print_event_line(event)
+                    sys.stdout.flush()
+                if not args.follow:
+                    return
+                continue
+            if deadline is not None and time.monotonic() >= deadline:
+                if as_json:
+                    print(
+                        json.dumps(
+                            {"events": [], "count": 0, "cursor": cursor, "timed_out": True},
+                            indent=2,
+                        )
+                    )
+                else:
+                    print("Idle timeout; no matching events.")
+                sys.exit(0 if matched_any else 2)
+    except KeyboardInterrupt:
+        if not as_json:
+            print("Stopped.", file=sys.stderr)
+
+
 def cmd_logstream(args):
     import json
 
@@ -1598,6 +1694,8 @@ def cmd_logstream(args):
                         _print_event_line(event)
             if result.get("timed_out"):
                 sys.exit(2)
+        elif args.logstream_action == "watch":
+            _logstream_watch(ls, args, as_json)
         elif args.logstream_action == "sync":
             from .logsync import load_peers, sync_all, sync_with_peer
 
@@ -3033,6 +3131,78 @@ def main():
         "--limit", type=int, default=50, help="Max events to return on match (default 50)"
     )
     p_ls_wait.add_argument("--json", action="store_true", help="Machine-readable output")
+
+    p_ls_watch = logstream_sub.add_parser(
+        "watch",
+        help="Background watcher: block until interesting events arrive, then wake (exit 2 on idle)",
+    )
+    p_ls_watch.add_argument(
+        "--agent",
+        default=None,
+        help=(
+            "Your identity. Shorthand for --to-agent <id> --exclude-from-agent <id>: "
+            "wake for what is addressed to you (broadcasts included) but never for "
+            "your own events"
+        ),
+    )
+    p_ls_watch.add_argument(
+        "--stream", action="append", default=None, help="Stream (repeatable; matches any)"
+    )
+    p_ls_watch.add_argument(
+        "--room", action="append", default=None, help="Room (repeatable; matches any)"
+    )
+    p_ls_watch.add_argument(
+        "--type", action="append", default=None, help="Event type (repeatable; matches any)"
+    )
+    p_ls_watch.add_argument(
+        "--status", action="append", default=None, help="Status (repeatable; matches any)"
+    )
+    p_ls_watch.add_argument(
+        "--to-agent", action="append", default=None, help="Target agent (repeatable; '*' matches)"
+    )
+    p_ls_watch.add_argument(
+        "--from-agent", action="append", default=None, help="Writer agent (repeatable)"
+    )
+    p_ls_watch.add_argument(
+        "--exclude-from-agent",
+        action="append",
+        default=None,
+        help="Never wake for events written by this agent (repeatable)",
+    )
+    p_ls_watch.add_argument(
+        "--correlation-id", action="append", default=None, help="Correlation id (repeatable)"
+    )
+    p_ls_watch.add_argument(
+        "--since-event-id",
+        default=None,
+        help="Start strictly after this event id (overrides --state-file)",
+    )
+    p_ls_watch.add_argument(
+        "--state-file",
+        default=None,
+        help="Persist the cursor here so a restart resumes exactly where it stopped",
+    )
+    p_ls_watch.add_argument(
+        "--follow",
+        action="store_true",
+        help="Keep watching after a match instead of exiting on the first one",
+    )
+    p_ls_watch.add_argument(
+        "--idle-exit-ms",
+        type=int,
+        default=0,
+        help="Give up after this long with no match (0 = wait forever)",
+    )
+    p_ls_watch.add_argument(
+        "--poll-timeout-ms",
+        type=int,
+        default=300000,
+        help="Long-poll length per iteration (default 300000, the server maximum)",
+    )
+    p_ls_watch.add_argument(
+        "--limit", type=int, default=50, help="Max events per poll (default 50)"
+    )
+    p_ls_watch.add_argument("--json", action="store_true", help="Machine-readable output")
 
     p_ls_ack = logstream_sub.add_parser(
         "ack", help="Acknowledge an event (appends event.ack, never mutates)"

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1615,8 +1615,18 @@ def _logstream_watch(ls, args, as_json):
         # Record the starting position immediately, even when the log is
         # empty and that position is None. Without the file, the next launch
         # is indistinguishable from a first run and would jump past anything
-        # that arrived while this watcher was stopped.
-        write_watch_cursor(args.state_file, cursor, agent=args.agent)
+        # that arrived while this watcher was stopped — so unlike later
+        # checkpoints this one must not fail quietly.
+        if args.state_file:
+            try:
+                write_watch_cursor(args.state_file, cursor, agent=args.agent, required=True)
+            except OSError as exc:
+                _logstream_fail(
+                    f"could not write the initial checkpoint to {args.state_file}: {exc}. "
+                    "Refusing to start: without it a restart would skip every event "
+                    "that arrives before then.",
+                    as_json,
+                )
     if not as_json:
         where = args.agent or ", ".join(sorted(spec["to_agents"] or [])) or "everything"
         print(f"Watching {where} from {cursor or 'now'}; Ctrl-C to stop.", file=sys.stderr)

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1612,21 +1612,26 @@ def _logstream_watch(ls, args, as_json):
         # what arrives from now on. Never silent: say what was skipped.
         cursor = ls.latest_event_id()
         skipped_from = cursor
-        # Record the starting position immediately, even when the log is
-        # empty and that position is None. Without the file, the next launch
-        # is indistinguishable from a first run and would jump past anything
-        # that arrived while this watcher was stopped — so unlike later
-        # checkpoints this one must not fail quietly.
-        if args.state_file:
-            try:
-                write_watch_cursor(args.state_file, cursor, agent=args.agent, required=True)
-            except OSError as exc:
-                _logstream_fail(
-                    f"could not write the initial checkpoint to {args.state_file}: {exc}. "
-                    "Refusing to start: without it a restart would skip every event "
-                    "that arrives before then.",
-                    as_json,
-                )
+
+    # One place decides the starting position; one place records it. That
+    # position can arrive three ways — an explicit --since-event-id, the tip
+    # above, or None (an empty log, or --from-start) — and every one of them
+    # needs the same immediate checkpoint when no state file exists yet.
+    # Deferring to the first watch_events yield leaves a window of up to a
+    # full poll timeout in which an interrupt leaves no file behind, and the
+    # next launch calls itself a first run and jumps to the tip, skipping
+    # whatever arrived in between. Unlike later checkpoints this one cannot
+    # fail quietly: losing it costs a skipped event, not a replay.
+    if args.state_file and state_condition == WATCH_STATE_ABSENT:
+        try:
+            write_watch_cursor(args.state_file, cursor, agent=args.agent, required=True)
+        except OSError as exc:
+            _logstream_fail(
+                f"could not write the initial checkpoint to {args.state_file}: {exc}. "
+                "Refusing to start: without it a restart would skip every event "
+                "that arrives before then.",
+                as_json,
+            )
     if not as_json:
         where = args.agent or ", ".join(sorted(spec["to_agents"] or [])) or "everything"
         print(f"Watching {where} from {cursor or 'now'}; Ctrl-C to stop.", file=sys.stderr)

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1564,7 +1564,13 @@ def _logstream_watch(ls, args, as_json):
     """
     import time
 
-    from .logstream import normalize_watch_values, read_watch_cursor, write_watch_cursor
+    from .logstream import (
+        WATCH_STATE_ABSENT,
+        WATCH_STATE_CORRUPT,
+        normalize_watch_values,
+        read_watch_state,
+        write_watch_cursor,
+    )
 
     to_agents = list(args.to_agent or [])
     exclude = list(args.exclude_from_agent or [])
@@ -1589,19 +1595,15 @@ def _logstream_watch(ls, args, as_json):
         # yield forever without ever polling, burning a core.
         _logstream_fail("--poll-timeout-ms must be a positive number of milliseconds", as_json)
 
-    stored_cursor = read_watch_cursor(args.state_file)
-    # read_watch_cursor returns None both for "no state file yet" and for
-    # "state file exists but could not be read". Those must not be treated
-    # alike: jumping to the tip after a *failed* read silently skips
-    # everything appended since the last good checkpoint, and the next
-    # checkpoint makes that loss permanent. A corrupt state file costs a
-    # replay, exactly as read_watch_cursor's contract promises.
-    recovery_failed = (
-        bool(args.state_file) and stored_cursor is None and os.path.exists(args.state_file)
-    )
+    stored_cursor, state_condition = read_watch_state(args.state_file)
+    # A missing cursor is four different facts, and only one of them may
+    # start at the tip. Treating a corrupt file or an empty-log restart as a
+    # first run skips everything that arrived since, then checkpoints past
+    # it — the loss is silent and permanent.
+    recovery_failed = state_condition == WATCH_STATE_CORRUPT
     cursor = args.since_event_id or stored_cursor
     skipped_from = None
-    if cursor is None and not args.from_start and not recovery_failed:
+    if cursor is None and not args.from_start and state_condition == WATCH_STATE_ABSENT:
         # Start at the tip, like the SSE live-tail does at connect time.
         # Starting from the beginning of a long fleet log means a fresh
         # watcher wakes holding weeks of history and cannot tell it is
@@ -1610,6 +1612,11 @@ def _logstream_watch(ls, args, as_json):
         # what arrives from now on. Never silent: say what was skipped.
         cursor = ls.latest_event_id()
         skipped_from = cursor
+        # Record the starting position immediately, even when the log is
+        # empty and that position is None. Without the file, the next launch
+        # is indistinguishable from a first run and would jump past anything
+        # that arrived while this watcher was stopped.
+        write_watch_cursor(args.state_file, cursor, agent=args.agent)
     if not as_json:
         where = args.agent or ", ".join(sorted(spec["to_agents"] or [])) or "everything"
         print(f"Watching {where} from {cursor or 'now'}; Ctrl-C to stop.", file=sys.stderr)

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1567,9 +1567,25 @@ def _logstream_watch(ls, args, as_json):
         "correlation_ids": normalize_watch_values(args.correlation_id),
     }
     cursor = args.since_event_id or read_watch_cursor(args.state_file)
+    skipped_from = None
+    if cursor is None and not args.from_start:
+        # Start at the tip, like the SSE live-tail does at connect time.
+        # Starting from the beginning of a long fleet log means a fresh
+        # watcher wakes holding weeks of history and cannot tell it is
+        # stale — measured 41 events, the oldest 49 days old, on a real
+        # shared brain. Backlog is the inbox sweep's job; a watcher is for
+        # what arrives from now on. Never silent: say what was skipped.
+        cursor = ls.latest_event_id()
+        skipped_from = cursor
     if not as_json:
         where = args.agent or ", ".join(sorted(spec["to_agents"] or [])) or "everything"
         print(f"Watching {where} from {cursor or 'now'}; Ctrl-C to stop.", file=sys.stderr)
+    if skipped_from:
+        print(
+            f"Starting at the tip ({skipped_from}); earlier events are not replayed. "
+            "Use --from-start to replay them, or sweep with `mempalace logstream list`.",
+            file=sys.stderr,
+        )
 
     idle_s = args.idle_exit_ms / 1000.0 if args.idle_exit_ms and args.idle_exit_ms > 0 else None
     deadline = time.monotonic() + idle_s if idle_s else None
@@ -3190,6 +3206,14 @@ def main():
         "--state-file",
         default=None,
         help="Persist the cursor here so a restart resumes exactly where it stopped",
+    )
+    p_ls_watch.add_argument(
+        "--from-start",
+        action="store_true",
+        help=(
+            "Replay the log from the beginning when there is no cursor "
+            "(default: start at the tip, like the SSE live-tail)"
+        ),
     )
     p_ls_watch.add_argument(
         "--follow",

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1574,17 +1574,20 @@ def _logstream_watch(ls, args, as_json):
     idle_s = args.idle_exit_ms / 1000.0 if args.idle_exit_ms and args.idle_exit_ms > 0 else None
     deadline = time.monotonic() + idle_s if idle_s else None
     matched_any = False
+
+    def _poll_timeout_ms():
+        if deadline is None:
+            return args.poll_timeout_ms
+        remaining_ms = int((deadline - time.monotonic()) * 1000)
+        return min(args.poll_timeout_ms, remaining_ms)
+
     try:
         for matched, cursor in ls.watch_events(
             cursor=cursor,
-            poll_timeout_ms=args.poll_timeout_ms,
+            poll_timeout_ms=_poll_timeout_ms,
             limit=args.limit,
             **spec,
         ):
-            # Checkpoint every advance, including idle ones: the cursor moves
-            # past events that were examined and rejected, and re-judging them
-            # after a restart is pure waste.
-            write_watch_cursor(args.state_file, cursor, agent=args.agent)
             if matched:
                 matched_any = True
                 if idle_s:
@@ -1608,9 +1611,15 @@ def _logstream_watch(ls, args, as_json):
                     for event in matched:
                         _print_event_line(event)
                     sys.stdout.flush()
+                # Matched batches checkpoint *after* stdout so a kill or
+                # broken pipe between the two replays the event instead of
+                # skipping it. Unmatched advances (below) are safe immediately:
+                # those events were examined and rejected.
+                write_watch_cursor(args.state_file, cursor, agent=args.agent)
                 if not args.follow:
                     return
                 continue
+            write_watch_cursor(args.state_file, cursor, agent=args.agent)
             if deadline is not None and time.monotonic() >= deadline:
                 if as_json:
                     print(

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1594,6 +1594,15 @@ def _logstream_watch(ls, args, as_json):
         # A configured zero would make watch_events' expired-deadline branch
         # yield forever without ever polling, burning a core.
         _logstream_fail("--poll-timeout-ms must be a positive number of milliseconds", as_json)
+    if args.idle_exit_ms is not None and args.idle_exit_ms < 0:
+        # Only 0 means "wait forever". A negative value arriving from config
+        # or from timeout arithmetic would otherwise take that same branch
+        # silently, leaving a harness waiting on a watcher it believes will
+        # time out.
+        _logstream_fail(
+            "--idle-exit-ms must be zero (wait forever) or a positive number of milliseconds",
+            as_json,
+        )
 
     stored_cursor, state_condition = read_watch_state(args.state_file)
     # A missing cursor is four different facts, and only one of them may
@@ -1622,6 +1631,31 @@ def _logstream_watch(ls, args, as_json):
     # next launch calls itself a first run and jumps to the tip, skipping
     # whatever arrived in between. Unlike later checkpoints this one cannot
     # fail quietly: losing it costs a skipped event, not a replay.
+    if cursor is not None:
+        # Verify the anchor before it is written anywhere. list_events raises
+        # on an unknown since_event_id, and the required startup write below
+        # happens first — so a typo'd or stale --since-event-id would be
+        # persisted, then crash the first poll, and every later run without
+        # the flag would reload it and crash again until someone deleted the
+        # file by hand. Fail cleanly instead, leaving no state behind.
+        try:
+            ls.list_events(since_event_id=cursor, limit=1)
+        except ValueError as exc:
+            if args.since_event_id:
+                # Explicitly supplied and wrong: user error, so refuse
+                # without leaving anything behind to reload next time.
+                _logstream_fail(f"{exc}. Nothing was written to the state file.", as_json)
+            # A *stored* cursor whose event has gone (log rebuilt, replica
+            # reset) is corrupt state rather than user error, and refusing to
+            # start would strand the watcher exactly as an unreadable file
+            # would. Replay instead: a duplicate, never a missed delegation.
+            print(
+                f"Stored cursor {cursor} no longer exists in this log; replaying from the "
+                "start rather than refusing to run.",
+                file=sys.stderr,
+            )
+            cursor = None
+
     if args.state_file and state_condition == WATCH_STATE_ABSENT:
         try:
             write_watch_cursor(args.state_file, cursor, agent=args.agent, required=True)

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1531,6 +1531,25 @@ def _print_event_line(event):
     )
 
 
+def _watch_json(payload, *, follow: bool) -> str:
+    """Serialize one ``logstream watch`` record.
+
+    A single-shot watch prints exactly one document, so it is pretty-printed
+    and ``json.load``-able as-is. Under ``--follow`` there are many records
+    on one stream: indented documents concatenated back-to-back are *not*
+    valid JSON, and ``json.load`` / ``jq`` reject them with trailing data —
+    which defeats the point of a machine-readable flag on the mode meant for
+    daemons. Follow mode therefore emits NDJSON, one compact record per line.
+    """
+    import json
+
+    return (
+        json.dumps(payload, ensure_ascii=False)
+        if follow
+        else json.dumps(payload, indent=2, ensure_ascii=False)
+    )
+
+
 def _logstream_watch(ls, args, as_json):
     """Run ``logstream watch`` — block until interesting events arrive.
 
@@ -1543,7 +1562,6 @@ def _logstream_watch(ls, args, as_json):
     idle timeout expired having seen nothing — the same convention
     ``logstream wait`` uses for a timeout.
     """
-    import json
     import time
 
     from .logstream import normalize_watch_values, read_watch_cursor, write_watch_cursor
@@ -1566,9 +1584,24 @@ def _logstream_watch(ls, args, as_json):
         "exclude_from_agents": normalize_watch_values(exclude),
         "correlation_ids": normalize_watch_values(args.correlation_id),
     }
-    cursor = args.since_event_id or read_watch_cursor(args.state_file)
+    if args.poll_timeout_ms is not None and args.poll_timeout_ms <= 0:
+        # A configured zero would make watch_events' expired-deadline branch
+        # yield forever without ever polling, burning a core.
+        _logstream_fail("--poll-timeout-ms must be a positive number of milliseconds", as_json)
+
+    stored_cursor = read_watch_cursor(args.state_file)
+    # read_watch_cursor returns None both for "no state file yet" and for
+    # "state file exists but could not be read". Those must not be treated
+    # alike: jumping to the tip after a *failed* read silently skips
+    # everything appended since the last good checkpoint, and the next
+    # checkpoint makes that loss permanent. A corrupt state file costs a
+    # replay, exactly as read_watch_cursor's contract promises.
+    recovery_failed = (
+        bool(args.state_file) and stored_cursor is None and os.path.exists(args.state_file)
+    )
+    cursor = args.since_event_id or stored_cursor
     skipped_from = None
-    if cursor is None and not args.from_start:
+    if cursor is None and not args.from_start and not recovery_failed:
         # Start at the tip, like the SSE live-tail does at connect time.
         # Starting from the beginning of a long fleet log means a fresh
         # watcher wakes holding weeks of history and cannot tell it is
@@ -1584,6 +1617,13 @@ def _logstream_watch(ls, args, as_json):
         print(
             f"Starting at the tip ({skipped_from}); earlier events are not replayed. "
             "Use --from-start to replay them, or sweep with `mempalace logstream list`.",
+            file=sys.stderr,
+        )
+    if recovery_failed:
+        print(
+            f"State file {args.state_file} is unreadable; replaying from the start "
+            "rather than skipping to the tip, so nothing since the last good "
+            "checkpoint is lost.",
             file=sys.stderr,
         )
 
@@ -1610,15 +1650,14 @@ def _logstream_watch(ls, args, as_json):
                     deadline = time.monotonic() + idle_s
                 if as_json:
                     print(
-                        json.dumps(
+                        _watch_json(
                             {
                                 "events": matched,
                                 "count": len(matched),
                                 "cursor": cursor,
                                 "timed_out": False,
                             },
-                            indent=2,
-                            ensure_ascii=False,
+                            follow=args.follow,
                         ),
                         flush=True,
                     )
@@ -1639,17 +1678,21 @@ def _logstream_watch(ls, args, as_json):
             if deadline is not None and time.monotonic() >= deadline:
                 if as_json:
                     print(
-                        json.dumps(
+                        _watch_json(
                             {"events": [], "count": 0, "cursor": cursor, "timed_out": True},
-                            indent=2,
+                            follow=args.follow,
                         )
                     )
                 else:
                     print("Idle timeout; no matching events.")
                 sys.exit(0 if matched_any else 2)
     except KeyboardInterrupt:
+        # Exit 0 is the documented "a match was printed" signal, so an
+        # interrupted watcher must not use it — a supervisor would report
+        # mail that never arrived. 128 + SIGINT, the shell convention.
         if not as_json:
             print("Stopped.", file=sys.stderr)
+        sys.exit(130)
 
 
 def cmd_logstream(args):

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1550,27 +1550,34 @@ def _watch_json(payload, *, follow: bool) -> str:
     )
 
 
-def _logstream_watch(ls, args, as_json):
-    """Run ``logstream watch`` — block until interesting events arrive.
+def _watch_spec(args, as_json) -> dict:
+    """Validate ``logstream watch`` arguments and build its filter spec.
 
-    Split out of ``cmd_logstream`` so that dispatcher stays under the
-    complexity gate: this branch carries cursor persistence, an idle timeout,
-    and follow-vs-exit semantics that no other subcommand needs.
-
-    Exit contract, chosen so a harness can background this process and treat
-    its exit as a wake-up: return (0) when a match was printed, 2 when the
-    idle timeout expired having seen nothing — the same convention
-    ``logstream wait`` uses for a timeout.
+    Kept apart from the watch loop so every bad input is rejected before any
+    polling, any cursor resolution, and any checkpoint write — several of the
+    bugs on this path were arguments that only failed once the loop had
+    already started and persisted state.
     """
-    import time
+    from .logstream import normalize_watch_values, sanitize_watch_spec
 
-    from .logstream import (
-        WATCH_STATE_ABSENT,
-        WATCH_STATE_CORRUPT,
-        normalize_watch_values,
-        read_watch_state,
-        write_watch_cursor,
-    )
+    if args.poll_timeout_ms is not None and args.poll_timeout_ms <= 0:
+        # A configured zero would make watch_events' expired-deadline branch
+        # yield forever without ever polling, burning a core.
+        _logstream_fail("--poll-timeout-ms must be a positive number of milliseconds", as_json)
+    if args.limit is not None and args.limit < 1:
+        # argparse accepts it; list_events would raise mid-loop, where the
+        # only handler is for KeyboardInterrupt — a traceback, and under
+        # --json no error document at all.
+        _logstream_fail("--limit must be a positive integer", as_json)
+    if args.idle_exit_ms is not None and args.idle_exit_ms < 0:
+        # Only 0 means "wait forever". A negative value arriving from config
+        # or from timeout arithmetic would otherwise take that same branch
+        # silently, leaving a harness waiting on a watcher it believes will
+        # time out.
+        _logstream_fail(
+            "--idle-exit-ms must be zero (wait forever) or a positive number of milliseconds",
+            as_json,
+        )
 
     to_agents = list(args.to_agent or [])
     exclude = list(args.exclude_from_agent or [])
@@ -1590,19 +1597,36 @@ def _logstream_watch(ls, args, as_json):
         "exclude_from_agents": normalize_watch_values(exclude),
         "correlation_ids": normalize_watch_values(args.correlation_id),
     }
-    if args.poll_timeout_ms is not None and args.poll_timeout_ms <= 0:
-        # A configured zero would make watch_events' expired-deadline branch
-        # yield forever without ever polling, burning a core.
-        _logstream_fail("--poll-timeout-ms must be a positive number of milliseconds", as_json)
-    if args.idle_exit_ms is not None and args.idle_exit_ms < 0:
-        # Only 0 means "wait forever". A negative value arriving from config
-        # or from timeout arithmetic would otherwise take that same branch
-        # silently, leaving a harness waiting on a watcher it believes will
-        # time out.
-        _logstream_fail(
-            "--idle-exit-ms must be zero (wait forever) or a positive number of milliseconds",
-            as_json,
-        )
+    try:
+        spec = sanitize_watch_spec(spec)
+    except ValueError as exc:
+        _logstream_fail(str(exc), as_json)
+
+    return spec
+
+
+def _logstream_watch(ls, args, as_json):
+    """Run ``logstream watch`` — block until interesting events arrive.
+
+    Split out of ``cmd_logstream`` so that dispatcher stays under the
+    complexity gate: this branch carries cursor persistence, an idle timeout,
+    and follow-vs-exit semantics that no other subcommand needs.
+
+    Exit contract, chosen so a harness can background this process and treat
+    its exit as a wake-up: return (0) when a match was printed, 2 when the
+    idle timeout expired having seen nothing — the same convention
+    ``logstream wait`` uses for a timeout.
+    """
+    import time
+
+    from .logstream import (
+        WATCH_STATE_ABSENT,
+        WATCH_STATE_CORRUPT,
+        read_watch_state,
+        write_watch_cursor,
+    )
+
+    spec = _watch_spec(args, as_json)
 
     stored_cursor, state_condition = read_watch_state(args.state_file)
     # A missing cursor is four different facts, and only one of them may
@@ -1749,6 +1773,12 @@ def _logstream_watch(ls, args, as_json):
         if not as_json:
             print("Stopped.", file=sys.stderr)
         sys.exit(130)
+    except ValueError as exc:
+        # Backstop. Every known bad input is rejected before the loop
+        # starts, but a validation error escaping mid-poll would otherwise
+        # surface as a traceback — and under --json as no error document at
+        # all, which a machine consumer cannot distinguish from a crash.
+        _logstream_fail(str(exc), as_json)
 
 
 def cmd_logstream(args):

--- a/mempalace/logstream.py
+++ b/mempalace/logstream.py
@@ -31,6 +31,8 @@ Usage:
 """
 
 import json
+import logging
+import os
 import random
 import re
 import secrets
@@ -43,6 +45,8 @@ from pathlib import Path
 from typing import Optional
 
 from .config import sanitize_iso_temporal, strip_lone_surrogates
+
+logger = logging.getLogger("mempalace_logstream")
 
 LOGSTREAM_DB_FILENAME = "logstream.sqlite3"
 
@@ -166,6 +170,147 @@ def _sanitize_metadata(value) -> str:
     if len(encoded.encode("utf-8")) > MAX_METADATA_BYTES:
         raise ValueError(f"metadata exceeds maximum size of {MAX_METADATA_BYTES} bytes")
     return encoded
+
+
+# ── Watch filters (RFC 003 follow-up: background watchers) ──────────────
+#
+# ``list_events`` filters are single-valued and positive-only, because they
+# map straight onto indexed SQL equality. A watcher needs two things that
+# shape cannot express:
+#
+#   * "wake me for task.request OR patch.ready" — several values per field
+#   * "everything addressed to me EXCEPT my own broadcasts" — a negation
+#
+# The second is not a nicety. ``to_agent=<me>`` deliberately also matches
+# broadcast events (``to_agent='*'``), and an agent's own broadcasts are
+# broadcasts — so a naive watcher wakes itself every time it posts a status.
+#
+# Watch therefore pushes down whatever single-valued filters it can (keeping
+# the SQL selective) and applies the multi-valued and negative parts here.
+
+
+def normalize_watch_values(value) -> Optional[set]:
+    """Coerce a watch filter argument to a set of strings, or ``None``.
+
+    ``None`` means "any" — an absent filter, not an empty one. An argument
+    holding only blanks collapses to ``None`` for the same reason, so a
+    stray ``--type ""`` cannot silently match nothing forever.
+    """
+    if value is None:
+        return None
+    values = [value] if isinstance(value, str) else list(value)
+    out = {str(v) for v in values if v not in (None, "")}
+    return out or None
+
+
+def event_matches_watch(
+    event: dict,
+    *,
+    streams=None,
+    rooms=None,
+    types=None,
+    statuses=None,
+    to_agents=None,
+    from_agents=None,
+    exclude_from_agents=None,
+    correlation_ids=None,
+) -> bool:
+    """Client-side half of a watch filter. Every argument is a set or ``None``.
+
+    Exclusion beats every positive match: an event from an excluded writer is
+    rejected even when it satisfies the rest of the filter.
+    """
+    if exclude_from_agents and event.get("from_agent") in exclude_from_agents:
+        return False
+
+    def _ok(allowed, actual, broadcast_matches=False):
+        if not allowed:
+            return True
+        if actual in allowed:
+            return True
+        # ``to_agent='*'`` reaches everyone, mirroring list_events' SQL.
+        return broadcast_matches and actual == "*"
+
+    return (
+        _ok(streams, event.get("stream"))
+        and _ok(rooms, event.get("room"))
+        and _ok(types, event.get("type"))
+        and _ok(statuses, event.get("status"))
+        and _ok(correlation_ids, event.get("correlation_id"))
+        and _ok(from_agents, event.get("from_agent"))
+        and _ok(to_agents, event.get("to_agent"), broadcast_matches=True)
+    )
+
+
+def pushdown_watch_filters(spec: dict) -> dict:
+    """The subset of a watch spec that ``list_events`` can evaluate in SQL.
+
+    Only single-valued fields push down. Narrowing the query is an
+    optimization, never a correctness dependency — whatever stays behind is
+    re-checked by :func:`event_matches_watch` on every candidate row.
+    """
+    pushdown = {}
+    for key, column in (
+        ("streams", "stream"),
+        ("rooms", "room"),
+        ("types", "type"),
+        ("statuses", "status"),
+        ("correlation_ids", "correlation_id"),
+        ("to_agents", "to_agent"),
+        ("from_agents", "from_agent"),
+    ):
+        values = spec.get(key)
+        if values and len(values) == 1:
+            pushdown[column] = next(iter(values))
+    return pushdown
+
+
+def read_watch_cursor(path: str) -> Optional[str]:
+    """Return the cursor stored in a watch state file, or ``None``.
+
+    A missing, empty, or corrupt state file is not an error: the caller
+    simply starts from wherever it was told to, or from the present. A
+    watcher that refused to start because its bookkeeping file was truncated
+    by a crash would be worse than one that re-reads a few events.
+    """
+    if not path:
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            cursor = json.load(handle).get("cursor")
+    except (OSError, ValueError):
+        return None
+    return cursor if isinstance(cursor, str) and cursor else None
+
+
+def write_watch_cursor(path: str, cursor: str, agent: str = None) -> None:
+    """Persist a watch cursor atomically, best effort.
+
+    Written to a temp file and renamed so a crash mid-write cannot leave a
+    half-file that reads back as a *different, earlier* cursor — that would
+    silently replay events the watcher had already handled. Failures are
+    swallowed: losing the checkpoint costs a replay, while crashing the
+    watcher costs every event after it.
+    """
+    if not path or not cursor:
+        return
+    payload = {"cursor": cursor, "updated_at": _utc_now_iso()}
+    if agent:
+        payload["agent"] = agent
+    tmp = f"{path}.tmp"
+    try:
+        parent = os.path.dirname(os.path.abspath(path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(tmp, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+        os.replace(tmp, path)
+    except OSError:
+        logger.debug("could not persist watch cursor to %s", path, exc_info=True)
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
 
 
 class Logstream:
@@ -799,6 +944,48 @@ class Logstream:
                 delay = base * (0.75 + random.random() * 0.25)
             time.sleep(min(delay, remaining))
             attempt += 1
+
+    def watch_events(
+        self,
+        *,
+        cursor: str = None,
+        poll_timeout_ms: int = MAX_WAIT_TIMEOUT_MS,
+        limit: int = DEFAULT_LIST_LIMIT,
+        poll_interval_s: float = None,
+        **spec,
+    ):
+        """Yield ``(matched_events, cursor)`` forever as new events arrive.
+
+        The long-poll primitive :meth:`wait_events` caps at
+        ``MAX_WAIT_TIMEOUT_MS`` and reports a timeout, which makes it a
+        building block rather than a watcher: every caller ends up writing
+        the same re-arm loop, and each one has to remember to carry the
+        cursor forward. This owns both.
+
+        An idle poll yields ``([], cursor)`` rather than blocking silently,
+        so a caller can implement an idle timeout, emit a heartbeat, or
+        checkpoint its cursor without running a second clock.
+
+        The cursor advances past every event *examined*, not merely those
+        that matched, so a watcher that restarts never rescans what it has
+        already judged. ``spec`` takes the set-valued filters described by
+        :func:`event_matches_watch`.
+        """
+        pushdown = pushdown_watch_filters(spec)
+        while True:
+            result = self.wait_events(
+                timeout_ms=poll_timeout_ms,
+                since_event_id=cursor,
+                limit=limit,
+                poll_interval_s=poll_interval_s,
+                **pushdown,
+            )
+            events = result.get("events") or []
+            if not events:
+                yield [], cursor
+                continue
+            cursor = events[-1]["id"]
+            yield [e for e in events if event_matches_watch(e, **spec)], cursor
 
     # ── Replication (RFC 004 step 0: logstream multi-master) ─────────────
 

--- a/mempalace/logstream.py
+++ b/mempalace/logstream.py
@@ -265,28 +265,60 @@ def pushdown_watch_filters(spec: dict) -> dict:
     return pushdown
 
 
-def read_watch_cursor(path: str) -> Optional[str]:
-    """Return the cursor stored in a watch state file, or ``None``.
+# Watch state-file conditions. "No cursor" is not one fact but four, and
+# conflating them loses events: see read_watch_state.
+WATCH_STATE_ABSENT = "absent"
+WATCH_STATE_OK = "ok"
+WATCH_STATE_EMPTY = "empty"
+WATCH_STATE_CORRUPT = "corrupt"
 
-    A missing, empty, or corrupt state file is not an error: the caller
-    simply starts from wherever it was told to, or from the present. A
-    watcher that refused to start because its bookkeeping file was truncated
-    by a crash would be worse than one that re-reads a few events.
+
+def read_watch_state(path: str) -> tuple:
+    """Return ``(cursor, condition)`` for a watch state file.
+
+    A cursor of ``None`` is ambiguous and the ambiguity is dangerous, so the
+    condition disambiguates it:
+
+    ``absent``
+        No state file. A genuine first run — the caller may start at the tip.
+    ``ok``
+        A usable cursor; resume strictly after it.
+    ``empty``
+        The file exists and records ``cursor: null`` — the watcher started
+        against an empty log and has not seen an event yet. **Not** a first
+        run: treating it as one and jumping to the tip would skip whatever
+        arrived while the watcher was stopped, and the next checkpoint would
+        make that permanent.
+    ``corrupt``
+        Unreadable, truncated, or valid JSON that is not an object. Costs a
+        replay, never a skip — refusing to start would cost every event
+        after it, and skipping would lose them silently.
     """
-    if not path:
-        return None
+    if not path or not os.path.exists(path):
+        return None, WATCH_STATE_ABSENT
     try:
         with open(path, "r", encoding="utf-8") as handle:
             payload = json.load(handle)
     except (OSError, ValueError):
-        return None
-    # Valid JSON that is not an object (``null``, ``[]``, a bare string) is
-    # just as corrupt as a truncated file, and must degrade the same way —
-    # calling .get() on it would raise and stop the watcher from starting.
+        return None, WATCH_STATE_CORRUPT
     if not isinstance(payload, dict):
-        return None
+        return None, WATCH_STATE_CORRUPT
     cursor = payload.get("cursor")
-    return cursor if isinstance(cursor, str) and cursor else None
+    if isinstance(cursor, str) and cursor:
+        return cursor, WATCH_STATE_OK
+    if "cursor" in payload:
+        return None, WATCH_STATE_EMPTY
+    return None, WATCH_STATE_CORRUPT
+
+
+def read_watch_cursor(path: str) -> Optional[str]:
+    """The cursor from a watch state file, or ``None``.
+
+    Convenience wrapper over :func:`read_watch_state` for callers that do not
+    need to tell a first run from a corrupt file. Watchers should prefer
+    ``read_watch_state``, because those two cases must not behave alike.
+    """
+    return read_watch_state(path)[0]
 
 
 def write_watch_cursor(path: str, cursor: str, agent: str = None) -> None:
@@ -298,9 +330,12 @@ def write_watch_cursor(path: str, cursor: str, agent: str = None) -> None:
     swallowed: losing the checkpoint costs a replay, while crashing the
     watcher costs every event after it.
     """
-    if not path or not cursor:
+    if not path:
         return
-    payload = {"cursor": cursor, "updated_at": _utc_now_iso()}
+    # ``cursor`` may be None: a watcher that started against an empty log
+    # must still leave a file behind, or its next launch looks like a first
+    # run and skips whatever arrived in between.
+    payload = {"cursor": cursor or None, "updated_at": _utc_now_iso()}
     if agent:
         payload["agent"] = agent
     tmp = f"{path}.tmp"

--- a/mempalace/logstream.py
+++ b/mempalace/logstream.py
@@ -242,6 +242,41 @@ def event_matches_watch(
     )
 
 
+def sanitize_watch_spec(spec: dict) -> dict:
+    """Validate and normalize every value in a watch spec.
+
+    ``list_events`` sanitizes the filters it is given, so a *single-valued*
+    watch filter is checked for free by being pushed down. Multi-valued ones
+    are not pushed down and were therefore compared raw, which made
+    validation depend on how many values you happened to pass:
+    ``--type Task.Request`` alone was rejected, while
+    ``--type Task.Request --type patch.ready`` was silently accepted and then
+    matched nothing, leaving the watcher waiting forever for an event type
+    that cannot exist.
+
+    Sanitizing here — with the same functions ``list_events`` uses — makes
+    the two paths agree, and normalizes values (stripping whitespace) so a
+    padded routing value still matches. Raises ``ValueError`` naming the
+    offending value.
+    """
+    sanitized = {}
+    for key, field in (
+        ("streams", "stream"),
+        ("rooms", "room"),
+        ("to_agents", "to_agent"),
+        ("from_agents", "from_agent"),
+        ("exclude_from_agents", "exclude_from_agent"),
+        ("correlation_ids", "correlation_id"),
+    ):
+        values = spec.get(key)
+        sanitized[key] = {_sanitize_routing(v, field) for v in values} if values else values
+    types = spec.get("types")
+    sanitized["types"] = {_sanitize_event_type(v) for v in types} if types else types
+    statuses = spec.get("statuses")
+    sanitized["statuses"] = {_sanitize_status(v) for v in statuses} if statuses else statuses
+    return sanitized
+
+
 def pushdown_watch_filters(spec: dict) -> dict:
     """The subset of a watch spec that ``list_events`` can evaluate in SQL.
 

--- a/mempalace/logstream.py
+++ b/mempalace/logstream.py
@@ -277,9 +277,15 @@ def read_watch_cursor(path: str) -> Optional[str]:
         return None
     try:
         with open(path, "r", encoding="utf-8") as handle:
-            cursor = json.load(handle).get("cursor")
+            payload = json.load(handle)
     except (OSError, ValueError):
         return None
+    # Valid JSON that is not an object (``null``, ``[]``, a bare string) is
+    # just as corrupt as a truncated file, and must degrade the same way —
+    # calling .get() on it would raise and stop the watcher from starting.
+    if not isinstance(payload, dict):
+        return None
+    cursor = payload.get("cursor")
     return cursor if isinstance(cursor, str) and cursor else None
 
 
@@ -979,8 +985,11 @@ class Logstream:
         while True:
             timeout = poll_timeout_ms() if callable(poll_timeout_ms) else poll_timeout_ms
             if timeout is not None and int(timeout) <= 0:
-                # Idle deadline already elapsed: yield immediately so the
-                # caller can exit without waiting out the next long-poll.
+                # Only reachable when an idle deadline has already elapsed —
+                # a *configured* timeout of zero would make this branch spin
+                # without ever polling, so callers must reject that up front
+                # (the CLI does). Yield at once so the caller can exit
+                # instead of waiting out another long-poll.
                 yield [], cursor
                 continue
             result = self.wait_events(

--- a/mempalace/logstream.py
+++ b/mempalace/logstream.py
@@ -294,11 +294,20 @@ def read_watch_state(path: str) -> tuple:
         replay, never a skip — refusing to start would cost every event
         after it, and skipping would lose them silently.
     """
-    if not path or not os.path.exists(path):
+    if not path:
         return None, WATCH_STATE_ABSENT
+    # Deliberately no os.path.exists() preflight. It answers False both for
+    # "no such file" and for "cannot traverse the parent directory", so a
+    # checkpoint that exists but is momentarily unreachable would be read as
+    # a first run and skip every event since the stored cursor. Opening
+    # directly lets FileNotFoundError mean absent and every other OSError
+    # (permissions, a directory in the way, I/O error) mean corrupt — which
+    # replays. It also closes the exists()/open() race.
     try:
         with open(path, "r", encoding="utf-8") as handle:
             payload = json.load(handle)
+    except FileNotFoundError:
+        return None, WATCH_STATE_ABSENT
     except (OSError, ValueError):
         return None, WATCH_STATE_CORRUPT
     if not isinstance(payload, dict):
@@ -321,14 +330,20 @@ def read_watch_cursor(path: str) -> Optional[str]:
     return read_watch_state(path)[0]
 
 
-def write_watch_cursor(path: str, cursor: str, agent: str = None) -> None:
-    """Persist a watch cursor atomically, best effort.
+def write_watch_cursor(path: str, cursor: str, agent: str = None, required: bool = False) -> None:
+    """Persist a watch cursor atomically.
 
     Written to a temp file and renamed so a crash mid-write cannot leave a
     half-file that reads back as a *different, earlier* cursor — that would
-    silently replay events the watcher had already handled. Failures are
-    swallowed: losing the checkpoint costs a replay, while crashing the
-    watcher costs every event after it.
+    silently replay events the watcher had already handled.
+
+    Ordinary checkpoints are best effort, because losing one costs a replay
+    while crashing the watcher costs every event after it. That trade-off
+    inverts for the *first* checkpoint of a fresh watch: if it never lands,
+    the next launch sees no state file, calls itself a first run, and starts
+    at the tip — skipping everything that arrived in between, permanently.
+    Pass ``required=True`` there so the failure is raised rather than
+    swallowed.
     """
     if not path:
         return
@@ -352,6 +367,8 @@ def write_watch_cursor(path: str, cursor: str, agent: str = None) -> None:
             os.unlink(tmp)
         except OSError:
             pass
+        if required:
+            raise
 
 
 class Logstream:

--- a/mempalace/logstream.py
+++ b/mempalace/logstream.py
@@ -966,6 +966,10 @@ class Logstream:
         so a caller can implement an idle timeout, emit a heartbeat, or
         checkpoint its cursor without running a second clock.
 
+        ``poll_timeout_ms`` may be a callable returning the timeout for
+        this iteration so a caller can cap it to a remaining idle
+        deadline (an idle of 400ms must not wait out a 300s long-poll).
+
         The cursor advances past every event *examined*, not merely those
         that matched, so a watcher that restarts never rescans what it has
         already judged. ``spec`` takes the set-valued filters described by
@@ -973,8 +977,14 @@ class Logstream:
         """
         pushdown = pushdown_watch_filters(spec)
         while True:
+            timeout = poll_timeout_ms() if callable(poll_timeout_ms) else poll_timeout_ms
+            if timeout is not None and int(timeout) <= 0:
+                # Idle deadline already elapsed: yield immediately so the
+                # caller can exit without waiting out the next long-poll.
+                yield [], cursor
+                continue
             result = self.wait_events(
-                timeout_ms=poll_timeout_ms,
+                timeout_ms=timeout,
                 since_event_id=cursor,
                 limit=limit,
                 poll_interval_s=poll_interval_s,

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -4594,8 +4594,10 @@ def _preview_event(event: dict) -> dict:
     Event bodies are stored verbatim and fleet status updates run to several
     KB, so listing many events full-body is a large payload. Preview keeps all
     routing/metadata fields and trims only ``body`` — enough to scan the stream
-    and decide which events to re-fetch in full (a targeted ``since_event_id``
-    call returns the untouched body)."""
+    and decide which events to re-fetch in full. ``since_event_id`` is
+    strictly *after* that id, so passing the truncated event's own id
+    skips it; repeat the original filters with ``preview=false`` (and
+    ``correlation_id`` / ``from_agent`` as needed) instead."""
     body = event.get("body") or ""
     if len(body) <= _PREVIEW_BODY_CHARS:
         return event
@@ -4623,8 +4625,9 @@ def tool_event_list(
 
     ``preview=True`` truncates each event's verbatim body to a short excerpt
     (marking ``body_truncated`` + ``body_length``) so scanning many events
-    stays cheap; re-fetch a specific event's full body with a targeted
-    ``since_event_id``.
+    stays cheap. ``since_event_id`` is strictly after that id, so do not
+    pass the truncated event's own id to re-fetch it — repeat the original
+    filters with ``preview=false``.
     """
     try:
         events = _call_logstream(
@@ -5532,8 +5535,10 @@ TOOLS = {
                     "type": "boolean",
                     "description": (
                         "Truncate each event body to a short excerpt (marks body_truncated +"
-                        " body_length) so scanning many events stays cheap; re-fetch a specific"
-                        " event's full body with a targeted since_event_id (default false)"
+                        " body_length) so scanning many events stays cheap. since_event_id is"
+                        " strictly AFTER that id, so do not pass the truncated event's own id"
+                        " to re-fetch it — repeat the original filters with preview=false"
+                        " (default false)"
                     ),
                 },
             },

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -5487,8 +5487,16 @@ TOOLS = {
     },
     "mempalace_event_list": {
         "description": (
-            "List agent-coordination events with structured filters, oldest first. Use"
-            " since_event_id as the precise resume cursor (strictly after that event)."
+            "List agent-coordination events with structured filters, oldest first (append"
+            " order, not timestamp order). Use since_event_id as the resume cursor: it means"
+            " strictly after that event in append order, so it cannot skip anything. Do NOT"
+            " resume with since_created_at — a peer's event syncs in whenever it arrives, so"
+            " it can already be older than a timestamp cursor and be missed permanently;"
+            " since_created_at is a time window ('what happened today'), not a cursor. Store"
+            " the id of the last event you processed — that is your whole watcher state. Pass"
+            " preview=true when sweeping a busy stream. to_agent=<you> also matches '*'"
+            " broadcasts, so no second call is needed. To wait for something that has not"
+            " happened yet, use mempalace_event_wait instead of polling this."
         ),
         "input_schema": {
             "type": "object",
@@ -5513,8 +5521,10 @@ TOOLS = {
                 "since_created_at": {
                     "type": "string",
                     "description": (
-                        "Return events created at or after this time"
-                        " (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ, optional)"
+                        "Time window filter, inclusive: events created at or after this time"
+                        " (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ, optional). NOT a resume cursor"
+                        " — use since_event_id for that; a timestamp cursor silently drops"
+                        " peer events that sync in late. Dedup by id when using this."
                     ),
                 },
                 "limit": {"type": "integer", "description": "Max events to return (default 50)"},
@@ -5532,8 +5542,14 @@ TOOLS = {
     },
     "mempalace_event_wait": {
         "description": (
-            "Block until a matching coordination event exists or the timeout expires (max 5"
-            " minutes). Returns {timed_out: true, events: []} on timeout instead of an error."
+            "Block until a matching coordination event exists or the timeout expires (default"
+            " 60s, max 5 minutes). Returns {timed_out: true, events: []} on timeout — a normal"
+            " result, not an error. This is the right tool for actively waiting on a"
+            " correlation_id you delegated or claimed. It already backs off internally, so do"
+            " not wrap it in a tight retry loop: on timeout just call it again with"
+            " since_event_id updated to the last event you processed. For long-lived consumers"
+            " (daemons, dashboards) prefer the push stream at GET /logstream/stream, which"
+            " takes the same filters and the same since_event_id resume."
         ),
         "input_schema": {
             "type": "object",
@@ -5558,8 +5574,8 @@ TOOLS = {
                 "since_created_at": {
                     "type": "string",
                     "description": (
-                        "Only match events created at or after this time"
-                        " (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ, optional)"
+                        "Time window filter, inclusive (optional). NOT a resume cursor — use"
+                        " since_event_id, which cannot skip a late-syncing peer event."
                     ),
                 },
                 "timeout_ms": {

--- a/tests/test_cli_logstream.py
+++ b/tests/test_cli_logstream.py
@@ -641,3 +641,44 @@ class TestLogstreamWatch:
         assert lines, "follow mode printed nothing"
         for line in lines:
             json.loads(line)  # every line stands alone — that is the contract
+
+    def test_empty_log_first_run_persists_a_starting_position(self, palace_path, tmp_path, capsys):
+        """A stateful watch against an empty log must leave a file behind.
+
+        latest_event_id() is None on an empty log, so without persisting that
+        the next launch looks like a first run, jumps to the tip, and skips
+        the event that arrived while the watcher was stopped — permanently,
+        because it then checkpoints past it.
+        """
+        state = tmp_path / "watch.json"
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(
+                _watch_args(
+                    palace_path, agent="mac-claude", state_file=str(state), from_start=False
+                )
+            )
+        assert exc.value.code == 2
+        assert state.exists(), "empty-log watch left no state file"
+        assert json.loads(state.read_text(encoding="utf-8"))["cursor"] is None
+
+    def test_event_arriving_while_stopped_is_not_skipped(self, palace_path, tmp_path, capsys):
+        """The full sequence Codex described, end to end."""
+        state = tmp_path / "watch.json"
+        # 1. First watch against an empty log; idles out.
+        with pytest.raises(SystemExit):
+            cmd_logstream(
+                _watch_args(
+                    palace_path, agent="mac-claude", state_file=str(state), from_start=False
+                )
+            )
+        capsys.readouterr()
+
+        # 2. An event arrives while nothing is watching.
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        capsys.readouterr()
+
+        # 3. Relaunch must deliver it, not skip past it.
+        cmd_logstream(
+            _watch_args(palace_path, agent="mac-claude", state_file=str(state), from_start=False)
+        )
+        assert _watch_payload(capsys)["count"] == 1, "event that arrived while stopped was skipped"

--- a/tests/test_cli_logstream.py
+++ b/tests/test_cli_logstream.py
@@ -682,3 +682,26 @@ class TestLogstreamWatch:
             _watch_args(palace_path, agent="mac-claude", state_file=str(state), from_start=False)
         )
         assert _watch_payload(capsys)["count"] == 1, "event that arrived while stopped was skipped"
+
+    def test_refuses_to_start_when_the_initial_checkpoint_cannot_be_written(
+        self, palace_path, tmp_path, monkeypatch, capsys
+    ):
+        """Continuing after a failed first checkpoint guarantees a later skip."""
+        import mempalace.logstream as logstream_module
+
+        def denied(*_a, **kw):
+            if kw.get("required"):
+                raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(logstream_module, "write_watch_cursor", denied)
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(
+                _watch_args(
+                    palace_path,
+                    agent="mac-claude",
+                    state_file=str(tmp_path / "nope" / "watch.json"),
+                    from_start=False,
+                )
+            )
+        assert exc.value.code == 1
+        assert "initial checkpoint" in json.loads(capsys.readouterr().out)["error"]

--- a/tests/test_cli_logstream.py
+++ b/tests/test_cli_logstream.py
@@ -373,6 +373,10 @@ def _watch_args(palace, **overrides):
         correlation_id=None,
         since_event_id=None,
         state_file=None,
+        # These cases seed events and then watch for them, so they opt into
+        # the replay. The tip default is exercised explicitly by the
+        # first-run tests below.
+        from_start=True,
         follow=False,
         idle_exit_ms=400,
         poll_timeout_ms=60,
@@ -528,3 +532,38 @@ class TestLogstreamWatch:
         with pytest.raises(OSError, match="broken pipe"):
             cmd_logstream(_watch_args(palace_path, agent="mac-claude", state_file=state))
         assert not (tmp_path / "watch.json").exists()
+
+    def test_fresh_watch_starts_at_the_tip_not_the_beginning(self, palace_path, capsys):
+        """A first watch must not replay the whole log.
+
+        Measured on a real shared brain, a cursorless watch woke holding 41
+        events, the oldest 49 days old — and nothing in the payload tells the
+        agent they are stale, so week-old task.requests read as new work.
+        The SSE live-tail already starts at the tip; the watcher now matches.
+        Backlog belongs to the inbox sweep.
+        """
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        capsys.readouterr()
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(_watch_args(palace_path, agent="mac-claude", from_start=False))
+        assert exc.value.code == 2, "fresh watch replayed a pre-existing event"
+
+    def test_from_start_opts_back_into_the_replay(self, palace_path, capsys):
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        capsys.readouterr()
+
+        cmd_logstream(_watch_args(palace_path, agent="mac-claude", from_start=True))
+        assert _watch_payload(capsys)["count"] == 1
+
+    def test_tip_default_does_not_override_an_explicit_cursor(self, palace_path, capsys):
+        """--since-event-id and a state file must still win over the tip."""
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        first_id = json.loads(capsys.readouterr().out)["id"]
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        capsys.readouterr()
+
+        cmd_logstream(
+            _watch_args(palace_path, agent="mac-claude", since_event_id=first_id, from_start=False)
+        )
+        assert _watch_payload(capsys)["count"] == 1

--- a/tests/test_cli_logstream.py
+++ b/tests/test_cli_logstream.py
@@ -761,3 +761,59 @@ class TestLogstreamWatch:
             assert exc.value.code == 130
             assert state.exists(), f"{label}: interrupted before any checkpoint landed"
             assert json.loads(state.read_text(encoding="utf-8"))["cursor"] == expected, label
+
+    def test_bad_cursor_fails_cleanly_without_poisoning_the_state_file(
+        self, palace_path, tmp_path, capsys
+    ):
+        """A typo'd --since-event-id must not be persisted.
+
+        The startup checkpoint happens before the first poll, and list_events
+        raises on an unknown anchor — so without validation the bad id lands
+        on disk, the poll crashes, and every later run without the flag
+        reloads it and crashes again until someone deletes the file by hand.
+        """
+        state = tmp_path / "watch.json"
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(
+                _watch_args(
+                    palace_path,
+                    agent="mac-claude",
+                    state_file=str(state),
+                    since_event_id="evt_does_not_exist",
+                    from_start=False,
+                )
+            )
+        assert exc.value.code == 1
+        assert "evt_does_not_exist" in json.loads(capsys.readouterr().out)["error"]
+        assert not state.exists(), "an invalid cursor was persisted"
+
+    def test_negative_idle_timeout_is_rejected_not_read_as_forever(self, palace_path, capsys):
+        """Only 0 means "wait forever".
+
+        A negative value took the same branch, silently disabling the idle
+        deadline and leaving a harness waiting on a watcher it believed would
+        time out.
+        """
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(_watch_args(palace_path, agent="mac-claude", idle_exit_ms=-1))
+        assert exc.value.code == 1
+        assert "idle-exit-ms" in json.loads(capsys.readouterr().out)["error"]
+
+    def test_stored_cursor_that_vanished_replays_instead_of_refusing(
+        self, palace_path, tmp_path, capsys
+    ):
+        """A stored cursor whose event is gone is corrupt state, not user error.
+
+        Refusing to start would strand the watcher exactly as an unreadable
+        file would. Only an explicitly supplied --since-event-id is treated
+        as user error worth refusing.
+        """
+        state = tmp_path / "watch.json"
+        state.write_text(json.dumps({"cursor": "evt_from_a_rebuilt_log"}), encoding="utf-8")
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        capsys.readouterr()
+
+        cmd_logstream(
+            _watch_args(palace_path, agent="mac-claude", state_file=str(state), from_start=False)
+        )
+        assert _watch_payload(capsys)["count"] == 1, "stranded instead of replaying"

--- a/tests/test_cli_logstream.py
+++ b/tests/test_cli_logstream.py
@@ -352,3 +352,146 @@ def _sha256(text):
     import hashlib
 
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# ── logstream watch ───────────────────────────────────────────────────────
+
+
+def _watch_args(palace, **overrides):
+    fields = dict(
+        palace=palace,
+        logstream_action="watch",
+        agent=None,
+        stream=None,
+        room=None,
+        type=None,
+        status=None,
+        to_agent=None,
+        from_agent=None,
+        exclude_from_agent=None,
+        correlation_id=None,
+        since_event_id=None,
+        state_file=None,
+        follow=False,
+        idle_exit_ms=400,
+        poll_timeout_ms=60,
+        limit=50,
+        json=True,
+    )
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def _watch_payload(capsys):
+    out = capsys.readouterr().out.strip()
+    assert out, "watch printed nothing"
+    return json.loads(out)
+
+
+class TestLogstreamWatch:
+    def test_wakes_on_a_matching_event_and_exits_zero(self, palace_path, capsys):
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        capsys.readouterr()
+
+        # No SystemExit: a clean return is exit 0, the "you have mail" signal
+        # a harness backgrounds this process to receive.
+        cmd_logstream(_watch_args(palace_path, agent="mac-claude"))
+        payload = _watch_payload(capsys)
+        assert payload["count"] == 1
+        assert payload["timed_out"] is False
+        assert payload["cursor"]
+
+    def test_idle_timeout_exits_two(self, palace_path, capsys):
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(_watch_args(palace_path, agent="nobody-home"))
+        assert exc.value.code == 2
+        assert _watch_payload(capsys)["timed_out"] is True
+
+    def test_agent_shorthand_does_not_wake_on_your_own_broadcast(self, palace_path, capsys):
+        """--agent exists for this case.
+
+        to_agent=<me> also matches '*' broadcasts, and your own broadcasts are
+        broadcasts, so a watcher without the exclusion wakes itself every time
+        it posts a status.
+        """
+        cmd_logstream(
+            _append_args(
+                palace_path,
+                from_agent="mac-claude",
+                to_agent="*",
+                type="status.update",
+            )
+        )
+        capsys.readouterr()
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(_watch_args(palace_path, agent="mac-claude"))
+        assert exc.value.code == 2, "watcher woke itself on its own broadcast"
+
+    def test_explicit_to_agent_still_sees_broadcasts(self, palace_path, capsys):
+        """Without --agent there is no exclusion, so '*' still reaches you."""
+        cmd_logstream(_append_args(palace_path, from_agent="mac-claude", to_agent="*"))
+        capsys.readouterr()
+
+        cmd_logstream(_watch_args(palace_path, to_agent=["mac-claude"]))
+        assert _watch_payload(capsys)["count"] == 1
+
+    def test_type_filter_is_an_or_and_ignores_the_rest(self, palace_path, capsys):
+        for event_type in ("status.update", "status.update", "patch.ready"):
+            cmd_logstream(
+                _append_args(
+                    palace_path,
+                    type=event_type,
+                    from_agent="windows-grok",
+                    to_agent="mac-claude",
+                )
+            )
+        capsys.readouterr()
+
+        cmd_logstream(
+            _watch_args(
+                palace_path,
+                agent="mac-claude",
+                type=["task.request", "patch.ready"],
+            )
+        )
+        payload = _watch_payload(capsys)
+        assert [e["type"] for e in payload["events"]] == ["patch.ready"]
+
+    def test_state_file_persists_the_cursor_and_prevents_replay(
+        self, palace_path, tmp_path, capsys
+    ):
+        state = str(tmp_path / "watch.json")
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        capsys.readouterr()
+
+        cmd_logstream(_watch_args(palace_path, agent="mac-claude", state_file=state))
+        first = _watch_payload(capsys)
+        assert first["count"] == 1
+        assert json.load(open(state, encoding="utf-8"))["cursor"] == first["cursor"]
+
+        # Second run resumes from the file: the same event must not replay.
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(_watch_args(palace_path, agent="mac-claude", state_file=state))
+        assert exc.value.code == 2
+
+    def test_since_event_id_overrides_the_state_file(self, palace_path, tmp_path, capsys):
+        state = str(tmp_path / "watch.json")
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        first_id = json.loads(capsys.readouterr().out)["id"]
+
+        cmd_logstream(_watch_args(palace_path, agent="mac-claude", state_file=state))
+        capsys.readouterr()
+
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        capsys.readouterr()
+        # Rewind explicitly: the flag wins over the stored cursor.
+        cmd_logstream(
+            _watch_args(
+                palace_path,
+                agent="mac-claude",
+                state_file=state,
+                since_event_id=first_id,
+            )
+        )
+        assert _watch_payload(capsys)["count"] == 1

--- a/tests/test_cli_logstream.py
+++ b/tests/test_cli_logstream.py
@@ -7,6 +7,7 @@ and error exits. Uses SimpleNamespace args like the rest of test_cli.py.
 
 import json
 import sys
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -495,3 +496,35 @@ class TestLogstreamWatch:
             )
         )
         assert _watch_payload(capsys)["count"] == 1
+
+    def test_idle_deadline_caps_the_poll(self, palace_path, capsys):
+        """--idle-exit-ms shorter than --poll-timeout-ms must not wait the poll."""
+        t0 = time.monotonic()
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(
+                _watch_args(
+                    palace_path,
+                    agent="nobody-home",
+                    idle_exit_ms=200,
+                    poll_timeout_ms=5000,
+                )
+            )
+        elapsed = time.monotonic() - t0
+        assert exc.value.code == 2
+        assert elapsed < 1.5, f"idle 200ms waited {elapsed:.2f}s (poll was 5s)"
+
+    def test_match_does_not_checkpoint_if_output_fails(
+        self, palace_path, tmp_path, capsys, monkeypatch
+    ):
+        """A broken pipe after a match must not persist the cursor."""
+        state = str(tmp_path / "watch.json")
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        capsys.readouterr()
+
+        def boom(*_a, **_k):
+            raise OSError("broken pipe")
+
+        monkeypatch.setattr("json.dumps", boom)
+        with pytest.raises(OSError, match="broken pipe"):
+            cmd_logstream(_watch_args(palace_path, agent="mac-claude", state_file=state))
+        assert not (tmp_path / "watch.json").exists()

--- a/tests/test_cli_logstream.py
+++ b/tests/test_cli_logstream.py
@@ -520,18 +520,29 @@ class TestLogstreamWatch:
     def test_match_does_not_checkpoint_if_output_fails(
         self, palace_path, tmp_path, capsys, monkeypatch
     ):
-        """A broken pipe after a match must not persist the cursor."""
-        state = str(tmp_path / "watch.json")
+        """A broken pipe after a match must not advance the cursor past it.
+
+        Asserting "no state file" would be pinning the symptom: since the
+        starting position is now checkpointed before the first poll, a file
+        legitimately exists. What must hold is that its cursor is still the
+        pre-match position, so the undelivered event replays on restart —
+        a duplicate, never a skip.
+        """
+        state = tmp_path / "watch.json"
         cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
-        capsys.readouterr()
+        matched_id = json.loads(capsys.readouterr().out)["id"]
 
         def boom(*_a, **_k):
             raise OSError("broken pipe")
 
         monkeypatch.setattr("json.dumps", boom)
         with pytest.raises(OSError, match="broken pipe"):
-            cmd_logstream(_watch_args(palace_path, agent="mac-claude", state_file=state))
-        assert not (tmp_path / "watch.json").exists()
+            cmd_logstream(_watch_args(palace_path, agent="mac-claude", state_file=str(state)))
+
+        monkeypatch.undo()
+        stored = json.loads(state.read_text(encoding="utf-8"))["cursor"]
+        assert stored != matched_id, "cursor advanced past an event that was never delivered"
+        assert stored is None, "cursor should still be the pre-match starting position"
 
     def test_fresh_watch_starts_at_the_tip_not_the_beginning(self, palace_path, capsys):
         """A first watch must not replay the whole log.
@@ -705,3 +716,48 @@ class TestLogstreamWatch:
             )
         assert exc.value.code == 1
         assert "initial checkpoint" in json.loads(capsys.readouterr().out)["error"]
+
+    def test_starting_cursor_is_checkpointed_before_the_first_poll(
+        self, palace_path, tmp_path, monkeypatch, capsys
+    ):
+        """Every entry path must checkpoint before polling, not after.
+
+        The starting position arrives three ways — an explicit
+        --since-event-id, the tip, or None (empty log / --from-start) — and
+        all three need the file on disk *before* the first poll. Deferring to
+        the first watch_events yield leaves a window of up to a full poll
+        timeout; an interrupt inside it leaves no file, so the next launch
+        calls itself a first run and jumps to the tip.
+
+        watch_events is stubbed to interrupt immediately, which is what makes
+        this pin the startup write. Letting the real loop run would pass on
+        the loop's own checkpoint instead, since the test poll timeout is
+        milliseconds rather than the five-minute default.
+        """
+        import mempalace.logstream as logstream_module
+
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        first_id = json.loads(capsys.readouterr().out)["id"]
+
+        def interrupt_before_yielding(*_a, **_k):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(logstream_module.Logstream, "watch_events", interrupt_before_yielding)
+
+        for label, overrides, expected in (
+            ("explicit cursor", {"since_event_id": first_id}, first_id),
+            ("tip", {}, first_id),
+            ("from-start", {"from_start": True}, None),
+        ):
+            state = tmp_path / f"{label.replace(' ', '_')}.json"
+            kwargs = {
+                "agent": "mac-claude",
+                "state_file": str(state),
+                "from_start": False,
+                **overrides,
+            }
+            with pytest.raises(SystemExit) as exc:
+                cmd_logstream(_watch_args(palace_path, **kwargs))
+            assert exc.value.code == 130
+            assert state.exists(), f"{label}: interrupted before any checkpoint landed"
+            assert json.loads(state.read_text(encoding="utf-8"))["cursor"] == expected, label

--- a/tests/test_cli_logstream.py
+++ b/tests/test_cli_logstream.py
@@ -817,3 +817,58 @@ class TestLogstreamWatch:
             _watch_args(palace_path, agent="mac-claude", state_file=str(state), from_start=False)
         )
         assert _watch_payload(capsys)["count"] == 1, "stranded instead of replaying"
+
+    def test_repeated_filters_are_validated_like_single_ones(self, palace_path, capsys):
+        """Validation must not depend on how many values you passed.
+
+        A single-valued filter is pushed down to list_events and sanitized
+        for free; a repeated one is not, so it was compared raw. That made
+        `--type Task.Request` an error alone but silently accepted alongside
+        a second value — and then it matched nothing, so the watcher waited
+        forever for an event type that cannot exist.
+        """
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(
+                _watch_args(
+                    palace_path,
+                    agent="mac-claude",
+                    type=["Task.Request", "patch.ready"],
+                )
+            )
+        assert exc.value.code == 1
+        assert "Task.Request" in json.loads(capsys.readouterr().out)["error"]
+
+    def test_repeated_status_and_routing_are_validated_too(self, palace_path, capsys):
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(
+                _watch_args(palace_path, agent="mac-claude", status=["open", "not_a_status"])
+            )
+        assert exc.value.code == 1
+        assert "not_a_status" in json.loads(capsys.readouterr().out)["error"]
+
+    def test_repeated_routing_values_are_normalized(self, palace_path, capsys):
+        """Whitespace in a repeated value must not quietly stop it matching."""
+        cmd_logstream(
+            _append_args(
+                palace_path,
+                to_agent="mac-claude",
+                from_agent="windows-grok",
+                stream="project/mempalace",
+            )
+        )
+        capsys.readouterr()
+        cmd_logstream(
+            _watch_args(
+                palace_path,
+                agent="mac-claude",
+                stream=["  project/mempalace  ", "project/other"],
+            )
+        )
+        assert _watch_payload(capsys)["count"] == 1
+
+    def test_invalid_limit_is_a_cli_error_not_a_traceback(self, palace_path, capsys):
+        """--json consumers must get an error document, never a stack trace."""
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(_watch_args(palace_path, agent="mac-claude", limit=0))
+        assert exc.value.code == 1
+        assert "limit" in json.loads(capsys.readouterr().out)["error"]

--- a/tests/test_cli_logstream.py
+++ b/tests/test_cli_logstream.py
@@ -567,3 +567,77 @@ class TestLogstreamWatch:
             _watch_args(palace_path, agent="mac-claude", since_event_id=first_id, from_start=False)
         )
         assert _watch_payload(capsys)["count"] == 1
+
+    def test_interrupted_watch_does_not_report_mail(self, palace_path, monkeypatch, capsys):
+        """Ctrl-C must not exit 0.
+
+        Exit 0 is the documented "a match was printed" signal, so a
+        supervisor that SIGINTs a watcher would otherwise be told it has
+        mail that never arrived.
+        """
+        import mempalace.logstream as logstream_module
+
+        def interrupt(*_a, **_k):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(logstream_module.Logstream, "watch_events", interrupt)
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(_watch_args(palace_path, agent="mac-claude"))
+        assert exc.value.code == 130
+
+    def test_nonpositive_poll_timeout_is_rejected(self, palace_path, capsys):
+        """A configured zero must be rejected up front, not merely survived.
+
+        With no idle deadline it would spin watch_events' expired-deadline
+        branch forever without ever polling. Asserting only "nonzero exit"
+        would pass for the wrong reason, since an idle timeout also exits
+        nonzero — so this pins the validation error itself.
+        """
+        with pytest.raises(SystemExit) as exc:
+            cmd_logstream(
+                _watch_args(palace_path, agent="mac-claude", poll_timeout_ms=0, idle_exit_ms=200)
+            )
+        assert exc.value.code == 1
+        assert "poll-timeout-ms" in json.loads(capsys.readouterr().out)["error"]
+
+    def test_unreadable_state_file_replays_instead_of_skipping(self, palace_path, tmp_path, capsys):
+        """A failed cursor read must not be treated as a first run.
+
+        read_watch_cursor returns None for both "no state file yet" and
+        "state file exists but is corrupt". Jumping to the tip on the second
+        silently skips everything since the last good checkpoint, and the
+        next checkpoint makes that loss permanent — the opposite of the
+        documented "a corrupt state file costs a replay".
+        """
+        state = tmp_path / "watch.json"
+        state.write_text("null", encoding="utf-8")  # valid JSON, not an object
+        cmd_logstream(_append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok"))
+        capsys.readouterr()
+
+        cmd_logstream(
+            _watch_args(palace_path, agent="mac-claude", state_file=str(state), from_start=False)
+        )
+        payload = _watch_payload(capsys)
+        assert payload["count"] == 1, "corrupt state file skipped the backlog instead of replaying"
+
+    def test_follow_json_is_ndjson_not_concatenated_documents(self, palace_path, tmp_path, capsys):
+        """--follow --json must be parseable.
+
+        Repeated indented documents on one stream are not valid JSON; jq and
+        json.load reject them with trailing data, which defeats the point of
+        a machine-readable flag on the mode intended for daemons.
+        """
+        for _ in range(2):
+            cmd_logstream(
+                _append_args(palace_path, to_agent="mac-claude", from_agent="windows-grok")
+            )
+        capsys.readouterr()
+
+        with pytest.raises(SystemExit):
+            cmd_logstream(
+                _watch_args(palace_path, agent="mac-claude", follow=True, idle_exit_ms=300)
+            )
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+        assert lines, "follow mode printed nothing"
+        for line in lines:
+            json.loads(line)  # every line stands alone — that is the contract

--- a/tests/test_logstream.py
+++ b/tests/test_logstream.py
@@ -491,3 +491,163 @@ class TestSizeLimits:
             assert evt["body"] == "x" * 10
         finally:
             ls.close()
+
+
+# ── Watch (background watchers) ───────────────────────────────────────────
+
+
+class TestWatchFilters:
+    """The multi-valued and negative filters ``list_events`` cannot express."""
+
+    def _event(self, **overrides):
+        base = {
+            "stream": "project/mempalace",
+            "room": "delegation",
+            "type": "task.request",
+            "status": "open",
+            "to_agent": "mac-claude",
+            "from_agent": "windows-grok",
+            "correlation_id": "task_1",
+        }
+        base.update(overrides)
+        return base
+
+    def test_normalize_treats_blank_as_absent_not_impossible(self):
+        from mempalace.logstream import normalize_watch_values
+
+        assert normalize_watch_values(None) is None
+        assert normalize_watch_values("a") == {"a"}
+        assert normalize_watch_values(["a", "b"]) == {"a", "b"}
+        # A blank filter must mean "any", never "match nothing" — otherwise a
+        # stray empty flag silently deafens the watcher forever.
+        assert normalize_watch_values(["", None]) is None
+
+    def test_own_broadcast_is_excluded(self):
+        """The bug that motivated --agent.
+
+        ``to_agent=<me>`` also matches '*' broadcasts, and an agent's own
+        broadcasts are broadcasts — so without the exclusion a watcher wakes
+        itself every time it posts a status.
+        """
+        from mempalace.logstream import event_matches_watch
+
+        own = self._event(from_agent="mac-claude", to_agent="*")
+        assert not event_matches_watch(
+            own, to_agents={"mac-claude"}, exclude_from_agents={"mac-claude"}
+        )
+        # The same broadcast from anyone else still reaches us.
+        other = self._event(from_agent="windows-grok", to_agent="*")
+        assert event_matches_watch(
+            other, to_agents={"mac-claude"}, exclude_from_agents={"mac-claude"}
+        )
+
+    def test_exclusion_beats_a_direct_address(self):
+        from mempalace.logstream import event_matches_watch
+
+        addressed = self._event(from_agent="noisy", to_agent="mac-claude")
+        assert not event_matches_watch(
+            addressed, to_agents={"mac-claude"}, exclude_from_agents={"noisy"}
+        )
+
+    def test_multi_valued_field_is_an_or(self):
+        from mempalace.logstream import event_matches_watch
+
+        evt = self._event(type="patch.ready")
+        assert event_matches_watch(evt, types={"task.request", "patch.ready"})
+        assert not event_matches_watch(evt, types={"task.request", "status.update"})
+
+    def test_absent_filter_matches_anything(self):
+        from mempalace.logstream import event_matches_watch
+
+        assert event_matches_watch(self._event(), types=None, streams=None)
+
+    def test_pushdown_only_takes_single_valued_filters(self):
+        from mempalace.logstream import pushdown_watch_filters
+
+        spec = {"types": {"task.request"}, "streams": {"a", "b"}, "rooms": None}
+        pushed = pushdown_watch_filters(spec)
+        # Multi-valued filters must stay client-side; pushing one arbitrary
+        # value would silently drop the others.
+        assert pushed == {"type": "task.request"}
+
+
+class TestWatchEvents:
+    def test_wakes_only_on_a_match_and_advances_cursor(self, logstream):
+        noise = _append(logstream, type="status.update", from_agent="windows-grok")
+        wanted = _append(logstream, type="patch.ready", from_agent="windows-grok")
+        watcher = logstream.watch_events(
+            poll_timeout_ms=200,
+            poll_interval_s=0.01,
+            types={"patch.ready"},
+        )
+        matched, cursor = next(watcher)
+        assert [e["id"] for e in matched] == [wanted["id"]]
+        # The cursor passes the rejected event too — re-judging it after a
+        # restart would be pure waste.
+        assert cursor == wanted["id"]
+        assert noise["id"] != cursor
+        watcher.close()
+
+    def test_idle_poll_yields_so_callers_can_time_out(self, logstream):
+        watcher = logstream.watch_events(
+            poll_timeout_ms=50, poll_interval_s=0.01, correlation_id=None, types={"nothing"}
+        )
+        matched, cursor = next(watcher)
+        assert matched == []
+        assert cursor is None
+        watcher.close()
+
+    def test_cursor_resumes_without_replaying(self, logstream):
+        first = _append(logstream)
+        watcher = logstream.watch_events(poll_timeout_ms=100, poll_interval_s=0.01)
+        matched, cursor = next(watcher)
+        assert [e["id"] for e in matched] == [first["id"]]
+        watcher.close()
+
+        second = _append(logstream)
+        resumed = logstream.watch_events(cursor=cursor, poll_timeout_ms=100, poll_interval_s=0.01)
+        matched, _ = next(resumed)
+        assert [e["id"] for e in matched] == [second["id"]]
+        resumed.close()
+
+    def test_self_broadcast_does_not_wake_the_author(self, logstream):
+        """End-to-end version of the --agent bug, through the real store."""
+        _append(logstream, from_agent="mac-claude", to_agent="*", type="status.update")
+        watcher = logstream.watch_events(
+            poll_timeout_ms=50,
+            poll_interval_s=0.01,
+            to_agents={"mac-claude"},
+            exclude_from_agents={"mac-claude"},
+        )
+        matched, cursor = next(watcher)
+        assert matched == []
+        # Still examined, so the cursor moved past it.
+        assert cursor is not None
+        watcher.close()
+
+
+class TestWatchCursorFile:
+    def test_roundtrip(self, tmp_path):
+        from mempalace.logstream import read_watch_cursor, write_watch_cursor
+
+        path = str(tmp_path / "nested" / "cursor.json")
+        write_watch_cursor(path, "evt_abc", agent="mac-claude")
+        assert read_watch_cursor(path) == "evt_abc"
+
+    def test_missing_or_corrupt_file_is_not_fatal(self, tmp_path):
+        """A truncated state file costs a replay; refusing to start costs
+        every event after it."""
+        from mempalace.logstream import read_watch_cursor
+
+        assert read_watch_cursor(str(tmp_path / "absent.json")) is None
+        corrupt = tmp_path / "corrupt.json"
+        corrupt.write_text("{not json", encoding="utf-8")
+        assert read_watch_cursor(str(corrupt)) is None
+        assert read_watch_cursor(None) is None
+
+    def test_write_leaves_no_temp_file_behind(self, tmp_path):
+        from mempalace.logstream import write_watch_cursor
+
+        path = str(tmp_path / "cursor.json")
+        write_watch_cursor(path, "evt_abc")
+        assert [p.name for p in tmp_path.iterdir()] == ["cursor.json"]

--- a/tests/test_logstream.py
+++ b/tests/test_logstream.py
@@ -651,3 +651,17 @@ class TestWatchCursorFile:
         path = str(tmp_path / "cursor.json")
         write_watch_cursor(path, "evt_abc")
         assert [p.name for p in tmp_path.iterdir()] == ["cursor.json"]
+
+    def test_non_object_json_is_treated_as_corrupt(self, tmp_path):
+        """Valid JSON that is not an object must degrade, not raise.
+
+        ``json.load(...).get()`` on ``null`` / ``[]`` / a bare string raises
+        AttributeError, which would stop the watcher from starting — the
+        exact opposite of the recovery contract.
+        """
+        from mempalace.logstream import read_watch_cursor
+
+        for payload in ("null", "[]", '"evt_abc"', "42"):
+            path = tmp_path / f"cursor_{abs(hash(payload))}.json"
+            path.write_text(payload, encoding="utf-8")
+            assert read_watch_cursor(str(path)) is None

--- a/tests/test_logstream.py
+++ b/tests/test_logstream.py
@@ -696,3 +696,58 @@ class TestWatchCursorFile:
         assert read_watch_state(str(broken)) == (None, WATCH_STATE_CORRUPT)
         broken.write_text('{"other": 1}', encoding="utf-8")
         assert read_watch_state(str(broken)) == (None, WATCH_STATE_CORRUPT)
+
+    def test_unreachable_file_is_corrupt_not_absent(self, tmp_path, monkeypatch):
+        """A checkpoint we cannot open must replay, never restart at the tip.
+
+        ``os.path.exists`` answers False both for "no such file" and for
+        "cannot traverse the parent directory", so a preflight check turns a
+        momentarily unreachable checkpoint into a fake first run and skips
+        every event since the stored cursor.
+        """
+        from mempalace.logstream import (
+            WATCH_STATE_ABSENT,
+            WATCH_STATE_CORRUPT,
+            read_watch_state,
+        )
+
+        # A directory where a file is expected: open() raises OSError on
+        # every platform (IsADirectoryError on POSIX, PermissionError on NT).
+        as_dir = tmp_path / "cursor.json"
+        as_dir.mkdir()
+        assert read_watch_state(str(as_dir)) == (None, WATCH_STATE_CORRUPT)
+
+        # Permission denied, simulated so the test is platform-independent.
+        real_open = open
+
+        def denied(path, *a, **k):
+            if str(path).endswith("locked.json"):
+                raise PermissionError(13, "Permission denied")
+            return real_open(path, *a, **k)
+
+        monkeypatch.setattr("builtins.open", denied)
+        assert read_watch_state(str(tmp_path / "locked.json")) == (None, WATCH_STATE_CORRUPT)
+
+        # A genuinely missing file is still absent, i.e. a real first run.
+        monkeypatch.undo()
+        assert read_watch_state(str(tmp_path / "gone.json")) == (None, WATCH_STATE_ABSENT)
+
+    def test_required_checkpoint_raises_instead_of_swallowing(self, tmp_path, monkeypatch):
+        """Best effort is safe only when a lost checkpoint costs a replay.
+
+        For the first checkpoint of a fresh watch it costs a skip instead, so
+        that one must surface the failure.
+        """
+        from mempalace.logstream import write_watch_cursor
+
+        target = str(tmp_path / "sub" / "cursor.json")
+
+        def denied(path, *a, **k):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr("builtins.open", denied)
+        # Ordinary checkpoint: swallowed, the watcher keeps running.
+        write_watch_cursor(target, "evt_abc")
+        # Initial checkpoint: raised, so the caller can refuse to start.
+        with pytest.raises(OSError):
+            write_watch_cursor(target, "evt_abc", required=True)

--- a/tests/test_logstream.py
+++ b/tests/test_logstream.py
@@ -665,3 +665,34 @@ class TestWatchCursorFile:
             path = tmp_path / f"cursor_{abs(hash(payload))}.json"
             path.write_text(payload, encoding="utf-8")
             assert read_watch_cursor(str(path)) is None
+
+    def test_conditions_distinguish_absent_empty_and_corrupt(self, tmp_path):
+        """ "No cursor" is four facts; only ``absent`` may start at the tip."""
+        from mempalace.logstream import (
+            WATCH_STATE_ABSENT,
+            WATCH_STATE_CORRUPT,
+            WATCH_STATE_EMPTY,
+            WATCH_STATE_OK,
+            read_watch_state,
+            write_watch_cursor,
+        )
+
+        assert read_watch_state(str(tmp_path / "nope.json")) == (None, WATCH_STATE_ABSENT)
+        assert read_watch_state(None) == (None, WATCH_STATE_ABSENT)
+
+        good = tmp_path / "good.json"
+        write_watch_cursor(str(good), "evt_abc")
+        assert read_watch_state(str(good)) == ("evt_abc", WATCH_STATE_OK)
+
+        # Empty-log sentinel: the file exists and says so explicitly.
+        empty = tmp_path / "empty.json"
+        write_watch_cursor(str(empty), None)
+        assert read_watch_state(str(empty)) == (None, WATCH_STATE_EMPTY)
+
+        broken = tmp_path / "broken.json"
+        broken.write_text("{not json", encoding="utf-8")
+        assert read_watch_state(str(broken)) == (None, WATCH_STATE_CORRUPT)
+        broken.write_text("null", encoding="utf-8")
+        assert read_watch_state(str(broken)) == (None, WATCH_STATE_CORRUPT)
+        broken.write_text('{"other": 1}', encoding="utf-8")
+        assert read_watch_state(str(broken)) == (None, WATCH_STATE_CORRUPT)

--- a/website/concepts/agent-logstream.md
+++ b/website/concepts/agent-logstream.md
@@ -174,7 +174,10 @@ wakes itself on every status it posts. Repeating a filter means "or", which is
 how you narrow to the events that genuinely require you and stop being woken by
 routine traffic. Exit is `0` on a match and `2` on `--idle-exit-ms`, matching
 `wait`'s timeout convention; `--follow` keeps the process alive past the first
-match for daemons.
+match for daemons. A cursorless first run starts at the tip, like the SSE
+live-tail, and says so on stderr — replaying a long fleet log would wake a new
+watcher holding weeks of history it cannot tell is stale. `--from-start` opts
+into the replay.
 
 `mempalace_event_wait` backs off internally (0.25s → 1s), so a tight retry
 loop around it buys nothing. Filter server-side — `to_agent`, `type`,

--- a/website/concepts/agent-logstream.md
+++ b/website/concepts/agent-logstream.md
@@ -149,9 +149,32 @@ So there are two different parameters, and only one of them is a cursor:
 | Mode | Best for | Mechanism |
 |---|---|---|
 | Inbox sweep | Session start, pre-task checks | `mempalace_event_list` + `to_agent` + `since_event_id`, `preview=true` |
-| Long-poll | Waiting on a specific correlation | `mempalace_event_wait` — 60s default, 300s max, returns `timed_out` rather than erroring |
+| Background watcher | Being woken while you work | `mempalace logstream watch`, run as a background process |
+| Long-poll | Waiting on one correlation, in-turn | `mempalace_event_wait` — 60s default, 300s max, returns `timed_out` rather than erroring |
 | Server-Sent Events | Daemons, dashboards, live viewers | `GET /logstream/stream`, same filters and `since_event_id` resume |
 | Declared-idle | Turn-based agents with no background loop | Publish your cursor and say you need a ping |
+
+`logstream watch` exists because `wait` is a primitive, not a watcher: it caps
+at five minutes and reports a timeout, so every caller ends up writing the same
+re-arm loop and each one has to remember to carry the cursor forward. `watch`
+owns both, adds the filters a watcher needs, and exits on a match so a harness
+can treat process exit as "you have mail":
+
+```bash
+mempalace logstream watch \
+  --agent mac-claude \
+  --type task.request --type patch.ready \
+  --state-file ~/.mempalace/watch/mac-claude.json --json
+```
+
+`--agent` is shorthand for `--to-agent <id> --exclude-from-agent <id>`. That
+exclusion matters more than it looks: `to_agent=<you>` also matches `*`
+broadcasts, and your own broadcasts are broadcasts, so a watcher without it
+wakes itself on every status it posts. Repeating a filter means "or", which is
+how you narrow to the events that genuinely require you and stop being woken by
+routine traffic. Exit is `0` on a match and `2` on `--idle-exit-ms`, matching
+`wait`'s timeout convention; `--follow` keeps the process alive past the first
+match for daemons.
 
 `mempalace_event_wait` backs off internally (0.25s → 1s), so a tight retry
 loop around it buys nothing. Filter server-side — `to_agent`, `type`,

--- a/website/concepts/agent-logstream.md
+++ b/website/concepts/agent-logstream.md
@@ -121,6 +121,63 @@ the stream over Server-Sent Events at `GET /logstream/stream` — same
 filters, same JSON envelope, `since_event_id` resume — see
 [Shared Brain](/guide/shared-brain#operating-the-shared-brain).
 
+## Monitoring
+
+Reading the stream efficiently is its own skill, and getting it wrong is the
+usual reason a coordinated task stalls: the event was written correctly, but
+nobody was listening.
+
+### Cursors
+
+Events are returned in **append order** (`ORDER BY rowid`), not timestamp
+order. That distinction matters as soon as a second replica exists — a peer's
+event created at 09:10:48Z is appended locally whenever it syncs, which can be
+*after* a local event created at 09:13:21Z.
+
+So there are two different parameters, and only one of them is a cursor:
+
+- **`since_event_id`** — strictly after that event in append order, whatever
+  the timestamps say. This is the resume cursor. A watcher's entire state is
+  the id of the last event it processed.
+- **`since_created_at`** — a time window (`>=`, inclusive; dedup by `id`).
+  Good for "what happened today", wrong for resumption: a late-arriving peer
+  event is already older than your high-water mark, so you skip it silently
+  and permanently.
+
+### Choosing a mode
+
+| Mode | Best for | Mechanism |
+|---|---|---|
+| Inbox sweep | Session start, pre-task checks | `mempalace_event_list` + `to_agent` + `since_event_id`, `preview=true` |
+| Long-poll | Waiting on a specific correlation | `mempalace_event_wait` — 60s default, 300s max, returns `timed_out` rather than erroring |
+| Server-Sent Events | Daemons, dashboards, live viewers | `GET /logstream/stream`, same filters and `since_event_id` resume |
+| Declared-idle | Turn-based agents with no background loop | Publish your cursor and say you need a ping |
+
+`mempalace_event_wait` backs off internally (0.25s → 1s), so a tight retry
+loop around it buys nothing. Filter server-side — `to_agent`, `type`,
+`status` and `correlation_id` are all indexed, and `to_agent=<you>` matches
+`*` broadcasts without a second query. Use `preview=true` when scanning a
+busy stream: bodies come back truncated with `body_truncated` and
+`body_length` set, so you spend tokens only on the event you actually want.
+
+### Make the watch visible
+
+A watcher nobody can see is nearly as bad as no watcher. The convention is to
+post a `status` event to `to_agent=*` when you begin monitoring a correlation,
+naming four things: the filter you are watching, the cursor you have reached,
+the work that must not be duplicated, and — implicitly — the fact that someone
+is home. Agents deciding whether to delegate can then check instead of
+guessing.
+
+The inverse is equally important. If your harness is turn-based and stops
+existing between prompts, declare that rather than staying quiet: publish your
+last-seen event id and say a ping is needed. Never advertise a watch you do
+not have — a requester who believes an agent is listening stops looking for a
+human to nudge.
+
+For the full protocol, see the
+[coordination protocol](https://github.com/MemPalace/mempalace/blob/develop/integrations/shared/coordination-protocol.md).
+
 ## Coordination vs. memory
 
 The logstream complements the palace; it does not replace it:

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -211,7 +211,7 @@ mempalace logstream watch --agent mac --type task.request --type patch.ready \
 | `append` | Append an immutable event (`--type`, `--stream`, `--room`, `--from-agent` required; `--body`/`--body-file`, `--artifact-id` repeatable) |
 | `list` | List events, oldest first (all routing fields as filters, `--since-event-id`, `--limit`) |
 | `wait` | Long-poll until a match or timeout (`--timeout-ms`, max 300000; exits `2` on timeout) |
-| `watch` | Background watcher: re-arms past the `wait` cap, carries the cursor, and exits `0` on a match / `2` on `--idle-exit-ms`. `--agent ID` is shorthand for `--to-agent ID --exclude-from-agent ID` so your own `*` broadcasts never wake you. Filters repeat to mean "or"; `--state-file` resumes exactly; `--follow` stays alive past the first match |
+| `watch` | Background watcher: re-arms past the `wait` cap, carries the cursor, and exits `0` on a match / `2` on `--idle-exit-ms`. `--agent ID` is shorthand for `--to-agent ID --exclude-from-agent ID` so your own `*` broadcasts never wake you. Filters repeat to mean "or"; `--state-file` resumes exactly; `--follow` stays alive past the first match; a cursorless first run starts at the tip (`--from-start` to replay) |
 | `ack` | Append an `event.ack` for an event (`--from-agent` required, `--status`, `--body`) |
 | `sync` | Pull missing events/artifacts from peer replicas (`--peer URL --token T`, or all peers in `peers.json`) |
 

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -211,7 +211,7 @@ mempalace logstream watch --agent mac --type task.request --type patch.ready \
 | `append` | Append an immutable event (`--type`, `--stream`, `--room`, `--from-agent` required; `--body`/`--body-file`, `--artifact-id` repeatable) |
 | `list` | List events, oldest first (all routing fields as filters, `--since-event-id`, `--limit`) |
 | `wait` | Long-poll until a match or timeout (`--timeout-ms`, max 300000; exits `2` on timeout) |
-| `watch` | Background watcher: re-arms past the `wait` cap, carries the cursor, and exits `0` on a match / `2` on `--idle-exit-ms`. `--agent ID` is shorthand for `--to-agent ID --exclude-from-agent ID` so your own `*` broadcasts never wake you. Filters repeat to mean "or"; `--state-file` resumes exactly; `--follow` stays alive past the first match; a cursorless first run starts at the tip (`--from-start` to replay) |
+| `watch` | Background watcher: re-arms past the `wait` cap, carries the cursor, and exits `0` on a match / `2` on `--idle-exit-ms`. `--agent ID` is shorthand for `--to-agent ID --exclude-from-agent ID` so your own `*` broadcasts never wake you. Filters repeat to mean "or"; `--state-file` resumes exactly; `--follow` stays alive past the first match; a cursorless first run starts at the tip (`--from-start` to replay); exits `130` if interrupted; `--follow --json` emits NDJSON |
 | `ack` | Append an `event.ack` for an event (`--from-agent` required, `--status`, `--body`) |
 | `sync` | Pull missing events/artifacts from peer replicas (`--peer URL --token T`, or all peers in `peers.json`) |
 

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -200,6 +200,10 @@ mempalace logstream list --stream project/myapp --room delegation --json
 mempalace logstream wait --correlation-id task_123 --type patch.ready \
   --timeout-ms 300000 --json
 mempalace logstream ack evt_... --from-agent mac --status applied
+
+# Background watcher: blocks, wakes on what needs you, exits 0 on a match
+mempalace logstream watch --agent mac --type task.request --type patch.ready \
+  --state-file ~/.mempalace/watch/mac.json --json
 ```
 
 | Subcommand | Description |
@@ -207,6 +211,7 @@ mempalace logstream ack evt_... --from-agent mac --status applied
 | `append` | Append an immutable event (`--type`, `--stream`, `--room`, `--from-agent` required; `--body`/`--body-file`, `--artifact-id` repeatable) |
 | `list` | List events, oldest first (all routing fields as filters, `--since-event-id`, `--limit`) |
 | `wait` | Long-poll until a match or timeout (`--timeout-ms`, max 300000; exits `2` on timeout) |
+| `watch` | Background watcher: re-arms past the `wait` cap, carries the cursor, and exits `0` on a match / `2` on `--idle-exit-ms`. `--agent ID` is shorthand for `--to-agent ID --exclude-from-agent ID` so your own `*` broadcasts never wake you. Filters repeat to mean "or"; `--state-file` resumes exactly; `--follow` stays alive past the first match |
 | `ack` | Append an `event.ack` for an event (`--from-agent` required, `--status`, `--body`) |
 | `sync` | Pull missing events/artifacts from peer replicas (`--peer URL --token T`, or all peers in `peers.json`) |
 


### PR DESCRIPTION
Coordination friction on the shared brain is usually a *listening* failure, not a protocol failure: a task sits `open` because the agent it was addressed to was never watching, and the requester cannot tell "working on it" from "nobody is home".

Two commits — the protocol, then the tool that makes it practical.

## `logstream watch`

`logstream wait` is a primitive, not a watcher. It caps at `MAX_WAIT_TIMEOUT_MS` and reports a timeout, so every caller writes the same re-arm loop and each one has to remember to carry the cursor forward. Most did not.

Two filters a watcher needs cannot be expressed by `list_events`, whose SQL is single-valued and positive-only:

- "wake me for `task.request` **or** `patch.ready`"
- "everything addressed to me **except** my own events"

The second is not a nicety. `to_agent=<me>` deliberately also matches `*` broadcasts, and an agent's own broadcasts are broadcasts — so a hand-rolled watcher wakes itself every time it posts a status. This was found by running one: it woke on its own fleet announcement within seconds.

```bash
mempalace logstream watch \
  --agent mac-claude \
  --type task.request --type patch.ready \
  --state-file ~/.mempalace/watch/mac-claude.json --json
```

- `--agent ID` is shorthand for `--to-agent ID --exclude-from-agent ID`
- repeat any filter to mean "or" — that is how you get "or nothing", so routine status traffic stops waking you
- `--state-file` resumes exactly; the cursor advances past events examined and rejected, not only matches
- exit `0` on a match, `2` on `--idle-exit-ms` — same convention as `wait`, so a harness can background the process and treat its exit as "you have mail"
- `--follow` stays alive past the first match, for daemons

Single-valued filters push down to SQL to keep the query selective; the multi-valued and negative parts are re-checked client-side. Pushdown is an optimization, never a correctness dependency.

## The cursor rule

Events are ordered by append order (`ORDER BY rowid`), not wall clock. Across replicas those diverge: a peer's event is appended whenever it syncs, so it can already be older than a timestamp high-water mark. **Resuming with `since_created_at` therefore drops late-arriving cross-replica events permanently.**

Measured one such inversion in a single 50-event window: a windows-origin event created `09:10:48Z` was ingested *after* a mac-origin event created `09:13:21Z`.

`list_events`' docstring already said `since_event_id` is "the precise cursor … regardless of timestamp ties" — that just never reached an agent. It now appears in the tool descriptions at the point of use, and both `since_created_at` params are marked "NOT a resume cursor".

## Docs

- `coordination-protocol.md` — new **Monitoring the stream** section: cursor rule, the modes, the announce-your-watch convention, and declaring when you are *not* watching. The **system-prompt snippet** is updated, since that block is copied verbatim into every agent's instructions.
- `website/concepts/agent-logstream.md` and `website/reference/cli.md` — matching sections.

The announce-your-watch shape is generalized from an existing fleet announcement that named its filter, its cursor, and the work not to duplicate.

## Testing

20 new tests: self-exclusion at both matcher and CLI level, multi-valued ORs, cursor advance-past-rejected, resume-without-replay, `--since-event-id` overriding the state file, corrupt state files degrading rather than raising, and the exit-code contract.

Full suite **4390 passed, 31 skipped**; ruff clean. Also exercised end-to-end against a live 165k-drawer palace and a real multi-machine fleet — the watcher is currently running as this repo's own coordination watcher.