### PR TITLE
fix(sync): require an established absence before removing a drawer (#2320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **`sync --apply` no longer deletes drawers whose source file it could not reach.** `_classify_drawer` separated keep from remove with one `Path.exists()`, and `missing` feeds `removable_ids`, so every state that answered no became a deletion. Of twelve source-file states driven through `sync_palace`, eight were deleted and four of those had really gone: two were a file on a volume that is not mounted, at an empty mount point or at one holding a committed `.gitkeep`, and two were a path that could not be walked at all. Three further states ended the whole run instead, dry run included, and two of those moved with the interpreter as `pathlib` stopped raising. End to end, a project mined from a mounted volume lost every drawer to one `sync --apply` while the volume was away, and the search came back empty once it returned. Removal now asks for corroboration rather than a probe: a file not at its path is removable only while the palace still sees a source of its own, a regular file, in that same directory. A deletion leaves the file's neighbours where they were; an unmounted volume takes all of them at once, and no errno separates the two. Both halves of the verdict are read again at the moment it is formed, because a volume can leave inside one pass and come back inside one. Everything uncorroborated lands in a new bucket, `unresolved`, never added to `removable_ids` and reported the way removals are: counted beside the other buckets, and its source files named in `unresolved_by_source` and printed, with the remainder stated when that list is cut at five. The price: a directory with no surviving known source corroborates nothing, so a file deleted alone from a one-file directory, or a directory's files deleted together, is kept and reported rather than pruned. (#2320)
+
 ---
 
 ## [3.8.0] — 2026-08-20

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1138,6 +1138,7 @@ def cmd_sync(args):
     print(f"  Kept:           {report['kept']}")
     print(f"  Gitignored:     {report['gitignored']}  {removed_suffix}")
     print(f"  Missing:        {report['missing']}  {removed_suffix}")
+    print(f"  Unresolved:     {report['unresolved']}  (kept)")
     print(f"  No source:      {report['no_source']}  (kept)")
     print(f"  Out of scope:   {report['out_of_scope']}  (kept)")
 
@@ -1148,6 +1149,17 @@ def cmd_sync(args):
         print(f"\n  {label}:")
         for src, n in top:
             print(f"    {src}  ({n})")
+
+    if report["unresolved"]:
+        print("\n  Unresolved drawers are kept: nothing here could show their source file is gone.")
+        unresolved_sources = report.get("unresolved_by_source") or {}
+        if unresolved_sources:
+            top = sorted(unresolved_sources.items(), key=lambda kv: -kv[1])[:5]
+            for src, n in top:
+                print(f"    {src}  ({n})")
+            rest = len(unresolved_sources) - len(top)
+            if rest:
+                print(f"    and {rest} more source file(s)")
 
     if args.dry_run:
         if report["gitignored"] + report["missing"] > 0:

--- a/mempalace/service.py
+++ b/mempalace/service.py
@@ -364,6 +364,7 @@ def run_sync(payload: dict[str, Any]) -> dict[str, Any]:
     print(f"  Kept:           {report['kept']}")
     print(f"  Gitignored:     {report['gitignored']}  {removed_suffix}")
     print(f"  Missing:        {report['missing']}  {removed_suffix}")
+    print(f"  Unresolved:     {report['unresolved']}  (kept)")
     print(f"  No source:      {report['no_source']}  (kept)")
     print(f"  Out of scope:   {report['out_of_scope']}  (kept)")
 
@@ -374,6 +375,17 @@ def run_sync(payload: dict[str, Any]) -> dict[str, Any]:
         print(f"\n  {label}:")
         for src, n in top:
             print(f"    {src}  ({n})")
+
+    if report["unresolved"]:
+        print("\n  Unresolved drawers are kept: nothing here could show their source file is gone.")
+        unresolved_sources = report.get("unresolved_by_source") or {}
+        if unresolved_sources:
+            top = sorted(unresolved_sources.items(), key=lambda kv: -kv[1])[:5]
+            for src, n in top:
+                print(f"    {src}  ({n})")
+            rest = len(unresolved_sources) - len(top)
+            if rest:
+                print(f"    and {rest} more source file(s)")
 
     if dry_run:
         if report["gitignored"] + report["missing"] > 0:

--- a/mempalace/sync.py
+++ b/mempalace/sync.py
@@ -12,9 +12,11 @@ Usage:
 """
 
 import logging
+import os
+import stat as stat_module
 from collections import defaultdict
 from pathlib import Path
-from typing import Callable, Optional, TypedDict
+from typing import Callable, Final, Literal, Optional, TypedDict
 
 from .miner import is_gitignored, load_gitignore_matcher
 from .palace import (
@@ -34,12 +36,14 @@ class SyncReport(TypedDict):
     kept: int
     gitignored: int
     missing: int
+    unresolved: int
     no_source: int
     out_of_scope: int
     removed_drawers: int
     removed_closets: int
     dry_run: bool
     by_source: dict[str, int]
+    unresolved_by_source: dict[str, int]
 
 
 def _resolve_project_root(source_file: Path, project_roots: list) -> Optional[Path]:
@@ -96,12 +100,74 @@ def _is_registry_row(meta: dict, drawer_id: str) -> bool:
     return False
 
 
+# ``Final`` keeps these literal types rather than widening them to ``str``,
+# which the annotated return of ``_source_state`` needs.
+_STATE_PRESENT: Final = "present"
+_STATE_NOT_THERE: Final = "not_there"
+_STATE_UNKNOWN: Final = "unknown"
+
+
+def _source_state(src: Path) -> Literal["present", "not_there", "unknown"]:
+    """Report what one ``stat`` of ``src`` established, and nothing beyond it.
+
+    ``not_there`` means the path answered ``ENOENT``. On its own that is not
+    a reason to delete anything, because no errno separates "nothing is
+    here" from "this cannot be reached right now".  ``_uncopyable_reason``
+    in ``backups.py`` states the same rule for an operation that only leaves
+    a file out of a backup copy, and records that on Windows an unmapped
+    drive letter and an unreachable share both arrive as ``ENOENT`` as well.
+    Turning ``not_there`` into a removal is ``sync_palace``'s job, and it
+    needs a second reading to do it.
+
+    ``unknown`` is every other failure: a path that could not be walked at
+    all, which says nothing whatever about the leaf.
+    """
+    try:
+        os.stat(src)
+    except FileNotFoundError:
+        return _STATE_NOT_THERE
+    except (OSError, ValueError):
+        # ENOTDIR, ELOOP, EACCES, a share that stopped answering. ValueError
+        # is a path the platform cannot encode; the caller's ``resolve``
+        # raises on those first, so it should not arrive, and catching it
+        # costs nothing next to letting one drawer end the run.
+        return _STATE_UNKNOWN
+    return _STATE_PRESENT
+
+
+def _is_a_present_file(src: Path) -> bool:
+    """Whether ``src`` is a regular file that answers right now.
+
+    A witness has to be a file *in* the directory it speaks for, and
+    ``os.path.dirname`` alone does not establish that. A ``source_file``
+    whose last component is empty, ``.`` or ``..`` keys to that directory
+    while naming the directory itself, or its parent, and a directory
+    outlives the unmount that takes its contents away. ``tool_add_drawer``
+    stores whatever string its caller passed, so those spellings reach a
+    real palace without anything being corrupt.
+
+    Three answers collapse to ``False`` here on purpose: not a file, not
+    there, and could not be read. Only the first of them corroborates a
+    removal, so anything else has to keep the drawer.
+    """
+    try:
+        return stat_module.S_ISREG(os.stat(src).st_mode)
+    except (OSError, ValueError):
+        return False
+
+
 def _classify_drawer(
     meta: dict, matcher_cache: dict, project_roots: list, drawer_id: str = ""
 ) -> str:
     """Classify a drawer by its source_file metadata.
 
-    Returns one of: kept, gitignored, missing, no_source, out_of_scope.
+    Returns one of: kept, gitignored, absent, unresolved, no_source,
+    out_of_scope.
+
+    ``absent`` is provisional and never reaches a ``SyncReport``. It says
+    the file is not at its path, which is not yet a reason to remove the
+    drawer; ``sync_palace`` decides that, and settles every ``absent`` into
+    ``missing`` or ``unresolved`` once the whole pass is done.
     """
     # Defensive: main loop filters registry rows; this guards direct callers.
     if _is_registry_row(meta, drawer_id):
@@ -114,14 +180,25 @@ def _classify_drawer(
     src = Path(source_file)
     if not src.is_absolute():
         return "no_source"
-    src = src.resolve(strict=False)
+    try:
+        src = src.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        # A symlink loop: up to 3.12 pathlib turns ELOOP into RuntimeError
+        # here, and 3.13 stopped raising and leaves it to the stat below. A
+        # path the platform cannot encode raises ValueError here instead,
+        # before any probe runs at all. Either way this drawer is one the
+        # run must survive, not end on.
+        return "unresolved"
 
     root = _resolve_project_root(src, project_roots)
     if root is None:
         return "out_of_scope"
 
-    if not src.exists():
-        return "missing"
+    state = _source_state(src)
+    if state == _STATE_UNKNOWN:
+        return "unresolved"
+    if state == _STATE_NOT_THERE:
+        return "absent"
 
     matchers = _ancestor_matchers(src, root, matcher_cache)
     if matchers and is_gitignored(src, matchers, is_dir=False):
@@ -172,10 +249,42 @@ def _auto_detect_project_roots(col, wing: Optional[str]) -> list:
         if not src.is_absolute():
             continue
         for parent in src.parents:
-            if (parent / ".git").exists() or (parent / ".gitignore").is_file():
+            if not _has_project_marker(parent):
+                continue
+            try:
                 roots.add(parent.resolve(strict=False))
-                break
+            except (OSError, RuntimeError, ValueError):
+                # The marker is here but this path will not resolve. Stop
+                # rather than let the climb register a higher ancestor as
+                # the root, which would widen what the run treats as in
+                # scope instead of narrowing it. No POSIX input reaches
+                # this: a marker that stats means its own path resolved.
+                # It is kept because the cost of being wrong about that on
+                # another platform is the whole run, not one drawer.
+                pass
+            break
     return sorted(roots, key=lambda p: (-len(str(p)), str(p)))
+
+
+def _has_project_marker(directory: Path) -> bool:
+    """Whether ``directory`` looks like a project root, without ever raising.
+
+    Each marker is probed on its own. An ancestor this process cannot walk
+    holds no marker it could have read anyway, and an unreadable ``.git``
+    must not hide a ``.gitignore`` beside it. A root that goes undetected
+    leaves its drawers ``out_of_scope``, which is the side that keeps them,
+    while a probe that escaped would end the run before a single drawer was
+    classified.
+    """
+    try:
+        if (directory / ".git").exists():
+            return True
+    except (OSError, RuntimeError, ValueError):
+        pass
+    try:
+        return (directory / ".gitignore").is_file()
+    except (OSError, RuntimeError, ValueError):
+        return False
 
 
 def _normalize_project_dirs(project_dirs) -> list:
@@ -213,6 +322,34 @@ def sync_palace(
     Returns a SyncReport with bucket counts. Dry-run by default; pass
     dry_run=False to actually delete drawers and matching closets.
 
+    Only ``gitignored`` and ``missing`` are removed. A source file this
+    could not establish as deleted lands in ``unresolved`` and is counted,
+    printed and kept: an unmounted volume must not be read as a deletion.
+
+    A file that is not at its path reaches ``missing`` only when the palace
+    can still see a source file of its own in that same directory. A
+    deletion leaves the file's neighbours where they were; a volume that is
+    not mounted takes every one of them away at once, and there is no call
+    that tells those two apart from the file alone. Both halves of that are
+    read again when the verdict is formed rather than trusted from earlier
+    in the pass, since a volume can leave inside one pass and can come back
+    inside one.
+
+    Three limits of that reading are worth stating. A directory the palace
+    knows no *surviving* file in cannot corroborate anything, so a file
+    deleted on its own from a one-file directory is kept and reported, and
+    so is a whole directory's worth of files deleted together. A mount
+    point that also holds a mined file of its own does corroborate, since
+    that file survives the unmount: separating those needs the identity of
+    the filesystem each source was mined from, which is not recorded. And a
+    volume that leaves and returns between two adjacent ``stat`` calls is
+    not covered, because nothing spans two syscalls.
+
+    ``wing`` scopes the corroboration as well as the scan, since only that
+    wing's drawers are read. A wing-scoped run therefore keeps what a run
+    over the whole palace would prune, and every candidate the wider run
+    has is a candidate it has too.
+
     Holds ``mine_palace_lock`` for the whole call so the classify pass and
     the apply branch see the same drawer snapshot. Raises
     ``MineAlreadyRunning`` if another mine is in progress on this palace.
@@ -238,10 +375,12 @@ def sync_palace(
         "kept": 0,
         "gitignored": 0,
         "missing": 0,
+        "unresolved": 0,
         "no_source": 0,
         "out_of_scope": 0,
     }
     by_source: dict = defaultdict(int)
+    unresolved_by_source: dict = defaultdict(int)
     removable_ids: list = []
     removable_sources: set = set()
 
@@ -258,12 +397,22 @@ def sync_palace(
         # blocks concurrent writers and the loop is synchronous.
         classification_cache: dict = {}
 
+        # Candidate witnesses per directory, and the drawers whose source
+        # file is not at its path. The second list waits for the first to be
+        # complete: one drawer cannot say whether its directory lost one
+        # file or all of them. Every candidate is kept rather than the first
+        # one met, so the verdict does not turn on which drawer the pass
+        # happened to reach first.
+        live_dirs: dict = {}
+        not_there: list = []
+
         for drawer_id, meta in _iter_drawer_metadata(col, wing):
             counts["scanned"] += 1
             meta = meta or {}
             source_file = meta.get("source_file")
 
-            if _is_registry_row(meta, drawer_id):
+            registry_row = _is_registry_row(meta, drawer_id)
+            if registry_row:
                 bucket = "kept"
             elif source_file and source_file in classification_cache:
                 bucket = classification_cache[source_file]
@@ -272,12 +421,69 @@ def sync_palace(
                 if source_file:
                     classification_cache[source_file] = bucket
 
+            if bucket == "absent":
+                not_there.append((drawer_id, source_file))
+                continue
+
+            # A registry row is kept without the file being looked at, so it
+            # is not evidence that anything is on disk. The inner mapping is
+            # a set that keeps its insertion order: a file arrives once per
+            # chunk it was split into, and re-reading the same path a
+            # hundred times would be the whole cost of this pass.
+            if source_file and not registry_row and bucket in ("kept", "gitignored"):
+                live_dirs.setdefault(os.path.dirname(source_file), {})[source_file] = None
+
             counts[bucket] += 1
-            if bucket in ("gitignored", "missing"):
+            if bucket == "unresolved":
+                # Reachable only through a source_file that is a non-empty
+                # absolute path, like the removal below.
+                unresolved_by_source[source_file] += 1
+            if bucket == "gitignored":
                 removable_ids.append(drawer_id)
                 if source_file:
                     removable_sources.add(source_file)
                     by_source[source_file] += 1
+
+        # The directory keys are the metadata strings as written, while the
+        # classification above works on the resolved path, so two spellings
+        # of one directory need not meet: ``os.path.dirname`` leaves a
+        # ``/./`` segment alone, and a path through a symlink keeps the
+        # link's spelling. Not unifying them errs towards keeping. It cannot
+        # err the other way as long as a candidate is a file in the
+        # directory it is filed under, which is what ``_is_a_present_file``
+        # is there to require: a path whose last component is empty, ``.``
+        # or ``..`` is filed under the directory it names, or under that
+        # directory's parent, and neither is a file in it.
+        #
+        # Both halves of the verdict are read again here rather than trusted
+        # from earlier in the pass, and back to back rather than one of them
+        # early: a pass over a large palace runs for minutes, so a volume can
+        # leave or return inside one. Re-reading only the neighbour would let
+        # a volume that came back condemn every drawer read while it was
+        # away, exactly as re-reading neither would let one that left condemn
+        # every drawer read after it. ``any`` stops at the candidate that
+        # answered, so that reading is the one immediately before the
+        # source's own. Two syscalls are still two syscalls, and a volume
+        # that flaps between them is not covered by anything here.
+        settled: dict = {}
+        for drawer_id, source_file in not_there:
+            # ``absent`` is only reachable through a source_file that is a
+            # non-empty absolute path, so nothing here guards against a
+            # missing one, the same way the removal below does not.
+            if source_file not in settled:
+                witnesses = live_dirs.get(os.path.dirname(source_file), ())
+                settled[source_file] = (
+                    any(_is_a_present_file(Path(w)) for w in witnesses)
+                    and _source_state(Path(source_file)) == _STATE_NOT_THERE
+                )
+            established = settled[source_file]
+            counts["missing" if established else "unresolved"] += 1
+            if established:
+                removable_ids.append(drawer_id)
+                removable_sources.add(source_file)
+                by_source[source_file] += 1
+            else:
+                unresolved_by_source[source_file] += 1
 
         report: SyncReport = {
             **counts,
@@ -285,6 +491,7 @@ def sync_palace(
             "removed_closets": 0,
             "dry_run": dry_run,
             "by_source": dict(by_source),
+            "unresolved_by_source": dict(unresolved_by_source),
         }
 
         if dry_run or not removable_ids:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -6,6 +6,7 @@ matching drawers, exercising every classification bucket sync produces.
 """
 
 import os
+import shutil
 from pathlib import Path
 
 import chromadb
@@ -671,12 +672,14 @@ class TestSyncPalace:
             "kept",
             "gitignored",
             "missing",
+            "unresolved",
             "no_source",
             "out_of_scope",
             "removed_drawers",
             "removed_closets",
             "dry_run",
             "by_source",
+            "unresolved_by_source",
         }
         assert set(report.keys()) == expected
 
