### PR TITLE
feat(cli): `mempalace rules` — render the canonical shared-brain rules block

### DIFF
--- a/integrations/shared/coordination-protocol.md
+++ b/integrations/shared/coordination-protocol.md
@@ -157,6 +157,38 @@ Notes that save round trips:
 - `to_agent=<you>` also matches `*` broadcasts automatically. You do not need
   a second call for them.
 
+### Arm it proactively, and re-arm after every wake
+
+Two lessons from running this fleet, both instruction-shaped rather than
+protocol-shaped:
+
+- **Arm at session start, unprompted.** An agent whose rules say "if your
+  harness can run a background process, start a watcher" reads that as
+  optional and never starts one — it happily uses the logstream in-turn and
+  stays deaf between turns. Rules meant to fire unprompted must be imperative
+  startup steps ("at the start of every session, launch…"), name a concrete
+  state-file path, and not hinge on a capability clause the agent can
+  satisfy by doing nothing.
+- **Re-arm is part of processing a wake.** The loop is: watcher exits 0 →
+  sweep your inbox from *your* cursor (the watcher's state file is not your
+  inbox cursor, and one wake can cover a batch) → act and ack → relaunch the
+  watcher with the same state file. The state-file cursor persists across
+  relaunches, so events arriving in the re-arm gap are caught, not lost.
+
+### Harness permission prompts stall the loop silently
+
+If the harness gates shell commands or MCP writes behind human approval
+prompts, every ack, reply, and patch submission can block on a prompt nobody
+is looking at. The observable symptom from the other side is an agent that
+claimed a task and went quiet — indistinguishable from a crash until someone
+walks over to the screen. A four-second round trip becomes minutes or hours.
+
+For unattended coordination, have the operator allowlist the mempalace MCP
+tools (at minimum the event append/ack tools and `mempalace_patch_submit`)
+and the `mempalace logstream watch` command in the harness's permission
+settings. Until that is done, treat yourself as semi-attended: expect your
+writes to wait on a human, and say so when you announce your watch.
+
 ### Announce your watch
 
 Before a coordinated task, post a `status` event to `to_agent=*` declaring
@@ -236,7 +268,16 @@ a declared-absent one: the requester stops looking for a human to nudge.
 ## System-Prompt Snippet
 
 Copy this block into an agent's system prompt / custom instructions.
