### PR TITLE
fix(search): reuse filtered-query fallback in CLI

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -740,7 +740,7 @@ def search(
         if where:
             kwargs["where"] = where
 
-        results = col.query(**kwargs)
+        results = _query_drawers_with_filter_fallback(col, kwargs, query, n_results, wing, room)
 
     except Exception as e:
         print(f"\n  Search error: {e}")

--- a/tests/test_search_drawer_id.py
+++ b/tests/test_search_drawer_id.py
@@ -7,6 +7,7 @@ from mempalace.searcher import (
     _aligned_query_ids,
     _finalize_candidate_hits,
     _query_drawers_with_filter_fallback,
+    search,
     search_memories,
 )
 
@@ -328,3 +329,58 @@ def test_union_results_use_parent_or_lexical_hit_id():
         and "_parent_drawer_id" not in hit
         for hit in hits
     )
+
+
+def test_cli_scoped_search_uses_existing_filter_fallback(capsys):
+    drawers_col = MagicMock()
+    drawers_col.distance_metric = "cosine"
+    drawers_col.metadata = {"hnsw:space": "cosine"}
+    drawers_col.query.side_effect = [
+        RuntimeError("Error finding id"),
+        {
+            "ids": [["drop-id", "keep-id"]],
+            "documents": [["drop document", "keep document"]],
+            "metadatas": [
+                [
+                    {
+                        "wing": "keep",
+                        "room": "other",
+                        "source_file": "/palace/drop.md",
+                    },
+                    {
+                        "wing": "keep",
+                        "room": "notes",
+                        "source_file": "/palace/keep.md",
+                    },
+                ]
+            ],
+            "distances": [[0.2, 0.1]],
+        },
+    ]
+
+    with patch(
+        "mempalace.searcher.resolve_backend_name",
+        return_value="sqlite_exact",
+    ):
+        with patch(
+            "mempalace.searcher._open_collection_or_explain",
+            return_value=drawers_col,
+        ):
+            search(
+                "needle",
+                "/unused",
+                wing="keep",
+                room="notes",
+                n_results=2,
+            )
+
+    output = capsys.readouterr().out
+    assert drawers_col.query.call_count == 2
+
+    filtered_call, fallback_call = drawers_col.query.call_args_list
+    assert filtered_call.kwargs["where"] == {"$and": [{"wing": "keep"}, {"room": "notes"}]}
+    assert "where" not in fallback_call.kwargs
+    assert fallback_call.kwargs["n_results"] == 30
+
+    assert "keep document" in output
+    assert "drop document" not in output


### PR DESCRIPTION
Closes #2373.

Routes the CLI `search()` drawer query through the existing `_query_drawers_with_filter_fallback()` recovery path already used by `search_memories()`.

When a scoped Chroma query (`--wing` / `--room`) hits the known `Error finding id` planner failure, the CLI now matches the MCP behavior: it retries unfiltered with the existing over-fetch and reapplies the requested scope in Python instead of hard-failing.

No new recovery semantics are introduced; this only removes the CLI/MCP asymmetry by reusing the existing helper. Unscoped query failures still raise as before because the helper only falls back when a `where` filter was present.

Regression coverage drives the CLI path through:
- a failing wing+room filtered query;
- the unfiltered fallback;
- Python-side scope filtering;
- output verification that only the in-scope drawer is rendered.

Validation against current `develop` (`a9f345c`):
- `python -m pytest -q tests/test_search_drawer_id.py` — **7 passed**
- `ruff check mempalace/searcher.py tests/test_search_drawer_id.py` — **passed**
- `ruff format --check mempalace/searcher.py tests/test_search_drawer_id.py` — **passed**
- `python -m compileall -q mempalace/searcher.py tests/test_search_drawer_id.py` — **passed**

Final branch shape: one commit, 1 ahead / 0 behind, two changed files only.