### PR TITLE
feat: name the stdio MCP writer in peer-writer refusal

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -817,9 +817,7 @@ def _mcp_peer_writer_refusal(req_id, tool_name: str):
     except Exception:
         logger.debug("could not read stdio writer marker", exc_info=True)
 
-    message = (
-        "Peer MCP writer active; this server is read-only for mutating tools"
-    )
+    message = "Peer MCP writer active; this server is read-only for mutating tools"
     if holder:
         message += f" (writer: pid {holder.get('pid')} since {holder.get('started_at')})"
 

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -697,6 +697,14 @@ def _release_mcp_writer_lock() -> None:
         # repeatedly without exiting the same context manager twice.
         _MCP_WRITER_LOCK_CM = None
         _MCP_WRITER_READ_ONLY = False
+        # Best-effort: drop the stdio writer marker only if it still names us,
+        # so a stale clear cannot remove a newer writer's record.
+        try:
+            from .server_registry import clear_stdio_writer
+
+            clear_stdio_writer(_config.palace_path)
+        except Exception:
+            logger.debug("could not clear stdio writer marker", exc_info=True)
         lock_cm.__exit__(None, None, None)
 
 
@@ -773,6 +781,16 @@ def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     if not _MCP_WRITER_ATEXIT_REGISTERED:
         atexit.register(_release_mcp_writer_lock)
         _MCP_WRITER_ATEXIT_REGISTERED = True
+    # Publish this process as the stdio MCP writer for this palace so read-only
+    # peers can name the lease holder in their refusal instead of an opaque
+    # "Peer MCP writer active". Best-effort: failure to write the marker never
+    # fails the acquire — the OS flock remains the real authority.
+    try:
+        from .server_registry import write_stdio_writer
+
+        write_stdio_writer(_config.palace_path)
+    except Exception:
+        logger.debug("could not publish stdio writer marker", exc_info=True)
     # Reads performed before promotion may have cached a query-only SQLite
     # collection. Drop it while ownership is held so the pending mutating
     # request reopens a writable handle rather than failing on query_only.
@@ -791,18 +809,35 @@ def _mcp_peer_writer_refusal(req_id, tool_name: str):
     if ok:
         return None
 
+    holder = None
+    try:
+        from .server_registry import read_stdio_writer
+
+        holder = read_stdio_writer(_config.palace_path)
+    except Exception:
+        logger.debug("could not read stdio writer marker", exc_info=True)
+
+    message = (
+        "Peer MCP writer active; this server is read-only for mutating tools"
+    )
+    if holder:
+        message += f" (writer: pid {holder.get('pid')} since {holder.get('started_at')})"
+
+    data = {
+        "tool": tool_name,
+        "palace": _config.palace_path,
+        "reason": reason,
+        "override_env": _MCP_ALLOW_PEER_WRITER_ENV,
+        "writer": holder,
+    }
+
     return {
         "jsonrpc": "2.0",
         "id": req_id,
         "error": {
             "code": -32001,
-            "message": "Peer MCP writer active; this server is read-only for mutating tools",
-            "data": {
-                "tool": tool_name,
-                "palace": _config.palace_path,
-                "reason": reason,
-                "override_env": _MCP_ALLOW_PEER_WRITER_ENV,
-            },
+            "message": message,
+            "data": data,
         },
     }
 

--- a/mempalace/server_registry.py
+++ b/mempalace/server_registry.py
@@ -97,6 +97,92 @@ def mesh_state_path(palace_path: str) -> Path:
     return server_state_dir(palace_path) / "mesh_state.json"
 
 
