### PR TITLE
fix(sync): keep drawers whose source path cannot be resolved instead of pruning

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1138,6 +1138,7 @@ def cmd_sync(args):
     print(f"  Kept:           {report['kept']}")
     print(f"  Gitignored:     {report['gitignored']}  {removed_suffix}")
     print(f"  Missing:        {report['missing']}  {removed_suffix}")
+    print(f"  Unreachable:    {report['unreachable']}  (kept)")
     print(f"  No source:      {report['no_source']}  (kept)")
     print(f"  Out of scope:   {report['out_of_scope']}  (kept)")
 

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -364,6 +364,7 @@ def run_sync(payload: dict[str, Any]) -> dict[str, Any]:
     print(f"  Kept:           {report['kept']}")
     print(f"  Gitignored:     {report['gitignored']}  {removed_suffix}")
     print(f"  Missing:        {report['missing']}  {removed_suffix}")
+    print(f"  Unreachable:    {report['unreachable']}  (kept)")
     print(f"  No source:      {report['no_source']}  (kept)")
     print(f"  Out of scope:   {report['out_of_scope']}  (kept)")
 

--- a/mempalace/sync.py
+++ b/mempalace/sync.py
@@ -12,7 +12,6 @@ Usage:
 """
 
 import logging
-import os
 from collections import defaultdict
 from pathlib import Path
 from typing import Callable, Optional, TypedDict
@@ -98,30 +97,6 @@ def _is_registry_row(meta: dict, drawer_id: str) -> bool:
     return False
 
 
-def _looks_unmounted(path: Path) -> bool:
-    """Return True if ``path`` appears to live on a not-currently-mounted volume.
-
-    A source file on a volume that is configured as a mount point but not
-    mounted right now fails ``stat`` with ``ENOENT`` — the same errno as a
-    genuinely deleted file. The distinguishing signal is an ancestor directory
-    that (a) exists, (b) is a mount point, and (c) is not the filesystem root
-    (the root is always a mount point and must never count).
-    """
-    cursor = path.parent
-    try:
-        while True:
-            if cursor.exists():
-                return cursor != Path(cursor.anchor) and os.path.ismount(cursor)
-            if cursor.parent == cursor:
-                return False
-            cursor = cursor.parent
-    except OSError:
-        # If we cannot walk the ancestors, fall back to the documented
-        # "ENOENT means deleted" behaviour rather than silently disabling
-        # the prune feature.
-        return False
-
-
 def _classify_drawer(
     meta: dict, matcher_cache: dict, project_roots: list, drawer_id: str = ""
 ) -> str:
@@ -141,7 +116,21 @@ def _classify_drawer(
     src = Path(source_file)
     if not src.is_absolute():
         return "no_source"
-    src = src.resolve(strict=False)
+
+    # ``resolve(strict=False)`` is not fully exception-free: a symlink loop
+    # raises ``RuntimeError`` up to Python 3.12, and an unencodable path (an
+    # embedded NUL, surrogate escapes) raises ``ValueError``. Neither means the
+    # source was deleted — it means the path cannot be resolved right now — so
+    # keep the drawer instead of ending the whole sync run on the first one.
+    try:
+        src = src.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.warning(
+            "sync: keeping drawer, source path cannot be resolved (%s): %s",
+            type(exc).__name__,
+            source_file,
+        )
+        return "unreachable"
 
     root = _resolve_project_root(src, project_roots)
     if root is None:
@@ -149,18 +138,16 @@ def _classify_drawer(
 
     # ``Path.exists()`` conflates every stat failure with "gone", which made
     # sync prune drawers whose source was merely unreachable (a path component
-    # that is a regular file, an unreadable directory, or a volume that is
-    # configured but not mounted). Stat the file directly and only treat a
-    # true ENOENT as a deletion.
+    # that is a regular file, or an unreadable directory). Stat the file
+    # directly and only treat a true ENOENT as a deletion.
     try:
         src.stat()
     except FileNotFoundError:
-        # ENOENT — the file (or an ancestor) is absent. This is normally the
-        # "deleted" case we prune for, but an unmounted volume also surfaces
-        # as ENOENT even though the data still exists. Never prune those.
-        if _looks_unmounted(src):
-            logger.warning("sync: keeping drawer, source is on an unmounted volume: %s", src)
-            return "unreachable"
+        # ENOENT — the file (or an ancestor) is absent. This is the "deleted"
+        # case we prune for. Note that an unmounted volume also surfaces as
+        # ENOENT even though the data still exists, and no filesystem call
+        # separates the two (#2320); that case needs corroboration from the
+        # palace's own record rather than a per-file errno.
         return "missing"
     except NotADirectoryError:
         # A path component is a regular file, not a directory. The source may
@@ -173,11 +160,11 @@ def _classify_drawer(
         # EACCES/EPERM — we cannot prove the file is gone, so keep it.
         logger.warning("sync: keeping drawer, source is not readable: %s", src)
         return "unreachable"
-    except OSError as exc:
-        # ELOOP, EIO, ENAMETOOLONG, ... — unverifiable, keep.
+    except (OSError, ValueError) as exc:
+        # ELOOP, EIO, ENAMETOOLONG, embedded NUL, ... — unverifiable, keep.
         logger.warning(
-            "sync: keeping drawer, source could not be stat'ed (errno %s): %s",
-            exc.errno,
+            "sync: keeping drawer, source could not be stat'ed (%s): %s",
+            type(exc).__name__,
             src,
         )
         return "unreachable"

--- a/mempalace/sync.py
+++ b/mempalace/sync.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import logging
+import os
 from collections import defaultdict
 from pathlib import Path
 from typing import Callable, Optional, TypedDict
@@ -34,6 +35,7 @@ class SyncReport(TypedDict):
     kept: int
     gitignored: int
     missing: int
+    unreachable: int
     no_source: int
     out_of_scope: int
     removed_drawers: int
@@ -96,12 +98,37 @@ def _is_registry_row(meta: dict, drawer_id: str) -> bool:
     return False
 
 
+def _looks_unmounted(path: Path) -> bool:
+    """Return True if ``path`` appears to live on a not-currently-mounted volume.
+
+    A source file on a volume that is configured as a mount point but not
+    mounted right now fails ``stat`` with ``ENOENT`` — the same errno as a
+    genuinely deleted file. The distinguishing signal is an ancestor directory
+    that (a) exists, (b) is a mount point, and (c) is not the filesystem root
+    (the root is always a mount point and must never count).
+    """
+    cursor = path.parent
+    try:
+        while True:
+            if cursor.exists():
+                return cursor != Path(cursor.anchor) and os.path.ismount(cursor)
+            if cursor.parent == cursor:
+                return False
+            cursor = cursor.parent
+    except OSError:
+        # If we cannot walk the ancestors, fall back to the documented
+        # "ENOENT means deleted" behaviour rather than silently disabling
+        # the prune feature.
+        return False
+
+
 def _classify_drawer(
     meta: dict, matcher_cache: dict, project_roots: list, drawer_id: str = ""
 ) -> str:
     """Classify a drawer by its source_file metadata.
 
