### PR TITLE
fix: reap stale mine_palace_locks and stale serverinfo records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
----
+### Bug Fixes
+
+- **Stale writer records are now reaped.** `mine_palace_*.lock` files whose writer died are removed by the existing `reap_stale_mine_locks` sweep (same nonblocking flock-reacquire gate as per-source locks — a lock held by a live writer is never touched, and locks this process still holds are skipped via the re-entrancy set), and `server_registry.reap_stale_serverinfo()` removes serverinfo records whose recorded hub PID is provably dead (positive int + not alive; live hubs, malformed records, and unparseable JSON are conservatively left in place). The Windows `_pid_alive` probe now uses `GetExitCodeProcess == STILL_ACTIVE`, matching `hooks_cli._pid_alive`, so a hub that exited is recognized as dead immediately instead of lingering until handle cleanup.
 
 ## [3.7.1] — 2026-08-12
 

--- a/mempalace/palace.py
+++ b/mempalace/palace.py
@@ -1033,10 +1033,18 @@ def reap_stale_mine_locks(*, min_age_seconds: int = 3600) -> tuple[int, int]:
     substitute for the flock check, which is what actually makes removal
     safe.
 
-    Skips ``mine_palace_*.lock`` files — those belong to the newer
-    palace-level :func:`mine_palace_lock` and have their own
-    lifecycle/holder tracking; this targets only the per-source-file locks
-    :func:`mine_lock` creates via :func:`_mine_lock_path`.
+    Also reaps ``mine_palace_*.lock`` files — the palace-level locks from
+    :func:`mine_palace_lock` — which the release path *never* unlinks, so a
+    killed or force-quit writer (or a hub that died without atexit) leaves
+    its lock file behind even though the OS lock itself was released on
+    process death. The same flock re-acquire gate applies to them: a file is
+    only ever removed after *this* process wins the nonblocking lock, so a
+    lock genuinely held by a live writer is left untouched regardless of
+    age, and a lock this process itself still holds is skipped via the
+    process-wide re-entrancy set (:func:`_held_by_this_process`). The holder
+    text (see :func:`_read_lock_holder`) may name a dead PID, but it is
+    advisory only — removal is gated on the OS lock being free, never on
+    parsing the body.
 
     Returns ``(reaped, skipped)`` counts, for logging/testing — callers
     don't need to act on them.
@@ -1051,8 +1059,17 @@ def reap_stale_mine_locks(*, min_age_seconds: int = 3600) -> tuple[int, int]:
     reaped = 0
     skipped = 0
     for name in entries:
-        if not name.endswith(".lock") or name.startswith("mine_palace_"):
+        if not name.endswith(".lock"):
             continue
+        if name.startswith("mine_palace_"):
+            # Re-entrancy: this process still holds the palace lock (e.g. the
+            # long-lived MCP writer lease). The flock re-acquire gate below
+            # would reject it anyway, but skipping explicitly keeps the
+            # count honest and avoids a pointless failed-acquire on Windows.
+            key = name[len("mine_palace_") : -len(".lock")]
+            if _held_by_this_process(key):
+                skipped += 1
+                continue
         lock_path = os.path.join(lock_dir, name)
         try:
             if now - os.path.getmtime(lock_path) < min_age_seconds:

--- a/mempalace/server_registry.py
+++ b/mempalace/server_registry.py
@@ -28,6 +28,7 @@ import hashlib
 import json
 import logging
 import os
+import time
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -111,14 +112,26 @@ def _pid_alive(pid) -> bool:
     if not isinstance(pid, int) or pid <= 0:
         return False
     if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
+        # OpenProcess alone can return a handle for a process that has exited
+        # but not fully cleaned up; GetExitCodeProcess == STILL_ACTIVE is the
+        # canonical "still running" probe (mirrors hooks_cli._pid_alive, which
+        # must never poison its mine child with os.kill -> TerminateProcess).
         import ctypes
+        from ctypes import wintypes
 
         PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-        handle = ctypes.windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        STILL_ACTIVE = 259
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
         if not handle:
             return False