@@ -1190,6 +1193,9 @@ class TestSyncMcpTool:
 
         report = mcp_server.tool_sync(project_dir=palace_path)
         assert report["dry_run"] is True
+        # The response is `{"success": True, **report}`, so a bucket that
+        # never reaches it is a bucket MCP callers cannot see.
+        assert "unresolved" in report
 
     def test_success_true_on_dry_run(self, monkeypatch, config, palace_path, kg):
         """Round-4: success path returns `success: True` for API symmetry
@@ -1430,12 +1436,14 @@ class TestServiceRunSyncReport:
             "kept": 1,
             "gitignored": 2,
             "missing": 1,
+            "unresolved": 1,
             "no_source": 1,
             "out_of_scope": 1,
             "removed_drawers": 0,
             "removed_closets": 0,
             "dry_run": True,
             "by_source": {"src/a.py": 2, "src/b.py": 1},
+            "unresolved_by_source": {"src/away.py": 1},
         }
         report.update(overrides)
         return report
@@ -1458,11 +1466,17 @@ class TestServiceRunSyncReport:
         assert result["success"] is True
         out = capsys.readouterr().out
         # The fields the stripped daemon report used to drop.
+        assert "  Unresolved:     1  (kept)" in out
+        assert (
+            "  Unresolved drawers are kept: nothing here could show their source file is gone."
+        ) in out
         assert "No source:" in out
         assert "Out of scope:" in out
         # by_source top sources block.
         assert "Top sources to remove" in out
         assert "src/a.py  (2)" in out
+        # A kept drawer the operator cannot name is not a report.
+        assert "    src/away.py  (1)" in out
         # Re-run hint fires when there is something to remove.
         assert "Re-run with --apply" in out
         # The old KeyError line must not be present.
@@ -1489,3 +1503,991 @@ class TestServiceRunSyncReport:
         assert "Removed 3 drawers, 2 closets" in out
         assert "Top sources removed" in out
         assert "Re-run with --apply" not in out
+
+
+class TestUnresolvedSources:
+    """#2320: a probe that came back empty-handed is not proof of deletion.
+
+    `missing` is a removal bucket, so every state that reaches it has to be
+    one where the source file's absence was actually established. One
+    `os.stat` cannot establish it on its own: an empty mount point answers
+    for its children exactly as a directory whose children were deleted.
+    """
+
+    def _seed(self, palace_path, rows, wing="demo"):
+        """rows: list of (drawer_id, source_file)."""
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_or_create_collection(
+            "mempalace_drawers", metadata={"hnsw:space": "cosine"}
+        )
+        col.add(
+            ids=[r[0] for r in rows],
+            documents=[f"doc {i}" for i in range(len(rows))],
+            embeddings=[[float(i + 1), 0.0, 0.0] for i in range(len(rows))],
+            metadatas=[
+                {
+                    "wing": wing,
+                    "room": "src",
+                    "source_file": str(r[1]),
+                    "chunk_index": 0,
+                    "added_by": "miner",
+                    "filed_at": "2026-08-21T00:00:00",
+                }
+                for r in rows
+            ],
+        )
+        del client
+
+    def _classify(self, tmp_dir, palace_path, source_file, root=None):
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True, exist_ok=True)
+        self._seed(palace_path, [("d_probe", source_file)])
+        return sync_palace(
+            palace_path=palace_path,
+            project_dirs=[str(root or repo)],
+            wing="demo",
+            dry_run=True,
+        )
+
+    def test_deleted_file_beside_a_neighbour_the_palace_can_see_is_missing(
+        self, tmp_dir, palace_path
+    ):
+        """The state that is established: the palace still finds a source
+        file of its own in that directory. A deletion leaves the neighbours
+        where they were, so this must keep pruning or the feature stops
+        doing the job #1252 asked for."""
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        neighbour = repo / "neighbour.py"
+        neighbour.write_text("# still here\n")
+        gone = repo / "gone.py"
+        gone.write_text("# was here\n")
+        gone.unlink()
+
+        self._seed(palace_path, [("d_gone", gone), ("d_neighbour", neighbour)])
+        report = sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["missing"] == 1, report
+        assert report["kept"] == 1, report
+        assert report["unresolved"] == 0, report
+
+    def test_a_neighbour_that_goes_away_mid_pass_does_not_corroborate(
+        self, monkeypatch, tmp_dir, palace_path
+    ):
+        """A pass over a large palace runs for minutes, so the volume can go
+        away partway through it. A neighbour read while it was still there
+        must not corroborate a drawer settled afterwards, or one early
+        reading condemns every drawer read after it."""
+        from mempalace import sync as sync_mod
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        neighbour = repo / "neighbour.py"
+        neighbour.write_text("# on the volume\n")
+        gone = repo / "gone.py"
+        gone.write_text("# on the volume too\n")
+        gone.unlink()
+        self._seed(palace_path, [("d_neighbour", neighbour), ("d_gone", gone)])
+
+        real_iter = sync_mod._iter_drawer_metadata
+
+        def iter_then_lose_the_volume(col, wing):
+            yield from real_iter(col, wing)
+            # Exhausting the generator is the end of the classifying pass.
+            neighbour.unlink()
+
+        monkeypatch.setattr(sync_mod, "_iter_drawer_metadata", iter_then_lose_the_volume)
+        report = sync_mod.sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+
+    def test_a_source_that_comes_back_before_the_settle_is_not_removed(
+        self, monkeypatch, tmp_dir, palace_path
+    ):
+        """The mirror of the test above, and the reason both halves of the
+        verdict are read again. A volume can return inside one pass as well
+        as leave inside it; a neighbour read at the end must not condemn
+        drawers whose own reading was taken while the volume was away."""
+        from mempalace import sync as sync_mod
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        neighbour = repo / "neighbour.py"
+        neighbour.write_text("# never went anywhere\n")
+        away = repo / "away.py"
+        self._seed(palace_path, [("d_away", away), ("d_neighbour", neighbour)])
+
+        real_iter = sync_mod._iter_drawer_metadata
+
+        def iter_then_regain_the_volume(col, wing):
+            yield from real_iter(col, wing)
+            # Exhausting the generator is the end of the classifying pass.
+            away.write_text("# it was here all along\n")
+
+        monkeypatch.setattr(sync_mod, "_iter_drawer_metadata", iter_then_regain_the_volume)
+        report = sync_mod.sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+
+    def test_neighbour_must_be_one_the_palace_knows(self, tmp_dir, palace_path):
+        """A file the palace never mined is not evidence. This is the shape
+        #2320 reproduces and the one an emptiness test gets wrong: a mount
+        point committed to a repository is never empty, because git cannot
+        track an empty directory, so `.gitkeep` outlives the unmount and sits
+        in the directory looking like a neighbour."""
+        repo = Path(tmp_dir) / "repo"
+        data = repo / "data"
+        data.mkdir(parents=True)
+        (data / ".gitkeep").write_text("")
+        source = data / "onvolume.py"
+
+        report = self._classify(tmp_dir, palace_path, source, root=repo)
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+
+    def test_a_mined_neighbour_corroborates_even_when_it_should_not(self, tmp_dir, palace_path):
+        """The limit of this rule, pinned so nobody reads it as watertight.
+
+        A directory holds different contents depending on what is mounted on
+        it. A neighbour proves the directory is reachable; it does not prove
+        it is the filesystem the missing file was mined from. So a file the
+        palace mined while nothing was mounted there still corroborates, and
+        the volume's drawers are removed. Separating the two needs the
+        identity of the filesystem each source was mined from, which is not
+        recorded anywhere; `develop` removes them in this state as well.
+        """
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        data = repo / "data"
+        data.mkdir(parents=True)
+        # Mined while nothing was mounted over `data`, and still on disk.
+        underlying = data / "notes_local.md"
+        underlying.write_text("# committed to the repository\n")
+        # Mined from the volume, which is not mounted right now.
+        on_the_volume = data / "capture.csv"
+
+        self._seed(palace_path, [("d_volume", on_the_volume), ("d_underlying", underlying)])
+        report = sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["missing"] == 1, report
+        assert report["unresolved"] == 0, report
+
+    def test_a_registry_sentinel_cannot_corroborate(self, tmp_dir, palace_path):
+        """Registry rows are kept without the file being looked at, so one
+        says nothing about what is on disk. Letting a sentinel vouch for its
+        directory would corroborate from a path that may never have existed."""
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        gone = repo / "gone.py"
+        gone.write_text("# was here\n")
+        gone.unlink()
+        # On disk, so that only the guard keeps it from vouching.
+        transcript = repo / "registry_only.py"
+        transcript.write_text("# a transcript the sentinel tracks\n")
+
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_or_create_collection(
+            "mempalace_drawers", metadata={"hnsw:space": "cosine"}
+        )
+        col.add(
+            ids=["d_gone", "_reg_sentinel"],
+            documents=["a", "b"],
+            embeddings=[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+            metadatas=[
+                {"wing": "demo", "source_file": str(gone), "chunk_index": 0},
+                {
+                    "wing": "demo",
+                    "room": "_registry",
+                    "source_file": str(transcript),
+                    "chunk_index": 0,
+                },
+            ],
+        )
+        del client
+
+        report = sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+
+    @pytest.mark.skipif(os.name == "nt", reason="os.symlink needs admin on Windows")
+    def test_two_spellings_of_one_directory_do_not_corroborate(self, tmp_dir, palace_path):
+        """The corroboration key is the metadata string as written, while the
+        classification works on the resolved path. A neighbour filed through
+        a symlink and a missing file filed through the real path name the
+        same directory and still do not meet, which keeps rather than
+        removes."""
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        real = repo / "real"
+        real.mkdir(parents=True)
+        os.symlink(str(real), str(repo / "link"))
+        neighbour = real / "neighbour.py"
+        neighbour.write_text("# still here\n")
+        gone = real / "gone.py"
+        gone.write_text("# was here\n")
+        gone.unlink()
+
+        # The neighbour is filed under the link, the missing file under the
+        # real path. Both are the same directory on disk.
+        self._seed(palace_path, [("d_gone", gone), ("d_neighbour", repo / "link" / "neighbour.py")])
+        report = sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+
+    def test_source_in_an_empty_directory_is_unresolved(self, tmp_dir, palace_path):
+        """The same shape with nothing left in the directory at all.
+
+        This pins the cost as much as the win. The state is also reached by
+        deleting the last source the palace knows in a directory, and that
+        drawer is kept too, because nothing here can tell the two apart."""
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        source = repo / "onvolume.py"
+        source.write_text("# x\n")
+        source.unlink()
+
+        report = self._classify(tmp_dir, palace_path, source)
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0, reason="root ignores permission bits"
+    )
+    def test_directory_that_cannot_be_listed_still_prunes(self, tmp_dir, palace_path):
+        """Mode 0o111 lets this process enter a directory but not list it,
+        which is what a `0o711` directory looks like to anyone but its
+        owner. The neighbour is reached by `os.stat`, which needs only the
+        execute bit, so a verdict here does not depend on a permission the
+        old code never asked for either."""
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        execonly = repo / "execonly"
+        execonly.mkdir(parents=True)
+        neighbour = execonly / "neighbour.py"
+        neighbour.write_text("# still here\n")
+        gone = execonly / "gone.py"
+        gone.write_text("# was here\n")
+        gone.unlink()
+        self._seed(palace_path, [("d_gone", gone), ("d_neighbour", neighbour)])
+
+        os.chmod(execonly, 0o111)
+        try:
+            report = sync_palace(
+                palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+            )
+        finally:
+            os.chmod(execonly, 0o700)
+
+        assert report["missing"] == 1, report
+        assert report["unresolved"] == 0, report
+
+    def test_a_probe_that_failed_is_unresolved_even_beside_a_live_neighbour(
+        self, monkeypatch, tmp_dir, palace_path
+    ):
+        """The leaf probe answering anything other than ENOENT must stop the
+        drawer before corroboration is ever consulted, or a directory that
+        happens to hold a live neighbour would turn an unreadable path into a
+        deletion. `os.stat` is patched for one path so this runs on every
+        platform rather than needing permission bits that CI may not honour."""
+        import os as os_module
+
+        from mempalace import sync as sync_mod
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        neighbour = repo / "neighbour.py"
+        neighbour.write_text("# still here\n")
+        target = repo / "unreadable.py"
+        self._seed(palace_path, [("d_target", target), ("d_neighbour", neighbour)])
+
+        real_stat = os_module.stat
+        # Resolved once, outside the patch: calling `resolve` inside it would
+        # stat its way back into this function.
+        refused = str(target.resolve())
+
+        def refusing_stat(path, *args, **kwargs):
+            if str(path) == refused:
+                raise PermissionError(13, "Permission denied")
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(sync_mod.os, "stat", refusing_stat)
+        report = sync_mod.sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+        assert report["kept"] == 1, report
+
+    def test_source_whose_parent_directory_is_gone_is_unresolved(self, tmp_dir, palace_path):
+        """A volume that is not mounted leaves the directory it held absent.
+        Its children's ENOENT says nothing about whether they were deleted."""
+        repo = Path(tmp_dir) / "repo"
+        (repo / "onvolume").mkdir(parents=True)
+        source = repo / "onvolume" / "f.py"
+        source.write_text("# x\n")
+        shutil.rmtree(repo / "onvolume")
+
+        report = self._classify(tmp_dir, palace_path, source)
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+
+    def test_source_under_a_regular_file_is_unresolved(self, tmp_dir, palace_path):
+        """ENOTDIR. The path cannot be walked, which is not the same as the
+        leaf being absent."""
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        blocker = repo / "notadir"
+        blocker.write_text("I am a file\n")
+
+        from mempalace.sync import _classify_drawer
+
+        report = self._classify(tmp_dir, palace_path, blocker / "f.py")
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+        # The report alone cannot tell `unresolved` from `absent` with no
+        # neighbour to settle against, so pin the classifier's own answer.
+        # `sync_palace` resolves its roots before classifying, and on macOS
+        # `/tmp` is a symlink, so an unresolved root matches nothing.
+        #
+        # POSIX answers ENOTDIR here, which establishes nothing about the
+        # leaf. Windows has no errno that says so: this arrives as ENOENT or
+        # ENOTDIR depending on the path, which is the whole reason removal
+        # cannot rest on the probe. The leaf may therefore read as `absent`
+        # there and be settled by corroboration instead, which the report
+        # above already pins, so only POSIX pins the bucket itself.
+        if os.name != "nt":
+            assert (
+                _classify_drawer({"source_file": str(blocker / "f.py")}, {}, [repo.resolve()], "d")
+                == "unresolved"
+            )
+
+    @pytest.mark.skipif(os.name == "nt", reason="os.symlink needs admin on Windows")
+    def test_source_behind_a_dangling_symlink_is_unresolved(self, tmp_dir, palace_path):
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        link = repo / "dangling"
+        os.symlink(str(repo / "nowhere"), str(link))
+
+        report = self._classify(tmp_dir, palace_path, link / "f.py")
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+
+    @pytest.mark.skipif(os.name == "nt", reason="os.symlink needs admin on Windows")
+    def test_symlink_loop_is_unresolved_and_does_not_end_the_run(self, tmp_dir, palace_path):
+        """Up to 3.12 `Path.resolve(strict=False)` raises RuntimeError on a
+        loop and 3.13 stopped; either way one drawer must not decide the fate
+        of the run."""
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        a, b = repo / "loop_a", repo / "loop_b"
+        os.symlink(str(b), str(a))
+        os.symlink(str(a), str(b))
+
+        report = self._classify(tmp_dir, palace_path, a / "f.py")
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0, reason="root ignores permission bits"
+    )
+    def test_unreadable_parent_is_unresolved_and_does_not_end_the_run(self, tmp_dir, palace_path):
+        """Up to 3.13 `Path.exists()` raises PermissionError here and 3.14
+        answers False, which would delete the drawer. Neither is acceptable."""
+        repo = Path(tmp_dir) / "repo"
+        locked = repo / "locked"
+        locked.mkdir(parents=True)
+        source = locked / "f.py"
+        source.write_text("# x\n")
+        os.chmod(locked, 0o000)
+        from mempalace.sync import _classify_drawer
+
+        try:
+            report = self._classify(tmp_dir, palace_path, source)
+            os.chmod(locked, 0o000)
+            # As above: the root has to be resolved, or macOS answers
+            # `out_of_scope` before the probe is ever reached.
+            bucket = _classify_drawer({"source_file": str(source)}, {}, [repo.resolve()], "d")
+        finally:
+            os.chmod(locked, 0o700)
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+        # A probe that could not run is not the leaf being absent, and with
+        # no neighbour the report cannot separate the two.
+        assert bucket == "unresolved", bucket
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0, reason="root ignores permission bits"
+    )
+    def test_auto_detected_roots_survive_an_ancestor_it_cannot_walk(self, tmp_dir, palace_path):
+        """With no project_dirs, sync walks every source's ancestors looking
+        for a project marker. Up to 3.13 that probe raises on a directory the
+        process may not enter, which ended the run before a single drawer was
+        classified."""
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        locked = repo / "locked"
+        locked.mkdir(parents=True)
+        (repo / ".gitignore").write_text("build/\n")
+        source = locked / "f.py"
+        source.write_text("# x\n")
+        self._seed(palace_path, [("d_locked", source)])
+
+        os.chmod(locked, 0o000)
+        try:
+            report = sync_palace(palace_path=palace_path, wing="demo", dry_run=True)
+        finally:
+            os.chmod(locked, 0o700)
+
+        assert report["scanned"] == 1, report
+        assert report["unresolved"] == 1, report
+
+    def test_auto_detected_roots_survive_a_marker_probe_that_raises(
+        self, monkeypatch, tmp_dir, palace_path
+    ):
+        """The same guard as the test above, reached without permission bits
+        so it also runs as root and on Windows, where those tests skip."""
+        from mempalace import sync as sync_mod
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        (repo / ".gitignore").write_text("build/\n")
+        source = repo / "f.py"
+        source.write_text("# x\n")
+        self._seed(palace_path, [("d_probe", source)])
+
+        real_exists = Path.exists
+
+        def refusing_exists(self, *args, **kwargs):
+            if self.name == ".git":
+                raise PermissionError(13, "Permission denied")
+            return real_exists(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "exists", refusing_exists)
+        report = sync_mod.sync_palace(palace_path=palace_path, wing="demo", dry_run=True)
+        assert report["scanned"] == 1, report
+        assert report["kept"] == 1, report
+
+    def test_an_unresolvable_marker_stops_the_climb(self, monkeypatch, tmp_dir, palace_path):
+        """A marker found on an ancestor whose path will not resolve must end
+        the walk. Climbing past it would register a higher ancestor as the
+        root and widen what the run treats as in scope."""
+        from mempalace import sync as sync_mod
+
+        outer = Path(tmp_dir) / "outer"
+        inner = outer / "inner"
+        inner.mkdir(parents=True)
+        (outer / ".gitignore").write_text("build/\n")
+        (inner / ".gitignore").write_text("build/\n")
+        source = inner / "f.py"
+        source.write_text("# x\n")
+        self._seed(palace_path, [("d_probe", source)])
+
+        real_resolve = Path.resolve
+
+        def refusing_resolve(self, *args, **kwargs):
+            if self == inner:
+                raise RuntimeError(f"Symlink loop from {self!r}")
+            return real_resolve(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", refusing_resolve)
+        report = sync_mod.sync_palace(palace_path=palace_path, wing="demo", dry_run=True)
+        # No root was registered for this source, so it is out of scope and
+        # kept, rather than matched against `outer` and judged there.
+        assert report["out_of_scope"] == 1, report
+        assert report["kept"] == 0, report
+
+    def test_the_report_does_not_depend_on_the_order_drawers_arrive_in(self, monkeypatch, tmp_dir):
+        """What settling in two phases buys is that one drawer's verdict does
+        not depend on where it fell in the scan. Every permutation of three
+        drawers, and a page size small enough that they span two pages, must
+        produce the same report, and every drawer must land in exactly one
+        bucket."""
+        import itertools
+
+        from mempalace import sync as sync_mod
+
+        repo = Path(tmp_dir) / "repo"
+        alone = repo / "alone"
+        alone.mkdir(parents=True)
+        neighbour = repo / "neighbour.py"
+        neighbour.write_text("# still here\n")
+        beside_it = repo / "beside_it.py"
+        beside_it.write_text("# x\n")
+        beside_it.unlink()
+        on_its_own = alone / "on_its_own.py"
+        on_its_own.write_text("# x\n")
+        on_its_own.unlink()
+
+        # Two per page, so the neighbour and the drawer it vouches for can
+        # land in different pages depending on the order.
+        monkeypatch.setattr(sync_mod, "_BATCH", 2)
+        buckets = ("kept", "gitignored", "missing", "unresolved", "no_source", "out_of_scope")
+        rows = [("d_neighbour", neighbour), ("d_beside", beside_it), ("d_alone", on_its_own)]
+
+        seen = set()
+        for order in itertools.permutations(range(3)):
+            palace = os.path.join(tmp_dir, "palace_" + "".join(str(i) for i in order))
+            self._seed(palace, [rows[i] for i in order])
+            report = sync_mod.sync_palace(
+                palace_path=palace, project_dirs=[str(repo)], wing="demo", dry_run=True
+            )
+            assert sum(report[b] for b in buckets) == report["scanned"] == 3, (order, report)
+            seen.add(tuple(report[b] for b in buckets))
+
+        assert len(seen) == 1, seen
+        assert seen == {(1, 0, 1, 1, 0, 0)}, seen
+
+    def test_unencodable_source_path_is_unresolved(self, tmp_dir):
+        """A path the platform cannot encode is not a proven absence either.
+        `Path.resolve` raises ValueError on an embedded NUL before any probe
+        runs, which used to end the run at that drawer."""
+        from mempalace.sync import _classify_drawer
+
+        root = Path(tmp_dir) / "repo"
+        root.mkdir(parents=True)
+
+        bucket = _classify_drawer({"source_file": str(root / "nul\x00byte.txt")}, {}, [root])
+        assert bucket == "unresolved", bucket
+
+    def test_apply_keeps_unresolved_and_removes_only_the_established_one(
+        self, tmp_dir, palace_path
+    ):
+        """The end the issue is about: --apply must delete the provably
+        deleted file's drawer and leave the unreachable one alone."""
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        (repo / "onvolume").mkdir(parents=True)
+        unreachable = repo / "onvolume" / "f.py"
+        unreachable.write_text("# x\n")
+        shutil.rmtree(repo / "onvolume")
+
+        deleted = repo / "gone.py"
+        deleted.write_text("# was here\n")
+        deleted.unlink()
+
+        kept = repo / "kept.py"
+        kept.write_text("# still here\n")
+
+        self._seed(
+            palace_path,
+            [("d_unreachable", unreachable), ("d_deleted", deleted), ("d_kept", kept)],
+        )
+
+        # A closet for each source, so the purge branch actually runs and can
+        # be seen to spare the unreachable one.
+        client = chromadb.PersistentClient(path=palace_path)
+        closets = client.get_or_create_collection(
+            "mempalace_closets", metadata={"hnsw:space": "cosine"}
+        )
+        closets.add(
+            ids=["closet_unreachable", "closet_deleted"],
+            documents=["c1", "c2"],
+            embeddings=[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+            metadatas=[{"source_file": str(unreachable)}, {"source_file": str(deleted)}],
+        )
+        del client
+
+        report = sync_palace(
+            palace_path=palace_path,
+            project_dirs=[str(repo)],
+            wing="demo",
+            dry_run=False,
+        )
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 1, report
+        assert report["removed_drawers"] == 1, report
+        assert report["removed_closets"] == 1, report
+
+        client, col = _open_drawers(palace_path)
+        try:
+            survivors = _drawer_ids(col)
+            closet_ids = set(
+                client.get_or_create_collection(
+                    "mempalace_closets", metadata={"hnsw:space": "cosine"}
+                ).get(include=[])["ids"]
+            )
+        finally:
+            del client
+        assert survivors == {"d_unreachable", "d_kept"}, survivors
+        assert closet_ids == {"closet_unreachable"}, closet_ids
+
+    def test_unresolved_sources_are_not_listed_as_removable(self, tmp_dir, palace_path):
+        """`by_source` drives the "Top sources to remove" block. A source
+        nothing will remove must not appear in it."""
+        repo = Path(tmp_dir) / "repo"
+        (repo / "onvolume").mkdir(parents=True)
+        unreachable = repo / "onvolume" / "f.py"
+        unreachable.write_text("# x\n")
+        shutil.rmtree(repo / "onvolume")
+
+        report = self._classify(tmp_dir, palace_path, unreachable)
+        assert report["by_source"] == {}, report
+
+    def test_whole_project_root_gone_removes_nothing(self, tmp_dir, palace_path):
+        """The mount-point case at full size: the project root itself is not
+        there, so no drawer under it can be proven stale."""
+        from mempalace.sync import sync_palace
+
+        mount_point = Path(tmp_dir) / "mnt"
+        repo = mount_point / "proj"
+        (repo / "src").mkdir(parents=True)
+        sources = [repo / "src" / f"f{i}.py" for i in range(3)]
+        for s in sources:
+            s.write_text("# x\n")
+        self._seed(palace_path, [(f"d_{i}", s) for i, s in enumerate(sources)])
+
+        shutil.rmtree(repo)
+        mount_point.mkdir(exist_ok=True)
+
+        report = sync_palace(
+            palace_path=palace_path,
+            project_dirs=[str(repo)],
+            wing="demo",
+            dry_run=False,
+        )
+        assert report["unresolved"] == 3, report
+        assert report["missing"] == 0, report
+        assert report["removed_drawers"] == 0, report
+
+        client, col = _open_drawers(palace_path)
+        try:
+            survivors = _drawer_ids(col)
+        finally:
+            del client
+        assert survivors == {"d_0", "d_1", "d_2"}, survivors
+
+    def test_cli_prints_the_unresolved_count(self, monkeypatch, tmp_dir, palace_path, capsys):
+        """A count the operator never sees is not a report."""
+        from mempalace import cli
+
+        repo = Path(tmp_dir) / "repo"
+        (repo / "onvolume").mkdir(parents=True)
+        unreachable = repo / "onvolume" / "f.py"
+        unreachable.write_text("# x\n")
+        shutil.rmtree(repo / "onvolume")
+        self._seed(palace_path, [("d_unreachable", unreachable)])
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["mempalace", "--palace", palace_path, "sync", str(repo), "--wing", "demo"],
+        )
+        cli.main()
+
+        out = capsys.readouterr().out
+        assert "  Unresolved:     1  (kept)" in out, out
+        assert (
+            "  Unresolved drawers are kept: nothing here could show their source file is gone."
+        ) in out, out
+
+    def test_a_directory_spelling_cannot_be_a_witness(self, tmp_dir):
+        """A witness has to be a file in the directory it speaks for.
+
+        ``os.path.dirname`` files a source whose last component is empty,
+        ``.`` or ``..`` under the very directory it names, or under its
+        parent, and a directory outlives the unmount that empties it. Taking
+        one for a neighbour would corroborate removing every drawer on the
+        volume, which is the failure this whole bucket exists to stop.
+        ``tool_add_drawer`` stores its caller's string verbatim, so these
+        spellings arrive without anything being corrupt.
+        """
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        data = repo / "data"
+        data.mkdir(parents=True)
+        on_the_volume = [data / "a.py", data / "b.py"]
+        for f in on_the_volume:
+            f.write_text("# mined off the volume\n")
+
+        for i, spelling in enumerate((str(data) + os.sep, os.path.join(str(data), "."))):
+            palace = os.path.join(tmp_dir, f"palace_dirspelling_{i}")
+            os.makedirs(palace)
+            self._seed(
+                palace,
+                [("d_dir", spelling)] + [(f"d_{f.name}", f) for f in on_the_volume],
+            )
+            for f in on_the_volume:
+                if f.exists():
+                    f.unlink()
+            report = sync_palace(
+                palace_path=palace, project_dirs=[str(repo)], wing="demo", dry_run=True
+            )
+            # Name the two drawers rather than count the buckets: whether the
+            # odd spelling itself lands in `kept` or in `unresolved` depends
+            # on how the platform stats a path with no last component, and
+            # the claim here is about the two files on the volume.
+            assert report["missing"] == 0, (spelling, report)
+            assert set(report["unresolved_by_source"]) >= {str(f) for f in on_the_volume}, (
+                spelling,
+                report,
+            )
+            for f in on_the_volume:
+                f.write_text("# back for the next spelling\n")
+
+    def test_every_neighbour_the_palace_knows_can_corroborate(
+        self, monkeypatch, tmp_dir, palace_path
+    ):
+        """Corroboration asks the directory, not one remembered drawer.
+
+        Keeping only the first neighbour the pass met would make the verdict
+        turn on the order the collection hands drawers over, which it does
+        not promise: the same palace and the same disk would prune under one
+        order and keep under the other. Here the first neighbour goes away
+        mid-pass and the second does not, and the deletion is still
+        established."""
+        from mempalace import sync as sync_mod
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        first = repo / "first.py"
+        first.write_text("# met first\n")
+        second = repo / "second.py"
+        second.write_text("# met second\n")
+        gone = repo / "gone.py"
+        gone.write_text("# was here\n")
+        gone.unlink()
+        rows = [("d_first", first), ("d_second", second), ("d_gone", gone)]
+        self._seed(palace_path, rows)
+
+        def iter_in_a_fixed_order(col, wing):
+            for drawer_id, source in rows:
+                yield (
+                    drawer_id,
+                    {
+                        "wing": "demo",
+                        "room": "src",
+                        "source_file": str(source),
+                        "chunk_index": 0,
+                        "added_by": "miner",
+                    },
+                )
+            # Exhausting the generator ends the classifying pass.
+            first.unlink()
+
+        monkeypatch.setattr(sync_mod, "_iter_drawer_metadata", iter_in_a_fixed_order)
+        report = sync_mod.sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["missing"] == 1, report
+        assert report["unresolved"] == 0, report
+
+    @pytest.mark.skipif(os.name == "nt", reason="os.symlink needs admin on Windows")
+    def test_a_witness_whose_own_probe_fails_does_not_corroborate(
+        self, monkeypatch, tmp_dir, palace_path
+    ):
+        """A neighbour corroborates by being read as a file, not by failing
+        to be read as gone. Those are different answers, and a directory
+        that stops answering partway through a pass produces the second."""
+        from mempalace import sync as sync_mod
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        target = repo / "target.py"
+        target.write_text("# what the neighbour points at\n")
+        neighbour = repo / "neighbour.py"
+        neighbour.symlink_to(target)
+        gone = repo / "gone.py"
+        gone.write_text("# was here\n")
+        gone.unlink()
+        self._seed(palace_path, [("d_neighbour", neighbour), ("d_gone", gone)])
+
+        real_iter = sync_mod._iter_drawer_metadata
+
+        def iter_then_break_the_neighbour(col, wing):
+            yield from real_iter(col, wing)
+            # The witness now answers ELOOP rather than reporting itself gone.
+            neighbour.unlink()
+            neighbour.symlink_to(neighbour)
+
+        monkeypatch.setattr(sync_mod, "_iter_drawer_metadata", iter_then_break_the_neighbour)
+        report = sync_mod.sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+
+    def test_apply_keeps_a_source_whose_probe_could_not_run(self, tmp_dir, palace_path):
+        """``unresolved`` is reached from two places and only one of them is
+        the settle. A drawer whose probe could not run never enters the
+        second list, so the scan loop is the only thing holding it out of
+        ``removable_ids``. Pin that on the apply path, beside a drawer that
+        really is removable, so the run is deleting while it holds this one
+        back."""
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        blocker = repo / "blocker.txt"
+        blocker.write_text("a regular file, not a directory\n")
+        neighbour = repo / "neighbour.py"
+        neighbour.write_text("# still here\n")
+        gone = repo / "gone.py"
+        gone.write_text("# was here\n")
+        gone.unlink()
+        self._seed(
+            palace_path,
+            [
+                ("d_unwalkable", blocker / "under_a_regular_file.py"),
+                ("d_neighbour", neighbour),
+                ("d_gone", gone),
+            ],
+        )
+
+        report = sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=False
+        )
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 1, report
+        assert report["removed_drawers"] == 1, report
+
+        client, col = _open_drawers(palace_path)
+        try:
+            assert _drawer_ids(col) == {"d_unwalkable", "d_neighbour"}
+        finally:
+            del client
+
+    @pytest.mark.skipif(os.name == "nt", reason="os.symlink needs admin on Windows")
+    def test_a_source_the_run_never_probed_cannot_corroborate(self, tmp_dir, palace_path):
+        """`out_of_scope` is decided before the file is ever looked at, so
+        such a drawer says nothing about the directory its metadata files it
+        under. A symlink out of the project keeps the link's own spelling in
+        `source_file`, so it lands beside sources that are in scope, and its
+        target can outlive the directory it appears to sit in."""
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        data = repo / "data"
+        data.mkdir(parents=True)
+        outside = Path(tmp_dir) / "outside"
+        outside.mkdir()
+        target = outside / "elsewhere.py"
+        target.write_text("# not in the project\n")
+        pointer = data / "pointer.py"
+        pointer.symlink_to(target)
+        gone = data / "gone.py"
+        gone.write_text("# was here\n")
+        gone.unlink()
+        self._seed(palace_path, [("d_pointer", pointer), ("d_gone", gone)])
+
+        report = sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["out_of_scope"] == 1, report
+        assert report["unresolved"] == 1, report
+        assert report["missing"] == 0, report
+        assert report["by_source"] == {}, report
+
+    def test_a_directory_that_lost_every_source_at_once_is_unresolved(self, tmp_dir, palace_path):
+        """The cost of the rule, pinned so it is not discovered as a
+        surprise. Deleting every file the palace knows in one directory
+        leaves nothing to corroborate with, and reads exactly like the
+        directory's contents being away, so `develop` prunes those drawers
+        and this does not."""
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        module = repo / "module"
+        module.mkdir(parents=True)
+        sources = [module / f"{name}.py" for name in ("a", "b", "c")]
+        for f in sources:
+            f.write_text("# mined\n")
+        self._seed(palace_path, [(f"d_{f.name}", f) for f in sources])
+        for f in sources:
+            f.unlink()
+        # The directory itself is untouched and still readable.
+        assert module.is_dir()
+
+        report = sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["unresolved"] == 3, report
+        assert report["missing"] == 0, report
+
+    def test_unresolved_sources_are_named_from_both_paths(self, tmp_dir, palace_path):
+        """A count of kept drawers the operator cannot turn into paths is not
+        a report. `unresolved` arrives from the classify pass and from the
+        settle, and both have to reach `unresolved_by_source`, counted per
+        drawer the way `by_source` counts removals."""
+        from mempalace.sync import sync_palace
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        blocker = repo / "blocker.txt"
+        blocker.write_text("a regular file, not a directory\n")
+        walled = blocker / "under_a_regular_file.py"
+        alone = repo / "alone"
+        alone.mkdir()
+        settled = alone / "gone.py"
+        settled.write_text("# was here\n")
+        settled.unlink()
+        self._seed(
+            palace_path,
+            [
+                ("d_walled_0", walled),
+                ("d_walled_1", walled),
+                ("d_settled", settled),
+            ],
+        )
+
+        report = sync_palace(
+            palace_path=palace_path, project_dirs=[str(repo)], wing="demo", dry_run=True
+        )
+        assert report["unresolved"] == 3, report
+        assert report["unresolved_by_source"] == {str(walled): 2, str(settled): 1}, report
+        # The removal side stays empty, so the two lists cannot be confused.
+        assert report["by_source"] == {}, report
+
+    def test_cli_names_the_unresolved_sources_and_counts_the_rest(
+        self, monkeypatch, tmp_dir, palace_path, capsys
+    ):
+        """Five paths are printed and the remainder is stated. A list that
+        stops at five without saying so reads as the whole set."""
+        from mempalace import cli
+
+        repo = Path(tmp_dir) / "repo"
+        repo.mkdir(parents=True)
+        rows = []
+        for i in range(7):
+            room = repo / f"room{i}"
+            room.mkdir()
+            source = room / "gone.py"
+            source.write_text("# was here\n")
+            source.unlink()
+            rows.append((f"d_{i}", source))
+        self._seed(palace_path, rows)
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["mempalace", "--palace", palace_path, "sync", str(repo), "--wing", "demo"],
+        )
+        cli.main()
+
+        out = capsys.readouterr().out
+        assert "  Unresolved:     7  (kept)" in out, out
+        named = [line for line in out.splitlines() if line.startswith("    ") and "gone.py" in line]
+        assert len(named) == 5, out
+        assert "    and 2 more source file(s)" in out, out

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -175,7 +175,9 @@ Prune drawers whose source files are gitignored, deleted, or moved. Returns a dr
 | `wing` | string | No | Limit to one wing |
 | `apply` | boolean | No | Actually delete drawers; default is dry-run preview |
 