-    Returns one of: kept, gitignored, missing, no_source, out_of_scope.
+    Returns one of: kept, gitignored, missing, unreachable, no_source,
+    out_of_scope. Only ``gitignored`` and ``missing`` are pruned on apply.
     """
     # Defensive: main loop filters registry rows; this guards direct callers.
     if _is_registry_row(meta, drawer_id):
@@ -120,8 +147,40 @@ def _classify_drawer(
     if root is None:
         return "out_of_scope"
 
-    if not src.exists():
+    # ``Path.exists()`` conflates every stat failure with "gone", which made
+    # sync prune drawers whose source was merely unreachable (a path component
+    # that is a regular file, an unreadable directory, or a volume that is
+    # configured but not mounted). Stat the file directly and only treat a
+    # true ENOENT as a deletion.
+    try:
+        src.stat()
+    except FileNotFoundError:
+        # ENOENT — the file (or an ancestor) is absent. This is normally the
+        # "deleted" case we prune for, but an unmounted volume also surfaces
+        # as ENOENT even though the data still exists. Never prune those.
+        if _looks_unmounted(src):
+            logger.warning("sync: keeping drawer, source is on an unmounted volume: %s", src)
+            return "unreachable"
         return "missing"
+    except NotADirectoryError:
+        # A path component is a regular file, not a directory. The source may
+        # still exist; pruning here would destroy data we could not verify.
+        logger.warning(
+            "sync: keeping drawer, source path has a non-directory component: %s", src
+        )
+        return "unreachable"
+    except PermissionError:
+        # EACCES/EPERM — we cannot prove the file is gone, so keep it.
+        logger.warning("sync: keeping drawer, source is not readable: %s", src)
+        return "unreachable"
+    except OSError as exc:
+        # ELOOP, EIO, ENAMETOOLONG, ... — unverifiable, keep.
+        logger.warning(
+            "sync: keeping drawer, source could not be stat'ed (errno %s): %s",
+            exc.errno,
+            src,
+        )
+        return "unreachable"
 
     matchers = _ancestor_matchers(src, root, matcher_cache)
     if matchers and is_gitignored(src, matchers, is_dir=False):
@@ -238,6 +297,7 @@ def sync_palace(
         "kept": 0,
         "gitignored": 0,
         "missing": 0,
+        "unreachable": 0,
         "no_source": 0,
         "out_of_scope": 0,
     }

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1025,6 +1025,36 @@ class TestSyncPalace:
         result = sync_mod._classify_drawer(meta, {}, [str(tmp_path)], "d1")
         assert result == "unreachable"
 
+    def test_unreachable_symlink_loop_kept(self, tmp_path):
+        """A symlink loop must classify as 'unreachable' (kept), never end the
+        run. On <=3.12 ``resolve(strict=False)`` raises ``RuntimeError`` before
+        ``stat``; on 3.13+ the loop reaches ``stat`` as ``OSError`` (ELOOP).
+        Either way the drawer must be kept."""
+        import os
+
+        from mempalace import sync as sync_mod
+
+        if os.name == "nt":
+            pytest.skip("symlinks unavailable on Windows")
+
+        loop = tmp_path / "loop"
+        loop.symlink_to(loop)
+        source = loop / "sub.py"  # walking this hits the loop
+
+        meta = {"source_file": str(source)}
+        result = sync_mod._classify_drawer(meta, {}, [str(tmp_path)], "d1")
+        assert result == "unreachable"
+
+    def test_unreachable_unencodable_path_kept(self, tmp_path):
+        """A source_file the platform cannot encode (embedded NUL) must classify
+        as 'unreachable' (kept), never end the run."""
+        from mempalace import sync as sync_mod
+
+        bad = str(tmp_path / "sub.py") + "\x00tail"
+        meta = {"source_file": bad}
+        result = sync_mod._classify_drawer(meta, {}, [str(tmp_path)], "d1")
+        assert result == "unreachable"
+
     def test_closet_batch_purge_single_call(self, synced_world, monkeypatch):
         """Batched $in closet purge: one delete() call across all removable
         source files, not N. Wraps the real collection so chromadb still

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -671,6 +671,7 @@ class TestSyncPalace:
             "kept",
             "gitignored",
             "missing",
