### PR TITLE
feat: add OrcaRouter as a named LLM provider

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -2749,7 +2749,7 @@ def main():
     p_init.add_argument(
         "--llm-provider",
         default="ollama",
-        choices=["ollama", "openai-compat", "anthropic"],
+        choices=["ollama", "openai-compat", "anthropic", "orcarouter"],
         help="LLM provider (default: ollama). Pass --no-llm to disable LLM-assisted refinement entirely.",
     )
     p_init.add_argument(
@@ -2770,6 +2770,7 @@ def main():
         default=None,
         help=(
             "API key for the provider. For anthropic, defaults to $ANTHROPIC_API_KEY; "
+            "for orcarouter, defaults to $ORCAROUTER_API_KEY; "
             "for openai-compat, defaults to $OPENAI_API_KEY."
         ),
     )

--- a/mempalace/llm_client.py
+++ b/mempalace/llm_client.py
@@ -1,7 +1,7 @@
 """
 llm_client.py — Minimal provider abstraction for LLM-assisted entity refinement.
 
-Three providers cover the useful space:
+Four providers cover the useful space:
 
 - ``ollama`` (default): local models via http://localhost:11434. Works fully
   offline. Honors MemPalace's "zero-API required" principle.
@@ -10,6 +10,10 @@ Three providers cover the useful space:
   Together, and most self-hosted setups.
 - ``anthropic``: the official Messages API. Opt-in for users who want Haiku
   quality without setting up a local model.
+- ``orcarouter``: the OrcaRouter OpenAI-compatible gateway at
+  https://api.orcarouter.ai. A named provider so the ``orcarouter/`` model
+  namespace is a first-class choice, with its own ``ORCAROUTER_API_KEY`` env
+  var, instead of requiring an anonymous openai-compat base URL.
 
 All providers expose the same ``classify(system, user, json_mode)`` method and
 the same ``check_available()`` probe. No external SDK dependencies — stdlib
@@ -170,8 +174,8 @@ class LLMProvider:
         warning before first use (issue #24). URL-based heuristic only —
         the endpoint determines, regardless of which provider class.
         Subclasses that resolve their endpoint dynamically should override
-        if needed; the default works for the three in-tree providers
-        (Ollama / OpenAI-compat / Anthropic).
+        if needed; the default works for the in-tree providers
+        (Ollama / OpenAI-compat / Anthropic / OrcaRouter).
         """
         return not _endpoint_is_local(self.endpoint)
 
@@ -436,6 +440,99 @@ class AnthropicProvider(LLMProvider):
         return LLMResponse(text=text, model=self.model, provider=self.name, raw=data)
 
 
+# ==================== ORCAROUTER ====================
+
+
+class OrcaRouterProvider(LLMProvider):
+    """The OrcaRouter OpenAI-compatible gateway at ``https://api.orcarouter.ai``.
+
+    A named provider for OrcaRouter's model namespace (``orcarouter/...``)
+    so users can select it with ``--llm-provider orcarouter`` instead of
+    treating it as an anonymous openai-compat base URL. Talks the same
+    ``/v1/chat/completions`` wire format as ``OpenAICompatProvider``, but
+    ships a default endpoint and reads its own ``ORCAROUTER_API_KEY`` env
+    var. API key via ``--llm-api-key`` or ``ORCAROUTER_API_KEY``.
+    """
+
+    name = "orcarouter"
+    DEFAULT_ENDPOINT = "https://api.orcarouter.ai"
+
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        timeout: int = 120,
+        **_: object,
+    ):
+        if api_key:
+            resolved_key = api_key
+            source: Optional[str] = "flag"
+        else:
+            env_key = os.environ.get("ORCAROUTER_API_KEY")
+            resolved_key = env_key or None
+            source = "env" if env_key else None
+        super().__init__(
+            model=model,
+            endpoint=endpoint or self.DEFAULT_ENDPOINT,
+            api_key=resolved_key,
+            timeout=timeout,
+            api_key_source=source,
+        )
+
+    def _resolve_url(self) -> str:
+        url = self.endpoint.rstrip("/")
+        if url.endswith("/chat/completions"):
+            return url
+        if not url.endswith("/v1"):
+            url = f"{url}/v1"
+        return f"{url}/chat/completions"
+
+    def check_available(self) -> tuple[bool, str]:
+        if not self.api_key:
+            return False, "ORCAROUTER_API_KEY not set (use --llm-api-key or env)"
+        base = self.endpoint.rstrip("/")
+        base = base.removesuffix("/chat/completions").removesuffix("/v1")
+        try:
+            req = Request(f"{base}/v1/models")
+            if self.api_key and (self.api_key_source != "env" or not self.is_external_service):
+                req.add_header("Authorization", f"Bearer {self.api_key}")
+            with urlopen(req, timeout=5):
+                pass
+        except (URLError, HTTPError, OSError) as e:
+            return False, f"Cannot reach {self.endpoint}: {e}"
+        return True, "ok"
+
+    def classify(
+        self,
+        system: str,
+        user: str,
+        json_mode: bool = True,
+        think: Optional[bool] = None,  # noqa: ARG002 — accepted for interface compat; OpenAI-compat has no thinking toggle
+    ) -> LLMResponse:
+        if not self.api_key:
+            raise LLMError("OrcaRouter provider requires ORCAROUTER_API_KEY env or --llm-api-key")
+        body: dict = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "temperature": 0.1,
+        }
+        if json_mode:
+            body["response_format"] = {"type": "json_object"}
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        data = _http_post_json(self._resolve_url(), body, headers=headers, timeout=self.timeout)
+        try:
+            text = data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as e:
+            raise LLMError(f"Unexpected response shape: {e}") from e
+        if not text:
+            raise LLMError(f"Empty response from {self.name} (model={self.model})")
+        return LLMResponse(text=text, model=self.model, provider=self.name, raw=data)
+
+
 # ==================== FACTORY ====================
 
 