-Replace `<AGENT_ID>` with the agent's stable identity.
+Replace `<AGENT_ID>` with the agent's stable identity — or let the CLI
+render it, marker-wrapped for later in-place re-rendering:
+
+```bash
+mempalace rules --agent mac-claude
+```
+
+The CLI reads a packaged copy of this snippet
+(`mempalace/instructions/shared_brain_rules.md`) that is test-pinned to
+this file, so the two cannot drift.
 
 ```text
 ## MemPalace shared brain
@@ -261,18 +302,32 @@ Coordination (logstream):
   cursor. Never resume with since_created_at: events are ordered by
   append order, so a peer's event can arrive already "older" than a
   timestamp cursor and be skipped forever.
-- Monitoring: if your harness can run a background process, start
-  `mempalace logstream watch --agent <AGENT_ID> --state-file <path> --json`
-  and treat its exit as "you have mail" (exit 0 = match, 2 = idle). Use
-  --agent, not --to-agent: it also excludes your own events, which
-  otherwise wake you via the '*' broadcast match. Repeat --type to wake
-  only for what needs you; if you delegate, include task.reply — blocked
-  and failed arrive as replies. In-turn, waiting on one known correlation,
-  mempalace_event_wait is enough. Before a coordinated task, post a
+- Monitoring: at the start of every session, right after the inbox
+  check, launch a background watcher — do not wait to be asked, and do
+  not wait for a coordinated task to begin:
+  `mempalace logstream watch --agent <AGENT_ID> --state-file
+  ~/.mempalace/watch/<AGENT_ID>.json --json`, run as a background
+  process. Treat its exit as "you have mail" (exit 0 = match, 2 = idle):
+  process your inbox from YOUR cursor — the watcher's state file is not
+  your inbox cursor, and one wake can cover several events — then
+  relaunch the watcher with the same state file. Keep this loop alive
+  all session. Use --agent, not --to-agent: it also excludes your own
+  events, which otherwise wake you via the '*' broadcast match. Repeat
+  --type to wake only for what needs you; if you delegate, include
+  task.reply — blocked and failed arrive as replies. In-turn, waiting on
+  one known correlation, mempalace_event_wait is enough — it complements
+  the watcher, never replaces it. Before a coordinated task, post a
   status event to to_agent=* naming your filter and your cursor so others
-  know you are listening. If you are turn-based and cannot watch between
-  prompts, say so and publish your cursor — never claim a watch you do
-  not have.
+  know you are listening. Only if your harness truly cannot run
+  background processes are you turn-based: say so and publish your
+  cursor — never claim a watch you do not have.
+- Acks: acknowledge with mempalace_event_ack (CLI: `mempalace logstream
+  ack`) — it fills type=event.ack and the ack_of link for you; don't
+  hand-roll event.ack appends.
+- If your harness gates shell commands or MCP writes behind approval
+  prompts, ask the operator to allowlist the mempalace tools and the
+  watch command: an unnoticed prompt stalls the loop silently, and to
+  your peers it looks like "claimed but gone quiet".
 - To delegate: mempalace_event_append (type=task.request, stream=
   project/<name>, room=delegation, correlation_id=task_..., status=open,
   body = goal + branch + base commit + definition of done), then

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -2331,6 +2331,13 @@ def cmd_instructions(args):
     run_instructions(name=args.name)
 
 
+def cmd_rules(args):
+    """Output the shared-brain agent rules block for a given agent identity."""
+    from .instructions_cli import run_rules
+
+    run_rules(agent_id=args.agent)
+
+
 def cmd_mcp(args):
     """Show how to wire MemPalace into MCP-capable hosts."""
     base_server_cmd = "mempalace-mcp"
@@ -3034,6 +3041,20 @@ def main():
     for instr_name in ["init", "search", "mine", "help", "status"]:
         instructions_sub.add_parser(instr_name, help=f"Output {instr_name} instructions")
 
+    # rules
+    p_rules = sub.add_parser(
+        "rules",
+        help=(
+            "Output the canonical shared-brain agent rules block for a system "
+            "prompt (CLAUDE.md, GEMINI.md, AGENTS.md, ...)"
+        ),
+    )
+    p_rules.add_argument(
+        "--agent",
+        required=True,
+        help="Stable agent identity to render into the rules, e.g. mac-claude",
+    )
+
     # repair
     p_repair = sub.add_parser(
         "repair",
@@ -3504,6 +3525,7 @@ def main():
 
     dispatch = {
         "init": cmd_init,
+        "rules": cmd_rules,
         "mine": cmd_mine,
         "split": cmd_split,
         "search": cmd_search,

--- a/mempalace/instructions/shared_brain_rules.md
+++ b/mempalace/instructions/shared_brain_rules.md
@@ -1,0 +1,60 @@
+## MemPalace shared brain
+
+You share a MemPalace hub with other agents. Your agent identity is
+<AGENT_ID> — use it as from_agent/created_by in every MemPalace call.
+
+Memory (recall + writing):
+- Before answering about past work, decisions, people, or projects,
+  search the palace (mempalace_search; mempalace_kg_query for
+  relational/temporal facts). Quote results verbatim — never paraphrase
+  stored content. If the palace has nothing, say so; don't guess.
+- File durable outcomes (decisions, conclusions, learned facts) with
+  mempalace_add_drawer. When a fact changes: mempalace_kg_invalidate the
+  old fact, then mempalace_kg_add the new one. Don't file secrets or
+  tokens.
+
+Coordination (logstream):
+- Check your inbox when starting work and before long tasks:
+  mempalace_event_list with to_agent=<AGENT_ID>, since_event_id=<last
+  event id you processed>, preview=true. Remember that id — it is your
+  cursor. Never resume with since_created_at: events are ordered by
+  append order, so a peer's event can arrive already "older" than a
+  timestamp cursor and be skipped forever.
+- Monitoring: at the start of every session, right after the inbox
+  check, launch a background watcher — do not wait to be asked, and do
+  not wait for a coordinated task to begin:
+  `mempalace logstream watch --agent <AGENT_ID> --state-file
+  ~/.mempalace/watch/<AGENT_ID>.json --json`, run as a background
+  process. Treat its exit as "you have mail" (exit 0 = match, 2 = idle):
+  process your inbox from YOUR cursor — the watcher's state file is not
+  your inbox cursor, and one wake can cover several events — then
+  relaunch the watcher with the same state file. Keep this loop alive
+  all session. Use --agent, not --to-agent: it also excludes your own
+  events, which otherwise wake you via the '*' broadcast match. Repeat
+  --type to wake only for what needs you; if you delegate, include
+  task.reply — blocked and failed arrive as replies. In-turn, waiting on
+  one known correlation, mempalace_event_wait is enough — it complements
+  the watcher, never replaces it. Before a coordinated task, post a
+  status event to to_agent=* naming your filter and your cursor so others
+  know you are listening. Only if your harness truly cannot run
+  background processes are you turn-based: say so and publish your
+  cursor — never claim a watch you do not have.
+- Acks: acknowledge with mempalace_event_ack (CLI: `mempalace logstream
+  ack`) — it fills type=event.ack and the ack_of link for you; don't
+  hand-roll event.ack appends.
+- If your harness gates shell commands or MCP writes behind approval
+  prompts, ask the operator to allowlist the mempalace tools and the
+  watch command: an unnoticed prompt stalls the loop silently, and to
+  your peers it looks like "claimed but gone quiet".
+- To delegate: mempalace_event_append (type=task.request, stream=
+  project/<name>, room=delegation, correlation_id=task_..., status=open,
+  body = goal + branch + base commit + definition of done), then
+  mempalace_event_wait on that correlation_id for the reply.
+- When you accept a task: ack it with status=claimed. Deliver code as a
+  patch via mempalace_patch_submit (never just push a branch and go
+  silent). If blocked, reply with status=blocked and verbatim notes.
+- When you receive a patch: mempalace_artifact_get, verify sha256,
+  apply only with explicit user-visible intent, run the stated tests,
+  then mempalace_event_ack with status=applied or failed.
+- Events are append-only and verbatim. Close every loop — no task you
+  touched stays open without an applied/failed/blocked ack.

--- a/mempalace/instructions_cli.py
+++ b/mempalace/instructions_cli.py
@@ -5,6 +5,7 @@ Each instruction lives as a .md file in the instructions/ directory
 inside the package. The CLI reads and prints the file content.
 """
 
+import re
 import sys
 from pathlib import Path
 
@@ -26,3 +27,52 @@ def run_instructions(name: str):
         sys.exit(1)
 
     print(md_path.read_text(encoding="utf-8"))
+
+
+SHARED_BRAIN_RULES_FILE = INSTRUCTIONS_DIR / "shared_brain_rules.md"
+
+_RULES_MARKER_START = (
+    "<!-- mempalace-shared-brain:start (canonical source: mempalace repo "
+    "integrations/shared/coordination-protocol.md — edit there, re-render "
+    "with `mempalace rules --agent {agent_id}`) -->"
+)
+_RULES_MARKER_END = "<!-- mempalace-shared-brain:end -->"
+
+
+def render_shared_brain_rules(agent_id: str) -> str:
+    """Render the canonical shared-brain rules block for one agent identity.
+
+    The template ships inside the package and is test-pinned to the
+    System-Prompt Snippet in integrations/shared/coordination-protocol.md,
+    so every harness pastes the same battle-tested block and a protocol
+    lesson lands in one file instead of N system prompts. The output is
+    wrapped in HTML-comment markers so a later re-render can replace the
+    block in place.
+    """
+    agent_id = agent_id.strip()
+    # The id lands inside an HTML comment marker and in every from_agent
+    # field, so it must be a plain token — no whitespace, no markup.
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", agent_id):
+        raise ValueError("--agent must be a single token like mac-claude (machine-harness)")
+    body = SHARED_BRAIN_RULES_FILE.read_text(encoding="utf-8").replace("<AGENT_ID>", agent_id)
+    return "\n".join(
+        [
+            _RULES_MARKER_START.format(agent_id=agent_id),
+            "",
+            body.rstrip("\n"),
+            "",
+            _RULES_MARKER_END,
+        ]
+    )
+
+
+def run_rules(agent_id: str):
+    """Print the rendered shared-brain rules block for the CLI."""
+    try:
+        print(render_shared_brain_rules(agent_id))
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+    except OSError as exc:
+        print(f"Rules template not readable: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -4362,6 +4362,31 @@ def tool_memories_filed_away():
 # ==================== SETTINGS TOOLS ====================
 
 
+def _attach_stale_library_warning(result: dict) -> dict:
+    """Stamp the stale-library write-guard state onto a reconnect result.
+
+    Reconnect reopens the database but cannot reload Python modules, so it
+    never clears the stale-library gate (#899). Without this, a reconnect
+    after an upgrade answers "success: Reconnected to palace" while every
+    write keeps failing — the caller has no way to tell the two states
+    apart from the reconnect result alone.
+    """
+    payload = _stale_library_payload()
+    if payload.get("stale") and "gate_disabled_by" not in payload:
+        described = ", ".join(
+            f"{entry['package']} {entry['serving']} -> {entry['installed']}"
+            for entry in payload.get("packages", [])
+        )
+        result["library_versions"] = payload
+        result["restart_required"] = True
+        result["warning"] = (
+            f"Reconnected, but this server is still running superseded code ({described}); "
+            "writes stay refused until the MCP server (or the host application that "
+            "spawned it) is restarted — reconnect cannot reload Python modules."
+        )
+    return result
+
+
 def tool_reconnect():
     """Force the MCP server to drop cached ChromaDB + KnowledgeGraph state.
 
@@ -4499,21 +4524,25 @@ def tool_reconnect():
                 result["error"] = "; ".join(close_errors)
             return result
         if close_errors:
-            return {
-                "success": False,
-                "message": "Reconnect reopened the palace but failed to fully reset cached handles",
+            return _attach_stale_library_warning(
+                {
+                    "success": False,
+                    "message": "Reconnect reopened the palace but failed to fully reset cached handles",
+                    "drawers": col.count(),
+                    "vector_disabled": _vector_disabled,
+                    "vector_disabled_reason": _vector_disabled_reason,
+                    "error": "; ".join(close_errors),
+                }
+            )
+        return _attach_stale_library_warning(
+            {
+                "success": True,
+                "message": "Reconnected to palace",
                 "drawers": col.count(),
                 "vector_disabled": _vector_disabled,
                 "vector_disabled_reason": _vector_disabled_reason,
-                "error": "; ".join(close_errors),
             }
-        return {
-            "success": True,
-            "message": "Reconnected to palace",
-            "drawers": col.count(),
-            "vector_disabled": _vector_disabled,
-            "vector_disabled_reason": _vector_disabled_reason,
-        }
+        )
     except Exception as e:
         return {"success": False, "error": str(e)}
 
@@ -6346,9 +6375,15 @@ def _mcp_stale_library_refusal(req_id, tool_name: str):
         "id": req_id,
         "error": {
             "code": _STALE_LIBRARY_ERROR_CODE,
+            # The remedy rides in the message itself, not only in data.hint:
+            # several MCP clients surface only the top-level message of an
+            # error, so a hint-only remedy never reaches the model that has
+            # to act on it.
             "message": (
                 "Server is running a library version that is no longer installed "
-                f"({described}); refusing writes until it is restarted"
+                f"({described}); refusing writes until it is restarted. Restart the "
+                "MCP server (or the host application that spawned it) to pick up the "
+                "installed version — mempalace_reconnect cannot clear this"
             ),
             "data": {
                 "tool": tool_name,

--- a/tests/test_cli_rules.py
+++ b/tests/test_cli_rules.py
@@ -1,0 +1,103 @@
+"""Tests for `mempalace rules` — the canonical shared-brain rules renderer."""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mempalace.instructions_cli import (
+    SHARED_BRAIN_RULES_FILE,
+    render_shared_brain_rules,
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+PROTOCOL_DOC = REPO_ROOT / "integrations" / "shared" / "coordination-protocol.md"
+
+
+def _snippet_from_protocol_doc() -> str:
+    """The ```text fence under '## System-Prompt Snippet' in the canonical doc."""
+    text = PROTOCOL_DOC.read_text(encoding="utf-8")
+    match = re.search(
+        r"^## System-Prompt Snippet$.*?^```text$\n(.*?)^```$",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match, "coordination-protocol.md lost its System-Prompt Snippet fence"
+    return match.group(1)
+
+
+class TestSharedBrainRulesTemplate:
+    def test_packaged_template_matches_canonical_doc(self):
+        """The doc says it is the single source of truth; the packaged copy the
+        CLI renders must be byte-identical, or the two drift per-agent — the
+        exact failure the template exists to prevent."""
+        assert SHARED_BRAIN_RULES_FILE.read_text(encoding="utf-8") == _snippet_from_protocol_doc()
+
+    def test_website_guide_copy_matches_canonical_doc(self):
+        """website/guide/shared-brain.md embeds the snippet for readers; it
+        drifts silently without a pin (there is no runtime path through it)."""
+        guide = REPO_ROOT / "website" / "guide" / "shared-brain.md"
+        match = re.search(
+            r"^## 5\. Wire the protocol into each agent$.*?^```text$\n(.*?)^```$",
+            guide.read_text(encoding="utf-8"),
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        assert match, "shared-brain.md lost its snippet fence"
+        assert match.group(1) == SHARED_BRAIN_RULES_FILE.read_text(encoding="utf-8")
+
+    def test_template_keeps_the_placeholder(self):
+        content = SHARED_BRAIN_RULES_FILE.read_text(encoding="utf-8")
+        assert "<AGENT_ID>" in content
+
+    def test_watcher_instruction_is_imperative_not_conditional(self):
+        """A capability-conditional watcher rule ('if your harness can...')
+        reads as optional and agents skip it; the template must open the
+        monitoring rule as a startup imperative."""
+        content = SHARED_BRAIN_RULES_FILE.read_text(encoding="utf-8")
+        assert "at the start of every session" in content.lower()
+        assert "if your harness can run a background process, start" not in content.lower()
+
+
+class TestRenderSharedBrainRules:
+    def test_substitutes_agent_id_everywhere(self):
+        rendered = render_shared_brain_rules("mac-claude")
+        assert "<AGENT_ID>" not in rendered
+        assert "mac-claude" in rendered
+
+    def test_wrapped_in_sync_markers(self):
+        rendered = render_shared_brain_rules("aero-opencode")
+        lines = rendered.splitlines()
+        assert lines[0].startswith("<!-- mempalace-shared-brain:start")
+        assert lines[-1] == "<!-- mempalace-shared-brain:end -->"
+        assert "canonical source" in lines[0]
+
+    @pytest.mark.parametrize("bad", ["", "   ", "two words", "tab\tid", "x-->", "a{b}"])
+    def test_rejects_non_token_identities(self, bad):
+        """Whitespace aside, the id lands inside an HTML comment marker, so
+        markup-breaking characters must be refused too."""
+        with pytest.raises(ValueError):
+            render_shared_brain_rules(bad)
+
+
+class TestRulesCli:
+    def test_cli_renders_rules(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "mempalace.cli", "rules", "--agent", "windows-codex"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "windows-codex" in result.stdout
+        assert "<AGENT_ID>" not in result.stdout
+        assert "mempalace-shared-brain:start" in result.stdout
+
+    def test_cli_rejects_bad_agent(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "mempalace.cli", "rules", "--agent", "two words"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "single token" in result.stderr

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6574,6 +6574,66 @@ class TestStaleLibraryGate:
         assert "mempalace_reconnect" in hint, "the hint must rule out the wrong remedy by name"
         assert "MEMPALACE_MCP_ALLOW_STALE_LIBRARY" in hint
 
+    def test_refusal_message_names_the_remedy(self, monkeypatch):
+        """Several MCP clients surface only the top-level message and drop
+        `data`, so the message alone must be enough to act on."""
+        from mempalace import mcp_server
+
+        self._reset(monkeypatch)
+        self._versions(monkeypatch, {"mempalace": "3.6.0"}, {"mempalace": "3.7.0"})
+
+        refusal = mcp_server._mcp_stale_library_refusal(1, "mempalace_add_drawer")
+
+        message = refusal["error"]["message"].lower()
+        assert "restart" in message
+        assert "mempalace_reconnect cannot clear this" in refusal["error"]["message"]
+
+    def test_reconnect_result_warns_when_stale(self, monkeypatch):
+        """A reconnect after an upgrade must not answer plain success while
+        every write keeps failing — reconnect cannot reload Python modules."""
+        from mempalace import mcp_server
+
+        self._reset(monkeypatch)
+        self._versions(monkeypatch, {"mempalace": "3.6.0"}, {"mempalace": "3.7.0"})
+
+        result = mcp_server._attach_stale_library_warning(
+            {"success": True, "message": "Reconnected to palace"}
+        )
+
+        assert result["restart_required"] is True
+        assert "restart" in result["warning"].lower()
+        assert "writes stay refused" in result["warning"]
+        assert result["library_versions"]["packages"] == [
+            {"package": "mempalace", "serving": "3.6.0", "installed": "3.7.0"}
+        ]
+
+    def test_reconnect_result_clean_when_versions_match(self, monkeypatch):
+        from mempalace import mcp_server
+
+        self._reset(monkeypatch)
+        self._versions(monkeypatch, {"mempalace": "3.6.0"}, {"mempalace": "3.6.0"})
+
+        result = mcp_server._attach_stale_library_warning(
+            {"success": True, "message": "Reconnected to palace"}
+        )
+
+        assert set(result) == {"success", "message"}
+
+    def test_reconnect_warning_suppressed_by_escape_hatch(self, monkeypatch):
+        """With the gate disabled writes actually work, so warning that they
+        are refused would be false."""
+        from mempalace import mcp_server
+
+        self._reset(monkeypatch)
+        self._versions(monkeypatch, {"mempalace": "3.6.0"}, {"mempalace": "3.7.0"})
+        monkeypatch.setenv("MEMPALACE_MCP_ALLOW_STALE_LIBRARY", "1")
+
+        result = mcp_server._attach_stale_library_warning(
+            {"success": True, "message": "Reconnected to palace"}
+        )
+
+        assert set(result) == {"success", "message"}
+
     def test_status_payload_carries_its_documented_fields(self, monkeypatch):
         """website/reference/mcp-tools.md promises these keys."""
         from mempalace import mcp_server

--- a/website/guide/antigravity.md
+++ b/website/guide/antigravity.md
@@ -269,6 +269,48 @@ For a manual re-test:
 rm -rf ~/.mempalace/hook_state/antigravity_woke_*
 ```
 
+## Joining the shared brain (multi-agent)
+
+If other agents on this machine (Claude Code, Codex, …) share one palace,
+the Antigravity agent can join the fleet as a first-class peer: same
+memory, same logstream, its own identity. Two pieces make it work.
+
+### 1. Global rules (`~/.gemini/config/GEMINI.md`)
+
+Antigravity discovers `GEMINI.md` rules in its global config directory and
+applies them to every workspace. Render the canonical shared-brain rules
+block with a stable identity for this agent and drop it there:
+
+```bash
+mempalace rules --agent mac-antigravity > ~/.gemini/config/GEMINI.md
+mkdir -p ~/.mempalace/watch
+```
+
+If the file already has other content, paste the rendered block into it
+instead of overwriting. The block comes from
+`integrations/shared/coordination-protocol.md` — the single source of
+truth for the protocol — so re-run the command after an upgrade to pick up
+protocol fixes rather than editing the copy by hand.
+
+Pick an identity distinct from your other agents (`mac-antigravity` next
+to `mac-claude`, …). Identities share nothing: inbox filters, cursors,
+and watcher state files are all keyed by it, and two agents sharing one
+name will silently eat each other's mail.
+
+### 2. Allowlist the tools, or the loop stalls
+
+Antigravity gates terminal commands and MCP writes behind approval prompts
+by default. An unnoticed prompt silently stalls an ack, reply, or patch
+submission — to the requesting agent this looks like "claimed but gone
+quiet", indistinguishable from a crash. For unattended coordination,
+allowlist the mempalace MCP tools and the `mempalace logstream watch`
+command in Antigravity's permission settings.
+
+With both pieces in place the agent arms a background watcher at session
+start, wakes on inbox events, acks with `mempalace_event_ack`, and
+re-arms on its own. Measured on an otherwise idle machine, the round trip
+from event append to ack is about five seconds.
+
 ## See also
 
 - [`hooks/antigravity/INVESTIGATION.md`](https://github.com/MemPalace/mempalace/blob/main/hooks/antigravity/INVESTIGATION.md)

--- a/website/guide/shared-brain.md
+++ b/website/guide/shared-brain.md
@@ -110,7 +110,17 @@ Agents don't discover the etiquette on their own; you teach it once, in
 their instruction files. The canonical copy lives in
 [`integrations/shared/coordination-protocol.md`](https://github.com/MemPalace/mempalace/blob/develop/integrations/shared/coordination-protocol.md)
 — that file is the single source of truth and the version below tracks it.
-Copy the snippet verbatim (so the rules never drift per-agent), replacing
+The easiest way to get a correct copy is to let the CLI render it with the
+agent's identity filled in:
+
+```bash
+mempalace rules --agent mac-claude >> ~/.claude/CLAUDE.md
+```
+
+The output is wrapped in `<!-- mempalace-shared-brain:start/end -->`
+markers, so after a protocol update you re-render and replace the block
+instead of hand-editing N system prompts. If you'd rather paste by hand,
+copy the snippet verbatim (so the rules never drift per-agent), replacing
 `<AGENT_ID>` with the agent's identity:
 
 ```text
@@ -136,18 +146,32 @@ Coordination (logstream):
   cursor. Never resume with since_created_at: events are ordered by
   append order, so a peer's event can arrive already "older" than a
   timestamp cursor and be skipped forever.
-- Monitoring: if your harness can run a background process, start
-  `mempalace logstream watch --agent <AGENT_ID> --state-file <path> --json`
-  and treat its exit as "you have mail" (exit 0 = match, 2 = idle). Use
-  --agent, not --to-agent: it also excludes your own events, which
-  otherwise wake you via the '*' broadcast match. Repeat --type to wake
-  only for what needs you; if you delegate, include task.reply — blocked
-  and failed arrive as replies. In-turn, waiting on one known correlation,
-  mempalace_event_wait is enough. Before a coordinated task, post a
+- Monitoring: at the start of every session, right after the inbox
+  check, launch a background watcher — do not wait to be asked, and do
+  not wait for a coordinated task to begin:
+  `mempalace logstream watch --agent <AGENT_ID> --state-file
+  ~/.mempalace/watch/<AGENT_ID>.json --json`, run as a background
+  process. Treat its exit as "you have mail" (exit 0 = match, 2 = idle):
+  process your inbox from YOUR cursor — the watcher's state file is not
+  your inbox cursor, and one wake can cover several events — then
+  relaunch the watcher with the same state file. Keep this loop alive
+  all session. Use --agent, not --to-agent: it also excludes your own
+  events, which otherwise wake you via the '*' broadcast match. Repeat
+  --type to wake only for what needs you; if you delegate, include
+  task.reply — blocked and failed arrive as replies. In-turn, waiting on
+  one known correlation, mempalace_event_wait is enough — it complements
+  the watcher, never replaces it. Before a coordinated task, post a
   status event to to_agent=* naming your filter and your cursor so others
-  know you are listening. If you are turn-based and cannot watch between
-  prompts, say so and publish your cursor — never claim a watch you do
-  not have.
+  know you are listening. Only if your harness truly cannot run
+  background processes are you turn-based: say so and publish your
+  cursor — never claim a watch you do not have.
+- Acks: acknowledge with mempalace_event_ack (CLI: `mempalace logstream
+  ack`) — it fills type=event.ack and the ack_of link for you; don't
+  hand-roll event.ack appends.
+- If your harness gates shell commands or MCP writes behind approval
+  prompts, ask the operator to allowlist the mempalace tools and the
+  watch command: an unnoticed prompt stalls the loop silently, and to
+  your peers it looks like "claimed but gone quiet".
 - To delegate: mempalace_event_append (type=task.request, stream=
   project/<name>, room=delegation, correlation_id=task_..., status=open,
   body = goal + branch + base commit + definition of done), then
@@ -169,7 +193,17 @@ Where it goes depends on the harness:
 | Claude Code | `~/.claude/CLAUDE.md` |
 | Codex CLI | `~/.codex/AGENTS.md` |
 | OpenCode | `~/.config/opencode/AGENTS.md` |
+| Antigravity IDE | `~/.gemini/config/GEMINI.md` (see the [Antigravity guide](./antigravity.md)) |
 | Hermes | the agent's `SOUL.md` |
+
+One phrasing lesson learned the hard way: rules meant to fire unprompted
+must be imperative startup steps. An earlier draft of the monitoring rule
+began "if your harness can run a background process, start a watcher" —
+and an agent that can run background processes read that as optional,
+used the logstream perfectly in-turn, and never armed a watcher until a
+human asked. The canonical block now opens that rule with "at the start
+of every session, launch…" and names a concrete state-file path, so
+there is nothing left to interpret.
 
 The memory half composes with the
 [recall protocol](https://github.com/MemPalace/mempalace/blob/develop/integrations/shared/recall-protocol.md);
@@ -319,6 +353,18 @@ How the loop plugs into a harness:
   reached and state that it needs a ping. A false watcher is worse than a
   declared-absent one, because a requester who believes someone is
   listening stops looking for a human to nudge.
+
+One operational trap deserves its own warning: **harness permission
+prompts stall the loop silently**. If the harness gates terminal commands
+or MCP writes behind human approval, every ack, reply, and patch
+submission can block on a prompt nobody is looking at. From the other side
+this is indistinguishable from a crash — the agent claimed a task and went
+quiet — and a five-second round trip quietly becomes minutes or hours
+(measured: the same ping that completed in 5 seconds once approved sat for
+4½ minutes behind an unnoticed prompt). For unattended coordination,
+allowlist the mempalace MCP tools (at minimum event append/ack and
+`mempalace_patch_submit`) and the `mempalace logstream watch` command in
+each harness's permission settings.
 
 Two etiquette rules close the loop. **Announce your watch**: before a
 coordinated task, post a `status` event to `to_agent=*` naming the filter you


### PR DESCRIPTION
## What

Multi-agent dogfooding of the shared brain (logstream watchers on two harnesses coordinating through one hub) surfaced three gaps. This PR closes them:

**1. `mempalace rules --agent <id>`** — a new CLI command that renders the canonical shared-brain System-Prompt Snippet from `integrations/shared/coordination-protocol.md` with the agent identity filled in, wrapped in `mempalace-shared-brain:start/end` markers so a later re-render can replace the block in place. The template ships in the package and tests pin it byte-identical to the canonical doc **and** to the copy embedded in the website guide — the three copies cannot drift anymore.

**2. The protocol snippet absorbs the fleet lessons** learned in live testing:
- The watcher rule is now an imperative session-start step with a concrete state-file path. The previous phrasing ("if your harness can run a background process, start…") was read as optional by an agent that *could* run background processes — it used the logstream perfectly in-turn and never armed a watcher until a human asked. A test now keeps the wording imperative.
- The wake loop is spelled out: exit 0 → sweep from *your own* cursor (the watcher's state file is not the inbox cursor; one wake can cover a batch) → re-arm with the same state file.
- Acks go through `mempalace_event_ack` / `logstream ack` instead of hand-rolled `event.ack` appends.
- Harness permission prompts are called out as a silent stall: an unnoticed approval prompt turned a measured ~5s event-to-ack round trip into 4½ minutes, and from the peer's side it is indistinguishable from a crash.

**3. Reconnect no longer hides the stale-library write guard** (the #899 gate). After a package upgrade, `mempalace_reconnect` answered a plain "Reconnected to palace" success while every write kept failing — reconnect cannot reload Python modules. The result now carries `restart_required`, the `library_versions` payload, and a warning naming the remedy. The refusal's top-level `message` also names the remedy now, because several MCP clients drop `data.hint` and surface only the message.

## Docs

- `website/guide/shared-brain.md`: section 5 leads with the CLI render, the embedded snippet is synced (and now test-pinned), the harness table gains Antigravity, and the wakeable section documents the permission-prompt trap.
- `website/guide/antigravity.md`: new "Joining the shared brain" section — global rules via `~/.gemini/config/GEMINI.md`, distinct identities, tool allowlisting.
- `integrations/shared/coordination-protocol.md`: matching prose (proactive arming, re-arm-after-every-wake, permission prompts) and a pointer to the new command.

## Testing

- 18 new tests (12 in `tests/test_cli_rules.py` incl. the three-way drift pins and an imperative-wording guard; 6 in `tests/test_mcp_server.py` for the reconnect warning and refusal message).
- Full suite: 4509 passed, 32 skipped.
- `ruff check` and `ruff format --check` clean on all touched files.