+def stdio_writer_path(palace_path: str) -> Path:
+    """Path of the stdio MCP writer marker for this palace.
+
+    Distinct from the HTTP-hub ``serverinfo.json``: stdio MCP replicas (the
+    long-lived ``mempalace.mcp_server`` processes an agent connects through)
+    do not bind a host/port and are never the hub, but they do contend for
+    the per-palace single-writer lease via ``flock``. The marker records which
+    replica currently holds that lease so a read-only peer can name the holder
+    instead of reporting an opaque "Peer MCP writer active".
+    """
+    return server_state_dir(palace_path) / "stdio_writer.json"
+
+
+def write_stdio_writer(palace_path: str) -> Path:
+    """Mark this process as the current stdio MCP writer for ``palace_path``.
+
+    Called by ``mcp_server._acquire_mcp_writer_lock`` right after the flock
+    lease is won. Reversible: :func:`clear_stdio_writer` removes it on lease
+    release, and readers ignore it if the recorded pid is no longer alive.
+    """
+    path = stdio_writer_path(palace_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(str(path.parent), 0o700)
+    except OSError:
+        pass
+    payload = {
+        "pid": os.getpid(),
+        "role": "writer",
+        "started_at": _utc_now(),
+        "palace_path": _canonical(palace_path),
+    }
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+            fh.write("\n")
+    except BaseException:
+        try:
+            os.unlink(str(path))
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def clear_stdio_writer(palace_path: str) -> None:
+    """Remove the stdio writer marker if it still names this process.
+
+    Guarded on the recorded pid so a slow exit from a previous writer cannot
+    delete the marker of a newer one that just won the lease for this palace.
+    """
+    path = stdio_writer_path(palace_path)
+    try:
+        recorded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    if recorded.get("pid") != os.getpid():
+        return
+    try:
+        path.unlink()
+    except OSError:
+        logger.debug("stdio writer cleanup failed for %s", path, exc_info=True)
+
+
+def read_stdio_writer(palace_path: str):
+    """Return the current stdio MCP writer marker for this palace, or None.
+
+    None when no marker exists, it is unreadable, or the recorded pid is no
+    longer alive (crashed writer — stale marker, ignore it). This mirrors the
+    liveness handling of :func:`read_live_serverinfo`.
+    """
+    path = stdio_writer_path(palace_path)
+    try:
+        info = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(info, dict):
+        return None
+    if not _pid_alive(info.get("pid")):
+        return None
+    if info.get("role") != "writer":
+        return None
+    return info
+
+
 def write_mesh_state(palace_path: str, *, peers: dict, profiles: dict) -> Path:
     """Publish the hub's mesh estate so other local processes can read it.
 

--- a/tests/test_stdio_writer_marker.py
+++ b/tests/test_stdio_writer_marker.py
@@ -1,0 +1,103 @@
+"""stdio MCP writer marker.
+
+The stdio MCP replicas an agent connects through contend for the per-palace
+single-writer lease via ``flock`` but are not HTTP hubs, so they are invisible
+to the hub-facing ``serverinfo.json``. A read-only peer would report an opaque
+"Peer MCP writer active" with no way to say *which* replica holds the lease.
+These tests cover the marker that names the current stdio writer so the
+refusal can be diagnostic, and that it stays conservative (never claims a
+dead writer, never clears another process's record).
+"""
+
+import os
+
+import pytest
+
+from mempalace import mcp_server, server_registry
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("MEMPALACE_HUB_FORWARD", raising=False)
+    return tmp_path
+
+
+class TestStdioWriterRegistry:
+    def test_write_then_read_roundtrip(self, isolated_home):
+        palace = str(isolated_home / "palace")
+        server_registry.write_stdio_writer(palace)
+        info = server_registry.read_stdio_writer(palace)
+        assert info is not None
+        assert info["pid"] == os.getpid()
+        assert info["role"] == "writer"
+        assert info["palace_path"].replace("\\", "/") == palace.replace("\\", "/")
+
+    def test_read_none_without_marker(self, isolated_home):
+        palace = str(isolated_home / "palace")
+        assert server_registry.read_stdio_writer(palace) is None
+
+    def test_clear_only_removes_own_pid(self, isolated_home):
+        palace = str(isolated_home / "palace")
+        server_registry.write_stdio_writer(palace)
+        # Simulate a newer writer's record by rewriting with a different pid.
+        path = server_registry.stdio_writer_path(palace)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            '{"pid": 99999999, "role": "writer", "started_at": "x", "palace_path": %r}\n' % palace,
+            encoding="utf-8",
+        )
+        server_registry.clear_stdio_writer(palace)
+        # clear must not unlink a record that belongs to another pid -- the
+        # file stays on disk (its pid is stale so read ignores it, but the
+        # marker is not actively deleted by a foreign process).
+        assert path.exists()
+
+    def test_clear_removes_live_own_pid(self, isolated_home):
+        palace = str(isolated_home / "palace")
+        server_registry.write_stdio_writer(palace)
+        assert server_registry.read_stdio_writer(palace) is not None
+        server_registry.clear_stdio_writer(palace)
+        assert server_registry.read_stdio_writer(palace) is None
+
+    def test_dead_pid_is_ignored(self, isolated_home):
+        palace = str(isolated_home / "palace")
+        path = server_registry.stdio_writer_path(palace)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            '{"pid": 99999999, "role": "writer", "started_at": "x", "palace_path": %r}\n' % palace,
+            encoding="utf-8",
+        )
+        # A pid that is almost certainly not alive should be treated as stale.
+        assert server_registry.read_stdio_writer(palace) is None
+
+
+class TestRefusalNamesWriter:
+    def test_refusal_includes_writer_info(self, isolated_home, monkeypatch):
+        palace = str(isolated_home / "palace")
+        server_registry.write_stdio_writer(palace)
+        monkeypatch.setattr(mcp_server, "_config", type("C", (), {"palace_path": palace})())
+
+        def denied(*_a, **_k):
+            return (False, "another mempalace writer already holds the palace lock")
+
+        monkeypatch.setattr(mcp_server, "_acquire_mcp_writer_lock", denied)
+        result = mcp_server._mcp_peer_writer_refusal(1, "mempalace_add_drawer")
+        assert result is not None
+        err = result["error"]
+        assert "Peer MCP writer active" in err["message"]
+        assert str(os.getpid()) in err["message"]
+        assert err["data"]["writer"]["pid"] == os.getpid()
+
+    def test_refusal_without_writer_marker(self, isolated_home, monkeypatch):
+        palace = str(isolated_home / "palace")
+
+        def denied(*_a, **_k):
+            return (False, "blocked")
+
+        monkeypatch.setattr(mcp_server, "_config", type("C", (), {"palace_path": palace})())
+        monkeypatch.setattr(mcp_server, "_acquire_mcp_writer_lock", denied)
+        result = mcp_server._mcp_peer_writer_refusal(1, "mempalace_add_drawer")
+        assert result is not None
+        assert result["error"]["data"]["writer"] is None


### PR DESCRIPTION
## Summary

When multiple stdio \mempalace.mcp_server\ replicas share one palace on the same host, exactly one holds the per-palace single-writer lease (via \lock\) and every other process is correctly refused palace writes. But the refusal message is opaque: `Peer MCP writer active; this server is read-only for mutating tools` with no way to tell *which* replica holds the lease. In a live multi-session setup (dev / suckz / orchestrator all connected to one palace) that reads like a fault even though the lease is working as designed.

This PR makes the refusal diagnostic by publishing a per-palace marker naming the current stdio writer, and including it in the refusal message.

## What changed

- \server_registry.py\: add \stdio_writer_path\ / \write_stdio_writer\ / \clear_stdio_writer\ / \ead_stdio_writer\. A small, hub-independent record (\{pid, role, started_at, palace_path}\) stored next to the existing \serverinfo.json\, guarded by the same \_pid_alive\ liveness rule so a crashed writer's marker is never reported as live.
- \mcp_server.py\:
  - \_acquire_mcp_writer_lock\ publishes the marker when the flock lease is won (best-effort; failure never fails the acquire — the OS flock stays the real authority).
  - \_release_mcp_writer_lock\ clears it (only if it still names this pid, so a slow exit can't delete a newer writer's record).
  - \_mcp_peer_writer_refusal\ reads the marker and appends `(writer: pid <pid> since <started_at>)` to the message plus a \writer\ data field.

## Why not a hard singleton guard

Rejecting a second replica outright would break the legitimate case where several sessions read one palace concurrently with a single writer. The lease already serializes writes correctly; the gap was only diagnosability. This stays purely informational and changes no write/deny behavior.

## Tests

\	ests/test_stdio_writer_marker.py\ (7 tests): write/read/clear roundtrip, clear only removes own pid, dead-pid marker is ignored, refusal names the writer, refusal without a marker still works.

Full run: \pytest tests/test_stdio_writer_marker.py tests/test_hub_forward.py tests/test_palace_locks.py tests/test_mcp_logstream.py\ \u2192 76 passed. \pytest tests/test_mcp_server.py -k 'writer or peer or refusal or lock'\ \u2192 20 passed. \uff check\ and \uff format --check\ clean.

## Scope

No new dependencies, no breaking changes, no upload/telemetry. Purely additive + a clearer error payload.