### PR TITLE
feat(normalize): add Google Antigravity and Gemini IDE transcript support

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -613,7 +613,8 @@ def _extract_authored_at(filepath):
                 if not line:
                     continue
                 try:
-                    ts = json.loads(line).get("timestamp")
+                    obj = json.loads(line)
+                    ts = obj.get("timestamp") or obj.get("created_at")
                 except (ValueError, TypeError, AttributeError):
                     continue
                 # ISO-8601 timestamps are strings; guard against a non-string

--- a/mempalace/normalize.py
+++ b/mempalace/normalize.py
@@ -9,6 +9,7 @@ Supported:
       array of them that a real data export ships)
     - Claude Code JSONL (with tool_use/tool_result block capture)
     - OpenAI Codex CLI JSONL
+    - Google Antigravity / Gemini IDE transcript JSONL (~/.gemini/antigravity-ide/brain/.../transcript.jsonl)
     - Gemini CLI JSONL (~/.gemini/tmp/<project_hash>/chats/session-*.jsonl)
     - Pi agent JSONL
     - Gemini CLI / Google AI Studio JSON sessions (contents / messages / flat list)
@@ -237,6 +238,10 @@ def _try_normalize_json_split(content: str) -> Optional[list]:
     a separate list entry (bundle formats) or a single-element list.
     """
 
+    normalized = _try_antigravity_jsonl(content)
+    if normalized:
+        return [normalized]
+
     normalized = _try_claude_code_jsonl(content)
     if normalized:
         return [normalized]
@@ -275,6 +280,59 @@ def _try_normalize_json_split(content: str) -> Optional[list]:
         if normalized:
             return [normalized]
 
+    return None
+
+
+def _try_antigravity_jsonl(content: str) -> Optional[str]:
+    """Google Antigravity / Gemini IDE transcript JSONL sessions (~/.gemini/antigravity-ide/brain/.../transcript.jsonl)."""
+    lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+    messages = []
+    has_antigravity_markers = False
+
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+
+        step_type = entry.get("type", "")
+        source = entry.get("source", "")
+        content_val = entry.get("content", "")
+
+        if step_type == "USER_INPUT" or source in ("USER_EXPLICIT", "USER_SYSTEM"):
+            has_antigravity_markers = True
+            if not isinstance(content_val, str):
+                continue
+            # Extract actual user request if enclosed in tags
+            m = re.search(r"<USER_REQUEST>\s*([\s\S]*?)\s*</USER_REQUEST>", content_val)
+            text = m.group(1).strip() if m else content_val.strip()
+            # Clean additional metadata / user settings tags
+            text = re.sub(r"<ADDITIONAL_METADATA>[\s\S]*?</ADDITIONAL_METADATA>", "", text).strip()
+            text = re.sub(r"<USER_SETTINGS_CHANGE>[\s\S]*?</USER_SETTINGS_CHANGE>", "", text).strip()
+            text = strip_noise(text)
+            if text:
+                messages.append(("user", text))
+
+        elif step_type == "PLANNER_RESPONSE" or source == "MODEL":
+            has_antigravity_markers = True
+            text = content_val.strip() if isinstance(content_val, str) else ""
+            tool_calls = entry.get("tool_calls", [])
+            if not text and tool_calls and isinstance(tool_calls, list):
+                tool_names = [tc.get("name", "tool") for tc in tool_calls if isinstance(tc, dict)]
+                if tool_names:
+                    text = f"[Action: {', '.join(tool_names)}]"
+            text = strip_noise(text)
+            if text:
+                if messages and messages[-1][0] == "assistant":
+                    prev_role, prev_text = messages[-1]
+                    messages[-1] = (prev_role, prev_text + "\n" + text)
+                else:
+                    messages.append(("assistant", text))
+
+    if len(messages) >= 2 and has_antigravity_markers:
+        return _messages_to_transcript(messages)
     return None
 
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -8,6 +8,7 @@ from mempalace.normalize import (
     _format_tool_result,
     _format_tool_use,
     _messages_to_transcript,
+    _try_antigravity_jsonl,
     _try_chatgpt_export_json_split,
     _try_chatgpt_json,
     _try_claude_ai_json,
@@ -2166,3 +2167,144 @@ def test_pi_jsonl_invalid_lines_skipped():
     ]
     result = _try_pi_jsonl("\n".join(lines))
     assert result is not None
+
+
+# ── Google Antigravity / Gemini IDE JSONL ─────────────────────────────────
+
+
+def test_antigravity_jsonl_basic():
+    """Extracts <USER_REQUEST> from user step and content from planner response."""
+    lines = [
+        json.dumps({
+            "step_index": 0,
+            "source": "USER_EXPLICIT",
+            "type": "USER_INPUT",
+            "content": "<USER_REQUEST>\nHow do I configure Supabase auth?\n</USER_REQUEST>\n<ADDITIONAL_METADATA>\nActive Document: app.py\n</ADDITIONAL_METADATA>"
+        }),
+        json.dumps({
+            "step_index": 1,
+            "source": "MODEL",
+            "type": "PLANNER_RESPONSE",
+            "content": "You can configure Supabase auth using createClient in utils/supabase/server.ts."
+        })
+    ]
+    result = _try_antigravity_jsonl("\n".join(lines))
+    assert result is not None
+    assert "> How do I configure Supabase auth?" in result
+    assert "You can configure Supabase auth using createClient" in result
+    assert "ADDITIONAL_METADATA" not in result
+    assert "Active Document" not in result
+
+
+def test_antigravity_jsonl_metadata_and_settings_stripped():
+    """Strips <ADDITIONAL_METADATA> and <USER_SETTINGS_CHANGE> tags without user request tags."""
+    lines = [
+        json.dumps({
+            "step_index": 0,
+            "source": "USER_EXPLICIT",
+            "type": "USER_INPUT",
+            "content": "Add dark mode toggle\n<ADDITIONAL_METADATA>\nCursor is on line: 1\n</ADDITIONAL_METADATA>\n<USER_SETTINGS_CHANGE>\nModel changed to Flash\n</USER_SETTINGS_CHANGE>"
+        }),
+        json.dumps({
+            "step_index": 1,
+            "source": "MODEL",
+            "type": "PLANNER_RESPONSE",
+            "content": "Dark mode toggle has been added."
+        })
+    ]
+    result = _try_antigravity_jsonl("\n".join(lines))
+    assert result is not None
+    assert "> Add dark mode toggle" in result
+    assert "Cursor is on line" not in result
+    assert "USER_SETTINGS_CHANGE" not in result
+    assert "Dark mode toggle has been added." in result
+
+
+def test_antigravity_jsonl_tool_calls_summary():
+    """When planner response content is empty but tool_calls exist, action names are summarized."""
+    lines = [
+        json.dumps({
+            "step_index": 0,
+            "source": "USER_EXPLICIT",
+            "type": "USER_INPUT",
+            "content": "<USER_REQUEST>\nCheck git status\n</USER_REQUEST>"
+        }),
+        json.dumps({
+            "step_index": 1,
+            "source": "MODEL",
+            "type": "PLANNER_RESPONSE",
+            "content": "",
+            "tool_calls": [{"name": "run_command", "args": {}}, {"name": "view_file", "args": {}}]
+        })
+    ]
+    result = _try_antigravity_jsonl("\n".join(lines))
+    assert result is not None
+    assert "> Check git status" in result
+    assert "[Action: run_command, view_file]" in result
+
+
+def test_antigravity_jsonl_multi_turn_assistant_merge():
+    """Consecutive planner responses in a single turn cycle are merged into one assistant block."""
+    lines = [
+        json.dumps({
+            "step_index": 0,
+            "source": "USER_EXPLICIT",
+            "type": "USER_INPUT",
+            "content": "<USER_REQUEST>Run analysis</USER_REQUEST>"
+        }),
+        json.dumps({
+            "step_index": 1,
+            "source": "MODEL",
+            "type": "PLANNER_RESPONSE",
+            "content": "Starting analysis..."
+        }),
+        json.dumps({
+            "step_index": 2,
+            "source": "MODEL",
+            "type": "PLANNER_RESPONSE",
+            "content": "Analysis complete with 0 errors."
+        })
+    ]
+    result = _try_antigravity_jsonl("\n".join(lines))
+    assert result is not None
+    assert "> Run analysis" in result
+    assert "Starting analysis...\nAnalysis complete with 0 errors." in result
+
+
+def test_antigravity_jsonl_under_two_turns_returns_none():
+    """Sessions with fewer than 2 turns return None."""
+    lines = [
+        json.dumps({
+            "step_index": 0,
+            "source": "USER_EXPLICIT",
+            "type": "USER_INPUT",
+            "content": "<USER_REQUEST>Hello</USER_REQUEST>"
+        })
+    ]
+    result = _try_antigravity_jsonl("\n".join(lines))
+    assert result is None
+
+
+def test_antigravity_jsonl_dispatch_integration(tmp_path):
+    """normalize_conversations recognizes Antigravity JSONL files end-to-end."""
+    lines = [
+        json.dumps({
+            "step_index": 0,
+            "source": "USER_EXPLICIT",
+            "type": "USER_INPUT",
+            "content": "<USER_REQUEST>\nFix bug in auth flow\n</USER_REQUEST>"
+        }),
+        json.dumps({
+            "step_index": 1,
+            "source": "MODEL",
+            "type": "PLANNER_RESPONSE",
+            "content": "Bug fixed in lib/auth.ts."
+        })
+    ]
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("\n".join(lines), encoding="utf-8")
+    res = normalize_conversations(str(f))
+    assert len(res) == 1
+    assert "> Fix bug in auth flow" in res[0]
+    assert "Bug fixed in lib/auth.ts." in res[0]
+


### PR DESCRIPTION
## What does this PR do?

Adds native parsing and normalization support for **Google Antigravity** and **Gemini IDE** conversation session transcripts (`~/.gemini/antigravity-ide/brain/.../transcript.jsonl`).

### Context & Motivation
Google Antigravity (and the Gemini IDE agentic platform) stores conversation transcripts as step-based trajectory JSONL logs (`step_index`, `USER_INPUT`, `PLANNER_RESPONSE`, `tool_calls`). Previously, these were unrecognized by `_try_gemini_jsonl` (which expects legacy Gemini CLI `session_metadata` / `type: gemini` records).

### Proposed Changes
1. **`mempalace/normalize.py`**:
   - Added `_try_antigravity_jsonl(content: str) -> Optional[str]`:
     - Parses `USER_INPUT` steps, extracts user query from `<USER_REQUEST>` blocks, and strips IDE runtime metadata (`<ADDITIONAL_METADATA>`, `<USER_SETTINGS_CHANGE>`).
     - Parses `PLANNER_RESPONSE` steps, merges multi-turn assistant outputs, and summarizes tool calls (`[Action: ...]`) when content is empty.
     - Formats into standard transcript pairs via `_messages_to_transcript`.
   - Wired `_try_antigravity_jsonl` into `_try_normalize_json_split` dispatch.
2. **`mempalace/convo_miner.py`**:
   - Extended `_extract_authored_at` to check `created_at` in addition to `timestamp` so ISO timestamps from Antigravity logs are preserved accurately.
3. **`tests/test_normalize.py`**:
   - Added comprehensive unit tests covering basic parsing, metadata stripping, tool call summarization, multi-turn assistant merging, and end-to-end normalization dispatch.

## How to test

1. Run normalization unit tests:
   ```bash
   pytest tests/test_normalize.py -v
   ```
2. Run convo miner tests:
   ```bash
   pytest tests/test_convo_miner.py tests/test_convo_miner_unit.py -v
   ```

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