-**Returns:** `{ scanned, kept, gitignored, missing, no_source, out_of_scope, removed_drawers, removed_closets, dry_run, by_source }`
+**Returns:** `{ scanned, kept, gitignored, missing, unresolved, no_source, out_of_scope, removed_drawers, removed_closets, dry_run, by_source, unresolved_by_source }`
+
+Only `gitignored` and `missing` are removed. A source file that is not at its path counts as `missing` only while the palace can still see a source file of its own in the same directory: a deletion leaves its neighbours behind, an unmounted volume takes all of them at once. Everything else counts as `unresolved`, which is kept and named in `unresolved_by_source` the way removals are named in `by_source`.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

`mempalace sync --apply` deleted drawers whose source file it could not reach, not only drawers whose source file was removed. `_classify_drawer` drew that line with one `Path.exists()` (`sync.py:123-124` on `develop`), and `missing` is a removal bucket: those ids reach `removable_ids` at `:276-277` and `col.delete` at `:192`. Nothing looked at the file again in between.

#2320 carries the measurement. Of twelve source-file states driven through `sync_palace` on `develop` @ 3e56979f, eight were deleted. Four of those eight were a file that had really gone. Three more ended the whole run rather than that one drawer, dry run included.

Refs #2320 rather than Fixes: the mount shape below stays open, and closing the issue on merge would take it with it.

