### PR TITLE
fix(qdrant): send versioned User-Agent header

### DIFF
--- a/mempalace/backends/qdrant.py
+++ b/mempalace/backends/qdrant.py
@@ -24,6 +24,7 @@ from urllib import request as urlrequest
 
 import numpy as np
 
+from ..version import __version__
 from ._sidecar import EMBEDDER_SIDECAR_FILENAME, read_embedder_sidecar, write_embedder_sidecar
 from .base import (
     BackendClosedError,
@@ -383,7 +384,10 @@ class _QdrantRESTClient:
         if query:
             url = f"{url}?{urlparse.urlencode(query)}"
         data = None
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": f"mempalace/{__version__}",
+        }
         if self._config.api_key:
             headers["api-key"] = self._config.api_key
         if body is not None:

--- a/tests/test_qdrant_user_agent.py
+++ b/tests/test_qdrant_user_agent.py
@@ -26,9 +26,7 @@ def test_qdrant_rest_client_sends_versioned_user_agent(monkeypatch):
 
     monkeypatch.setattr(qdrant.urlrequest, "urlopen", fake_urlopen)
 
-    client = _QdrantRESTClient(
-        _QdrantConfig(url="https://qdrant.example.invalid", timeout=7.5)
-    )
+    client = _QdrantRESTClient(_QdrantConfig(url="https://qdrant.example.invalid", timeout=7.5))
 
     assert client.request("GET", "/collections") == {}
     assert captured["user_agent"] == f"mempalace/{__version__}"

--- a/tests/test_qdrant_user_agent.py
+++ b/tests/test_qdrant_user_agent.py
@@ -1,0 +1,36 @@
+from mempalace.backends.qdrant import _QdrantConfig, _QdrantRESTClient
+from mempalace.version import __version__
+
+
+class _FakeResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return b"{}"
+
+
+def test_qdrant_rest_client_sends_versioned_user_agent(monkeypatch):
+    import mempalace.backends.qdrant as qdrant
+
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["user_agent"] = request.get_header("User-agent")
+        captured["content_type"] = request.get_header("Content-type")
+        captured["timeout"] = timeout
+        return _FakeResponse()
+
+    monkeypatch.setattr(qdrant.urlrequest, "urlopen", fake_urlopen)
+
+    client = _QdrantRESTClient(
+        _QdrantConfig(url="https://qdrant.example.invalid", timeout=7.5)
+    )
+
+    assert client.request("GET", "/collections") == {}
+    assert captured["user_agent"] == f"mempalace/{__version__}"
+    assert captured["content_type"] == "application/json"
+    assert captured["timeout"] == 7.5


### PR DESCRIPTION
## What does this PR do?

Closes #2338.

Adds an explicit versioned `User-Agent` to every request made by the Qdrant REST client:

```text
mempalace/<package version>
```

The value comes from MemPalace's existing `mempalace.version.__version__` single source of truth rather than hard-coding the current release number. This prevents `urllib` from falling back to its generic Python user agent for Qdrant traffic, which can be rejected by reverse proxies such as the Cloudflare setup reported in #2338.

## Regression coverage

Adds a network-free test that intercepts the actual `urllib.request.Request` and verifies:

- the versioned MemPalace `User-Agent` is present;
- the existing JSON content type is preserved;
- the configured request timeout is still forwarded.

## Scope

No Qdrant API paths, payloads, authentication behavior, filtering, storage, or retry semantics change. The existing `api-key` header remains untouched; this only adds client identification.

## Checklist

- [x] Based on current `develop`
- [x] No hard-coded package version
- [x] No new dependencies
- [x] No network access in regression test
- [x] Focused regression coverage added
