### PR TITLE
feat: add opt-in update awareness

### DIFF
--- a/.antigravity-plugin/skills/mempalace/SKILL.md
+++ b/.antigravity-plugin/skills/mempalace/SKILL.md
@@ -90,3 +90,13 @@ The MCP server is auto-registered when this plugin is installed at `~/.gemini/co
 - **Background everything** — filing, indexing, and timestamps happen via hooks in the background; zero tokens spent on bookkeeping in the chat window.
 
 If a request would violate any of these principles, refuse and explain — even if it would be technically convenient.
+
+## Release awareness
+
+Release checks are opt-in. Ask before enabling weekly checks with
+`mempalace update configure --enable --installer uv-tool` (or `pipx` / `pip`,
+matching the installation); the default is disabled. Enabling checks
+contacts PyPI but sends no palace content, identity, or telemetry. When
+`mempalace_status` reports an available release, surface it to the user and use
+`mempalace update plan` to show the exact actions. Never install an update
+without explicit user authorization.

--- a/.antigravity-plugin/skills/mempalace/SKILL.md
+++ b/.antigravity-plugin/skills/mempalace/SKILL.md
@@ -97,6 +97,7 @@ Release checks are opt-in. Ask before enabling weekly checks with
 `mempalace update configure --enable --installer uv-tool` (or `pipx` / `pip`,
 matching the installation); the default is disabled. Enabling checks
 contacts PyPI but sends no palace content, identity, or telemetry. When
-`mempalace_status` reports an available release, surface it to the user and use
-`mempalace update plan` to show the exact actions. Never install an update
-without explicit user authorization.
+`mempalace_status` reports an available release, distinguish `updates.server`
+from a local proxy's `updates.client`. Use the local update plan only for the
+client scope; a remote server update must be planned and authorized on the hub
+host by its operator. Never install an update without explicit user authorization.

--- a/.claude-plugin/skills/mempalace-task/SKILL.md
+++ b/.claude-plugin/skills/mempalace-task/SKILL.md
@@ -17,8 +17,9 @@ discipline live in the public
    either is missing, do not assume the older runtime has update-awareness
    commands. Explain that it is incompatible, hand off to the `mempalace` setup
    skill, and propose the package-manager-appropriate upgrade (`uv tool upgrade
