### PR TITLE
docs(shared-brain): teach the from-zero guide about logstream watch

### DIFF
--- a/website/guide/shared-brain.md
+++ b/website/guide/shared-brain.md
@@ -131,8 +131,22 @@ Memory (recall + writing):
 
 Coordination (logstream):
 - Check your inbox when starting work and before long tasks:
-  mempalace_event_list with to_agent=<AGENT_ID> (new since your last
-  seen event id).
+  mempalace_event_list with to_agent=<AGENT_ID>, since_event_id=<last
+  event id you processed>, preview=true. Remember that id — it is your
+  cursor. Never resume with since_created_at: events are ordered by
+  append order, so a peer's event can arrive already "older" than a
+  timestamp cursor and be skipped forever.
+- Monitoring: if your harness can run a background process, start
+  `mempalace logstream watch --agent <AGENT_ID> --state-file <path> --json`
+  and treat its exit as "you have mail" (exit 0 = match, 2 = idle). Use
+  --agent, not --to-agent: it also excludes your own events, which
+  otherwise wake you via the '*' broadcast match. Repeat --type to wake
+  only for what needs you. In-turn, waiting on one known correlation,
+  mempalace_event_wait is enough. Before a coordinated task, post a
+  status event to to_agent=* naming your filter and your cursor so others
+  know you are listening. If you are turn-based and cannot watch between
+  prompts, say so and publish your cursor — never claim a watch you do
+  not have.
 - To delegate: mempalace_event_append (type=task.request, stream=
   project/<name>, room=delegation, correlation_id=task_..., status=open,
   body = goal + branch + base commit + definition of done), then
@@ -238,6 +252,65 @@ timeout the CLI exits `2` instead of erroring, so agents loop on it, passing
 still replies — `task.reply` with `status=blocked` or `failed` and verbatim
 notes. Silence is the only unrecoverable failure.
 
+## 7. Keep agents wakeable
+
+Everything so far works with agents that *check* their inbox. The step most
+new fleets skip is making agents that get *woken* — because a delegation to
+an agent that only polls at session start sits unread until someone happens
+to open a terminal.
+
+`mempalace logstream watch` (3.8.0+) is the primitive for this. It blocks
+until an event matching its filters lands, then exits — so any harness that
+can background a process and react to its exit gets a wake-up call, whatever
+model it runs:
+
+```bash
+mempalace logstream watch \
+  --agent <AGENT_ID> \
+  --type task.request --type patch.ready \
+  --state-file ~/.mempalace/watch/<AGENT_ID>.json --json
+```
+
+Four things to get right, in the order people get them wrong:
+
+- **Use `--agent`, not `--to-agent`.** `--agent <id>` expands to
+  `--to-agent <id> --exclude-from-agent <id>`. The exclusion is load-bearing:
+  `to_agent=<you>` also matches `*` broadcasts, and your own broadcasts are
+  broadcasts — a watcher without it wakes itself on every status it posts.
+- **React to the exit code, not the output.** `0` means "you have mail" —
+  wake the agent and have it sweep its inbox. `2` means `--idle-exit-ms`
+  expired with nothing; `130` means interrupted. Only `0` starts work.
+- **Always pass `--state-file`.** That file carries the cursor, so a restart
+  resumes exactly where the last run stopped — it may replay one event, it
+  never silently misses one. A cursorless first run starts at the live tip
+  rather than replaying weeks of fleet history (`--from-start` if you really
+  want the replay).
+- **Repeat `--type` to mean "or".** Filter to the events that genuinely need
+  you (`task.request`, `patch.ready`) so routine status traffic doesn't burn
+  wake-ups.
+
+How the loop plugs into a harness:
+
+- **A CLI agent** (Claude Code, Codex) backgrounds the command and treats
+  process exit as the signal to check `mempalace_event_list` with its
+  cursor. Harnesses that re-invoke the agent when a background task
+  finishes get this for free.
+- **A daemon or dashboard** passes `--follow`, which stays alive past the
+  first match and emits one JSON event per line (NDJSON) with `--json`.
+- **A turn-based assistant** that stops existing between prompts cannot
+  watch — and should say so rather than stay silent: publish the cursor it
+  reached and state that it needs a ping. A false watcher is worse than a
+  declared-absent one, because a requester who believes someone is
+  listening stops looking for a human to nudge.
+
+Two etiquette rules close the loop. **Announce your watch**: before a
+coordinated task, post a `status` event to `to_agent=*` naming the filter you
+watch and the cursor you have reached, so others delegate to an agent they
+know is home. And **resume by event id, never by timestamp**: events append
+in arrival order, so a peer's event can sync in already "older" than a
+wall-clock high-water mark — `since_created_at` as a resume cursor drops it
+permanently, `since_event_id` never does.
+
 ## Fleet roles and cadence
 
 Not every agent should do every job. Lessons the fleet reported from its own
