### PR TITLE
docs: refresh the release entry-point check and plugin tool counts

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,6 +1,6 @@
 # MemPalace Claude Code Plugin
 
-A Claude Code plugin that gives your AI a persistent memory system. Mine projects and conversations into a searchable palace backed by ChromaDB, with 36 MCP tools, auto-save hooks, and 5 guided skills.
+A Claude Code plugin that gives your AI a persistent memory system. Mine projects and conversations into a searchable palace backed by ChromaDB, with 44 MCP tools, auto-save hooks, and 5 guided skills.
 
 ## Prerequisites
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "mempalace",
       "source": "./.claude-plugin",
-      "description": "AI memory system — mine projects and conversations into a searchable palace. 36 MCP tools, auto-save hooks, guided setup.",
+      "description": "AI memory system — mine projects and conversations into a searchable palace. 44 MCP tools, auto-save hooks, guided setup.",
       "version": "3.8.0",
       "author": {
         "name": "milla-jovovich"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mempalace",
   "version": "3.8.0",
-  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 36 MCP tools, auto-save hooks, and guided setup.",
+  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 44 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"
   },

--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -1,6 +1,6 @@
 # MemPalace - Codex CLI Plugin
 
-Give your AI a persistent memory -- mine projects and conversations into a searchable palace backed by ChromaDB, with 36 MCP tools, auto-save hooks, and guided skills.
+Give your AI a persistent memory -- mine projects and conversations into a searchable palace backed by ChromaDB, with 44 MCP tools, auto-save hooks, and guided skills.
 
 ## Prerequisites
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mempalace",
   "version": "3.8.0",
-  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 36 MCP tools, auto-save hooks, and guided setup.",
+  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 44 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"
   },