-   mempalace`, `pipx upgrade mempalace`, or `python -m pip install --upgrade
-   mempalace`) plus `npx skills update mempalace mempalace-recall
+   mempalace`, `pipx upgrade mempalace`, or the interpreter backing the active
+   MemPalace command followed by `-m pip install --upgrade mempalace`) plus
+   `npx skills update mempalace mempalace-recall
    mempalace-task`. Require explicit authorization before running anything.
 2. Confirm the MemPalace MCP tools are connected and the active palace is the
    intended shared brain.

--- a/.claude-plugin/skills/mempalace-task/SKILL.md
+++ b/.claude-plugin/skills/mempalace-task/SKILL.md
@@ -13,6 +13,13 @@ discipline live in the public
 ## Verify the coordination seam
 
 1. Confirm `mempalace --version` succeeds.
+   Also confirm `mempalace task --help` and `mempalace_task_create` exist; if
+   either is missing, do not assume the older runtime has update-awareness
+   commands. Explain that it is incompatible, hand off to the `mempalace` setup
+   skill, and propose the package-manager-appropriate upgrade (`uv tool upgrade
+   mempalace`, `pipx upgrade mempalace`, or `python -m pip install --upgrade
+   mempalace`) plus `npx skills update mempalace mempalace-recall
+   mempalace-task`. Require explicit authorization before running anything.
 2. Confirm the MemPalace MCP tools are connected and the active palace is the
    intended shared brain.
 3. Establish the current agent's stable identity. Never impersonate another

--- a/.claude-plugin/skills/mempalace/SKILL.md
+++ b/.claude-plugin/skills/mempalace/SKILL.md
@@ -124,10 +124,14 @@ Ask whether the user wants weekly stable-release checks. The default is no.
 Explain that enabling them contacts PyPI but sends no palace content, identity,
 or telemetry. When enabling, record the installer actually used with
 `mempalace update configure --enable --installer uv-tool` (or `pipx` / `pip`);
-use `--disable` to opt out. Checks never install anything. When `mempalace_status` reports an
-available release, surface it naturally and ask before preparing an
-upgrade. Use `mempalace update plan` to show the exact actions; never execute
-them without explicit approval.
+use `--disable` to opt out. Checks never install anything. In
+`mempalace_status`, treat `updates.server` as the palace-serving runtime and
+`updates.client` (when present) as the local proxy runtime; do not conflate
+their versions or installers. For a client update, use the local `mempalace
+update plan`. A remote server update is informational on the client: surface it
+naturally and ask the hub operator to prepare and authorize the plan on the
+palace-serving machine. Never use a client-generated plan to upgrade the
+server, and never execute any plan without explicit approval.
 
 ## Recalling past work
 

--- a/.claude-plugin/skills/mempalace/SKILL.md
+++ b/.claude-plugin/skills/mempalace/SKILL.md
@@ -120,6 +120,15 @@ Summarize the installed version, palace location or hub URL (without secrets),
 MCP connection, stable agent identity, watcher mode, and the first safe next
 action. For active delegation, hand off to the `mempalace-task` skill.
 
+Ask whether the user wants weekly stable-release checks. The default is no.
+Explain that enabling them contacts PyPI but sends no palace content, identity,
+or telemetry. When enabling, record the installer actually used with
+`mempalace update configure --enable --installer uv-tool` (or `pipx` / `pip`);
+use `--disable` to opt out. Checks never install anything. When `mempalace_status` reports an
+available release, surface it naturally and ask before preparing an
+upgrade. Use `mempalace update plan` to show the exact actions; never execute
+them without explicit approval.
+
 ## Recalling past work
 
 This skill covers setup, mining, and status. For questions about past

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Features
 
+- **Release awareness is opt-in and agent-visible.** `mempalace update` can configure or explicitly run stable-release checks and prepare an exact upgrade plan, while `mempalace_status` exposes only cached state so agents can ask for authorization without blocking or installing anything automatically.
+
 - **Skill-first setup is now the recommended agent onboarding path.** `npx skills add MemPalace/mempalace` discovers a guided `mempalace` setup skill that can bootstrap the Python package and MCP connection, distinguish a private local palace from a shared-brain hub or client, assign a stable fleet identity, install the canonical shared-brain rules, and verify logstream readiness. The new `mempalace-task` skill covers active coordination without mixing it into the recall protocol.
 - **High-level task creation turns raw logstream primitives into a complete handoff.** `mempalace task create` and the equivalent remote-safe `mempalace_task_create` MCP tool accept the goal, worker identities, project, branch, immutable hexadecimal base commit id, and definition of done; they reject mutable branch/tag base references, create the canonical immutable `task.request`, generate its correlation id, and return one ready-to-paste line that wakes the destination agent while the exact specification stays in the logstream. `task launch` is an explicit controlled-mode adapter for Codex and Claude: it validates the complete stored request, proves the worker checkout is clean and on the stored branch/base commit, validates the worker identity, releases the logstream handle, and invokes the runner without a shell or permission-bypass flags.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ operations, `mempalace-recall` for search-before-answer recall, and
 itself install the MemPalace CLI or MCP server; the setup skill guides the
 agent through those system changes and verifies the live connection.
 
+During guided setup the agent can offer weekly stable-release checks. They are
+disabled by default, contact only PyPI when enabled, and never install updates
+automatically. Cached availability appears in `mempalace_status`, allowing the
+agent to explain the release and request authorization before showing an exact
+upgrade plan. Setup records whether the runtime came from `uv tool`, `pipx`, or
+`pip` so the plan never proposes an upgrade command for the wrong installation.
+
 ### Direct CLI setup
 
 MemPalace ships a CLI, so install it in an isolated environment to avoid

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ agent through those system changes and verifies the live connection.
 
 During guided setup the agent can offer weekly stable-release checks. They are
 disabled by default, contact only PyPI when enabled, and never install updates
-automatically. Cached availability appears in `mempalace_status`, allowing the
-agent to explain the release and request authorization before showing an exact
+automatically. Cached availability appears in scoped `mempalace_status` fields
+for the serving runtime and, when a local proxy is present, its client runtime,
+allowing the agent to explain the release and request authorization before showing an exact
 upgrade plan. Setup records whether the runtime came from `uv tool`, `pipx`, or
 `pip` so the plan never proposes an upgrade command for the wrong installation.
 

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1438,6 +1438,31 @@ def cmd_status(args):
     status(palace_path=palace_path)
 
 
+def cmd_update(args):
+    """Configure, check, or prepare updates without installing automatically."""
+    import json
+
+    from .update_awareness import check_updates, configure_updates, prepare_upgrade
+
+    try:
+        if args.update_action == "configure":
+            result = configure_updates(
+                enabled=args.enabled,
+                interval_days=args.interval_days,
+                installer=args.installer,
+            )
+        elif args.update_action == "check":
+            result = check_updates(force=True)
+        elif args.update_action == "plan":
+            result = prepare_upgrade(installer=args.installer)
+        else:
+            raise ValueError("choose update configure, check, or plan")
+    except (OSError, ValueError) as exc:
+        print(f"mempalace update: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
 # ── Logstream (RFC 003 agent coordination) ────────────────────────────────
 
 
@@ -3413,6 +3438,19 @@ def main():
         default=None,
         help="Storage backend to use for status (default: config/env/detected/chroma)",
     )
+    p_update = sub.add_parser("update", help="Opt-in release checks and upgrade planning")
+    update_sub = p_update.add_subparsers(dest="update_action")
+    p_update_configure = update_sub.add_parser("configure", help="Configure periodic checks")
+    update_consent = p_update_configure.add_mutually_exclusive_group(required=True)
+    update_consent.add_argument("--enable", dest="enabled", action="store_true")
+    update_consent.add_argument("--disable", dest="enabled", action="store_false")
+    p_update_configure.add_argument("--interval-days", type=int, default=7)
+    p_update_configure.add_argument("--installer", choices=("uv-tool", "pipx", "pip"))
+    update_sub.add_parser("check", help="Explicitly check the latest stable release")
+    p_update_plan = update_sub.add_parser(
+        "plan", help="Show the exact upgrade plan without applying it"
+    )
+    p_update_plan.add_argument("--installer", choices=("uv-tool", "pipx", "pip"))
 
     # logstream (RFC 003 agent coordination)
     p_logstream = sub.add_parser(
@@ -3770,6 +3808,7 @@ def main():
         "migrate-wings": cmd_migrate_wings,
         "hallways": cmd_hallways,
         "status": cmd_status,
+        "update": cmd_update,
     }
     dispatch[args.command](args)
 

--- a/mempalace/mcp_proxy.py
+++ b/mempalace/mcp_proxy.py
@@ -28,6 +28,8 @@ import sys
 import urllib.error
 import urllib.request
 
+from .update_awareness import cached_update_status, schedule_update_check
+
 logger = logging.getLogger(__name__)
 
 # Shared with the in-server forwarder and the CLI forwarder.
@@ -147,6 +149,38 @@ def _annotate_degraded(response):
     return response
 
 
+def _annotate_forwarded_update_status(request: dict, response):
+    """Attach this proxy runtime's cached state beside the hub's state."""
+    params = request.get("params") or {}
+    if request.get("method") != "tools/call" or params.get("name") != "mempalace_status":
+        return response
+
+    local_status = cached_update_status()
+    schedule_update_check()
+    try:
+        content = response["result"]["content"]
+    except (KeyError, TypeError):
+        return response
+    for block in content if isinstance(content, list) else ():
+        if not isinstance(block, dict) or block.get("type") != "text":
+            continue
+        try:
+            payload = json.loads(block.get("text", ""))
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        remote_updates = payload.get("updates")
+        if not isinstance(remote_updates, dict):
+            remote_updates = {}
+        elif "server" not in remote_updates and "client" not in remote_updates:
+            remote_updates = {"server": remote_updates}
+        payload["updates"] = {**remote_updates, "client": local_status}
+        block["text"] = json.dumps(payload, indent=2, ensure_ascii=False)
+        break
+    return response
+
+
 class _LocalServer:
     """Lazily-imported full server, plus the background services it expects.
 
@@ -222,7 +256,7 @@ def _handle(request: dict, palace_path, local: _LocalServer):
     if target is not None:
         base_url, headers = target
         try:
-            return _forward(base_url, headers, request)
+            return _annotate_forwarded_update_status(request, _forward(base_url, headers, request))
         except (urllib.error.URLError, OSError, TimeoutError, ValueError) as exc:
             # Reaching the hub and getting an HTTP error means it may have run
             # the call; so does any mid-flight failure on a mutating tool.

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -6567,8 +6567,12 @@ def _decorate_mcp_tool_result(tool_name: str, result):
     """Attach MCP transport-only diagnostics outside handle_request complexity."""
 
     if tool_name == "mempalace_status" and isinstance(result, dict):
+        from .update_awareness import cached_update_status, schedule_update_check
+
         result.setdefault("sqlite_integrity", _sqlite_integrity_payload())
         result.setdefault("library_versions", _stale_library_payload())
+        result.setdefault("updates", cached_update_status())
+        schedule_update_check()
 
     return result
 
@@ -8484,6 +8488,13 @@ def main():
     os.environ.pop("PYTHONPATH", None)
 
     _install_shutdown_signal_handlers()
+
+    # Consent is persisted locally and defaults off. When enabled, refresh the
+    # release cache in the background so the first agent status call never
+    # waits on PyPI and can naturally surface a newly available version.
+    from .update_awareness import schedule_update_check
+
+    schedule_update_check()
 
     if _args.transport == "http":
         _run_http_loop()

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -6571,7 +6571,7 @@ def _decorate_mcp_tool_result(tool_name: str, result):
 
         result.setdefault("sqlite_integrity", _sqlite_integrity_payload())
         result.setdefault("library_versions", _stale_library_payload())
-        result.setdefault("updates", cached_update_status())
+        result.setdefault("updates", {"server": cached_update_status()})
         schedule_update_check()
 
     return result
@@ -8265,7 +8265,11 @@ def _dispatch_stdio_request(request: dict):
         return handle_request(request)
     base_url, headers = target
     try:
-        return _forward_request_to_hub(base_url, headers, request)
+        from .mcp_proxy import _annotate_forwarded_update_status
+
+        return _annotate_forwarded_update_status(
+            request, _forward_request_to_hub(base_url, headers, request)
+        )
     except (urllib.error.URLError, OSError, TimeoutError, ValueError) as exc:
         reached_hub = isinstance(exc, urllib.error.HTTPError)
         if not reached_hub and not _request_is_mutating(request):

--- a/mempalace/update_awareness.py
+++ b/mempalace/update_awareness.py
@@ -1,0 +1,220 @@
+"""Opt-in, cached release awareness without automatic installation."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+from .version import __version__
+
+
+_POLICY_FILE = "updates.json"
+_CACHE_FILE = "updates-cache.json"
+_STABLE_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+_CHECK_LOCK = threading.Lock()
+_INSTALL_ACTIONS = {
+    "uv-tool": "uv tool upgrade mempalace",
+    "pipx": "pipx upgrade mempalace",
+    "pip": "python -m pip install --upgrade mempalace",
+}
+
+
+def _config_dir(value=None) -> Path:
+    return Path(value) if value is not None else Path(os.path.expanduser("~/.mempalace"))
+
+
+def _read_json(name: str, config_dir=None) -> dict:
+    try:
+        value = json.loads((_config_dir(config_dir) / name).read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _write_json(name: str, value: dict, config_dir=None) -> None:
+    directory = _config_dir(config_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=".updates-", suffix=".json", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, directory / name)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def configure_updates(
+    *, enabled: bool, interval_days: int = 7, installer: str | None = None, config_dir=None
+) -> dict:
+    """Persist explicit release-check consent and return the resulting policy."""
+    if not isinstance(interval_days, int) or interval_days < 1:
+        raise ValueError("interval_days must be a positive integer")
+    existing = _read_json(_POLICY_FILE, config_dir)
+    installer = installer or existing.get("installer")
+    if enabled and installer not in _INSTALL_ACTIONS:
+        raise ValueError("enabling checks requires --installer uv-tool, pipx, or pip")
+    if installer is not None and installer not in _INSTALL_ACTIONS:
+        raise ValueError("installer must be uv-tool, pipx, or pip")
+    policy = {"enabled": bool(enabled), "interval_days": interval_days, "channel": "stable"}
+    if installer:
+        policy["installer"] = installer
+    _write_json(_POLICY_FILE, policy, config_dir)
+    return policy
+
+
+def fetch_latest_stable() -> str:
+    """Return the latest stable version advertised by the official PyPI project."""
+    request = Request(
+        "https://pypi.org/pypi/mempalace/json",
+        headers={"Accept": "application/json", "User-Agent": "mempalace-update-check"},
+    )
+    with urlopen(request, timeout=2.0) as response:  # noqa: S310 -- fixed HTTPS origin
+        payload = json.load(response)
+    version = payload.get("info", {}).get("version") if isinstance(payload, dict) else None
+    if not isinstance(version, str) or not _STABLE_VERSION.fullmatch(version):
+        raise ValueError("PyPI returned an invalid stable MemPalace version")
+    return version
+
+
+def _version_key(version: str) -> tuple[int, int, int]:
+    if not _STABLE_VERSION.fullmatch(version):
+        raise ValueError(f"invalid stable version: {version!r}")
+    return tuple(int(part) for part in version.split("."))
+
+
+def _utc_text(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _result(state: dict, installed: str, *, checked: bool) -> dict:
+    latest = state.get("latest")
+    result = {
+        "enabled": bool(state.get("enabled", False)),
+        "installed": installed,
+    }
+    if (
+        isinstance(latest, str)
+        and _STABLE_VERSION.fullmatch(latest)
+        and isinstance(state.get("checked_at"), str)
+    ):
+        result.update(
+            {
+                "latest": latest,
+                "available": _version_key(latest) > _version_key(installed),
+                "checked": checked,
+                "checked_at": state["checked_at"],
+                "restart_required_after_upgrade": True,
+            }
+        )
+    else:
+        result["checked"] = checked
+    return result
+
+
+def check_updates(
+    *,
+    force: bool = False,
+    config_dir=None,
+    installed_version: str = __version__,
+    fetch_latest=fetch_latest_stable,
+    now: datetime | None = None,
+) -> dict:
+    """Check or read cached stable-release state without ever installing it."""
+    policy = _read_json(_POLICY_FILE, config_dir)
+    cache = _read_json(_CACHE_FILE, config_dir)
+    enabled = bool(policy.get("enabled", False))
+    if not enabled and not force:
+        return {"enabled": False, "installed": installed_version, "checked": False}
+
+    now = now or datetime.now(timezone.utc)
+    attempted_at = cache.get("attempted_at") or cache.get("checked_at")
+    if not force and attempted_at:
+        try:
+            last = datetime.fromisoformat(attempted_at.replace("Z", "+00:00"))
+            if last.utcoffset() is None:
+                raise ValueError("cached update timestamp has no timezone")
+            interval = int(policy.get("interval_days", 7))
+        except (AttributeError, TypeError, ValueError):
+            pass
+        else:
+            if interval > 0 and now - last < timedelta(days=interval):
+                return _result({**policy, **cache}, installed_version, checked=False)
+
+    attempted_at = _utc_text(now)
+    cache = {**cache, "attempted_at": attempted_at}
+    _write_json(_CACHE_FILE, cache, config_dir)
+    cache.update({"latest": fetch_latest(), "checked_at": attempted_at})
+    _write_json(_CACHE_FILE, cache, config_dir)
+    return _result({**policy, **cache}, installed_version, checked=True)
+
+
+def cached_update_status(*, config_dir=None, installed_version: str = __version__) -> dict:
+    """Return agent-safe cached state without performing network access."""
+    policy = _read_json(_POLICY_FILE, config_dir)
+    if not policy.get("enabled"):
+        return {"enabled": False, "installed": installed_version}
+    cache = _read_json(_CACHE_FILE, config_dir)
+    return _result({**policy, **cache}, installed_version, checked=False)
+
+
+def prepare_upgrade(
+    *, config_dir=None, installed_version: str = __version__, installer: str | None = None
+) -> dict:
+    """Describe an upgrade without executing or authorizing it."""
+    policy = _read_json(_POLICY_FILE, config_dir)
+    cache = _read_json(_CACHE_FILE, config_dir)
+    status = _result({**policy, **cache}, installed_version, checked=False)
+    if not status.get("available"):
+        return {"available": False, "installed": installed_version, "actions": []}
+    installer = installer or policy.get("installer")
+    if installer not in _INSTALL_ACTIONS:
+        return {
+            "available": True,
+            "installed": installed_version,
+            "latest": status["latest"],
+            "requires_installer_selection": True,
+            "installers": dict(_INSTALL_ACTIONS),
+            "actions": [],
+        }
+    return {
+        "available": True,
+        "installed": installed_version,
+        "latest": status["latest"],
+        "requires_user_authorization": True,
+        "actions": [
+            _INSTALL_ACTIONS[installer],
+            "npx skills update mempalace mempalace-recall mempalace-task",
+            "restart the MemPalace MCP server or shared hub",
+            "refresh agent MCP tool lists",
+        ],
+    }
+
+
+def schedule_update_check(
+    *, config_dir=None, fetch_latest=fetch_latest_stable, now: datetime | None = None
+) -> bool:
+    """Start one non-blocking due check when the user opted in."""
+    policy = _read_json(_POLICY_FILE, config_dir)
+    if not policy.get("enabled") or not _CHECK_LOCK.acquire(blocking=False):
+        return False
+
+    def run() -> None:
+        try:
+            check_updates(config_dir=config_dir, fetch_latest=fetch_latest, now=now)
+        except (OSError, ValueError):
+            return
+        finally:
+            _CHECK_LOCK.release()
+
+    threading.Thread(target=run, name="mempalace-update-check", daemon=True).start()
+    return True

--- a/mempalace/update_awareness.py
+++ b/mempalace/update_awareness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 import tempfile
 import threading
 from datetime import datetime, timedelta, timezone
@@ -19,10 +20,19 @@ _CACHE_FILE = "updates-cache.json"
 _STABLE_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
 _CHECK_LOCK = threading.Lock()
 _INSTALL_ACTIONS = {
-    "uv-tool": "uv tool upgrade mempalace",
-    "pipx": "pipx upgrade mempalace",
-    "pip": "python -m pip install --upgrade mempalace",
+    "uv-tool": ("uv", "tool", "upgrade", "mempalace"),
+    "pipx": ("pipx", "upgrade", "mempalace"),
+    "pip": None,
 }
+
+
+def _installer_action(installer: str) -> dict:
+    argv = (
+        [sys.executable, "-m", "pip", "install", "--upgrade", "mempalace"]
+        if installer == "pip"
+        else list(_INSTALL_ACTIONS[installer] or ())
+    )
+    return {"kind": "command", "argv": argv}
 
 
 def _config_dir(value=None) -> Path:
@@ -183,7 +193,7 @@ def prepare_upgrade(
             "installed": installed_version,
             "latest": status["latest"],
             "requires_installer_selection": True,
-            "installers": dict(_INSTALL_ACTIONS),
+            "installers": {name: _installer_action(name) for name in _INSTALL_ACTIONS},
             "actions": [],
         }
     return {
@@ -192,10 +202,23 @@ def prepare_upgrade(
         "latest": status["latest"],
         "requires_user_authorization": True,
         "actions": [
-            _INSTALL_ACTIONS[installer],
-            "npx skills update mempalace mempalace-recall mempalace-task",
-            "restart the MemPalace MCP server or shared hub",
-            "refresh agent MCP tool lists",
+            _installer_action(installer),
+            {
+                "kind": "command",
+                "argv": [
+                    "npx",
+                    "skills",
+                    "update",
+                    "mempalace",
+                    "mempalace-recall",
+                    "mempalace-task",
+                ],
+            },
+            {
+                "kind": "instruction",
+                "text": "restart the MemPalace MCP server or shared hub",
+            },
+            {"kind": "instruction", "text": "refresh agent MCP tool lists"},
         ],
     }
 

--- a/skills/mempalace-task/SKILL.md
+++ b/skills/mempalace-task/SKILL.md
@@ -17,8 +17,9 @@ discipline live in the public
    either is missing, do not assume the older runtime has update-awareness
    commands. Explain that it is incompatible, hand off to the `mempalace` setup
    skill, and propose the package-manager-appropriate upgrade (`uv tool upgrade