@@ -443,6 +540,7 @@ PROVIDERS: dict[str, type[LLMProvider]] = {
     "ollama": OllamaProvider,
     "openai-compat": OpenAICompatProvider,
     "anthropic": AnthropicProvider,
+    "orcarouter": OrcaRouterProvider,
 }
 
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -15,6 +15,7 @@ from mempalace.llm_client import (
     LLMError,
     OllamaProvider,
     OpenAICompatProvider,
+    OrcaRouterProvider,
     _http_post_json,
     get_provider,
 )
@@ -39,6 +40,13 @@ def test_get_provider_anthropic():
     p = get_provider("anthropic", "claude-haiku", api_key="sk-xxx")
     assert isinstance(p, AnthropicProvider)
     assert p.api_key == "sk-xxx"
+
+
+def test_get_provider_orcarouter():
+    p = get_provider("orcarouter", "orcarouter/fusion-mini", api_key="sk-orca-xxx")
+    assert isinstance(p, OrcaRouterProvider)
+    assert p.api_key == "sk-orca-xxx"
+    assert p.endpoint == OrcaRouterProvider.DEFAULT_ENDPOINT
 
 
 def test_get_provider_unknown_raises():
@@ -325,6 +333,137 @@ def test_anthropic_no_key_raises_on_classify(monkeypatch):
     p = AnthropicProvider(model="claude-haiku")
     with pytest.raises(LLMError, match="requires ANTHROPIC_API_KEY"):
         p.classify("s", "u")
