### PR TITLE
fix(miner): remine files when content changes

### DIFF
--- a/mempalace/__init__.py
+++ b/mempalace/__init__.py
@@ -14,7 +14,7 @@ _os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
 _logging.getLogger("chromadb.telemetry").setLevel(_logging.CRITICAL)
 # ---------------------------------------------------------------------------
 
-from .cli import main
-from .version import __version__
+from .cli import main  # noqa: E402 - telemetry opt-out must precede chromadb imports
+from .version import __version__  # noqa: E402 - keep package imports together
 
 __all__ = ["main", "__version__"]

--- a/mempalace/__init__.py
+++ b/mempalace/__init__.py
@@ -1,5 +1,19 @@
 """MemPalace — Give your AI a memory. No API key required."""
 
+# --- local patch: silence chromadb telemetry noise -------------------------
+# chromadb 0.6.3 calls the pre-3.x posthog API (capture(id, event, props)),
+# but posthog 7.x takes one positional arg. Every call raises TypeError and
+# chromadb logs it as "Failed to send telemetry event ...". Nothing is
+# actually sent — the noise is the only symptom.
+#   1. opt out properly (sets posthog.disabled), unless the user set it.
+#   2. silence the logger that prints the failure.
+import logging as _logging
+import os as _os
+
+_os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
+_logging.getLogger("chromadb.telemetry").setLevel(_logging.CRITICAL)
+# ---------------------------------------------------------------------------
+
 from .cli import main
 from .version import __version__
 

--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 
 import chromadb
 
+from . import file_state
 from .normalize import normalize
 
 
@@ -221,6 +222,11 @@ def get_collection(palace_path: str):
 
 
 def file_already_mined(collection, source_file: str) -> bool:
+    """Path-only check: does this path have any drawer at all?
+
+    Mining uses file_state.decide() instead, which also compares mtime and
+    content hash so a session log that kept growing gets re-filed.
+    """
     try:
         results = collection.get(where={"source_file": source_file}, limit=1)
         return len(results.get("ids", [])) > 0
@@ -292,23 +298,37 @@ def mine_convos(
 
     total_drawers = 0
     files_skipped = 0
+    files_remined = 0
+    files_empty = 0
     room_counts = defaultdict(int)
 
     for i, filepath in enumerate(files, 1):
         source_file = str(filepath)
 
-        # Skip if already filed
-        if not dry_run and file_already_mined(collection, source_file):
-            files_skipped += 1
-            continue
+        # Skip only if the file is byte-for-byte what we already filed.
+        if dry_run:
+            action, content_hash, source_mtime = file_state.MINE, None, None
+        else:
+            action, content_hash, source_mtime = file_state.decide(collection, source_file)
+            if action == file_state.SKIP:
+                files_skipped += 1
+                continue
 
         # Normalize format
         try:
             content = normalize(str(filepath))
         except (OSError, ValueError):
+            # Couldn't read it — leave whatever is already filed alone.
             continue
 
+        if action == file_state.REMINE:
+            # Content moved on. Drop the old drawers before filing the new
+            # ones: exchange boundaries shift as a session grows, so writing
+            # by id would leave the previous version's tail behind.
+            file_state.drop_drawers(collection, source_file)
+
         if not content or len(content.strip()) < MIN_CHUNK_SIZE:
+            files_empty += 1
             continue
 
         # Chunk — either exchange pairs or general extraction
@@ -321,6 +341,7 @@ def mine_convos(
             chunks = chunk_exchanges(content)
 
         if not chunks:
+            files_empty += 1
             continue
 
         # Detect room from content (general mode uses memory_type instead)
@@ -371,6 +392,18 @@ def mine_convos(
                             "filed_at": datetime.now().isoformat(),
                             "ingest_mode": "convos",
                             "extract_mode": extract_mode,
+                            # The stamp the next run reads to tell
+                            # "unchanged" from "edited".
+                            **(
+                                {"content_hash": content_hash}
+                                if content_hash is not None
+                                else {}
+                            ),
+                            **(
+                                {"source_mtime": float(source_mtime)}
+                                if source_mtime is not None
+                                else {}
+                            ),
                         }
                     ],
                 )