-   mempalace`, `pipx upgrade mempalace`, or `python -m pip install --upgrade
-   mempalace`) plus `npx skills update mempalace mempalace-recall
+   mempalace`, `pipx upgrade mempalace`, or the interpreter backing the active
+   MemPalace command followed by `-m pip install --upgrade mempalace`) plus
+   `npx skills update mempalace mempalace-recall
    mempalace-task`. Require explicit authorization before running anything.
 2. Confirm the MemPalace MCP tools are connected and the active palace is the
    intended shared brain.

--- a/skills/mempalace-task/SKILL.md
+++ b/skills/mempalace-task/SKILL.md
@@ -13,6 +13,13 @@ discipline live in the public
 ## Verify the coordination seam
 
 1. Confirm `mempalace --version` succeeds.
+   Also confirm `mempalace task --help` and `mempalace_task_create` exist; if
+   either is missing, do not assume the older runtime has update-awareness
+   commands. Explain that it is incompatible, hand off to the `mempalace` setup
+   skill, and propose the package-manager-appropriate upgrade (`uv tool upgrade
+   mempalace`, `pipx upgrade mempalace`, or `python -m pip install --upgrade
+   mempalace`) plus `npx skills update mempalace mempalace-recall
+   mempalace-task`. Require explicit authorization before running anything.
 2. Confirm the MemPalace MCP tools are connected and the active palace is the
    intended shared brain.
 3. Establish the current agent's stable identity. Never impersonate another

--- a/skills/mempalace/SKILL.md
+++ b/skills/mempalace/SKILL.md
@@ -124,10 +124,14 @@ Ask whether the user wants weekly stable-release checks. The default is no.
 Explain that enabling them contacts PyPI but sends no palace content, identity,
 or telemetry. When enabling, record the installer actually used with
 `mempalace update configure --enable --installer uv-tool` (or `pipx` / `pip`);
-use `--disable` to opt out. Checks never install anything. When `mempalace_status` reports an
-available release, surface it naturally and ask before preparing an
-upgrade. Use `mempalace update plan` to show the exact actions; never execute
-them without explicit approval.
+use `--disable` to opt out. Checks never install anything. In
+`mempalace_status`, treat `updates.server` as the palace-serving runtime and
+`updates.client` (when present) as the local proxy runtime; do not conflate
+their versions or installers. For a client update, use the local `mempalace
+update plan`. A remote server update is informational on the client: surface it
+naturally and ask the hub operator to prepare and authorize the plan on the
+palace-serving machine. Never use a client-generated plan to upgrade the
+server, and never execute any plan without explicit approval.
 
 ## Recalling past work
 

--- a/skills/mempalace/SKILL.md
+++ b/skills/mempalace/SKILL.md
@@ -120,6 +120,15 @@ Summarize the installed version, palace location or hub URL (without secrets),
 MCP connection, stable agent identity, watcher mode, and the first safe next
 action. For active delegation, hand off to the `mempalace-task` skill.
 
+Ask whether the user wants weekly stable-release checks. The default is no.
+Explain that enabling them contacts PyPI but sends no palace content, identity,
+or telemetry. When enabling, record the installer actually used with
+`mempalace update configure --enable --installer uv-tool` (or `pipx` / `pip`);
+use `--disable` to opt out. Checks never install anything. When `mempalace_status` reports an
+available release, surface it naturally and ask before preparing an
+upgrade. Use `mempalace update plan` to show the exact actions; never execute
+them without explicit approval.
+
 ## Recalling past work
 
 This skill covers setup, mining, and status. For questions about past

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,0 +1,53 @@
+"""CLI contracts for opt-in update awareness."""
+
+import json
+import sys
+
+from mempalace.cli import main
+from mempalace.version import __version__
+
+
+def test_update_configure_requires_explicit_consent_and_persists_it(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "mempalace",
+            "update",
+            "configure",
+            "--enable",
+            "--interval-days",
+            "14",
+            "--installer",
+            "uv-tool",
+        ],
+    )
+
+    main()
+
+    assert json.loads(capsys.readouterr().out) == {
+        "enabled": True,
+        "interval_days": 14,
+        "channel": "stable",
+        "installer": "uv-tool",
+    }
+    stored = json.loads((tmp_path / ".mempalace" / "updates.json").read_text(encoding="utf-8"))
+    assert stored["enabled"] is True
+    assert stored["interval_days"] == 14
+    assert stored["installer"] == "uv-tool"
+
+
+def test_update_plan_does_not_execute_commands(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["mempalace", "update", "plan"])
+
+    main()
+
+    assert json.loads(capsys.readouterr().out) == {
+        "available": False,
+        "installed": __version__,
+        "actions": [],
+    }

--- a/tests/test_hub_forward.py
+++ b/tests/test_hub_forward.py
@@ -343,6 +343,37 @@ class TestStdioProxy:
         assert response["id"] == 7
         assert "result" in response
 
+    def test_dynamic_proxy_status_adds_local_client_update_state(self, proxied_palace, monkeypatch):
+        from mempalace import mcp_server, mcp_proxy
+
+        hub = _FakeHub(mine_result={"updates": {"server": {"enabled": True, "installed": "3.9.0"}}})
+        try:
+            self._local_sentinel(monkeypatch)
+            _register_hub(proxied_palace, hub)
+            self._disown_record(proxied_palace)
+            monkeypatch.setattr(
+                mcp_proxy,
+                "cached_update_status",
+                lambda: {"enabled": True, "installed": "3.8.0"},
+            )
+            monkeypatch.setattr(mcp_proxy, "schedule_update_check", lambda: False)
+            request = {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {"name": "mempalace_status", "arguments": {}},
+            }
+
+            response = mcp_server._dispatch_stdio_request(request)
+
+            payload = json.loads(response["result"]["content"][0]["text"])
+            assert payload["updates"] == {
+                "server": {"enabled": True, "installed": "3.9.0"},
+                "client": {"enabled": True, "installed": "3.8.0"},
+            }
+        finally:
+            hub.stop()
+
     def test_no_hub_handles_locally(self, proxied_palace, monkeypatch):
         from mempalace import mcp_server
 

--- a/tests/test_mcp_proxy.py
+++ b/tests/test_mcp_proxy.py
@@ -124,6 +124,42 @@ class TestRouting:
         assert mcp_proxy._handle(dict(self._REQUEST), "/p", local) is forwarded
         assert local.load_count == 0
 
+    def test_proxied_status_distinguishes_hub_and_local_update_state(self, monkeypatch):
+        request = {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {"name": "mempalace_status", "arguments": {}},
+        }
+        hub_payload = {
+            "total_drawers": 10,
+            "updates": {"server": {"enabled": True, "installed": "3.9.0"}},
+        }
+        forwarded = {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "result": {"content": [{"type": "text", "text": json.dumps(hub_payload)}]},
+        }
+        monkeypatch.setattr(mcp_proxy, "_hub_target", lambda p: ("http://hub", {}))
+        monkeypatch.setattr(mcp_proxy, "_forward", lambda *a: forwarded)
+        monkeypatch.setattr(
+            mcp_proxy,
+            "cached_update_status",
+            lambda: {"enabled": True, "installed": "3.8.0"},
+            raising=False,
+        )
+        monkeypatch.setattr(mcp_proxy, "schedule_update_check", lambda: False, raising=False)
+        local = _LoadedLocal(_FakeServer())
+
+        out = mcp_proxy._handle(request, "/p", local)
+
+        payload = json.loads(out["result"]["content"][0]["text"])
+        assert payload["updates"] == {
+            "server": {"enabled": True, "installed": "3.9.0"},
+            "client": {"enabled": True, "installed": "3.8.0"},
+        }
+        assert local.load_count == 0
+
     def test_no_hub_falls_back_locally_and_warns(self, monkeypatch):
         monkeypatch.setattr(mcp_proxy, "_hub_target", lambda p: None)
         server = _FakeServer()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7152,6 +7152,11 @@ class TestStaleLibraryGate:
 
         self._reset(monkeypatch)
         self._versions(monkeypatch, {"mempalace": "3.6.0"}, {"mempalace": "3.7.0"})
+        monkeypatch.setattr(
+            "mempalace.update_awareness.cached_update_status",
+            lambda: {"enabled": True, "installed": "3.6.0", "available": True},
+        )
+        monkeypatch.setattr("mempalace.update_awareness.schedule_update_check", lambda: False)
 
         decorated = mcp_server._decorate_mcp_tool_result("mempalace_status", {"total_drawers": 0})
 
@@ -7159,6 +7164,11 @@ class TestStaleLibraryGate:
         assert decorated["library_versions"]["packages"] == [
             {"package": "mempalace", "serving": "3.6.0", "installed": "3.7.0"}
         ]
+        assert decorated["updates"] == {
+            "enabled": True,
+            "installed": "3.6.0",
+            "available": True,
+        }
 
     def test_unreadable_metadata_fails_open_but_says_so(self, monkeypatch):
         """An unreadable metadata directory must not take the server down, but

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7165,9 +7165,11 @@ class TestStaleLibraryGate:
             {"package": "mempalace", "serving": "3.6.0", "installed": "3.7.0"}
         ]
         assert decorated["updates"] == {
-            "enabled": True,
-            "installed": "3.6.0",
-            "available": True,
+            "server": {
+                "enabled": True,
+                "installed": "3.6.0",
+                "available": True,
+            }
         }
 
     def test_unreadable_metadata_fails_open_but_says_so(self, monkeypatch):

--- a/tests/test_update_awareness.py
+++ b/tests/test_update_awareness.py
@@ -1,0 +1,212 @@
+"""Public-interface tests for opt-in release awareness."""
+
+import threading
+import time
+from datetime import datetime, timezone
+
+from mempalace.update_awareness import (
+    cached_update_status,
+    check_updates,
+    configure_updates,
+    prepare_upgrade,
+    schedule_update_check,
+)
+
+
+NOW = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+
+
+def test_disabled_automatic_check_never_contacts_release_source(tmp_path):
+    calls = []
+
+    result = check_updates(
+        config_dir=tmp_path,
+        installed_version="3.8.0",
+        fetch_latest=lambda: calls.append(True) or "3.9.0",
+        now=NOW,
+    )
+
+    assert result == {"enabled": False, "installed": "3.8.0", "checked": False}
+    assert calls == []
+
+
+def test_disabled_background_check_never_starts_or_contacts_release_source(tmp_path):
+    calls = []
+
+    assert not schedule_update_check(
+        config_dir=tmp_path,
+        fetch_latest=lambda: calls.append(True) or "3.9.0",
+        now=NOW,
+    )
+    assert calls == []
+
+
+def test_explicit_check_fetches_and_caches_latest_release_when_disabled(tmp_path):
+    result = check_updates(
+        config_dir=tmp_path,
+        installed_version="3.8.0",
+        fetch_latest=lambda: "3.9.0",
+        now=NOW,
+        force=True,
+    )
+
+    assert result == {
+        "enabled": False,
+        "installed": "3.8.0",
+        "latest": "3.9.0",
+        "available": True,
+        "checked": True,
+        "checked_at": "2026-08-28T12:00:00Z",
+        "restart_required_after_upgrade": True,
+    }
+    assert (
+        prepare_upgrade(config_dir=tmp_path, installed_version="3.8.0", installer="uv-tool")[
+            "requires_user_authorization"
+        ]
+        is True
+    )
+    assert cached_update_status(config_dir=tmp_path, installed_version="3.8.0") == {
+        "enabled": False,
+        "installed": "3.8.0",
+    }
+
+
+def test_opted_in_check_uses_fresh_cache_without_network(tmp_path):
+    configure_updates(config_dir=tmp_path, enabled=True, interval_days=7, installer="uv-tool")
+    check_updates(
+        config_dir=tmp_path,
+        installed_version="3.8.0",
+        fetch_latest=lambda: "3.9.0",
+        now=NOW,
+        force=True,
+    )
+    calls = []
+
+    result = check_updates(
+        config_dir=tmp_path,
+        installed_version="3.8.0",
+        fetch_latest=lambda: calls.append(True) or "4.0.0",
+        now=datetime(2026, 8, 29, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert result["latest"] == "3.9.0"
+    assert result["available"] is True
+    assert result["checked"] is False
+    assert calls == []
+
+
+def test_corrupt_cached_release_is_ignored_and_refreshed(tmp_path):
+    configure_updates(config_dir=tmp_path, enabled=True, installer="uv-tool")
+    (tmp_path / "updates-cache.json").write_text(
+        '{"latest": "not-a-version", "checked_at": 123}',
+        encoding="utf-8",
+    )
+
+    assert cached_update_status(config_dir=tmp_path, installed_version="3.8.0") == {
+        "enabled": True,
+        "installed": "3.8.0",
+        "checked": False,
+    }
+    refreshed = check_updates(
+        config_dir=tmp_path,
+        installed_version="3.8.0",
+        fetch_latest=lambda: "3.9.0",
+        now=NOW,
+    )
+    assert refreshed["latest"] == "3.9.0"
+    assert refreshed["checked"] is True
+
+
+def test_failed_periodic_check_is_not_retried_until_interval_expires(tmp_path):
+    configure_updates(config_dir=tmp_path, enabled=True, installer="uv-tool")
+    calls = []
+
+    def fail():
+        calls.append(True)
+        raise OSError("offline")
+
+    for _ in range(2):
+        try:
+            check_updates(
+                config_dir=tmp_path,
+                installed_version="3.8.0",
+                fetch_latest=fail,
+                now=NOW,
+            )
+        except OSError:
+            pass
+
+    assert calls == [True]
+
+
+def test_timezone_naive_cached_attempt_is_treated_as_stale(tmp_path):
+    configure_updates(config_dir=tmp_path, enabled=True, installer="uv-tool")
+    (tmp_path / "updates-cache.json").write_text(
+        '{"attempted_at": "2026-08-28T12:00:00"}', encoding="utf-8"
+    )
+
+    result = check_updates(
+        config_dir=tmp_path,
+        installed_version="3.8.0",
+        fetch_latest=lambda: "3.9.0",
+        now=NOW,
+    )
+
+    assert result["checked"] is True
+
+
+def test_cached_agent_status_and_plan_never_apply_the_upgrade(tmp_path):
+    configure_updates(config_dir=tmp_path, enabled=True, installer="uv-tool")
+    check_updates(
+        config_dir=tmp_path,
+        installed_version="3.8.0",
+        fetch_latest=lambda: "3.9.0",
+        now=NOW,
+        force=True,
+    )
+
+    assert cached_update_status(config_dir=tmp_path, installed_version="3.8.0")["available"]
+    plan = prepare_upgrade(config_dir=tmp_path, installed_version="3.8.0")
+    assert plan["requires_user_authorization"] is True
+    assert plan["actions"][0] == "uv tool upgrade mempalace"
+    assert plan["actions"][1] == ("npx skills update mempalace mempalace-recall mempalace-task")
+    assert all("--yes" not in action for action in plan["actions"])
+
+
+def test_opted_in_background_check_publishes_cached_state_for_agents(tmp_path):
+    configure_updates(config_dir=tmp_path, enabled=True, installer="uv-tool")
+    assert schedule_update_check(config_dir=tmp_path, fetch_latest=lambda: "3.9.0", now=NOW)
+    deadline = time.monotonic() + 2
+    cache_file = tmp_path / "updates-cache.json"
+    while not cache_file.exists() or "3.9.0" not in cache_file.read_text(encoding="utf-8"):
+        assert time.monotonic() < deadline
+        time.sleep(0.01)
+
+    assert cached_update_status(config_dir=tmp_path, installed_version="3.8.0")["available"]
+
+
+def test_in_flight_check_cannot_restore_withdrawn_consent(tmp_path):
+    entered_fetch = threading.Event()
+    release_fetch = threading.Event()
+
+    def fetch_latest():
+        entered_fetch.set()
+        assert release_fetch.wait(timeout=2)
+        return "3.9.0"
+
+    configure_updates(config_dir=tmp_path, enabled=True, installer="uv-tool")
+    assert schedule_update_check(config_dir=tmp_path, fetch_latest=fetch_latest, now=NOW)
+    assert entered_fetch.wait(timeout=2)
+
+    configure_updates(config_dir=tmp_path, enabled=False)
+    release_fetch.set()
+    deadline = time.monotonic() + 2
+    cache_file = tmp_path / "updates-cache.json"
+    while "3.9.0" not in cache_file.read_text(encoding="utf-8"):
+        assert time.monotonic() < deadline
+        time.sleep(0.01)
+
+    assert cached_update_status(config_dir=tmp_path, installed_version="3.8.0") == {
+        "enabled": False,
+        "installed": "3.8.0",
+    }

--- a/tests/test_update_awareness.py
+++ b/tests/test_update_awareness.py
@@ -1,5 +1,7 @@
 """Public-interface tests for opt-in release awareness."""
 
+import json
+import sys
 import threading
 import time
 from datetime import datetime, timezone
@@ -168,9 +170,43 @@ def test_cached_agent_status_and_plan_never_apply_the_upgrade(tmp_path):
     assert cached_update_status(config_dir=tmp_path, installed_version="3.8.0")["available"]
     plan = prepare_upgrade(config_dir=tmp_path, installed_version="3.8.0")
     assert plan["requires_user_authorization"] is True
-    assert plan["actions"][0] == "uv tool upgrade mempalace"
-    assert plan["actions"][1] == ("npx skills update mempalace mempalace-recall mempalace-task")
-    assert all("--yes" not in action for action in plan["actions"])
+    assert plan["actions"][0] == {
+        "kind": "command",
+        "argv": ["uv", "tool", "upgrade", "mempalace"],
+    }
+    assert plan["actions"][1] == {
+        "kind": "command",
+        "argv": ["npx", "skills", "update", "mempalace", "mempalace-recall", "mempalace-task"],
+    }
+    assert plan["actions"][2] == {
+        "kind": "instruction",
+        "text": "restart the MemPalace MCP server or shared hub",
+    }
+    assert plan["actions"][3] == {
+        "kind": "instruction",
+        "text": "refresh agent MCP tool lists",
+    }
+    assert "--yes" not in json.dumps(plan["actions"])
+
+
+def test_pip_plan_targets_the_interpreter_running_mempalace(tmp_path, monkeypatch):
+    runtime = tmp_path / "venv" / "bin" / "python"
+    monkeypatch.setattr(sys, "executable", str(runtime))
+    configure_updates(config_dir=tmp_path, enabled=True, installer="pip")
+    check_updates(
+        config_dir=tmp_path,
+        installed_version="3.8.0",
+        fetch_latest=lambda: "3.9.0",
+        now=NOW,
+        force=True,
+    )
+
+    plan = prepare_upgrade(config_dir=tmp_path, installed_version="3.8.0")
+
+    assert plan["actions"][0] == {
+        "kind": "command",
+        "argv": [str(runtime), "-m", "pip", "install", "--upgrade", "mempalace"],
+    }
 
 
 def test_opted_in_background_check_publishes_cached_state_for_agents(tmp_path):

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -4,6 +4,18 @@ All commands accept `--palace <path>` to override the default palace location.
 The top-level command also accepts `--backend <name>` to select a storage
 backend such as `sqlite_exact`, `milvus`, `qdrant`, or `pgvector`.
 
+## `mempalace update`
+
+Release checks are disabled by default. Enable weekly checks explicitly with
+`mempalace update configure --enable --installer uv-tool` (using `pipx` or
+`pip` when that is how the runtime was installed), or disable them with `--disable`.
+`mempalace update check` performs an explicit check regardless of that setting.
+`mempalace update plan` prints the runtime, skill, restart, and tool-refresh
+actions but never executes them. For an explicit check made without saved setup
+state, pass the matching installer to `plan --installer`. Cached state appears in `mempalace_status` so
+agents can ask the user to authorize an upgrade without blocking on a network
+request.
+
 ## `mempalace init`
 
 Scan a project directory for people, projects, and rooms, and set up the palace.

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -11,7 +11,9 @@ Release checks are disabled by default. Enable weekly checks explicitly with
 `pip` when that is how the runtime was installed), or disable them with `--disable`.
 `mempalace update check` performs an explicit check regardless of that setting.
 `mempalace update plan` prints the runtime, skill, restart, and tool-refresh
-actions but never executes them. For an explicit check made without saved setup
+actions but never executes them. Command actions use structured `argv`; for a
+`pip` installation the first argument is the exact interpreter running
+MemPalace, not whichever `python` happens to be on `PATH`. For an explicit check made without saved setup
 state, pass the matching installer to `plan --installer`. Cached state appears in `mempalace_status` so
 agents can ask the user to authorize an upgrade without blocking on a network
 request.

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -14,10 +14,15 @@ Palace overview: total drawers, wing and room counts, AAAK spec, and memory prot
 
 `library_versions` reports the versions this server loaded and whether they still match what is installed on disk. `stale: true` means they no longer match, which happens when the package is upgraded or removed while the server is running; write tools are then refused with error `-32005` until the server is restarted, unless `MEMPALACE_MCP_ALLOW_STALE_LIBRARY=1` is set in its environment, in which case `gate_disabled_by` names that variable. An `unreadable` key lists the distributions the check is not covering — either their installed metadata could not be read, or they could not be resolved at all when the server started — so `stale: false` is never mistaken for "checked and fine" when nothing was checked.
 
-`updates` is local cached release state. Checks are disabled by default; when
-the user opts in, the MCP server refreshes the cache in a background thread so
-this tool never waits on PyPI. An available release is informational only and
-must be authorized by the user before any upgrade commands run.
+`updates.server` is cached release state for the runtime serving the palace.
+When a local stdio process proxies to a hub, it also adds `updates.client` for
+that proxy's locally installed runtime; a direct HTTP client receives only the
+server scope because it has no local MemPalace process to inspect. Checks are
+disabled by default and refresh in a background thread, so this tool never
+waits on PyPI. An available release is informational only and must be authorized
+by the user before any upgrade commands run. A remote `updates.server` release
+must be planned on the hub host; a client's local plan applies only to
+`updates.client`.
 
 ---
 

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -10,9 +10,14 @@ Palace overview: total drawers, wing and room counts, AAAK spec, and memory prot
 
 **Parameters:** None
 
-**Returns:** `{ total_drawers, wings, rooms, protocol, aaak_dialect, sqlite_integrity, library_versions }`
+**Returns:** `{ total_drawers, wings, rooms, protocol, aaak_dialect, sqlite_integrity, library_versions, updates }`
 
 `library_versions` reports the versions this server loaded and whether they still match what is installed on disk. `stale: true` means they no longer match, which happens when the package is upgraded or removed while the server is running; write tools are then refused with error `-32005` until the server is restarted, unless `MEMPALACE_MCP_ALLOW_STALE_LIBRARY=1` is set in its environment, in which case `gate_disabled_by` names that variable. An `unreadable` key lists the distributions the check is not covering — either their installed metadata could not be read, or they could not be resolved at all when the server started — so `stale: false` is never mistaken for "checked and fine" when nothing was checked.
+
+`updates` is local cached release state. Checks are disabled by default; when
+the user opts in, the MCP server refreshes the cache in a background thread so
+this tool never waits on PyPI. An available release is informational only and
+must be authorized by the user before any upgrade commands run.
 
 ---
 


### PR DESCRIPTION
## Summary

- add explicit, opt-in stable-release checks with no network access by default
- expose cached update availability through `mempalace_status` without blocking agent calls
- generate installer-specific, authorization-gated upgrade plans for the runtime and all three shipped skills
- synchronize the setup and task workflows into the Claude marketplace package and Antigravity guidance
- preserve withdrawn consent across concurrent checks by separating policy from refreshable cache state

## Validation

- `uv run pytest tests/test_update_awareness.py tests/test_cli_update.py tests/test_mcp_server.py tests/test_claude_marketplace_skills.py tests/test_antigravity_plugin_manifest.py tests/test_readme_claims.py -q --disable-warnings` — 458 passed, 9 skipped
- broad non-benchmark suite excluding known Windows baselines — 4,234 passed, 382 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `npm run docs:build`
- `npx -y skills add . --list` — discovers `mempalace`, `mempalace-recall`, and `mempalace-task`
- independent Standards and Spec reviews — no remaining blockers

## Known repository baselines

- the Claude hook-wrapper tests fail under Windows because WSL `bash.exe` cannot resolve the Windows worktree path
- `test_eperm_on_both_names_falls_back_too` hangs in its existing Windows atomic-config fallback path and was deselected from the broad run
