### PR TITLE
feat: accept hermes as a hook harness

### DIFF
--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -2828,6 +2828,15 @@ def _reconfigure_stdio_utf8_on_windows():
     reconfigure_stdio_utf8_on_windows(stdout_errors="replace", stderr_errors="replace")
 
 
+# Harness names accepted by ``hook run --harness``. Duplicated from
+# ``hooks_cli.SUPPORTED_HARNESSES`` on purpose: the parser is rebuilt on every
+# CLI invocation and ``hooks_cli`` is a deliberate lazy import (see ``run_hook``)
+# to hold the startup budget, so importing it here to derive the list would put
+# the hook module on the critical path of every unrelated command.
+# ``test_cli_harness_choices_match_supported_harnesses`` asserts the two stay equal.
+HOOK_HARNESS_CHOICES = ("claude-code", "codex", "hermes")
+
+
 def main():
     """CLI entry point for the ``mempalace`` console script.
 
@@ -3196,7 +3205,7 @@ def main():
     p_hook_run.add_argument(
         "--harness",
         required=True,
-        choices=["claude-code", "codex"],
+        choices=list(HOOK_HARNESS_CHOICES),
         help="Harness type (determines stdin JSON format)",
     )
 

--- a/mempalace/hooks_cli.py
+++ b/mempalace/hooks_cli.py
@@ -3,7 +3,7 @@ Hook logic for MemPalace — Python implementation of session-start, stop, sessi
 
 Reads JSON from stdin, outputs JSON to stdout.
 Supported hooks: session-start, stop, session-end, precompact
-Supported harnesses: claude-code, codex (extensible to cursor, gemini, etc.)
+Supported harnesses: claude-code, codex, hermes (extensible to cursor, gemini, etc.)
 """
 
 import hashlib
@@ -1130,7 +1130,16 @@ def _ingest_transcript(transcript_path: str):
         _log(f"transcript ingest hook failed: {exc}")
 
 