@@ -253,13 +326,16 @@ first delegations:
   logstream; they ask their assistant. Its most valuable fleet role is
   translation — turning `patch.ready` events into a plain-language summary,
   and turning conversational intent into well-formed coordination events.
-- **Match inbox cadence to agent shape.** A daemon-adjacent CLI agent can
-  long-poll continuously; an ad hoc assistant should check at session start
-  and before long tasks, and no more.
+- **Match inbox cadence to agent shape.** A CLI agent with a persistent
+  terminal should run `logstream watch` in the background and be woken
+  (see [Keep agents wakeable](#_7-keep-agents-wakeable)); an ad hoc
+  assistant should check at session start and before long tasks, and no
+  more.
 - **Watch your whole inbox, not just known tasks.** A watcher filtered on
-  one `correlation_id` misses unsolicited requests and broadcasts. Poll
-  `to_agent=<you>` (which also matches `*`) with `--since-event-id` as the
-  cursor.
+  one `correlation_id` misses unsolicited requests and broadcasts. Watch
+  (or poll) `to_agent=<you>` — which also matches `*` — with the event id
+  as the cursor; `watch --agent <you>` does exactly this while filtering
+  out your own broadcasts.
 - **Keep memory writes user-visible.** File a drawer when a durable decision
   is made — and say so ("saving this decision to the shared brain") rather
   than filing silently. Transparency is what makes a fleet the user cannot

--- a/website/guide/shared-brain.md
+++ b/website/guide/shared-brain.md
@@ -277,24 +277,32 @@ Four things to get right, in the order people get them wrong:
   `--to-agent <id> --exclude-from-agent <id>`. The exclusion is load-bearing:
   `to_agent=<you>` also matches `*` broadcasts, and your own broadcasts are
   broadcasts — a watcher without it wakes itself on every status it posts.
-- **React to the exit code, not the output.** `0` means "you have mail" —
-  wake the agent and have it sweep its inbox. `2` means `--idle-exit-ms`
-  expired with nothing; `130` means interrupted. Only `0` starts work.
-- **Always pass `--state-file`.** That file carries the cursor, so a restart
-  resumes exactly where the last run stopped — it may replay one event, it
-  never silently misses one. A cursorless first run starts at the live tip
-  rather than replaying weeks of fleet history (`--from-start` if you really
-  want the replay).
+- **The exit code is the wake signal; the output is the mail.** `0` means
+  a match was printed — hand the printed batch (with `--json`, ready-made
+  JSON) to the agent, or let the agent sweep from **its own** last-processed
+  event id. `2` means `--idle-exit-ms` expired with nothing; `130` means
+  interrupted. Only `0` starts work.
+- **Always pass `--state-file` — but it is the watcher's cursor, not the
+  agent's.** The file lets a restarted watcher resume exactly where it
+  stopped: it may replay one event, it never silently misses one. On a
+  match, though, it checkpoints *past* the printed batch before exiting —
+  and `since_event_id` is exclusive — so an agent that sweeps from the
+  watcher's state file skips the very event that woke it. The agent's inbox
+  cursor is the last event *it processed*, tracked separately. A cursorless
+  first run starts at the live tip rather than replaying weeks of fleet
+  history (`--from-start` if you really want the replay).
 - **Repeat `--type` to mean "or".** Filter to the events that genuinely need
   you (`task.request`, `patch.ready`) so routine status traffic doesn't burn
   wake-ups.
 
 How the loop plugs into a harness:
 
-- **A CLI agent** (Claude Code, Codex) backgrounds the command and treats
-  process exit as the signal to check `mempalace_event_list` with its
-  cursor. Harnesses that re-invoke the agent when a background task
-  finishes get this for free.
+- **A CLI agent** (Claude Code, Codex) backgrounds the command; on exit
+  `0` it feeds the watcher's printed events to the agent, or has the agent
+  sweep `mempalace_event_list` from the agent's own last-processed event
+  id — never from the watcher's state file, which has already advanced
+  past the match. Harnesses that re-invoke the agent when a background
+  task finishes get the wake-up for free.
 - **A daemon or dashboard** passes `--follow`, which stays alive past the
   first match and emits one JSON event per line (NDJSON) with `--json`.
 - **A turn-based assistant** that stops existing between prompts cannot

--- a/website/guide/shared-brain.md
+++ b/website/guide/shared-brain.md
@@ -267,7 +267,7 @@ model it runs:
 ```bash
 mempalace logstream watch \
   --agent <AGENT_ID> \
-  --type task.request --type patch.ready \
+  --type task.request --type task.reply --type patch.ready \
   --state-file ~/.mempalace/watch/<AGENT_ID>.json --json
 ```
 
@@ -284,16 +284,21 @@ Four things to get right, in the order people get them wrong:
   interrupted. Only `0` starts work.
 - **Always pass `--state-file` — but it is the watcher's cursor, not the
   agent's.** The file lets a restarted watcher resume exactly where it
-  stopped: it may replay one event, it never silently misses one. On a
+  stopped: it may replay the batch it printed but had not yet checkpointed
+  — up to `--limit` events, 50 by default — so dedupe by event id; it
+  never silently misses one. On a
   match, though, it checkpoints *past* the printed batch before exiting —
   and `since_event_id` is exclusive — so an agent that sweeps from the
   watcher's state file skips the very event that woke it. The agent's inbox
   cursor is the last event *it processed*, tracked separately. A cursorless
   first run starts at the live tip rather than replaying weeks of fleet
   history (`--from-start` if you really want the replay).
-- **Repeat `--type` to mean "or".** Filter to the events that genuinely need
-  you (`task.request`, `patch.ready`) so routine status traffic doesn't burn
-  wake-ups.
+- **Repeat `--type` to mean "or" — and wake for replies, not just work.**
+  Filter to the events that genuinely need you so routine status traffic
+  doesn't burn wake-ups, but if you ever delegate, include `task.reply`:
+  a worker reporting `blocked` or `failed` sends exactly that, and a
+  watcher that rejects it advances its durable cursor past it silently —
+  the delegation then sits unanswered until a manual sweep.
 
 How the loop plugs into a harness:
 
@@ -304,7 +309,10 @@ How the loop plugs into a harness:
   past the match. Harnesses that re-invoke the agent when a background
   task finishes get the wake-up for free.
 - **A daemon or dashboard** passes `--follow`, which stays alive past the
-  first match and emits one JSON event per line (NDJSON) with `--json`.
+  first match; with `--json` it emits NDJSON — one compact **batch
+  envelope** per line (`{"events": [...], "count": N, "cursor": ...}`),
+  not one event per line. A single poll can match several events, so
+  parse the `events` array.
 - **A turn-based assistant** that stops existing between prompts cannot
   watch — and should say so rather than stay silent: publish the cursor it
   reached and state that it needs a ping. A false watcher is worse than a


### PR DESCRIPTION
The shared-brain setup guide predates 3.8.0 in three places. They matter most for the audience the guide exists for — someone standing up the shared brain (or MemPalace itself) for the first time, who won't see the CLI reference or `coordination-protocol.md` unless this guide sends them there.

## 1. The embedded system-prompt snippet had drifted from canonical

The guide says `integrations/shared/coordination-protocol.md` "is the single source of truth and the version below tracks it" — but the tracked copy was the pre-3.8.0 version: no cursor rule, no monitoring bullet at all. An agent wired up from the guide would poll with no cursor discipline and never learn `watch` exists.

Re-synced **verbatim** (extracted programmatically from the canonical file's snippet block, not retyped).

## 2. New step 7 — "Keep agents wakeable"

The numbered setup flow (hub → agents → remote machines → names → protocol → first delegation) never sets up a watcher, so a fleet built from it has agents that check their inbox but are never woken. The new section covers, in the order people get them wrong:

- `--agent` vs `--to-agent` (the self-broadcast wake loop)
- the exit-code contract (`0` mail / `2` idle / `130` interrupted)
- `--state-file` cursor semantics (replay-at-most-one, never miss)
- repeatable `--type` filters
- per-harness wiring: CLI agent on exit, daemon via `--follow`/NDJSON, and the turn-based assistant that *cannot* watch and must declare that instead of claiming a watch it doesn't have
- announce-your-watch, and resume-by-event-id-never-timestamp

## 3. Two stale "Fleet roles and cadence" bullets

Both still taught the pre-watch polling worldview ("long-poll continuously", "Poll `to_agent=<you>`"). They now lead with the watcher and note `watch --agent` implements the whole-inbox pattern directly.

## Verification

- `bun run docs:build` passes; the built page contains `id="_7-keep-agents-wakeable"` and the synced snippet.
- Anchor slug convention (`_7-…` for numbered headings) verified against the deployed site's existing `_1-…`–`_6-…` ids.
- Content cross-checked against `website/reference/cli.md`, `website/concepts/agent-logstream.md`, and the 3.8.0 changelog — no new claims beyond what those already document.