+
+
+# ── OrcaRouterProvider ──────────────────────────────────────────────────
+
+
+def _mock_orcarouter_response(content: str):
+    mock = MagicMock()
+    payload = {"choices": [{"message": {"content": content}}]}
+    mock.read.return_value = json.dumps(payload).encode()
+    mock.__enter__.return_value = mock
+    mock.__exit__.return_value = False
+    return mock
+
+
+def test_orcarouter_resolves_default_url():
+    captured = {}
+
+    def fake_urlopen(req, *, timeout):
+        captured["url"] = req.full_url
+        return _mock_orcarouter_response('{"ok": true}')
+
+    with patch("mempalace.llm_client.urlopen", side_effect=fake_urlopen):
+        p = OrcaRouterProvider(model="orcarouter/fusion-mini", api_key="sk-orca-abc")
+        p.classify("s", "u")
+    assert captured["url"] == "https://api.orcarouter.ai/v1/chat/completions"
+
+
+def test_orcarouter_resolves_url_with_existing_v1():
+    captured = {}
+
+    def fake_urlopen(req, *, timeout):
+        captured["url"] = req.full_url
+        return _mock_orcarouter_response('{"ok": true}')
+
+    with patch("mempalace.llm_client.urlopen", side_effect=fake_urlopen):
+        p = OrcaRouterProvider(
+            model="orcarouter/fusion-mini", endpoint="http://h:1234/v1", api_key="sk-orca"
+        )
+        p.classify("s", "u")
+    assert captured["url"] == "http://h:1234/v1/chat/completions"
+
+
+def test_orcarouter_sends_authorization_when_key_present():
+    captured = {}
+
+    def fake_urlopen(req, *, timeout):
+        captured["auth"] = req.get_header("Authorization")
+        return _mock_orcarouter_response('{"ok": true}')
+
+    with patch("mempalace.llm_client.urlopen", side_effect=fake_urlopen):
+        p = OrcaRouterProvider(model="orcarouter/fusion-mini", api_key="sk-orca-abc")
+        p.classify("s", "u")
+    assert captured["auth"] == "Bearer sk-orca-abc"
+
+
+def test_orcarouter_sends_response_format_json():
+    captured = {}
+
+    def fake_urlopen(req, *, timeout):
+        captured["body"] = json.loads(req.data.decode())
+        return _mock_orcarouter_response('{"ok": true}')
+
+    with patch("mempalace.llm_client.urlopen", side_effect=fake_urlopen):
+        p = OrcaRouterProvider(model="orcarouter/fusion-mini", api_key="sk-orca")
+        p.classify("s", "u", json_mode=True)
+    assert captured["body"]["response_format"] == {"type": "json_object"}
+
+
+def test_orcarouter_uses_env_var_fallback(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-env")
+    p = OrcaRouterProvider(model="orcarouter/fusion-mini")
+    assert p.api_key == "sk-orca-env"
+
+
+def test_orcarouter_requires_api_key(monkeypatch):
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+    p = OrcaRouterProvider(model="orcarouter/fusion-mini")
+    ok, msg = p.check_available()
+    assert not ok
+    assert "ORCAROUTER_API_KEY" in msg
+    with pytest.raises(LLMError, match="requires ORCAROUTER_API_KEY"):
+        p.classify("s", "u")
+
+
+def test_orcarouter_check_available_probes_models(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca")
+    mock = MagicMock()
+    mock.__enter__.return_value = mock
+    with patch("mempalace.llm_client.urlopen", return_value=mock):
+        p = OrcaRouterProvider(model="orcarouter/fusion-mini")
+        ok, msg = p.check_available()
+    assert ok
+    assert msg == "ok"
+
+
+def test_orcarouter_default_endpoint_is_external():
+    """OrcaRouterProvider's default endpoint is the hosted gateway, which
+    must be classified as external so the privacy warning fires by default
+    for users who pass --llm-provider orcarouter."""
+    p = OrcaRouterProvider(model="orcarouter/fusion-mini", api_key="sk-orca")
+    assert p.is_external_service is True, (
+        f"Default OrcaRouterProvider endpoint must be external; got "
+        f"is_external_service={p.is_external_service} for endpoint={p.endpoint}"
+    )
+
+
+def test_orcarouter_api_key_source_tracking(monkeypatch):
+    """OrcaRouterProvider tracks api_key_source the same way as the other
+    cloud providers: 'flag' when passed explicitly, 'env' when resolved
+    from ORCAROUTER_API_KEY env."""
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-env")
+    p_flag = OrcaRouterProvider(model="orcarouter/fusion-mini", api_key="sk-orca-flag")
+    assert p_flag.api_key_source == "flag", (
+        f"Explicit api_key must produce 'flag'; got {p_flag.api_key_source!r}"
+    )
+    p_env = OrcaRouterProvider(model="orcarouter/fusion-mini")
+    assert p_env.api_key == "sk-orca-env"
+    assert p_env.api_key_source == "env", (
+        f"Env-fallback must produce 'env'; got {p_env.api_key_source!r}"
+    )
+
+
+def test_orcarouter_unexpected_shape_raises():
+    mock = MagicMock()
+    mock.read.return_value = b'{"nothing": "here"}'
+    mock.__enter__.return_value = mock
+    mock.__exit__.return_value = False
+    with patch("mempalace.llm_client.urlopen", return_value=mock):
+        p = OrcaRouterProvider(model="orcarouter/fusion-mini", api_key="sk-orca")
+        with pytest.raises(LLMError, match="Unexpected response shape"):
+            p.classify("s", "u")
 
 
 # ── is_external_service property (issue #24 — privacy warning support) ──


### PR DESCRIPTION
## What does this PR do?

MemPalace is **local-first AI memory** — it stores your conversation history verbatim and retrieves it with semantic search, with "zero API calls" as the headline default. When you do opt into LLM-assisted entity refinement during `init`, the current provider choices are `ollama`, `openai-compat`, and `anthropic`. An [OrcaRouter](https://www.orcarouter.ai) user today has to reach for the anonymous `openai-compat` escape hatch and hand-wire `https://api.orcarouter.ai/v1` as a custom base URL.

This PR makes OrcaRouter a **first-class named provider** (`--llm-provider orcarouter`), mirroring exactly how `AnthropicProvider` is wired in `mempalace/llm_client.py`: a default endpoint (`https://api.orcarouter.ai`), its own `ORCAROUTER_API_KEY` env var fallback, and a `check_available()` probe against `/v1/models`.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Implementation

- `mempalace/llm_client.py` — new `OrcaRouterProvider` class (OpenAI-compatible `/v1/chat/completions`, `response_format` JSON mode, `Bearer` auth), registered in `PROVIDERS`.
- `mempalace/cli.py` — added `orcarouter` to `--llm-provider` choices and documented the `ORCAROUTER_API_KEY` env fallback in the `--llm-api-key` help.
- `tests/test_llm_client.py` — 9 new unit tests mirroring the existing Anthropic/OpenAI-compat coverage (URL resolution, auth header, JSON mode, env fallback, `api_key_source` provenance, external-service classification).

The privacy flow from issue #24/#26 applies unchanged: `orcarouter` is external by default, so `mempalace init` surfaces the external-API warning and the consent gate for env-resolved keys.

## How to test

```bash
python -m pytest tests/test_llm_client.py -v
ruff check mempalace/llm_client.py mempalace/cli.py tests/test_llm_client.py
```

Live smoke (real `ORCAROUTER_API_KEY`): `get_provider("orcarouter", "orcarouter/fusion-mini").check_available()` → OK; `.classify(...)` returns a 200 JSON-mode response.

## Checklist
- [x] Tests pass (`python -m pytest tests/test_llm_client.py -v` — 47 passed; full suite: 4413 passed, pre-existing env failures unrelated to this change)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .` on changed files)

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