-SUPPORTED_HARNESSES = {"claude-code", "codex"}
+# Harness names accepted by ``hook run --harness``. The name is not just a
+# validation token: ``_diary_agent_for_harness`` derives the diary identity from
+# it, so a harness missing from this set has to borrow another one's name and
+# files its checkpoints into that agent's diary — the #1693 invisibility bug in
+# a new shape. ``_parse_harness_input`` is harness-agnostic (session_id,
+# transcript_path, stop_hook_active), so adding a name here is all a new harness
+# needs once it can produce a transcript in a format ``normalize`` recognises.
+# Keep in sync with the ``--harness`` choices in ``cli.py``
+# (``test_cli_harness_choices_match_supported_harnesses`` guards the pair).
+SUPPORTED_HARNESSES = {"claude-code", "codex", "hermes"}
 
 
 def _diary_agent_for_harness(harness: str) -> str:

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -15,6 +15,7 @@ import mempalace.hooks_cli as hooks_cli_mod
 from mempalace.config import sanitize_name
 from mempalace.hooks_cli import (
     SAVE_INTERVAL,
+    SUPPORTED_HARNESSES,
     _count_human_messages,
     _diary_agent_for_harness,
     _extract_recent_messages,
@@ -401,6 +402,27 @@ def test_stop_hook_tracks_save_point(tmp_path):
 def test_diary_agent_for_harness_maps_known_harnesses():
     assert _diary_agent_for_harness("claude-code") == "claude"
     assert _diary_agent_for_harness("codex") == "codex"
+    assert _diary_agent_for_harness("hermes") == "hermes"
+
+
+def test_every_supported_harness_has_its_own_diary_identity():
+    """No supported harness may borrow another one's diary name.
+
+    A harness absent from SUPPORTED_HARNESSES has to be invoked under a
+    different one, and _diary_agent_for_harness then files its checkpoints
+    into that agent's diary — the session's own diary_read finds nothing,
+    which is #1693 in a new shape.
+    """
+    agents = {h: _diary_agent_for_harness(h) for h in SUPPORTED_HARNESSES}
+    assert len(set(agents.values())) == len(agents), agents
+
+
+def test_cli_harness_choices_match_supported_harnesses():
+    """cli.py repeats the harness list so hooks_cli can stay a lazy import
+    (CLI startup budget). Guard the duplication against drift."""
+    from mempalace.cli import HOOK_HARNESS_CHOICES
+
+    assert set(HOOK_HARNESS_CHOICES) == SUPPORTED_HARNESSES
 
 
 def test_diary_agent_for_harness_unknown_falls_back_to_name():
@@ -413,7 +435,7 @@ def test_diary_agent_for_harness_unknown_falls_back_to_name():
 
 @pytest.mark.parametrize(
     "harness,expected_agent",
-    [("claude-code", "claude"), ("codex", "codex")],
+    [("claude-code", "claude"), ("codex", "codex"), ("hermes", "hermes")],
 )
 def test_stop_hook_files_checkpoint_under_harness_agent(tmp_path, harness, expected_agent):
     """The Stop hook must file checkpoints under the agent identity that the


### PR DESCRIPTION
## Problem

`SUPPORTED_HARNESSES` is not only an input-validation set — `_diary_agent_for_harness` derives the diary identity from the same string:

```python
return "claude" if harness == "claude-code" else harness
```

So a harness that is *not* in the set has no way to run hooks under its own name. It has to borrow an existing one, and every checkpoint it files then lands in that harness's diary. The session's own `mempalace_diary_read(agent_name=...)` returns nothing — which is exactly the invisibility failure #1693 fixed for the hardcoded `"session-hook"` identity, reappearing through a different door.

The concrete case: [Hermes Agent](https://github.com/NousResearch/hermes-agent) stores sessions in SQLite rather than JSONL transcripts, so bridging them into MemPalace means exporting to a transcript `normalize` already recognises and calling `mempalace hook run`. That call currently has to pass `--harness claude-code`, and every Hermes diary checkpoint is filed under agent `claude`, mixed into the Claude Code diary. Drawers are unaffected (they key on wing, not agent), so only continuity between the bridged agent's own sessions breaks — silently, since the hook still exits 0.

## Why this is a small change

Nothing downstream of the name is harness-specific:

- `_parse_harness_input` reads `session_id`, `transcript_path` and `stop_hook_active` and nothing else — it validates the harness and is otherwise format-agnostic.
- `_count_human_messages` distinguishes the Claude Code and Codex line shapes by inspecting each line, not by the harness argument.

Adding a name to the set is therefore all a new harness needs, once it can produce a transcript `normalize` accepts. The `_diary_agent_for_harness` docstring already states this as the intent:

> returning the harness name keeps a newly supported harness discoverable instead of silently invisible again

## Changes

- `mempalace/hooks_cli.py` — add `hermes` to `SUPPORTED_HARNESSES`; document that the set drives diary identity, so an omission is a correctness bug rather than a missing convenience.
- `mempalace/cli.py` — lift the `--harness` choices into `HOOK_HARNESS_CHOICES`. The list stays duplicated rather than imported from `hooks_cli`: the parser is rebuilt on every CLI invocation and `hooks_cli` is a deliberate lazy import (see `run_hook`), so deriving it there would put the hook module on the critical path of every unrelated command and eat the startup budget.
- `tests/test_hooks_cli.py`
  - `_diary_agent_for_harness("hermes") == "hermes"`
  - `test_every_supported_harness_has_its_own_diary_identity` — no supported harness may collide with another's diary name, so the next addition cannot silently reintroduce the bug
  - `test_cli_harness_choices_match_supported_harnesses` — guards the deliberate duplication against drift
  - `test_stop_hook_files_checkpoint_under_harness_agent` extended to `hermes`

## Verification

```
149 passed, 1 skipped
ruff check .            All checks passed!
ruff format --check .   237 files already formatted
```

No change to storage format, hook wire protocol, or existing harness behaviour.
