### PR TITLE
refactor: remove seven unused helpers

### DIFF
--- a/benchmarks/locomo_bench.py
+++ b/benchmarks/locomo_bench.py
@@ -23,14 +23,13 @@ import os
 import sys
 import json
 import re
-import string
 import shutil
 import tempfile
 import argparse
 import urllib.request
 import urllib.error
 from pathlib import Path
-from collections import Counter, defaultdict
+from collections import defaultdict
 from datetime import datetime
 
 import chromadb
@@ -87,35 +86,6 @@ CATEGORIES = {
     4: "Open-domain",
     5: "Adversarial",
 }
-
-
-# =============================================================================
-# METRICS (from LoCoMo's evaluation.py)
-# =============================================================================
-
-
-def normalize_answer(s):
-    """Normalize answer for F1 comparison."""
-    s = s.replace(",", "")
-    s = re.sub(r"\b(a|an|the|and)\b", " ", s)
-    s = " ".join(s.split())
-    s = "".join(ch for ch in s if ch not in string.punctuation)
-    return s.lower().strip()
-
-
-def f1_score(prediction, ground_truth):
-    """Token-level F1 with normalization."""
-    pred_tokens = normalize_answer(prediction).split()
-    truth_tokens = normalize_answer(ground_truth).split()
-    if not pred_tokens or not truth_tokens:
-        return float(pred_tokens == truth_tokens)
-    common = Counter(pred_tokens) & Counter(truth_tokens)
-    num_same = sum(common.values())
-    if num_same == 0:
-        return 0.0
-    precision = num_same / len(pred_tokens)
-    recall = num_same / len(truth_tokens)
-    return (2 * precision * recall) / (precision + recall)
 
 
 # =============================================================================
@@ -441,34 +411,6 @@ def _assign_room(session_text, api_key, model="claude-haiku-4-5-20251001"):
         if first_word and first_word in room:
             return room
     return "general"
-
-
-def _route_question(question, api_key, model="claude-haiku-4-5-20251001"):
-    """Ask LLM which 1-2 rooms a question is about. Returns list of room names."""
-    prompt = (
-        f"Which 1 or 2 rooms from the list below does this question relate to?\n"
-        f"Reply with ONLY room name(s), comma-separated if two, nothing else.\n\n"
-        f"Rooms:\n{_PALACE_ROOM_LIST}\n\n"
-        f"Question: {question}"
-    )
-    raw = _llm_call(prompt, api_key, model=model, max_tokens=40)
-    raw_lower = raw.lower()
-    found = []
-    for room in PALACE_ROOMS:
-        if room in raw_lower:
-            found.append(room)
-        if len(found) >= 2:
-            break
-    if not found:
-        # fallback: partial word match
-        for part in re.split(r"[,\s]+", raw_lower):
-            part = part.strip("_").strip()
-            for room in PALACE_ROOMS:
-                if part and part in room and room not in found:
-                    found.append(room)
-                if len(found) >= 2:
-                    break
-    return found or PALACE_ROOMS  # if routing fails, search everywhere
 
 
 def palace_assign_rooms(sessions, sample_id, api_key, cache, model="claude-haiku-4-5-20251001"):

--- a/benchmarks/model_eval/orchestrator.py
+++ b/benchmarks/model_eval/orchestrator.py
@@ -296,13 +296,5 @@ def main():
     print(f"\nDone in {elapsed/60:.1f}min. Wrote {len(rows)} rows to {output_summary}")
 
 