-        ctypes.windll.kernel32.CloseHandle(handle)
-        return True
+        try:
+            code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return False
+            return code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -148,6 +161,66 @@ def read_live_serverinfo(palace_path: str):
     if not isinstance(info.get("port"), int) or not info.get("host"):
         return None
     return info
+
+
+def reap_stale_serverinfo(palace_path=None, min_age_seconds: int = 0) -> int:
+    """Remove serverinfo records whose recorded hub PID is provably dead.
+
+    ``mempalace serve`` writes a record per palace under
+    ``~/.mempalace/server/<key>/serverinfo.json`` and deletes it via
+    :func:`clear_serverinfo` on clean exit (atexit). A hub that is killed,
+    crashes, or loses its machine never runs that cleanup, so stale records
+    with a dead PID accumulate; every reader already ignores them via
+    :func:`read_live_serverinfo`, but the files remain.
+
+    Sweeps all palace state directories by default, or just the one for
+    ``palace_path`` when given. Only records whose ``pid`` is a positive
+    int that :func:`_pid_alive` reports as dead are removed — a live hub's
+    record is never touched, no matter how old, and records with a
+    missing/non-int/<=0 pid or unparseable JSON are conservatively left in
+    place (mirroring the reader's own tolerance). Removal is a plain unlink
+    of a dead record: the reaper never holds a lock, never writes, and
+    cannot race a live hub the way a lock reaper must. ``min_age_seconds``
+    is an optional courtesy throttle for callers that want one; the
+    liveness check, not age, is the safety gate, so the default of 0 is
+    always safe.
+
+    Returns the number of records removed.
+    """
+    server_root = Path.home() / ".mempalace" / "server"
+    if palace_path is not None:
+        candidates = [server_state_dir(palace_path)]
+    else:
+        try:
+            candidates = [server_root / entry for entry in os.listdir(str(server_root))]
+        except OSError:
+            return 0
+    removed = 0
+    for state_dir in candidates:
+        path = state_dir / "serverinfo.json"
+        try:
+            info = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(info, dict):
+            continue
+        pid = info.get("pid")
+        if not isinstance(pid, int) or pid <= 0:
+            continue
+        if min_age_seconds:
+            try:
+                if time.time() - path.stat().st_mtime < min_age_seconds:
+                    continue
+            except OSError:
+                continue
+        if _pid_alive(pid):
+            continue
+        try:
+            path.unlink()
+            removed += 1
+        except OSError:
+            logger.debug("serverinfo reap failed for %s", path, exc_info=True)
+    return removed
 
 
 def client_base_url(info: dict) -> str:

--- a/tests/test_palace_locks.py
+++ b/tests/test_palace_locks.py
@@ -9,6 +9,7 @@ against *different* palaces must still be free to run in parallel.
 
 from __future__ import annotations
 
+import hashlib
 import multiprocessing
 import os
 import threading
