### PR TITLE
fix: align pre-commit ruff pin with pyproject and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
       # This drifted once (CI on 0.15.14 against pyproject's 0.15.20) and the
       # drift was invisible: the lint job never installs from pyproject, so a
       # dependabot bump to the pin there passes CI without the new version
-      # ever running. test_ruff_pins_match asserts the two stay equal.
+      # ever running. test_ruff_pins_match asserts the two stay equal, and
+      # also covers the pre-commit config's ruff rev (all three must agree).
       - run: pip install "ruff==0.16.1"
       - run: ruff check .
       - run: ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     # ([project.optional-dependencies].dev / [dependency-groups].dev) and
     # .github/workflows/ci.yml. A different ruff here produces different
     # formatter output than CI and breaks `ruff format --check` in lint.
-    rev: v0.15.14
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [--fix]

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -36,22 +36,51 @@ def _ci_ruff_pins() -> list[str]:
     return re.findall(r'pip install "ruff==([^"]+)"', content)
 
 
+def _precommit_ruff_revs(content: str) -> list[str]:
+    ruff_repo = re.search(
+        r"(?ms)^[ \t]*-[ \t]+repo:[ \t]+https://github\.com/astral-sh/ruff-pre-commit[ \t]*$.*?(?=^[ \t]*-[ \t]+repo:|\Z)",
+        content,
+    )
+    if ruff_repo is None:
+        return []
+    return re.findall(r"^[ \t]*rev:[ \t]+v(\d+\.\d+\.\d+)[ \t]*$", ruff_repo.group(), re.MULTILINE)
+
+
+def _precommit_ruff_rev() -> list[str]:
+    content = (_repo_root() / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    return _precommit_ruff_revs(content)
+
+
+def test_precommit_ruff_rev_ignores_other_repositories():
+    content = """
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.1
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+"""
+    assert _precommit_ruff_revs(content) == ["0.16.1"]
+
+
 def test_ruff_pins_match():
-    """CI's ruff and pyproject's ruff must be the same version.
+    """CI's ruff, pyproject's ruff, and pre-commit's ruff rev must match.
 
     The lint job installs ruff by literal pin rather than from pyproject, so
-    the two can drift with nothing to notice: CI went on linting with 0.15.14
+    the pins can drift with nothing to notice: CI went on linting with 0.15.14
     while pyproject asked for 0.15.20. A dependabot bump to pyproject then
     passes CI green without the new version ever running — which matters,
     because 0.16 started formatting Python inside markdown fences and would
     have landed a lint config that disagreed with every contributor's local
-    `ruff format`.
+    `ruff format`. The pre-commit config pins the same ruff in its own rev, so
+    all three sources must stay in lock-step.
     """
     pyproject_pins = _pyproject_ruff_pins()
     ci_pins = _ci_ruff_pins()
+    precommit_revs = _precommit_ruff_rev()
 
     assert pyproject_pins, "no ruff pin found in pyproject.toml"
     assert ci_pins, "no ruff pin found in .github/workflows/ci.yml"
+    assert precommit_revs, "no ruff rev found in .pre-commit-config.yaml"
     assert len(set(pyproject_pins)) == 1, (
         f"pyproject.toml pins ruff at more than one version: {sorted(set(pyproject_pins))}"
     )
@@ -59,4 +88,10 @@ def test_ruff_pins_match():
         f"ruff pin drift — ci.yml has {sorted(set(ci_pins))}, "
         f"pyproject.toml has {sorted(set(pyproject_pins))}. "
         "Bump both together so CI and local runs format identically."
+    )
+    assert set(precommit_revs) == set(pyproject_pins), (
+        f"ruff pin drift — .pre-commit-config.yaml rev has "
+        f"{sorted(set(precommit_revs))}, pyproject.toml has "
+        f"{sorted(set(pyproject_pins))}. "
+        "Bump the pre-commit rev to match so local hooks and CI format identically."
     )


### PR DESCRIPTION
## What does this PR do?

Aligns the Ruff version used by local pre-commit hooks with the version pinned by `pyproject.toml` and CI. Extends `test_ruff_pins_match` to check all three sources and scopes the pre-commit extraction to the Ruff repository block, preventing unrelated hook revisions from causing false failures.

Fixes #2339.

## How to test

- `uv run pytest tests/test_version_consistency.py tests/test_antigravity_hooks_install.py -q` -> 18 passed
- `uv run ruff check .` -> passed
- `uv run ruff format --check .` -> 229 files already formatted
- `uv run pre-commit validate-config` -> passed

The full suite was also attempted. It is currently blocked by the pre-existing order-dependent MCP writer-lock failure tracked in #2334; the focused tests for this change pass.

## Checklist

- [x] Tests pass (`python -m pytest tests/ -v`) for the affected test surface
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
