### PR TITLE
fix(search): preserve closet hit provenance

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -1301,13 +1301,14 @@ def _enrich_closet_hits(
     query: str,
     stop_words: frozenset = frozenset(),
 ) -> list:
-    """Hydrate closet-boosted hits and memoise each source/group fetch."""
-    query_terms = set(
-        _tokenize(
-            query,
-            stop_words,
-        )
-    )
+    """Hydrate closet-boosted hits around the hit's own drawer chunk.
+
+    Closet agreement may widen the rendered context, but it must never
+    substitute another drawer's text under the original ``drawer_id``.
+    Source/group fetches are memoised for the search. If the candidate's
+    ``chunk_index`` cannot be resolved exactly and unambiguously, the
+    original direct-drawer text is preserved unchanged.
+    """
     source_cache: dict = {}
 
     for hit in hits:
@@ -1315,29 +1316,18 @@ def _enrich_closet_hits(
             continue
 
         full_source = hit.get("_source_file_full") or ""
-
-        if not full_source:
+        chunk_index = hit.get("_chunk_index")
+        if not full_source or not isinstance(chunk_index, int):
             continue
 
         parent_drawer_id = hit.get("_parent_drawer_id") or None
-        cache_key = (
-            full_source,
-            parent_drawer_id,
-        )
+        cache_key = (full_source, parent_drawer_id)
 
         if cache_key not in source_cache:
             try:
                 source_drawers = drawers_col.get(
-                    where=(
-                        _scoped_source_filter(
-                            full_source,
-                            parent_drawer_id,
-                        )
-                    ),
-                    include=[
-                        "documents",
-                        "metadatas",
-                    ],
+                    where=_scoped_source_filter(full_source, parent_drawer_id),
+                    include=["documents", "metadatas"],
                 )
             except Exception:
                 logger.debug(
@@ -1348,105 +1338,55 @@ def _enrich_closet_hits(
                 source_cache[cache_key] = None
             else:
                 source_cache[cache_key] = (
-                    list(
-                        getattr(
-                            source_drawers,
-                            "documents",
-                            None,
-                        )
-                        or []
-                    ),
-                    list(
-                        getattr(
-                            source_drawers,
-                            "metadatas",
-                            None,
-                        )
-                        or []
-                    ),
+                    list(getattr(source_drawers, "documents", None) or []),
+                    list(getattr(source_drawers, "metadatas", None) or []),
                 )
 
         cached = source_cache[cache_key]
-
         if cached is None:
             continue
 
         docs, metadatas = cached
-
-        if len(docs) <= 1:
-            continue
-
         indexed = []
-
-        for index, (
-            document,
-            metadata,
-        ) in enumerate(
-            zip(
-                docs,
-                metadatas,
-            )
-        ):
-            chunk_index = (
-                metadata.get(
-                    "chunk_index",
-                    index,
-                )
-                if isinstance(
-                    metadata,
-                    dict,
-                )
-                else index
-            )
-
-            if not isinstance(
-                chunk_index,
-                int,
-            ):
-                chunk_index = index
-
-            indexed.append(
-                (
-                    chunk_index,
-                    document or "",
-                )
-            )
+        for index, (document, metadata) in enumerate(zip(docs, metadatas)):
+            metadata = metadata if isinstance(metadata, dict) else {}
+            candidate_index = metadata.get("chunk_index", index)
+            if not isinstance(candidate_index, int):
+                candidate_index = index
+            indexed.append((candidate_index, document or ""))
 
         indexed.sort(key=lambda pair: pair[0])
-        ordered_docs = [document for _, document in indexed]
+        positions = [
+            position
+            for position, (candidate_index, _) in enumerate(indexed)
+            if candidate_index == chunk_index
+        ]
+        if len(positions) != 1:
+            continue
 
-        best_index = 0
-        best_score = -1
+        matched_position = positions[0]
+        start = max(0, matched_position - 1)
+        end = min(len(indexed), matched_position + 2)
+        expanded = "\n\n".join(document for _, document in indexed[start:end])
 
-        for index, document in enumerate(ordered_docs):
-            lowered = document.lower()
-            score = sum(1 for term in query_terms if term in lowered)
-
-            if score > best_score:
-                best_score = score
-                best_index = index
-
-        start = max(
-            0,
-            best_index - 1,
-        )
-        end = min(
-            len(ordered_docs),
-            best_index + 2,
-        )
-        expanded = "\n\n".join(ordered_docs[start:end])
+        original_text = hit.get("text", "") or ""
+        if original_text and original_text not in expanded:
+            logger.debug(
+                "Closet enrichment provenance mismatch for %s chunk %s; keeping raw hit",
+                full_source,
+                chunk_index,
+            )
+            continue
 
         if len(expanded) > _MAX_HYDRATION_CHARS:
             expanded = expanded[:_MAX_HYDRATION_CHARS] + (
-                f"\n\n[...truncated. "
-                f"{len(ordered_docs)} total drawers. "
-                "Use mempalace_get_drawer "
-                "for full content.]"
+                f"\n\n[...truncated. {len(indexed)} total drawers. "
+                "Use mempalace_get_drawer for full content.]"
             )
 
         hit["text"] = expanded
-        hit["drawer_index"] = best_index
-        hit["total_drawers"] = len(ordered_docs)
+        hit["drawer_index"] = chunk_index
+        hit["total_drawers"] = len(indexed)
 
     return hits
 
@@ -1912,11 +1852,11 @@ def _backend_capabilities(col) -> frozenset:
 
 
 def _closet_boosts(closets_col, *, query: str, n_results: int, where: dict) -> dict:
-    """Best-per-source closet hits used as a rank boost, never a gate.
+    """Best-per-drawer closet hits used as a rank boost, never a gate.
 
-    sqlite_exact (and any lexical backend) uses FTS instead of a second
-    exact-cosine scan over the closet collection — closets are pointer
-    lines, so BM25 is the better signal anyway.
+    A closet document names the drawers it supports through ``→drawer_id``
+    pointers. Boost only those exact drawer ids; sharing ``source_file`` is
+    not evidence that an unrelated sibling drawer matched the closet (#2377).
     """
     boosts: dict = {}
     n_hits = max(1, n_results * 2)
@@ -1924,11 +1864,10 @@ def _closet_boosts(closets_col, *, query: str, n_results: int, where: dict) -> d
         result = closets_col.lexical_search(query=query, n_results=n_hits, where=where or None)
         hits = getattr(result, "hits", None) or []
         for rank, hit in enumerate(hits):
-            meta = hit.metadata or {}
-            source = meta.get("source_file", "")
-            if source and source not in boosts:
-                preview = (hit.document or "")[:200]
-                boosts[source] = (rank, 0.0, preview)
+            preview = (hit.document or "")[:200]
+            for drawer_id in _extract_drawer_ids_from_closet(hit.document or ""):
+                if drawer_id not in boosts:
+                    boosts[drawer_id] = (rank, 0.0, preview)
         return boosts
 
     ckwargs = {
@@ -1939,17 +1878,17 @@ def _closet_boosts(closets_col, *, query: str, n_results: int, where: dict) -> d
     if where:
         ckwargs["where"] = where
     closet_results = closets_col.query(**ckwargs)
-    for rank, (cdoc, cmeta, cdist) in enumerate(
+    for rank, (cdoc, _cmeta, cdist) in enumerate(
         zip(
             _first_or_empty(closet_results, "documents"),
             _first_or_empty(closet_results, "metadatas"),
             _first_or_empty(closet_results, "distances"),
         )
     ):
-        cmeta = cmeta or {}
-        source = cmeta.get("source_file", "")
-        if source and source not in boosts:
-            boosts[source] = (rank, cdist, (cdoc or "")[:200])
+        preview = (cdoc or "")[:200]
+        for drawer_id in _extract_drawer_ids_from_closet(cdoc or ""):
+            if drawer_id not in boosts:
+                boosts[drawer_id] = (rank, cdist, preview)
     return boosts
 
 
@@ -2081,10 +2020,10 @@ def search_memories(
         return _search_error_result(f"Search error: {e}")
 
     # Gather closet hits (best-per-source) to build a boost lookup.
-    closet_boost_by_source: dict = {}  # source_file -> (rank, closet_dist, preview)
+    closet_boost_by_drawer: dict = {}  # drawer_id -> (rank, closet_dist, preview)
     try:
         closets_col = get_closets_collection(palace_path, create=False)
-        closet_boost_by_source = _closet_boosts(
+        closet_boost_by_drawer = _closet_boosts(
             closets_col, query=query, n_results=n_results, where=where
         )
     except Exception:
@@ -2116,8 +2055,8 @@ def search_memories(
         boost = 0.0
         matched_via = "drawer"
         closet_preview = None
-        if source in closet_boost_by_source:
-            c_rank, c_dist, c_preview = closet_boost_by_source[source]
+        if stored_drawer_id in closet_boost_by_drawer:
+            c_rank, c_dist, c_preview = closet_boost_by_drawer[stored_drawer_id]
             if c_dist <= CLOSET_DISTANCE_CAP and c_rank < len(CLOSET_RANK_BOOSTS):
                 boost = CLOSET_RANK_BOOSTS[c_rank]
                 matched_via = "drawer+closet"

--- a/tests/test_search_distinct_closet_results.py
+++ b/tests/test_search_distinct_closet_results.py
@@ -10,6 +10,7 @@ from mempalace.palace import (
 )
 from mempalace.searcher import (
     _candidate_pool_limits,
+    _closet_boosts,
     _dedupe_rendered_hits,
     _enrich_closet_hits,
     search_memories,
@@ -68,97 +69,76 @@ def test_rendered_dedup_preserves_first_ranked_closet_hit_and_plain_repeats():
 def test_closet_enrichment_memoises_by_source_and_parent_group():
     drawers_col = MagicMock()
 
-    def get_group(
-        *,
-        where,
-        include,
-    ):
-        assert include == [
-            "documents",
-            "metadatas",
-        ]
-
+    def get_group(*, where, include):
+        assert include == ["documents", "metadatas"]
         parent = where["$and"][1]["parent_drawer_id"]
-
         return SimpleNamespace(
-            documents=[
-                (f"{parent} token best chunk"),
-                (f"{parent} neighboring context"),
-            ],
-            metadatas=[
-                {
-                    "chunk_index": 0,
-                },
-                {
-                    "chunk_index": 1,
-                },
-            ],
+            documents=[f"{parent} raw {index}" for index in range(5)],
+            metadatas=[{"chunk_index": index} for index in range(5)],
         )
 
     drawers_col.get.side_effect = get_group
-
     hits = [
         {
-            "drawer_id": "a-0",
-            "text": "raw a0",
-            "matched_via": ("drawer+closet"),
-            "_source_file_full": ("/shared/log.md"),
-            "_parent_drawer_id": ("parent-a"),
+            "drawer_id": "a_0",
+            "text": "parent-a raw 0",
+            "matched_via": "drawer+closet",
+            "_source_file_full": "/shared/log.md",
+            "_parent_drawer_id": "parent-a",
+            "_chunk_index": 0,
         },
         {
-            "drawer_id": "a-1",
-            "text": "raw a1",
-            "matched_via": ("drawer+closet"),
-            "_source_file_full": ("/shared/log.md"),
-            "_parent_drawer_id": ("parent-a"),
+            "drawer_id": "a_4",
+            "text": "parent-a raw 4",
+            "matched_via": "drawer+closet",
+            "_source_file_full": "/shared/log.md",
+            "_parent_drawer_id": "parent-a",
+            "_chunk_index": 4,
         },
         {
-            "drawer_id": "b-0",
-            "text": "raw b0",
-            "matched_via": ("drawer+closet"),
-            "_source_file_full": ("/shared/log.md"),
-            "_parent_drawer_id": ("parent-b"),
+            "drawer_id": "b_2",
+            "text": "parent-b raw 2",
+            "matched_via": "drawer+closet",
+            "_source_file_full": "/shared/log.md",
+            "_parent_drawer_id": "parent-b",
+            "_chunk_index": 2,
         },
     ]
 
-    _enrich_closet_hits(
-        hits,
-        drawers_col,
-        "token",
-    )
+    _enrich_closet_hits(hits, drawers_col, "token")
 
     assert drawers_col.get.call_count == 2
-    assert hits[0]["text"] == hits[1]["text"]
-    assert "parent-a" in hits[0]["text"]
-    assert "parent-b" in hits[2]["text"]
-    assert hits[0]["text"] != hits[2]["text"]
+    assert "parent-a raw 0" in hits[0]["text"]
+    assert "parent-a raw 4" not in hits[0]["text"]
+    assert "parent-a raw 4" in hits[1]["text"]
+    assert "parent-a raw 0" not in hits[1]["text"]
+    assert "parent-b raw 2" in hits[2]["text"]
+    assert [hit["drawer_id"] for hit in hits] == ["a_0", "a_4", "b_2"]
+    assert [hit["drawer_index"] for hit in hits] == [0, 4, 2]
 
 
-def test_search_promotes_distinct_results_from_wider_pool_and_fetches_source_once():
+def test_search_promotes_only_drawers_named_by_matching_closet():
     repeated_source = "/project/large.md"
     query = "quasar authentication token rotation"
-
-    repeated_documents = [(f"raw repeated-source drawer {index}") for index in range(5)]
-    fallback_documents = [(f"independent fallback passage {index}") for index in range(4)]
-    documents = repeated_documents + fallback_documents
-
-    repeated_metadatas = [
+    documents = [f"source drawer {index}" for index in range(5)] + [
+        f"independent fallback passage {index}" for index in range(4)
+    ]
+    metadatas = [
         {
-            "source_file": (repeated_source),
+            "source_file": repeated_source,
             "wing": "code",
             "room": "docs",
             "chunk_index": index,
-            "filed_at": (f"2026-08-04T00:00:0{index}"),
+            "filed_at": f"2026-08-04T00:00:0{index}",
         }
         for index in range(5)
-    ]
-    fallback_metadatas = [
+    ] + [
         {
-            "source_file": (f"/project/fallback-{index}.md"),
+            "source_file": f"/project/fallback-{index}.md",
             "wing": "code",
             "room": "docs",
             "chunk_index": 0,
-            "filed_at": (f"2026-08-04T00:01:0{index}"),
+            "filed_at": f"2026-08-04T00:01:0{index}",
         }
         for index in range(4)
     ]
@@ -167,101 +147,38 @@ def test_search_promotes_distinct_results_from_wider_pool_and_fetches_source_onc
     drawers_col.distance_metric = "cosine"
     drawers_col.query.return_value = {
         "ids": [
-            [
-                *[f"same-{index}" for index in range(5)],
-                *[f"fallback-{index}" for index in range(4)],
-            ]
+            [*[f"same_{index}" for index in range(5)], *[f"fallback_{index}" for index in range(4)]]
         ],
         "documents": [documents],
-        "metadatas": [(repeated_metadatas + fallback_metadatas)],
-        "distances": [
-            [
-                0.05,
-                0.06,
-                0.07,
-                0.08,
-                0.09,
-                0.45,
-                0.46,
-                0.47,
-                0.48,
-            ]
-        ],
+        "metadatas": [metadatas],
+        "distances": [[0.05, 0.06, 0.07, 0.08, 0.09, 0.45, 0.46, 0.47, 0.48]],
     }
     drawers_col.get.return_value = SimpleNamespace(
-        documents=[
-            ("context before the target"),
-            ("quasar authentication token rotation exact target"),
-            ("context after the target"),
-        ],
-        metadatas=[
-            {
-                "chunk_index": 0,
-            },
-            {
-                "chunk_index": 1,
-            },
-            {
-                "chunk_index": 2,
-            },
-        ],
+        documents=[f"source drawer {index}" for index in range(5)],
+        metadatas=[{"chunk_index": index} for index in range(5)],
     )
 
     closets_col = MagicMock()
     closets_col.query.return_value = {
-        "ids": [
-            [
-                "closet-1",
-            ]
-        ],
-        "documents": [
-            [
-                query,
-            ]
-        ],
-        "metadatas": [
-            [
-                {
-                    "source_file": (repeated_source),
-                }
-            ]
-        ],
-        "distances": [
-            [
-                0.1,
-            ]
-        ],
+        "ids": [["closet_1"]],
+        "documents": [[f"{query}|topic|→same_2"]],
+        "metadatas": [[{"source_file": repeated_source}]],
+        "distances": [[0.1]],
     }
 
-    with patch(
-        "mempalace.searcher.get_collection",
-        return_value=drawers_col,
-    ):
-        with patch(
-            "mempalace.searcher.get_closets_collection",
-            return_value=closets_col,
-        ):
-            result = search_memories(
-                query,
-                "/fake/palace",
-                n_results=5,
-            )
+    with patch("mempalace.searcher.get_collection", return_value=drawers_col):
+        with patch("mempalace.searcher.get_closets_collection", return_value=closets_col):
+            result = search_memories(query, "/fake/palace", n_results=9)
 
-    hits = result["results"]
-    rendered_keys = {
-        (
-            hit["source_path"],
-            hit["text"],
-        )
-        for hit in hits
-    }
-
-    assert len(hits) == 5
-    assert len(rendered_keys) == 5
-    assert hits[0]["drawer_id"] == "same-0"
-    assert drawers_col.query.call_args.kwargs["n_results"] == 20
+    by_id = {hit["drawer_id"]: hit for hit in result["results"]}
     assert drawers_col.get.call_count == 1
-    assert sum(hit["source_path"] == repeated_source for hit in hits) == 1
+    assert by_id["same_2"]["matched_via"] == "drawer+closet"
+    assert by_id["same_2"]["closet_boost"] > 0
+    assert "source drawer 2" in by_id["same_2"]["text"]
+    for drawer_id in ("same_0", "same_1", "same_3", "same_4"):
+        assert by_id[drawer_id]["matched_via"] == "drawer"
+        assert by_id[drawer_id]["closet_boost"] == 0
+        assert by_id[drawer_id]["text"] == documents[int(drawer_id.rsplit("_", 1)[1])]
 
 
 def test_process_file_preserves_legitimate_exact_repeats_at_different_positions(
@@ -414,3 +331,22 @@ def test_candidate_pool_limits_widen_only_default_vector_strategy():
         15,
         5,
     )
+
+
+def test_closet_boosts_ignore_unreferenced_siblings_from_same_source():
+    closets_col = MagicMock()
+    closets_col.query.return_value = {
+        "ids": [["closet_1"]],
+        "documents": [["target topic|entity|→keep_id,second_id"]],
+        "metadatas": [[{"source_file": "/shared/source.md"}]],
+        "distances": [[0.12]],
+    }
+    boosts = _closet_boosts(
+        closets_col,
+        query="target topic",
+        n_results=5,
+        where={},
+    )
+    assert set(boosts) == {"keep_id", "second_id"}
+    assert "unrelated_same_source_id" not in boosts
+    assert boosts["keep_id"][1] == 0.12


### PR DESCRIPTION
Closes #2377.

`drawer+closet` search results had two independent provenance leaks:

1. `_closet_boosts()` keyed a matching closet by `source_file`, so every direct drawer candidate from that file inherited the closet boost even when the closet's `→drawer_id` pointer did not name that drawer.
2. `_enrich_closet_hits()` then searched the whole source/group for the query-best chunk and replaced each boosted hit's `text` with that neighborhood while leaving the original `drawer_id` attached. Multiple different drawer IDs could therefore render the same unrelated passage.

This patch keeps the existing drawer-first / closet-as-ranking-signal architecture, but makes the signal provenance-preserving:

- closet boosts are keyed by the exact drawer IDs parsed from each matching closet's existing `→...` pointers;
- same-source sibling drawers that are not named by the closet remain ordinary `matched_via="drawer"` hits with zero closet boost;
- closet context hydration is anchored to the hit's own stored `chunk_index`, not the query-best chunk elsewhere in the source;
- if that chunk cannot be resolved exactly and unambiguously, or the proposed expanded context cannot be verified to contain the original direct-drawer text, enrichment fails closed and leaves the raw hit unchanged;
- source/group fetch memoization and ±1 neighbor context are preserved.

This also aligns search behavior with `docs/CLOSETS.md`: closets are pointer indexes to concrete drawers, not source-wide relevance grants.

Regression coverage verifies:

- only drawer IDs explicitly named by a matching closet receive `drawer+closet` status and boost;
- unrelated drawers sharing the same `source_file` remain unboosted and retain their own raw text;
- two boosted hits from the same source/group hydrate around their own distinct chunk indexes while sharing the memoized source fetch;
- exact closet-pointer parsing controls the boost map.

Validation against current `develop` (`a9f345c`):

- `python -m pytest -q tests/test_search_distinct_closet_results.py tests/test_search_drawer_id.py tests/test_closets.py` — **87 passed**
- `ruff check mempalace/searcher.py tests/test_search_distinct_closet_results.py` — **passed**
- `ruff format --check mempalace/searcher.py tests/test_search_distinct_closet_results.py` — **passed**
- `python -m compileall -q mempalace/searcher.py tests/test_search_distinct_closet_results.py` — **passed**

Final branch shape: one commit, 1 ahead / 0 behind, two changed files only.