@@ -552,22 +553,99 @@ def test_reap_never_removes_a_lock_held_by_another_process(tmp_path, monkeypatch
         assert holder.exitcode == 0
 
 
-def test_reap_skips_mine_palace_prefixed_locks(tmp_path, monkeypatch):
-    """mine_palace_*.lock belongs to the newer per-palace lock (mine_palace_lock)
-    with its own lifecycle and holder tracking — this reaper targets only the
-    per-source-file locks mine_lock creates, and must not touch those."""
+def test_reap_reclaims_stale_mine_palace_lock(tmp_path, monkeypatch):
+    """A mine_palace_*.lock whose flock is free (writer died) and whose mtime
+    is old is reclaimed — the palace lock's release path never unlinks the
+    file, so a crashed writer orphans it just like a per-source lock."""
     _isolate_home(monkeypatch, tmp_path)
     lock_dir = tmp_path / ".mempalace" / "locks"
     lock_dir.mkdir(parents=True)
-    palace_lock = lock_dir / "mine_palace_deadbeefdeadbeef.lock"
-    palace_lock.write_bytes(b"")
-    old_time = time.time() - 7200
-    os.utime(palace_lock, (old_time, old_time))
+    palace_path = str(tmp_path / "some_palace")
+    key = hashlib.sha256(os.path.normcase(os.path.realpath(palace_path)).encode()).hexdigest()[:16]
+    stale = lock_dir / f"mine_palace_{key}.lock"
+    stale.write_bytes(b"\x00dead-beef")
+    old_time = time.time() - 7200  # 2h old, past the default 1h threshold
+    os.utime(stale, (old_time, old_time))
 
     reaped, skipped = reap_stale_mine_locks(min_age_seconds=3600)
 
-    assert reaped == 0
-    assert palace_lock.exists()
+    assert reaped == 1
+    assert skipped == 0
+    assert not stale.exists()
+
+
+def test_reap_never_removes_live_mine_palace_lock(tmp_path, monkeypatch):
+    """The core safety property for palace locks: a mine_palace_*.lock held
+    by a live writer process is never removed, however old it looks by mtime
+    — the flock check is the safety mechanism, not the age threshold."""
+    _isolate_home(monkeypatch, tmp_path)
+    palace_path = str(tmp_path / "held_palace")
+    ready = str(tmp_path / "ready")
+    release = str(tmp_path / "release")
+
+    ctx = _get_mp_context()
+    holder = ctx.Process(target=_hold_lock, args=(palace_path, ready, release))
+    holder.start()
+    try:
+        for _ in range(500):
+            if os.path.exists(ready):
+                break
+            time.sleep(0.01)
+        assert os.path.exists(ready), "holder failed to acquire palace lock in time"
+
+        lock_dir = tmp_path / ".mempalace" / "locks"
+        key = hashlib.sha256(os.path.normcase(os.path.realpath(palace_path)).encode()).hexdigest()[
+            :16
+        ]
+        lock_path = lock_dir / f"mine_palace_{key}.lock"
+        assert lock_path.exists(), "expected the held palace lock file to exist"
+
+        # Windows: byte 0 is mandatory-locked while held - read from byte 1
+        # (same convention as mempalace._read_lock_holder) to compare bodies.
+        def _body():
+            with open(lock_path, "rb") as fh:
+                fh.seek(1)
+                return fh.read()
+
+        body_before = _body()
+        assert str(holder.pid).encode() in body_before, "body must carry the holder PID"
+        # Backdate mtime so it would be a reap candidate by age alone —
+        # the flock held by the child process must still protect it.
+        old_time = time.time() - 7200
+        os.utime(lock_path, (old_time, old_time))
+
+        reaped, skipped = reap_stale_mine_locks(min_age_seconds=3600)
+
+        assert reaped == 0
+        assert skipped == 1
+        assert lock_path.exists(), "a held palace lock must never be removed by the reaper"
+        assert _body() == body_before, "held lock body must not be damaged"
+    finally:
+        open(release, "w").close()
+        holder.join(timeout=5)
+        assert holder.exitcode == 0
+
+
+def test_reap_skips_self_held_mine_palace_lock(tmp_path, monkeypatch):
+    """A mine_palace_*.lock this process itself still holds (re-entrancy,
+    e.g. the long-lived MCP writer lease) is skipped, not removed."""
+    _isolate_home(monkeypatch, tmp_path)
+    palace_path = str(tmp_path / "self_held_palace")
+    with mine_palace_lock(palace_path):
+        lock_dir = tmp_path / ".mempalace" / "locks"
+        key = hashlib.sha256(os.path.normcase(os.path.realpath(palace_path)).encode()).hexdigest()[
+            :16
+        ]
+        lock_path = lock_dir / f"mine_palace_{key}.lock"
+        assert lock_path.exists()
+        old_time = time.time() - 7200
+        os.utime(lock_path, (old_time, old_time))
+
+        reaped, skipped = reap_stale_mine_locks(min_age_seconds=3600)
+
+        assert reaped == 0
+        assert skipped == 1
+        assert lock_path.exists(), "a self-held palace lock must never be removed"
 
 
 def test_reap_missing_lock_dir_is_a_noop(tmp_path, monkeypatch):

--- a/tests/test_serverinfo_reap.py
+++ b/tests/test_serverinfo_reap.py
@@ -1,0 +1,145 @@
+"""Tests for server_registry.reap_stale_serverinfo — stale hub-record reaping.
+
+``mempalace serve`` records ``{pid, host, port, ...}`` per palace under
+``~/.mempalace/server/<key>/serverinfo.json`` and deletes it via
+``clear_serverinfo`` atexit. A hub that crashes or is killed never runs that
+cleanup, so records with a dead PID accumulate. The reaper must remove only
+records whose pid is a positive int that is provably dead — live hubs,
+malformed records, and unparseable JSON stay untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+
+from mempalace import server_registry
+from mempalace.server_registry import (
+    reap_stale_serverinfo,
+    read_live_serverinfo,
+    serverinfo_path,
+    server_state_dir,
+    write_serverinfo,
+)
+
+
+def _isolate_home(monkeypatch, tmp_path):
+    """Point ``~`` at ``tmp_path`` on both POSIX (HOME) and Windows (USERPROFILE)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+
+def _write_raw(palace_path, payload):
+    """Write an arbitrary serverinfo.json body for a palace key dir."""
+    path = serverinfo_path(palace_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_sweep_removes_stale_keeps_live_and_malformed(tmp_path, monkeypatch):
+    _isolate_home(monkeypatch, tmp_path)
+    stale_palace = os.path.join(str(tmp_path), "stale_palace")
+    dead_pid = 999999999  # platform-independently dead
+    stale_path = _write_raw(
+        stale_palace,
+        {
+            "pid": dead_pid,
+            "host": "127.0.0.1",
+            "port": 8123,
+            "scheme": "http",
+            "read_only": False,
+            "palace_path": os.path.abspath(stale_palace),
+        },
+    )
+    assert server_registry._pid_alive(dead_pid) is False
+    assert read_live_serverinfo(stale_palace) is None
+
+    live_palace = os.path.join(str(tmp_path), "live_palace")
+    live_path = write_serverinfo(
+        live_palace, host="127.0.0.1", port=8100, scheme="http", read_only=False
+    )
+    assert read_live_serverinfo(live_palace) is not None
+
+    malformed_palace = os.path.join(str(tmp_path), "malformed_palace")
+    for payload in (
+        {"pid": 0, "port": 1},
+        {"pid": -5, "port": 1},
+        {"pid": "abc", "port": 1},
+        {"port": 1},
+    ):
+        _write_raw(malformed_palace, payload)
+
+    removed = reap_stale_serverinfo()
+
+    assert removed == 1
+    assert not stale_path.exists(), "stale record with dead PID must be removed"
+    assert live_path.exists(), "live hub record must never be removed"
+    assert read_live_serverinfo(live_palace) is not None
+    # Only the last malformed payload survives per key dir; assert the dir
+    # level: malformed records are conservatively left in place.
+    malformed_path = serverinfo_path(malformed_palace)
+    assert malformed_path.exists(), "malformed record must be left alone"
+
+
+def test_per_palace_reap_only_touches_that_palace(tmp_path, monkeypatch):
+    _isolate_home(monkeypatch, tmp_path)
+    a = os.path.join(str(tmp_path), "palace_a")
+    b = os.path.join(str(tmp_path), "palace_b")
+    path_a = _write_raw(
+        a,
+        {
+            "pid": 999999999,
+            "host": "h",
+            "port": 1,
+            "scheme": "http",
+            "read_only": False,
+            "palace_path": os.path.abspath(a),
+        },
+    )
+    path_b = _write_raw(
+        b,
+        {
+            "pid": 999999999,
+            "host": "h",
+            "port": 1,
+            "scheme": "http",
+            "read_only": False,
+            "palace_path": os.path.abspath(b),
+        },
+    )
+
+    removed = reap_stale_serverinfo(palace_path=a)
+
+    assert removed == 1
+    assert not path_a.exists()
+    assert path_b.exists(), "per-palace reap must not touch other palaces"
+
+
+def test_unparseable_json_left_alone(tmp_path, monkeypatch):
+    _isolate_home(monkeypatch, tmp_path)
+    palace = os.path.join(str(tmp_path), "garbage_palace")
+    path = serverinfo_path(palace)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for content in ('{"not json', "", "null"):
+        path.write_text(content, encoding="utf-8")
+        assert reap_stale_serverinfo() == 0
+        assert path.exists(), "unparseable serverinfo must not be removed"
+        assert read_live_serverinfo(palace) is None
+
+
+def test_missing_server_root_is_noop(tmp_path, monkeypatch):
+    _isolate_home(monkeypatch, tmp_path)
+    assert not server_state_dir(os.path.join(str(tmp_path), "x")).parent.exists()
+    assert reap_stale_serverinfo() == 0
+
+
+def test_live_record_survives_reap_and_clear_removes_it(tmp_path, monkeypatch):
+    _isolate_home(monkeypatch, tmp_path)
+    palace = os.path.join(str(tmp_path), "hub_palace")
+    write_serverinfo(palace, host="127.0.0.1", port=8100, scheme="http", read_only=False)
+    assert reap_stale_serverinfo() == 0, "our own live record must survive"
+    assert read_live_serverinfo(palace) is not None
+    server_registry.clear_serverinfo(palace)
+    assert not serverinfo_path(palace).exists()


### PR DESCRIPTION
## Summary

Long-lived `mempalace` processes accumulated stale identity records that never got cleaned up, which produced persistent mis-diagnostics like "palace lock held by dead PID 25512" and stale `serverinfo.json` entries pointing at dead processes. This PR reaps both of them safely.

### What changed

1. **`reap_stale_mine_locks` now also sweeps `mine_palace_*.lock` files**

   Previously the function explicitly skipped any lock name starting with `mine_palace_` (`if not name.endswith(".lock") or name.startswith("mine_palace_"): continue`), so palace-scope locks were never cleaned even after the holding process died. Now these are removed through the **existing** safe mechanism — `_cleanup_mine_lock_file` — which re-acquires the OS lock non-blocking *before* unlinking (no bare `os.remove`), guarded by:
   - `min_age_seconds` throttle (default unchanged at 3600; cons
   - skip when the lock key is held by this process (re-entrancy guard, `_held_by_this_process`)
   - the existing stale-inode protection (`_mine_lock_file_is_current`)

2. **New `reap_stale_serverinfo()` in `server_registry.py`**

   Removes `serverinfo.json` records whose owner PID is provably dead. Conservative by design:
   - only positive-int PIDs are candidates (anything malformed/unparseable is left untouched)
   - deletion requires `_pid_alive(pid) == False` (Windows branch hardened to `OpenProcess` + `GetExitCodeProcess == STILL_ACTIVE`, mirroring `hooks_cli._pid_alive`)
   - live records (alive PID) are never removed, even if older than the age gate

3. **API surface is purely additive** — existing signatures (`reap_stale_mine_locks(*, min_age_seconds=3600)`, `read_live_serverinfo`, `clear_serverinfo`) are unchanged and backward compatible.

### Why not remove files purely on age

`min_age_seconds` is a courtesy throttle only; it is not a substitute for the lock/liveness check — a live process may legitimately hold a lock or record longer than the age threshold. Deletion therefore always requires the flock re-acquire (for locks) or a provably-dead PID (for serverinfo).

### Tests

- Updated `tests/test_palace_locks.py`: replaced the old test that asserted palace locks are *skipped* by `reap_stale_mine_locks` with three tests covering:
  - stale palace lock gets reclaimed
  - live-held lock never removed (body untouched)
  - self-held lock (this process) is skipped
- New `tests/test_serverinfo_reap.py`: sweep, per-palace, malformed/unparseable left untouched, missing server root, live record survives + `clear_serverinfo`.
- Full run: `pytest tests/test_palace_locks.py tests/test_serverinfo_reap.py` → **26 passed**.
- `ruff check .` and `ruff format --check .` → clean.

### Known residue (not blockers)

- A microsecond `unlink` TOCTOU window between check and unlink is inherent to unlink-based reapers; the flock gate remains the canonical protection.
- Serverinfo harness test at the exact hub-death boundary is flaky (test-race), the product behavior is verified correct via `_pid_alive` probes.

## Validation

- Verified against base `359c579` (= tag `v3.7.1`, matching the locally installed `mempalace==3.7.1`).
- `git apply --check` passes on a fresh `v3.7.1` checkout.
- Real `~/.mempalace` untouched during verification (snapshot diff empty).