### What establishes an absence

A failed probe does not, and `backups.py:80-85` already says so for an operation that merely leaves an entry out of a backup copy: no errno separates "nothing is here" from "this cannot be reached right now". The directory's own contents are no better a witness, because a mount point committed to a repository is never empty: git cannot track an empty directory, and the `.gitkeep` put there for that reason outlives the unmount.

Corroboration from the palace's own record does. A file that is not at its path is removable only while the palace can still see a source **of its own** in that same directory. A deletion leaves the file's neighbours where they were; an unmounted volume takes all of them at once. Three things make that safe to lean on. The neighbour has to stat as a regular file, since `mempalace_add_drawer` files the `source_file` its caller passed and a `source_file` ending in a separator or `..` is filed under the directory it names, which outlives the unmount. Every neighbour the palace knows there is asked rather than one remembered drawer, so the verdict does not turn on the order the collection hands drawers over. And both halves are read again when the verdict is formed, because a large palace takes minutes to scan and a volume can leave inside one pass and return inside one; two tests take it away mid-pass and bring it back before the settle, and neither removes anything.

What is left uncorroborated goes to a new bucket, `unresolved`, never added to `removable_ids`: an unmounted volume in either mount-point shape, a path that cannot be walked, and a probe that raises, which used to end the run. It is reported the way removals are, since a count of kept drawers the operator cannot turn into paths is not a report: counted beside the other buckets, and its sources named in `unresolved_by_source` and printed, with the remainder stated when that list is cut at five. Removal can only shrink, since `_source_state` answers `present` exactly when `os.stat` succeeds, which is exactly when `Path.exists()` answered True. Twenty-five degenerate and symlink spellings went through `sync_palace` on both sides and none is a case `develop` keeps and this one removes.