@@ -22,7 +22,7 @@
   "interface": {
     "displayName": "MemPalace",
     "shortDescription": "AI memory system for Codex",
-    "longDescription": "Give your AI a persistent memory — mine projects and conversations into a searchable palace backed by ChromaDB, with 36 MCP tools, auto-save hooks, and guided skills.",
+    "longDescription": "Give your AI a persistent memory — mine projects and conversations into a searchable palace backed by ChromaDB, with 44 MCP tools, auto-save hooks, and guided skills.",
     "developerName": "milla-jovovich",
     "category": "Coding",
     "capabilities": [

--- a/.cursor-plugin/README.md
+++ b/.cursor-plugin/README.md
@@ -1,6 +1,6 @@
 # MemPalace Cursor Plugin
 
-A Cursor IDE plugin that gives your agent a persistent memory system. Auto-registers the `mempalace-mcp` server (36 MCP tools), ships 5 slash commands, two model-invocable skills (setup/mining/search and a recall protocol), and an optional recall rule.
+A Cursor IDE plugin that gives your agent a persistent memory system. Auto-registers the `mempalace-mcp` server (44 MCP tools), ships 5 slash commands, two model-invocable skills (setup/mining/search and a recall protocol), and an optional recall rule.
 
 > Hooks (auto-save + session-start memory recall) are shipped separately under `hooks/cursor/` so the plugin is safe to install in any Cursor workspace without touching the agent loop. See [Hooks](#hooks-optional) below.
 

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "mempalace",
       "source": ".",
-      "description": "AI memory system — mine projects and conversations into a searchable palace. 36 MCP tools, slash commands, and a guided skill for Cursor.",
+      "description": "AI memory system — mine projects and conversations into a searchable palace. 44 MCP tools, slash commands, and a guided skill for Cursor.",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 36 MCP tools, slash commands, and a guided skill for Cursor.",
+  "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 44 MCP tools, slash commands, and a guided skill for Cursor.",
   "author": {
     "name": "milla-jovovich"
   },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,22 +13,39 @@ config pointing at a binary that was never installed — exactly what broke
 v3.3.2 ([#1093](https://github.com/MemPalace/mempalace/issues/1093)).
 
 ```bash
-grep -r mempalace-mcp pyproject.toml .claude-plugin .codex-plugin
+grep -r mempalace-mcp pyproject.toml .mcp.json .claude-plugin .codex-plugin
 ```
 
-Expected on a healthy `develop` (post-[#340](https://github.com/MemPalace/mempalace/pull/340)) — one line per file:
+Expected on a healthy `develop`:
 
 ```
-pyproject.toml:mempalace-mcp = "mempalace.mcp_server:main"
-.claude-plugin/plugin.json:      "command": "mempalace-mcp"
-.codex-plugin/plugin.json:      "command": "mempalace-mcp"
+.mcp.json:      "command": "mempalace-mcp"
+pyproject.toml:mempalace-mcp = "mempalace.mcp_proxy:main"
 .claude-plugin/.mcp.json:    "command": "mempalace-mcp"
+.claude-plugin/plugin.json:      "command": "mempalace-mcp"
+.codex-plugin/README.md:2. Install the Python package so the `mempalace-mcp` script lands on
 ```
 
-If `pyproject.toml` has no match, **stop** — the entry point is missing and
-any fresh `pip install` will ship a broken plugin config. Investigate whether
-the release branch was cut before
-[#340](https://github.com/MemPalace/mempalace/pull/340) landed on `develop`.
+Two things about that list are easy to misread, and both have cost a
+releaser time:
+
+- **`pyproject.toml` points at `mcp_proxy`, not `mcp_server`.** A proxied
+  stdio session loads only the forwarding path and pulls in the full server
+  lazily ([#2312](https://github.com/MemPalace/mempalace/pull/2312)). A
+  `mempalace.mcp_server:main` here means the branch predates that change.
+- **`.codex-plugin/plugin.json` is *supposed* to have no match.** It carries
+  `"mcpServers": "./.mcp.json"`, a path resolved against the marketplace
+  entry's `source.path` of `./` — the repo root — so the Codex command lives
+  in the root `.mcp.json` above, not under `.codex-plugin/`. This is what
+  [#2178](https://github.com/MemPalace/mempalace/pull/2178) changed to make
+  the marketplace plugin installable, and `tests/test_codex_plugin_manifest.py`
+  pins it. A missing `.codex-plugin/.mcp.json` is not a bug.
+
+If `pyproject.toml` has no match at all, **stop** — the entry point is
+missing and any fresh `pip install` will ship a plugin config pointing at a
+binary that was never installed. Investigate whether the release branch was
+cut before [#340](https://github.com/MemPalace/mempalace/pull/340) landed on
+`develop`.
 
 ## Publishing to PyPI
 


### PR DESCRIPTION
Two documentation drifts found while cutting v3.8.0.

## The entry-point check described an older tree

`docs/RELEASING.md` tells the releaser to run a grep and compare against an expected block. Both halves had gone stale, and following it during the 3.8.0 cut produced two false alarms:

- It expects `pyproject.toml:mempalace-mcp = "mempalace.mcp_server:main"`. Since #2312 the value is `mempalace.mcp_proxy:main` — a proxied stdio session loads only the forwarding path and pulls the full server in lazily.
- It expects a match in `.codex-plugin/plugin.json`. Since #2178 that file carries `"mcpServers": "./.mcp.json"` instead, a path resolved against the marketplace entry's `source.path` of `./`, so the Codex command lives in the **repo-root** `.mcp.json` — which the documented grep never covered.

The second one is the dangerous shape: the check as written makes a correctly-configured Codex plugin look broken, because the file it seems to point at (`.codex-plugin/.mcp.json`) is absent by design and the file that actually holds the command is outside the grep's paths. `tests/test_codex_plugin_manifest.py` already pins the real arrangement.

The grep now covers the root `.mcp.json`, the expected block is the real output, and the doc says outright that `.codex-plugin/plugin.json` having no match is correct.

## The plugin manifests advertised 36 tools

All three plugin directories — `.claude-plugin`, `.codex-plugin`, `.cursor-plugin` — described the package as "36 MCP tools" across nine README, `plugin.json`, and `marketplace.json` lines. The server registers 44, which `README.md` and `website/reference/mcp-tools.md` already state. The marketplace listings were understating the package to people deciding whether to install it.

Kept as a separate commit so it can be dropped independently of the RELEASING.md change.

## Test

- `tests/test_codex_plugin_manifest.py`, `tests/test_cursor_plugin_manifest.py`, `tests/test_antigravity_plugin_manifest.py`, `tests/test_readme_claims.py` — 110 passed.
- All five edited JSON manifests re-parse.
- No test pins the tool count in these descriptions; the manifest tests assert only that a description is present and substantive.

Docs and manifest strings only — no runtime code touched.