### PR TITLE
fix(miner): include C and C++ source files

### DIFF
--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -162,6 +162,14 @@ READABLE_EXTENSIONS = {
     ".toml",
     ".tex",
     ".bib",
+    # C / C++
+    ".c",
+    ".h",
+    ".cpp",
+    ".hpp",
+    ".cc",
+    ".cxx",
+    ".inl",
     # C# / .NET
     ".cs",
     ".csproj",

--- a/tests/test_cpp_readable_extensions.py
+++ b/tests/test_cpp_readable_extensions.py
@@ -1,0 +1,23 @@
+from mempalace.miner import READABLE_EXTENSIONS, scan_project
+
+
+CPP_EXTENSIONS = {".c", ".h", ".cpp", ".hpp", ".cc", ".cxx", ".inl"}
+
+
+def test_cpp_extensions_are_readable():
+    assert CPP_EXTENSIONS <= READABLE_EXTENSIONS
+
+
+def test_scan_project_includes_cpp_files_case_insensitively(tmp_path):
+    expected = []
+    for index, extension in enumerate(sorted(CPP_EXTENSIONS)):
+        filename = f"example_{index}{extension}"
+        (tmp_path / filename).write_text("int main() { return 0; }\n", encoding="utf-8")
+        expected.append(filename)
+
+    (tmp_path / "uppercase.CPP").write_text("int main() { return 0; }\n", encoding="utf-8")
+    expected.append("uppercase.CPP")
+
+    files = scan_project(str(tmp_path))
+    scanned = sorted(path.relative_to(tmp_path).as_posix() for path in files)
+    assert scanned == sorted(expected)


### PR DESCRIPTION
## What does this PR do?

Closes #2323.

Adds the missing C/C++ suffixes to `READABLE_EXTENSIONS` so `mempalace mine` no longer silently skips common C and C++ source/header files before room routing:

- `.c`
- `.h`
- `.cpp`
- `.hpp`
- `.cc`
- `.cxx`
- `.inl`

The existing scanner already lowercases `Path.suffix` before membership testing, so uppercase forms such as `.CPP` are covered without a second extension list.

## Regression coverage

Adds focused tests that:

- assert the C/C++ extension set remains part of `READABLE_EXTENSIONS`;
- exercise `scan_project()` across every added suffix;
- verify case-insensitive scanning with an uppercase `.CPP` fixture.

## Scope

No routing, chunking, storage, or indexing semantics change. This only widens the existing readable-text allowlist for C/C++ files.

## Testing

Focused regression coverage is included. The final PR patch was inspected before marking ready: two files changed, 31 additions, 0 deletions, with no unrelated changes. Repository CI/status checks are left to the upstream PR workflow.

## Checklist

- [x] Based on current `develop`
- [x] No hardcoded paths
- [x] No new dependencies
- [x] Regression tests added