-def write_csv(path: Path, rows: list[dict]):
-    """Batch-write helper, kept for callers that already have all rows in memory."""
-    with open(path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
-        writer.writeheader()
-        writer.writerows(rows)
-
-
 if __name__ == "__main__":
     main()

--- a/benchmarks/model_eval/tasks/room_classification/score.py
+++ b/benchmarks/model_eval/tasks/room_classification/score.py
@@ -36,39 +36,3 @@ def score_open(
         "similarity": sim,
         "exact_match": p == preferred_label.strip().lower(),
     }
-
-
-def score_clustering(
-    predicted_labels: list[str], ground_truth_themes: list[str]
-) -> dict:
-    """Compute clustering quality across the corpus.
-
-    Reports unique-label count, label collision rate, and a simple
-    homogeneity proxy (samples sharing a ground-truth theme should share
-    a predicted label).
-    """
-    if len(predicted_labels) != len(ground_truth_themes):
-        raise ValueError("predicted_labels and ground_truth_themes must have the same length")
-
-    pred_norm = [p.strip().lower() for p in predicted_labels]
-    distinct_predicted = len(set(pred_norm))
-    distinct_themes = len(set(ground_truth_themes))
-
-    by_theme: dict[str, list[str]] = {}
-    for theme, pred in zip(ground_truth_themes, pred_norm):
-        by_theme.setdefault(theme, []).append(pred)
-
-    homogeneity_scores = []
-    for theme, preds in by_theme.items():
-        if len(preds) <= 1:
-            continue
-        most_common_count = max(preds.count(p) for p in set(preds))
-        homogeneity_scores.append(most_common_count / len(preds))
-    homogeneity = sum(homogeneity_scores) / len(homogeneity_scores) if homogeneity_scores else 0.0
-
-    return {
-        "distinct_predicted_labels": distinct_predicted,
-        "distinct_ground_truth_themes": distinct_themes,
-        "label_compression_ratio": distinct_themes / max(1, distinct_predicted),
-        "theme_homogeneity": homogeneity,
-    }

--- a/mempalace/backends/sqlite_exact.py
+++ b/mempalace/backends/sqlite_exact.py
@@ -69,10 +69,6 @@ def _json_loads(text: str | None) -> dict:
     return value if isinstance(value, dict) else {}
 
 
-def _encode_vector(vector: list[float]) -> bytes:
-    return _as_vector_array(vector).tobytes()
-
-
 def _as_vector_array(vector: list[float]) -> np.ndarray:
     arr = np.asarray(vector, dtype=np.float32)
     if arr.ndim != 1 or arr.size == 0:

--- a/mempalace/diary_ingest.py
+++ b/mempalace/diary_ingest.py
@@ -64,19 +64,6 @@ def _split_entries(text):
     return entries
 
 
-def _diary_drawer_id(wing: str, date_str: str) -> str:
-    """Stable, wing-scoped legacy drawer ID (file-level).
-
-    Retained for backwards-compatible cleanup of palaces that ingested
-    diaries before #1539 — those palaces hold one ``drawer_diary_{...}``
-    per file. New drawers use ``_diary_drawer_id_entry`` so each ``##``
-    entry becomes its own drawer (with per-entry character chunking
-    when an entry exceeds ``chunk_size``).
-    """
-    suffix = hashlib.sha256(f"{wing}|{date_str}".encode()).hexdigest()[:24]
-    return f"drawer_diary_{suffix}"
-
-
 def _diary_drawer_id_entry(wing: str, date_str: str, entry_idx: int, entry_chunk_idx: int) -> str:
     """Per-entry, per-chunk drawer ID introduced in #1539.
 


### PR DESCRIPTION
## What does this PR do?

Removes seven helper functions that have no callers anywhere in the repo (verified with a repo-wide search, tests included). Two focused commits — benchmarks, then core.

| Symbol | File | Why it's dead |
|---|---|---|
| `normalize_answer` + `f1_score` | `benchmarks/locomo_bench.py` | One dead chain — `normalize_answer` is only called by `f1_score`, which nothing scores with. Also drops the now-unused `string` / `Counter` imports. |
| `_route_question` | `benchmarks/locomo_bench.py` | Room routing uses keyword overlap, not this LLM helper. |
| `write_csv` | `benchmarks/model_eval/orchestrator.py` | `main()` writes the CSV incrementally; the "kept for callers" docstring was stale (no callers exist). |
| `score_clustering` | `benchmarks/model_eval/tasks/room_classification/score.py` | The runner uses `score_closed` / `score_open` only. |
| `_encode_vector` | `mempalace/backends/sqlite_exact.py` | Thin wrapper; callers use `_as_vector_array(...).tobytes()` directly. |
| `_diary_drawer_id` | `mempalace/diary_ingest.py` | Legacy file-level ID. Full-rebuild cleanup purges old drawers via the `source_file` metadata key (`delete(where={"source_file": ...})`), not by recomputing this ID — so the "retained for cleanup" docstring was stale. New drawers use `_diary_drawer_id_entry`. |

No behavior change: every removed symbol was unreferenced, and the live replacements (`_as_vector_array`, `_diary_drawer_id_entry`, incremental CSV writing in `main()`) are untouched.

### Deliberately kept
Not touched, despite looking unused to a static scan: `Embedder` (`backends/base.py`) is the RFC 001 public Protocol; `run_maintenance` and other polymorphic/compatibility hooks are intended contracts, not dead code.

## How to test

```bash
python -m pytest tests/ -v --ignore=tests/benchmarks
ruff check .
ruff format --check .
```

All still pass — the change only deletes unreferenced code. (Removing these uncovered core helpers slightly *raises* the coverage ratio rather than lowering it.)

## Checklist
- [x] Tests pass
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .` + `ruff format --check .` on the changed core files; `benchmarks/` is excluded from ruff by config)