+            "unreachable",
             "no_source",
             "out_of_scope",
             "removed_drawers",
@@ -1010,6 +1011,19 @@ class TestSyncPalace:
         assert call_count["n"] == 1, (
             f"cache miss: expected 1 _classify_drawer call (4 cache hits), got {call_count['n']}"
         )
+
+    def test_unreachable_non_directory_component_kept(self, tmp_path):
+        """A source whose path has a regular file as a directory component must
+        classify as 'unreachable' (kept), never 'missing' (pruned)."""
+        from mempalace import sync as sync_mod
+
+        blocker = tmp_path / "file.txt"
+        blocker.write_text("not a directory")
+        source = blocker / "sub.py"  # blocker is a file → stat raises ENOTDIR
+
+        meta = {"source_file": str(source)}
+        result = sync_mod._classify_drawer(meta, {}, [str(tmp_path)], "d1")
+        assert result == "unreachable"
 
     def test_closet_batch_purge_single_call(self, synced_world, monkeypatch):
         """Batched $in closet purge: one delete() call across all removable
@@ -1430,6 +1444,7 @@ class TestServiceRunSyncReport:
             "kept": 1,
             "gitignored": 2,
             "missing": 1,
+            "unreachable": 0,
             "no_source": 1,
             "out_of_scope": 1,
             "removed_drawers": 0,


### PR DESCRIPTION
## Problem

`sync --apply` used `Path.exists()` to detect deleted source files. `exists()` conflates every stat failure with "gone", so a drawer whose source was merely *unreachable* was pruned as if deleted — and two of those unreachable states crashed the whole sync run instead of being classified. This violates MemPalace's "Incremental only — never destroy existing data" principle.

## Fix

Replace the lossy `exists()` check with a direct `stat()`, classify each failure precisely, and guard path resolution itself:

- `FileNotFoundError` (ENOENT): treated as a true deletion → `missing` (pruned), as before.
- `NotADirectoryError` (ENOTDIR): a path component is a regular file → `unreachable` (kept).
- `PermissionError` (EACCES/EPERM): cannot prove the file is gone → `unreachable` (kept).
- `RuntimeError` from `resolve(strict=False)`: symlink loop (raised up to Python 3.12) → `unreachable` (kept). Previously ended the whole run.
- `ValueError`: unencodable `source_file` (e.g. embedded NUL) → `unreachable` (kept). Previously ended the whole run.
- other `OSError` (ELOOP/EIO/ENAMETOOLONG/...): unverifiable → `unreachable` (kept).

Only `gitignored` and `missing` are pruned on apply. `unreachable` drawers are kept and surfaced in the report output (`cli.py`/`service.py`).

Refs #2320.

## Not fixed here (important)

An unmounted volume also surfaces as `ENOENT` — indistinguishable from a real deletion by any filesystem call, because `os.path.ismount()` returns `False` on an empty mount point. That case (the heart of #2320) is not solved by per-file errno classification and is addressed by the corroboration approach in #2322.

## Test

- `test_unreachable_non_directory_component_kept` (ENOTDIR)
- `test_unreachable_symlink_loop_kept` (ELOOP → `RuntimeError`)
- `test_unreachable_unencodable_path_kept` (embedded NUL → `ValueError`)
- Full `tests/test_sync.py` suite passes (43 tests).
