### PR TITLE
fix(config): init() persists the resolved palace_path, not the hardcoded default

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -1122,7 +1122,7 @@ class MempalaceConfig:
             # dropping legitimate short conversation exchanges. Module-level
             # defaults already apply correctly when these keys are absent.
             default_config = {
-                "palace_path": DEFAULT_PALACE_PATH,
+                "palace_path": self.palace_path,
                 "collection_name": DEFAULT_COLLECTION_NAME,
                 "topic_wings": DEFAULT_TOPIC_WINGS,
                 "hall_keywords": DEFAULT_HALL_KEYWORDS,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -283,6 +283,16 @@ def test_cmd_init_honors_palace_flag(tmp_path, monkeypatch):
     monkeypatch.delenv("MEMPALACE_PALACE_PATH")
     monkeypatch.delenv("MEMPAL_PALACE_PATH")
 
+    # cmd_init's MempalaceConfig() has no config_dir, so an unpatched call
+    # here now persists this test's tmp_path into the shared ~/.mempalace
+    # (#2366's fix made init() write what actually resolved, not a constant).
+    from mempalace.config import MempalaceConfig
+
+    monkeypatch.setattr(
+        "mempalace.cli.MempalaceConfig",
+        lambda *a, **kw: MempalaceConfig(*a, config_dir=str(tmp_path / ".mempalace"), **kw),
+    )
+
     args = argparse.Namespace(
         dir=str(project),
         palace=str(palace),

--- a/tests/test_config_palace_path.py
+++ b/tests/test_config_palace_path.py
@@ -1,6 +1,8 @@
 """Tests for palace_path tilde expansion in MempalaceConfig."""
 
+import json
 import os
+import tempfile
 from mempalace.config import MempalaceConfig
 
 
@@ -31,3 +33,53 @@ def test_palace_path_absolute_unchanged():
     cfg = MempalaceConfig()
     cfg._file_config["palace_path"] = "/tmp/test_palace"
     assert cfg.palace_path == "/tmp/test_palace"
+
+
+def test_init_persists_constructor_override_not_default():
+    """init() must persist the resolved palace_path, not the hardcoded default.
+
+    `mempalace --palace <custom> init` passes palace_path via the constructor
+    (mirrored from cli.py's env-var write for cmd_init). The persisted
+    config.json must record that custom path so a later invocation with no
+    --palace flag (e.g. `mempalace status`) still finds it.
+    """
+    config_dir = tempfile.mkdtemp()
+    custom_palace = os.path.join(tempfile.mkdtemp(), "custom-palace")
+    cfg = MempalaceConfig(config_dir=config_dir, palace_path=custom_palace)
+    assert cfg.palace_path == custom_palace
+
+    cfg.init()
+
+    with open(os.path.join(config_dir, "config.json")) as f:
+        saved = json.load(f)
+    assert saved["palace_path"] == custom_palace
+
+    # A later invocation with no override must read the persisted path back.
+    later_cfg = MempalaceConfig(config_dir=config_dir)
+    assert later_cfg.palace_path == custom_palace
+
+
+def test_init_persists_env_var_palace_path():
+    """init() must persist a MEMPALACE_PALACE_PATH override, not the default.
+
+    cmd_init sets this env var before constructing MempalaceConfig() when
+    --palace is passed (cli.py:308); init() must write what it resolved to,
+    not the module-level default.
+    """
+    config_dir = tempfile.mkdtemp()
+    custom_palace = os.path.join(tempfile.mkdtemp(), "env-palace")
+    os.environ["MEMPALACE_PALACE_PATH"] = custom_palace
+    try:
+        cfg = MempalaceConfig(config_dir=config_dir)
+        cfg.init()
+    finally:
+        del os.environ["MEMPALACE_PALACE_PATH"]
+
+    with open(os.path.join(config_dir, "config.json")) as f:
+        saved = json.load(f)
+    assert saved["palace_path"] == custom_palace
+
+    # A later invocation with no --palace and no env var must still resolve
+    # to the persisted custom path, not silently fall back to the default.
+    later_cfg = MempalaceConfig(config_dir=config_dir)
+    assert later_cfg.palace_path == custom_palace


### PR DESCRIPTION
## What does this PR do?

Fixes `MempalaceConfig.init()` so a fresh `config.json` records the palace path that was actually resolved for this process (constructor override, then `MEMPALACE_PALACE_PATH`/`MEMPAL_PALACE_PATH`, then the default), instead of always writing the hardcoded default.

**Root cause**: `init()` (`mempalace/config.py:1107-1131`) built its `default_config` dict from the module-level `DEFAULT_PALACE_PATH` constant directly, never from `self.palace_path`, the property that already does the override/env/default resolution correctly. So `mempalace --palace <custom> init` (which sets `MEMPALACE_PALACE_PATH` before constructing `MempalaceConfig()`, `cli.py:307-308`) used the custom path for the run but persisted the default into `config.json`. Every later command with no `--palace` flag, such as `mempalace status`, then silently fell back to the default location, matching #2366's report.

Scoped to that one bug: the reporter's secondary observation (a stray `origin.json` written with contents that look unrelated to the target directory) is a separate code path I have not reproduced or investigated, so this PR leaves it alone. Using `Refs #2366` rather than `Fixes #2366` for that reason; happy to look at the `origin.json` behavior separately if useful.

**Test isolation fix, same PR**: `test_cmd_init_honors_palace_flag` calls the real `cmd_init()`, which constructs `MempalaceConfig()` with no `config_dir` (the real `~/.mempalace`, redirected to a session tmp dir by `conftest.py`) and does not mock `.init()`. Before this fix, `init()` always wrote the same hardcoded default there regardless of context, so this was harmless. With the fix, it started persisting the test's own `tmp_path`-based `--palace` value into that shared session config, which two unrelated tests (`test_hallways_palace_scoped.py`, `test_palace_graph_tunnels.py`) then read back and failed against. Patched that test's `MempalaceConfig` to use its own `tmp_path` config dir, matching the isolation every other test in the suite already uses.

## How to test

```
python -m pytest tests/test_config_palace_path.py tests/test_cli.py::test_cmd_init_honors_palace_flag tests/test_hallways_palace_scoped.py tests/test_palace_graph_tunnels.py -v
```

Added two regression tests to `tests/test_config_palace_path.py` covering both resolution paths that feed `init()` (constructor override, `MEMPALACE_PALACE_PATH` env var): both fail on unmodified `develop` (assert the persisted `config.json` value, get the hardcoded default back) and pass on this branch, confirmed both ways in a `python:3.13-slim` container against a fresh clone at `4c1e6d0c`.

Full suite (`pytest tests/ --ignore=tests/benchmarks --cov=mempalace --cov-fail-under=80`), same container: 4501 passed, 55 skipped, coverage 82.1%. 4 failures are pre-existing and unrelated to this change (`test_mcp_server.py::TestStaleLibraryGate` x3, `test_sqlite_exact_backend.py::test_sqlite_exact_read_only_open_sees_active_writer_wal`), reproduced identically on an unmodified checkout.

Not verified: the Windows/macOS legs, or the actual CLI end to end (`mempalace init --palace ... ` followed by `mempalace status` against a real palace) beyond the unit-level repro above.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