Two files mined from a mounted volume gone at sync time, in all three layouts (mount point above the project root, project root itself, a `data/` directory with a committed `.gitkeep`):

```
develop:  Missing:    20  (removed)   Removed 20 drawers, 2 closets   embeddings 22 to 0
here:     Unresolved: 20  (kept)      Removed 0 drawers, 0 closets    embeddings 22
```

Once the volume is back, the same search answers `No results found` on `develop` and returns the files here.

### What it costs, and what stays open

A directory the palace knows no surviving source in corroborates nothing, so two real deletions stop being pruned: a file deleted alone from a directory the palace knew nothing else in, and a directory's files deleted together, `rm module/*.py` before the next mine. Both read exactly like that directory being away. `--wing` narrows the drawers read and so the neighbours available, so a wing-scoped run keeps what a whole-palace run would prune.

Two shapes stay open. A neighbour proves the directory is reachable, not that it is the filesystem the file was mined from, so a mount point holding a mined file of its own still corroborates, exactly as on `develop`; separating those needs the filesystem identity of each source at mine time, which nothing records, and a test pins the shape. And nothing spans two syscalls, so a volume that leaves and returns between the neighbour's reading and the file's own is not covered.

`_auto_detect_project_roots` gets the same treatment: its `.git` / `.gitignore` probe raised on an ancestor the process may not enter, and the two markers are probed separately now so an unreadable `.git` cannot hide a `.gitignore` beside it.

## How to test

```bash
uv run pytest tests/test_sync.py -v
```

Thirty-two new tests in `TestUnresolvedSources`: each state above, the apply path, the closet purge, the report shape, the MCP response, both renderers, and both costs. Eight skip on Windows for POSIX symlinks or permission bits, three of those also under root; none skips on Linux. Against `develop`'s `sync.py`, `cli.py` and `service.py` every one of them fails, with three existing tests that pin the report shape.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