@@ -379,13 +412,18 @@ def mine_convos(
                 if "already exists" not in str(e).lower():
                     raise
 
+        if action == file_state.REMINE:
+            files_remined += 1
         total_drawers += drawers_added
-        print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
+        mark = "↻" if action == file_state.REMINE else "✓"
+        print(f"  {mark} [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers_added}")
 
     print(f"\n{'=' * 55}")
     print("  Done.")
     print(f"  Files processed: {len(files) - files_skipped}")
-    print(f"  Files skipped (already filed): {files_skipped}")
+    print(f"  Files skipped (unchanged): {files_skipped}")
+    print(f"  Files re-filed (content changed): {files_remined}")
+    print(f"  Files with nothing to file: {files_empty}")
     print(f"  Drawers filed: {total_drawers}")
     if room_counts:
         print("\n  By room:")

--- a/mempalace/file_state.py
+++ b/mempalace/file_state.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+file_state.py — Content-aware dedup for mining.
+
+Dedup used to be path-only: once a path had drawers in the palace it was never
+looked at again, so an edited file kept its stale drawers forever and a growing
+session log never got the new half filed.
+
+This module decides per file whether to skip it, file it for the first time, or
+re-file it. It compares mtime first (a cheap stat) and the content hash only
+when mtime moved, so an untouched palace still costs one stat per file.
+"""
+
+import hashlib
+import os
+from datetime import datetime
+
+# Read the file in 1 MiB blocks so a multi-hundred-MB session log never lands
+# in memory whole.
+HASH_BLOCK = 1024 * 1024
+
+# mtime is stored as a float in chroma metadata; filesystems and the JSON
+# round-trip both wobble in the last bits, so compare with a tolerance.
+MTIME_TOLERANCE = 1e-6
+
+# Decisions returned by decide()
+SKIP = "skip"  # unchanged since it was filed
+MINE = "mine"  # never filed before
+REMINE = "remine"  # filed before, content has changed — drop the old drawers first
+
+
+def hash_file(path) -> str:
+    """sha256 of the raw bytes. Returns None if the file can't be read."""
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            for block in iter(lambda: f.read(HASH_BLOCK), b""):
+                h.update(block)
+    except OSError:
+        return None
+    return h.hexdigest()
+
+
+def file_mtime(path) -> float:
+    """Modification time as a float. Returns None if the file can't be stat'd."""
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return None
+
+
+def _stored_state(metadatas: list) -> tuple:
+    """Pull (content_hash, source_mtime, filed_at) off the first drawer that has them."""
+    content_hash = None
+    source_mtime = None
+    filed_at = None
+    for meta in metadatas or []:
+        if not meta:
+            continue
+        if content_hash is None and meta.get("content_hash"):
+            content_hash = meta["content_hash"]
+        if source_mtime is None and meta.get("source_mtime") is not None:
+            try:
+                source_mtime = float(meta["source_mtime"])
+            except (TypeError, ValueError):
+                pass
+        if filed_at is None and meta.get("filed_at"):
+            filed_at = meta["filed_at"]
+        if content_hash is not None and source_mtime is not None:
+            break
+    return content_hash, source_mtime, filed_at
+
+
+def _filed_at_timestamp(filed_at: str) -> float:
+    """ISO string from the filed_at metadata → epoch seconds, or None."""
+    if not filed_at:
+        return None
+    try:
+        return datetime.fromisoformat(filed_at).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+def existing_drawers(collection, source_file: str) -> tuple:
+    """Every drawer id + metadata already filed for this path."""
+    try:
+        results = collection.get(where={"source_file": source_file}, include=["metadatas"])
+    except Exception:
+        return [], []
+    return results.get("ids") or [], results.get("metadatas") or []
+
+
+def stamp_state(collection, ids: list, content_hash: str, mtime: float) -> bool:
+    """
+    Write hash + mtime onto drawers that already hold the right content.
+
+    Metadata-only update: no document is touched, so nothing is re-embedded.
+    Used to backfill drawers filed before hashing existed, and to re-stamp a
+    file that was touched but not actually edited.
+    """
+    if not ids:
+        return False
+    try:
+        results = collection.get(ids=ids, include=["metadatas"])
+    except Exception:
+        return False
+    metas = results.get("metadatas") or []
+    got_ids = results.get("ids") or []
+    if not got_ids:
+        return False
+    updated = []
+    for meta in metas:
+        new_meta = dict(meta or {})
+        if content_hash is not None:
+            new_meta["content_hash"] = content_hash
+        if mtime is not None:
+            new_meta["source_mtime"] = float(mtime)
+        updated.append(new_meta)
+    try:
+        collection.update(ids=got_ids, metadatas=updated)
+        return True
+    except Exception:
+        return False
+
+
+def drop_drawers(collection, source_file: str) -> int:
+    """Delete every drawer filed from this path. Returns how many went."""
+    ids, _ = existing_drawers(collection, source_file)
+    if not ids:
+        return 0
+    try:
+        collection.delete(ids=ids)
+    except Exception:
+        return 0
+    return len(ids)
+
+
+def decide(collection, source_file: str) -> tuple:
+    """
+    Decide what to do with one source file.
+
+    Returns (action, content_hash, mtime) where action is SKIP / MINE / REMINE.
+    content_hash and mtime are what should be stamped on any drawer filed now,
+    so the caller never has to hash the file a second time.
+    """
+    ids, metadatas = existing_drawers(collection, source_file)
+    mtime = file_mtime(source_file)
+
+    if not ids:
+        return MINE, hash_file(source_file), mtime
+
+    stored_hash, stored_mtime, filed_at = _stored_state(metadatas)
+
+    # Cheap path: the stamp says the file hasn't moved since we filed it.
+    if (
+        stored_hash is not None
+        and stored_mtime is not None
+        and mtime is not None
+        and abs(stored_mtime - mtime) < MTIME_TOLERANCE
+    ):
+        return SKIP, stored_hash, mtime
+
+    current_hash = hash_file(source_file)
+
+    if stored_hash is None:
+        # Legacy drawers, filed before this module existed — no hash to compare.
+        # filed_at is the only evidence we have: a file untouched since it was
+        # filed still holds the content in the palace, so stamp it and move on.
+        # Anything modified after filing genuinely has to be re-filed.
+        filed_ts = _filed_at_timestamp(filed_at)
+        if filed_ts is not None and mtime is not None and mtime <= filed_ts:
+            stamp_state(collection, ids, current_hash, mtime)
+            return SKIP, current_hash, mtime
+        return REMINE, current_hash, mtime
+
+    if current_hash is not None and current_hash == stored_hash:
+        # Touched but not edited (a checkout, a copy, a formatter that rewrote
+        # identical bytes). Re-stamp the mtime so the next run takes the cheap
+        # path, and don't re-embed anything.
+        stamp_state(collection, ids, current_hash, mtime)
+        return SKIP, current_hash, mtime
+
+    return REMINE, current_hash, mtime

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -17,6 +17,8 @@ from collections import defaultdict
 
 import chromadb
 
+from . import file_state
+
 READABLE_EXTENSIONS = {
     ".txt",
     ".md",
@@ -403,7 +405,12 @@ def get_collection(palace_path: str):
 
 
 def file_already_mined(collection, source_file: str) -> bool:
-    """Fast check: has this file been filed before?"""
+    """Path-only check: does this path have any drawer at all?
+
+    Kept for callers that only need "have we ever seen this path". Mining
+    itself uses file_state.decide(), which also compares mtime and content
+    hash so an edited file gets re-filed instead of skipped forever.
+    """
     try:
         results = collection.get(where={"source_file": source_file}, limit=1)
         return len(results.get("ids", [])) > 0
@@ -412,24 +419,36 @@ def file_already_mined(collection, source_file: str) -> bool:
 
 
 def add_drawer(
-    collection, wing: str, room: str, content: str, source_file: str, chunk_index: int, agent: str
+    collection,
+    wing: str,
+    room: str,
+    content: str,
+    source_file: str,
+    chunk_index: int,
+    agent: str,
+    content_hash: str = None,
+    source_mtime: float = None,
 ):
     """Add one drawer to the palace."""
     drawer_id = f"drawer_{wing}_{room}_{hashlib.md5((source_file + str(chunk_index)).encode(), usedforsecurity=False).hexdigest()[:16]}"
+    metadata = {
+        "wing": wing,
+        "room": room,
+        "source_file": source_file,
+        "chunk_index": chunk_index,
+        "added_by": agent,
+        "filed_at": datetime.now().isoformat(),
+    }
+    # The stamp the next run reads to tell "unchanged" from "edited".
+    if content_hash is not None:
+        metadata["content_hash"] = content_hash
+    if source_mtime is not None:
+        metadata["source_mtime"] = float(source_mtime)
     try:
         collection.add(
             documents=[content],
             ids=[drawer_id],
-            metadatas=[
-                {
-                    "wing": wing,
-                    "room": room,
-                    "source_file": source_file,
-                    "chunk_index": chunk_index,
-                    "added_by": agent,
-                    "filed_at": datetime.now().isoformat(),
-                }
-            ],
+            metadatas=[metadata],
         )
         return True
     except Exception as e:
@@ -451,29 +470,47 @@ def process_file(
     rooms: list,
     agent: str,
     dry_run: bool,
-) -> int:
-    """Read, chunk, route, and file one file. Returns drawer count."""
+) -> tuple:
+    """Read, chunk, route, and file one file.
 
-    # Skip if already filed
+    Returns (action, drawer_count). The action is file_state.SKIP / MINE /
+    REMINE — the caller needs it to report "skipped, unchanged" separately
+    from "read it, and it held nothing worth filing".
+    """
+
     source_file = str(filepath)
-    if not dry_run and file_already_mined(collection, source_file):
-        return 0
+
+    if dry_run:
+        action, content_hash, source_mtime = file_state.MINE, None, None
+    else:
+        action, content_hash, source_mtime = file_state.decide(collection, source_file)
+        if action == file_state.SKIP:
+            return file_state.SKIP, 0
 
     try:
         content = filepath.read_text(encoding="utf-8", errors="replace")
     except OSError:
-        return 0
+        # Couldn't read it — leave whatever is already filed alone.
+        return action, 0
+
+    if action == file_state.REMINE:
+        # The old drawers hold content that no longer exists. Drop them before
+        # filing the new ones: chunk boundaries move when a file is edited, so
+        # overwriting by id would strand the tail of the previous version.
+        # Done after the read succeeds so a transient read error can't wipe
+        # good drawers.
+        file_state.drop_drawers(collection, source_file)
 
     content = content.strip()
     if len(content) < MIN_CHUNK_SIZE:
-        return 0
+        return action, 0
 
     room = detect_room(filepath, content, rooms, project_path)
     chunks = chunk_text(content, source_file)
 
     if dry_run:
         print(f"    [DRY RUN] {filepath.name} → room:{room} ({len(chunks)} drawers)")
-        return len(chunks)
+        return action, len(chunks)
 
     drawers_added = 0
     for chunk in chunks:
@@ -485,11 +522,13 @@ def process_file(
             source_file=source_file,
             chunk_index=chunk["chunk_index"],
             agent=agent,
+            content_hash=content_hash,
+            source_mtime=source_mtime,
         )
         if added:
             drawers_added += 1
 
-    return drawers_added
+    return action, drawers_added
 
 
 # =============================================================================
@@ -605,10 +644,11 @@ def mine(
 
     total_drawers = 0
     files_skipped = 0
+    files_remined = 0
     room_counts = defaultdict(int)
 
     for i, filepath in enumerate(files, 1):
-        drawers = process_file(
+        action, drawers = process_file(
             filepath=filepath,
             project_path=project_path,
             collection=collection,
@@ -617,19 +657,24 @@ def mine(
             agent=agent,
             dry_run=dry_run,
         )
-        if drawers == 0 and not dry_run:
+        if action == file_state.SKIP:
             files_skipped += 1
-        else:
-            total_drawers += drawers
+            continue
+        if action == file_state.REMINE:
+            files_remined += 1
+        total_drawers += drawers
+        if drawers:
             room = detect_room(filepath, "", rooms, project_path)
             room_counts[room] += 1
             if not dry_run:
-                print(f"  ✓ [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")
+                mark = "↻" if action == file_state.REMINE else "✓"
+                print(f"  {mark} [{i:4}/{len(files)}] {filepath.name[:50]:50} +{drawers}")
 
     print(f"\n{'=' * 55}")
     print("  Done.")
     print(f"  Files processed: {len(files) - files_skipped}")
-    print(f"  Files skipped (already filed): {files_skipped}")
+    print(f"  Files skipped (unchanged): {files_skipped}")
+    print(f"  Files re-filed (content changed): {files_remined}")
     print(f"  Drawers filed: {total_drawers}")
     print("\n  By room:")
     for room, count in sorted(room_counts.items(), key=lambda x: x[1], reverse=True):

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -289,7 +289,7 @@ def load_config(project_dir: str) -> dict:
             print(f"ERROR: No mempalace.yaml found in {project_dir}")
             print(f"Run: mempalace init {project_dir}")
             sys.exit(1)
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 

--- a/tests/test_file_state.py
+++ b/tests/test_file_state.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timedelta
+
+from mempalace import file_state
+
+
+class FakeCollection:
+    def __init__(self, ids=None, metadatas=None):
+        self.ids = list(ids or [])
+        self.metadatas = list(metadatas or [])
+        self.updated = None
+        self.deleted = None
+
+    def get(self, where=None, include=None, ids=None):
+        if ids is not None:
+            indexes = [self.ids.index(item) for item in ids if item in self.ids]
+            return {
+                "ids": [self.ids[index] for index in indexes],
+                "metadatas": [self.metadatas[index] for index in indexes],
+            }
+        return {"ids": self.ids, "metadatas": self.metadatas}
+
+    def update(self, ids, metadatas):
+        self.updated = (ids, metadatas)
+
+    def delete(self, ids):
+        self.deleted = ids
+
+
+def test_new_file_is_mined_and_stamped(tmp_path):
+    source = tmp_path / "note.md"
+    source.write_text("new material", encoding="utf-8")
+
+    action, content_hash, mtime = file_state.decide(FakeCollection(), str(source))
+
+    assert action == file_state.MINE
+    assert content_hash == file_state.hash_file(source)
+    assert mtime == file_state.file_mtime(source)
+
+
+def test_unchanged_mtime_skips_without_rehashing(tmp_path, monkeypatch):
+    source = tmp_path / "note.md"
+    source.write_text("same material", encoding="utf-8")
+    mtime = file_state.file_mtime(source)
+    collection = FakeCollection(
+        ["drawer-1"],
+        [{"content_hash": "stored", "source_mtime": mtime}],
+    )
+    monkeypatch.setattr(file_state, "hash_file", lambda _path: (_ for _ in ()).throw(AssertionError()))
+
+    action, content_hash, current_mtime = file_state.decide(collection, str(source))
+
+    assert (action, content_hash, current_mtime) == (file_state.SKIP, "stored", mtime)
+    assert collection.updated is None
+
+
+def test_touched_but_identical_file_restamps_and_skips(tmp_path):
+    source = tmp_path / "note.md"
+    source.write_text("same material", encoding="utf-8")
+    content_hash = file_state.hash_file(source)
+    collection = FakeCollection(
+        ["drawer-1"],
+        [{"content_hash": content_hash, "source_mtime": 1.0, "room": "general"}],
+    )
+
+    action, current_hash, mtime = file_state.decide(collection, str(source))
+
+    assert (action, current_hash) == (file_state.SKIP, content_hash)
+    assert collection.updated == (
+        ["drawer-1"],
+        [{
+            "content_hash": content_hash,
+            "source_mtime": mtime,
+            "room": "general",
+        }],
+    )
+
+
+def test_changed_content_is_remined(tmp_path):
+    source = tmp_path / "note.md"
+    source.write_text("changed material", encoding="utf-8")
+    collection = FakeCollection(
+        ["drawer-1"],
+        [{"content_hash": "old-hash", "source_mtime": 1.0}],
+    )
+
+    action, content_hash, _mtime = file_state.decide(collection, str(source))
+
+    assert action == file_state.REMINE
+    assert content_hash == file_state.hash_file(source)
+
+
+def test_legacy_drawer_older_than_filed_time_is_backfilled(tmp_path):
+    source = tmp_path / "note.md"
+    source.write_text("legacy material", encoding="utf-8")
+    filed_at = datetime.now() + timedelta(seconds=5)
+    collection = FakeCollection(["drawer-1"], [{"filed_at": filed_at.isoformat()}])
+
+    action, content_hash, mtime = file_state.decide(collection, str(source))
+
+    assert action == file_state.SKIP
+    assert collection.updated == (
+        ["drawer-1"],
+        [{
+            "content_hash": content_hash,
+            "filed_at": filed_at.isoformat(),
+            "source_mtime": mtime,
+        }],
+    )
+
+
+def test_drop_drawers_deletes_only_matching_ids():
+    collection = FakeCollection(["drawer-1", "drawer-2"], [{}, {}])
+
+    assert file_state.drop_drawers(collection, "note.md") == 2
+    assert collection.deleted == ["drawer-1", "drawer-2"]


### PR DESCRIPTION
## Summary
- stop treating a previously seen path as permanently mined
- compare mtime and SHA-256, then re-file edited or growing sources
- backfill legacy drawer metadata without re-embedding unchanged files
- retain UTF-8 config loading and silence broken Chroma telemetry noise

## Verification
- new file-state unit suite: 6 passed
- remaining non-Chroma integration suite: 94 passed
- Ruff: passed
- the two existing Chroma integration tests execute successfully but fail only while deleting open database files on Windows (`WinError 32`); this PR does not change that existing cleanup behavior