### PR TITLE
feat: add logstream topic routing and reverse pagination

### DIFF
--- a/docs/rfcs/003-agent-logstream-coordination.md
+++ b/docs/rfcs/003-agent-logstream-coordination.md
@@ -66,6 +66,7 @@ Required fields:
 
 Common optional fields:
 
+- `topic`: topic name grouping related tasks or sub-teams (e.g. `auth-v2`, `ui-redesign`).
 - `to_agent`: target agent or `*`.
 - `correlation_id`: task or conversation id tying request/reply events together.
 - `branch`: Git branch, when relevant.
@@ -111,6 +112,7 @@ Example event:
   "type": "patch.ready",
   "stream": "project/mempalace",
   "room": "patches",
+  "topic": "ranking",
   "from_agent": "windows-codex",
   "to_agent": "mac-codex",
   "correlation_id": "task_01J...",
@@ -151,6 +153,7 @@ CREATE TABLE events (
   type TEXT NOT NULL,
   stream TEXT NOT NULL,
   room TEXT NOT NULL,
+  topic TEXT,
   from_agent TEXT NOT NULL,
   to_agent TEXT,
   correlation_id TEXT,
@@ -163,6 +166,7 @@ CREATE TABLE events (
 );
 
 CREATE INDEX events_stream_created_idx ON events(stream, created_at);
+CREATE INDEX events_topic_created_idx ON events(topic, created_at);
 CREATE INDEX events_correlation_idx ON events(correlation_id, created_at);
 CREATE INDEX events_to_agent_idx ON events(to_agent, created_at);
 CREATE INDEX events_type_idx ON events(type, created_at);
@@ -235,12 +239,16 @@ Filters:
 
 - `stream`
 - `room`
+- `topic`
 - `type`
 - `to_agent`
 - `from_agent`
 - `correlation_id`
+- `status`
 - `since_event_id`
+- `before_event_id`
 - `since_created_at`
+- `order` (`asc` or `desc`)
 - `limit`
 
 Default limit: 50.

--- a/integrations/shared/coordination-protocol.md
+++ b/integrations/shared/coordination-protocol.md
@@ -29,13 +29,20 @@ Every agent uses one stable `from_agent` identity, formatted
 `aero-opencode`). Never impersonate another agent; never rotate names —
 the event trail is only auditable if identities are stable.
 
+## Topic Routing
+
+When multiple sessions or sub-teams share one stable `<machine>-<harness>` identity, use the optional `topic` routing attribute to isolate tracks and avoid cross-talk:
+- Set `topic=<topic-name>` (e.g. `auth-v2`, `ui-redesign`) on `mempalace_event_append` or `mempalace_patch_submit`.
+- Filter with `topic=<topic-name>` in `mempalace_event_list`, `mempalace_event_wait`, or `--topic <topic-name>` in `mempalace logstream watch`.
+- `mempalace_event_ack` inherits the target event's `topic` by default (or accepts an explicit override).
+
 ## Delegating work (requester)
 
 1. Generate a `correlation_id` for the task: `task_<short-description>`
    plus enough entropy to be unique (e.g. `task_fix_ranking_7f3a`).
 2. `mempalace_event_append` with `type=task.request`, `stream=project/<name>`,
-   `room=delegation`, `to_agent=<worker>`, `status=open`, and a body that
-   states the goal, the branch, the base commit, and the definition of done.
+   `room=delegation`, `to_agent=<worker>`, `status=open`, optional `topic=<topic-name>`,
+   and a body that states the goal, the branch, the base commit, and the definition of done.
 3. Wait for the reply: `mempalace_event_wait` with the `correlation_id`
    and `to_agent=<you>`. Waits cap at 5 minutes — loop, passing
    `since_event_id` of the last event you saw.
@@ -93,7 +100,7 @@ processed.
 | **Inbox sweep** | Start of every session, and before any long task | `mempalace_event_list` with `to_agent=<you>`, `since_event_id=<last seen>`, `preview=true` |
 | **Background watcher** | You want to be woken while you work | `mempalace logstream watch` as a background process — see below |
 | **Long-poll** | Actively waiting on one known correlation, in-turn | `mempalace_event_wait` with `correlation_id` + `to_agent=<you>` |
-| **Push (SSE)** | Persistent processes: daemons, dashboards, live viewers | `GET /logstream/stream` — same filters, same envelope, `since_event_id` resume |
+| **Push (SSE)** | Persistent processes: daemons, dashboards, live viewers | `GET /logstream/stream` — live-tail filters, same envelope, `since_event_id` resume |
 | **Declared-idle** | Turn-based agents that stop existing between prompts | You cannot watch. Say so, publish your cursor, and let the requester ping you |
 
 ### The background watcher
@@ -329,7 +336,8 @@ Coordination (logstream):
   watch command: an unnoticed prompt stalls the loop silently, and to
   your peers it looks like "claimed but gone quiet".
 - To delegate: mempalace_event_append (type=task.request, stream=
-  project/<name>, room=delegation, correlation_id=task_..., status=open,
+  project/<name>, room=delegation, topic=<name> (optional for sub-teams),
+  correlation_id=task_..., status=open,
   body = goal + branch + base commit + definition of done), then
   mempalace_event_wait on that correlation_id for the reply.
 - When you accept a task: ack it with status=claimed. Deliver code as a

--- a/mempalace/cli.py
+++ b/mempalace/cli.py
@@ -1532,6 +1532,7 @@ def _parse_metadata_arg(raw):
 def _print_event_line(event):
     target = event["to_agent"] or "*"
     corr = f" corr={event['correlation_id']}" if event["correlation_id"] else ""
+    topic = f" topic={event['topic']}" if event.get("topic") else ""
     status = f" [{event['status']}]" if event["status"] else ""
     arts = f" artifacts={len(event['artifact_ids'])}" if event["artifact_ids"] else ""
     body = event["body"].replace("\n", " ")
@@ -1541,7 +1542,7 @@ def _print_event_line(event):
     print(
         f"  {event['id']}  {event['created_at']}  {event['type']}  "
         f"{event['stream']}/{event['room']}  {event['from_agent']}->{target}"
-        f"{status}{corr}{arts}{body}"
+        f"{status}{topic}{corr}{arts}{body}"
     )
 
 
@@ -1604,6 +1605,7 @@ def _watch_spec(args, as_json) -> dict:
     spec = {
         "streams": normalize_watch_values(args.stream),
         "rooms": normalize_watch_values(args.room),
+        "topics": normalize_watch_values(getattr(args, "topic", None)),
         "types": normalize_watch_values(args.type),
         "statuses": normalize_watch_values(args.status),
         "to_agents": normalize_watch_values(to_agents),
@@ -1811,6 +1813,7 @@ def cmd_logstream(args):
                     type=args.type,
                     stream=args.stream,
                     room=args.room,
+                    topic=getattr(args, "topic", None),
                     from_agent=args.from_agent,
                     to_agent=args.to_agent,
                     correlation_id=args.correlation_id,
@@ -1832,6 +1835,7 @@ def cmd_logstream(args):
             filters = {
                 "stream": args.stream,
                 "room": args.room,
+                "topic": getattr(args, "topic", None),
                 "type": args.type,
                 "to_agent": args.to_agent,
                 "from_agent": args.from_agent,
@@ -1842,7 +1846,12 @@ def cmd_logstream(args):
             }
             try:
                 if args.logstream_action == "list":
-                    events = ls.list_events(limit=args.limit, **filters)
+                    events = ls.list_events(
+                        limit=args.limit,
+                        order=getattr(args, "order", "asc"),
+                        before_event_id=getattr(args, "before_event_id", None),
+                        **filters,
+                    )
                     result = {"events": events, "count": len(events)}
                 else:
                     result = ls.wait_events(timeout_ms=args.timeout_ms, limit=args.limit, **filters)
@@ -1905,6 +1914,7 @@ def cmd_logstream(args):
                     from_agent=args.from_agent,
                     status=args.status,
                     body=args.body or "",
+                    topic=getattr(args, "topic", None),
                 )
             except ValueError as exc:
                 _logstream_fail(str(exc), as_json)
@@ -3424,6 +3434,7 @@ def main():
     def _add_logstream_filters(p):
         p.add_argument("--stream", default=None, help="Stream, e.g. project/mempalace")
         p.add_argument("--room", default=None, help="Room, e.g. delegation, patches")
+        p.add_argument("--topic", default=None, help="Topic, e.g. auth-v2")
         p.add_argument("--type", default=None, help="Event type, e.g. task.request")
         p.add_argument("--to-agent", default=None, help="Target agent (also matches '*')")
         p.add_argument("--from-agent", default=None, help="Writer agent")
@@ -3444,6 +3455,7 @@ def main():
     p_ls_append.add_argument("--type", required=True, help="Event type, e.g. task.request")
     p_ls_append.add_argument("--stream", required=True, help="Stream, e.g. project/mempalace")
     p_ls_append.add_argument("--room", required=True, help="Room, e.g. delegation")
+    p_ls_append.add_argument("--topic", default=None, help="Topic name, e.g. auth-v2")
     p_ls_append.add_argument("--from-agent", required=True, help="Writer agent identity")
     p_ls_append.add_argument("--to-agent", default=None, help="Target agent or '*'")
     p_ls_append.add_argument("--correlation-id", default=None, help="Task/conversation id")
@@ -3467,8 +3479,19 @@ def main():
     )
     p_ls_append.add_argument("--json", action="store_true", help="Machine-readable output")
 
-    p_ls_list = logstream_sub.add_parser("list", help="List events, oldest first")
+    p_ls_list = logstream_sub.add_parser("list", help="List events")
     _add_logstream_filters(p_ls_list)
+    p_ls_list.add_argument(
+        "--before-event-id",
+        default=None,
+        help="Only events strictly before this id in append order",
+    )
+    p_ls_list.add_argument(
+        "--order",
+        choices=["asc", "desc"],
+        default="asc",
+        help="asc (oldest first, default) or desc (newest first)",
+    )
     p_ls_list.add_argument("--limit", type=int, default=50, help="Max events (default 50)")
     p_ls_list.add_argument("--json", action="store_true", help="Machine-readable output")
 
@@ -3505,6 +3528,9 @@ def main():
     )
     p_ls_watch.add_argument(
         "--room", action="append", default=None, help="Room (repeatable; matches any)"
+    )
+    p_ls_watch.add_argument(
+        "--topic", action="append", default=None, help="Topic (repeatable; matches any)"
     )
     p_ls_watch.add_argument(
         "--type", action="append", default=None, help="Event type (repeatable; matches any)"
@@ -3576,6 +3602,9 @@ def main():
         "--status",
         default=None,
         help="open|claimed|ready|applied|blocked|failed|superseded",
+    )
+    p_ls_ack.add_argument(
+        "--topic", default=None, help="Topic override (defaults to target event's topic)"
     )
     p_ls_ack.add_argument("--body", default=None, help="Verbatim ack notes")
     p_ls_ack.add_argument("--json", action="store_true", help="Machine-readable output")

--- a/mempalace/instructions/shared_brain_rules.md
+++ b/mempalace/instructions/shared_brain_rules.md
@@ -47,7 +47,8 @@ Coordination (logstream):
   watch command: an unnoticed prompt stalls the loop silently, and to
   your peers it looks like "claimed but gone quiet".
 - To delegate: mempalace_event_append (type=task.request, stream=
-  project/<name>, room=delegation, correlation_id=task_..., status=open,
+  project/<name>, room=delegation, topic=<name> (optional for sub-teams),
+  correlation_id=task_..., status=open,
   body = goal + branch + base commit + definition of done), then
   mempalace_event_wait on that correlation_id for the reply.
 - When you accept a task: ack it with status=claimed. Deliver code as a

--- a/mempalace/logstream.py
+++ b/mempalace/logstream.py
@@ -208,6 +208,7 @@ def event_matches_watch(
     *,
     streams=None,
     rooms=None,
+    topics=None,
     types=None,
     statuses=None,
     to_agents=None,
@@ -234,6 +235,7 @@ def event_matches_watch(
     return (
         _ok(streams, event.get("stream"))
         and _ok(rooms, event.get("room"))
+        and _ok(topics, event.get("topic"))
         and _ok(types, event.get("type"))
         and _ok(statuses, event.get("status"))
         and _ok(correlation_ids, event.get("correlation_id"))
@@ -263,6 +265,7 @@ def sanitize_watch_spec(spec: dict) -> dict:
     for key, field in (
         ("streams", "stream"),
         ("rooms", "room"),
+        ("topics", "topic"),
         ("to_agents", "to_agent"),
         ("from_agents", "from_agent"),
         ("exclude_from_agents", "exclude_from_agent"),
@@ -288,6 +291,7 @@ def pushdown_watch_filters(spec: dict) -> dict:
     for key, column in (
         ("streams", "stream"),
         ("rooms", "room"),
+        ("topics", "topic"),
         ("types", "type"),
         ("statuses", "status"),
         ("correlation_ids", "correlation_id"),
@@ -451,6 +455,7 @@ class Logstream:
                 type TEXT NOT NULL,
                 stream TEXT NOT NULL,
                 room TEXT NOT NULL,
+                topic TEXT,
                 from_agent TEXT NOT NULL,
                 to_agent TEXT,
                 correlation_id TEXT,
@@ -494,23 +499,27 @@ class Logstream:
                 PRIMARY KEY (event_id, artifact_id)
             );
         """)
-        self._migrate_replication_schema(conn)
+        self._migrate_schema(conn)
         conn.commit()
         # Seed the HLC from the newest stamp in the log so monotonicity
         # survives restarts (RFC 004 op envelope).
         row = conn.execute("SELECT max(hlc) AS last FROM events").fetchone()
         self._clock = HybridLogicalClock(self.replica_id, last=row["last"] if row else None)
 
-    def _migrate_replication_schema(self, conn):
-        """RFC 004 step 0: add provenance columns to pre-replication logs.
+    def _migrate_schema(self, conn):
+        """RFC 004 / RFC 003 migration: add provenance and topic columns to pre-existing logs.
 
         Fresh databases get the columns from the canonical CREATE TABLE; this
-        path upgrades logs created before step 0. Backfill stamps existing
-        rows as authored by THIS replica (they were: pre-replication, only
-        one copy existed) with origin_seq = rowid and an HLC derived from
-        created_at + rowid, preserving their original total order.
+        path upgrades logs created before provenance or topic fields were added.
+        Backfill stamps existing rows as authored by THIS replica with origin_seq = rowid
+        and an HLC derived from created_at + rowid.
         """
         existing = {row["name"] for row in conn.execute("PRAGMA table_info(events)")}
+        if "topic" not in existing:
+            conn.execute("ALTER TABLE events ADD COLUMN topic TEXT")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS events_topic_created_idx ON events(topic, created_at)"
+        )
         if "origin_replica" not in existing:
             conn.execute("ALTER TABLE events ADD COLUMN origin_replica TEXT")
         if "origin_seq" not in existing:
@@ -594,6 +603,7 @@ class Logstream:
             "type": row["type"],
             "stream": row["stream"],
             "room": row["room"],
+            "topic": row["topic"],
             "from_agent": row["from_agent"],
             "to_agent": row["to_agent"],
             "correlation_id": row["correlation_id"],
@@ -636,6 +646,7 @@ class Logstream:
         body: str = "",
         metadata: dict = None,
         artifact_ids: list = None,
+        topic: str = None,
     ) -> dict:
         """Append one immutable event. Returns the stored event dict.
 
@@ -645,6 +656,7 @@ class Logstream:
         type = _sanitize_event_type(type)
         stream = _sanitize_routing(stream, "stream")
         room = _sanitize_routing(room, "room")
+        topic = _sanitize_routing(topic, "topic", required=False)
         from_agent = _sanitize_routing(from_agent, "from_agent")
         to_agent = _sanitize_routing(to_agent, "to_agent", required=False)
         correlation_id = _sanitize_routing(correlation_id, "correlation_id", required=False)
@@ -678,15 +690,16 @@ class Logstream:
                             f"artifact_ids references unknown artifact {artifact_id!r}"
                         )
                 cursor = conn.execute(
-                    "INSERT INTO events (id, type, stream, room, from_agent, to_agent,"
+                    "INSERT INTO events (id, type, stream, room, topic, from_agent, to_agent,"
                     " correlation_id, branch, base_commit, status, body, created_at,"
                     " metadata_json, origin_replica, hlc)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         event_id,
                         type,
                         stream,
                         room,
+                        topic,
                         from_agent,
                         to_agent,
                         correlation_id,
@@ -815,11 +828,12 @@ class Logstream:
         from_agent: str,
         status: str = None,
         body: str = "",
+        topic: str = None,
     ) -> dict:
         """Append an ``event.ack`` referencing a prior event.
 
         The target event is never mutated. The ack copies the target's
-        stream/room, copies its ``correlation_id`` (falling back to the
+        stream/room/topic, copies its ``correlation_id`` (falling back to the
         target's id so request/ack stay tied together), and routes back
         to the target's ``from_agent``.
         """
@@ -832,10 +846,13 @@ class Logstream:
         if target is None:
             raise ValueError(f"event {event_id!r} not found")
 
+        resolved_topic = topic if topic is not None else target["topic"]
+
         return self.append_event(
             type=ACK_EVENT_TYPE,
             stream=target["stream"],
             room=target["room"],
+            topic=resolved_topic,
             from_agent=from_agent,
             to_agent=target["from_agent"],
             correlation_id=target["correlation_id"] or target["id"],
@@ -856,6 +873,7 @@ class Logstream:
         base_commit: str = None,
         body: str = "",
         metadata: dict = None,
+        topic: str = None,
     ) -> dict:
         """Convenience wrapper: store a patch artifact + ``patch.ready`` event.
 
@@ -873,6 +891,7 @@ class Logstream:
             type="patch.ready",
             stream=stream,
             room=room,
+            topic=topic,
             from_agent=from_agent,
             to_agent=to_agent,
             correlation_id=correlation_id,
@@ -915,27 +934,35 @@ class Logstream:
         self,
         stream: str = None,
         room: str = None,
+        topic: str = None,
         type: str = None,
         to_agent: str = None,
         from_agent: str = None,
         correlation_id: str = None,
         status: str = None,
         since_event_id: str = None,
+        before_event_id: str = None,
         since_created_at: str = None,
         limit: int = DEFAULT_LIST_LIMIT,
+        order: str = "asc",
     ) -> list[dict]:
-        """List events matching structured filters, oldest first.
+        """List events matching structured filters.
 
-        Cursor semantics:
+        Cursor and ordering semantics:
 
-        - ``since_event_id`` is the precise cursor: strictly after that
-          event in append order (rowid), regardless of timestamp ties.
+        - ``since_event_id`` is the precise cursor: strictly AFTER that
+          event in append order (``rowid > anchor``), regardless of timestamp ties
+          or output ordering.
+        - ``before_event_id`` filters strictly BEFORE that event in append
+          order (``rowid < anchor``) for reverse / historical paging.
+        - ``order`` is ``'asc'`` (oldest first, default) or ``'desc'`` (newest first).
         - ``since_created_at`` is inclusive (``>=``) so second-granularity
           timestamps never skip events; callers dedup by ``id``.
         - ``to_agent`` also matches broadcast events (``to_agent='*'``).
         """
         stream = _sanitize_routing(stream, "stream", required=False)
         room = _sanitize_routing(room, "room", required=False)
+        topic = _sanitize_routing(topic, "topic", required=False)
         if type not in (None, ""):
             type = _sanitize_event_type(type)
         else:
@@ -945,7 +972,10 @@ class Logstream:
         correlation_id = _sanitize_routing(correlation_id, "correlation_id", required=False)
         status = _sanitize_status(status)
         since_event_id = _sanitize_routing(since_event_id, "since_event_id", required=False)
+        before_event_id = _sanitize_routing(before_event_id, "before_event_id", required=False)
         since_created_at = sanitize_iso_temporal(since_created_at, "since_created_at") or None
+        if order not in ("asc", "desc"):
+            raise ValueError(f"order={order!r} must be 'asc' or 'desc'")
         if not isinstance(limit, int) or limit < 1:
             raise ValueError("limit must be a positive integer")
         limit = min(limit, MAX_LIST_LIMIT)
@@ -955,6 +985,7 @@ class Logstream:
         for column, value in (
             ("stream", stream),
             ("room", room),
+            ("topic", topic),
             ("type", type),
             ("from_agent", from_agent),
             ("correlation_id", correlation_id),
@@ -980,11 +1011,20 @@ class Logstream:
                     raise ValueError(f"since_event_id {since_event_id!r} not found")
                 where.append("rowid > ?")
                 params.append(anchor["rowid"])
+            if before_event_id is not None:
+                before_anchor = conn.execute(
+                    "SELECT rowid FROM events WHERE id = ?", (before_event_id,)
+                ).fetchone()
+                if before_anchor is None:
+                    raise ValueError(f"before_event_id {before_event_id!r} not found")
+                where.append("rowid < ?")
+                params.append(before_anchor["rowid"])
 
+            order_clause = "DESC" if order == "desc" else "ASC"
             sql = "SELECT rowid, * FROM events"
             if where:
                 sql += " WHERE " + " AND ".join(where)
-            sql += " ORDER BY rowid ASC LIMIT ?"
+            sql += f" ORDER BY rowid {order_clause} LIMIT ?"
             params.append(limit)
             rows = conn.execute(sql, params).fetchall()
             events = [self._event_dict(row) for row in rows]
@@ -1156,6 +1196,7 @@ class Logstream:
             return False  # our own op echoed back — by definition already present
         artifact_ids = list(dict.fromkeys(event.get("artifact_ids") or []))
         metadata_json = _sanitize_metadata(event.get("metadata"))
+        topic = _sanitize_routing(event.get("topic"), "topic", required=False)
 
         with self._lock:
             conn = self._conn()
@@ -1176,15 +1217,16 @@ class Logstream:
                             f"{artifact_id!r} not yet applied locally"
                         )
                 conn.execute(
-                    "INSERT INTO events (id, type, stream, room, from_agent, to_agent,"
+                    "INSERT INTO events (id, type, stream, room, topic, from_agent, to_agent,"
                     " correlation_id, branch, base_commit, status, body, created_at,"
                     " metadata_json, origin_replica, origin_seq, hlc)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         event["id"],
                         event["type"],
                         event["stream"],
                         event["room"],
+                        topic,
                         event["from_agent"],
                         event.get("to_agent"),
                         event.get("correlation_id"),

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -4706,6 +4706,7 @@ def tool_event_append(
     body: str = "",
     metadata: dict = None,
     artifact_ids: list = None,
+    topic: str = None,
 ):
     """Append one immutable coordination event."""
     try:
@@ -4723,6 +4724,7 @@ def tool_event_append(
                 body=body,
                 metadata=metadata,
                 artifact_ids=artifact_ids,
+                topic=topic,
             )
         )
     except ValueError as e:
@@ -4786,37 +4788,43 @@ def _preview_event(event: dict) -> dict:
 def tool_event_list(
     stream: str = None,
     room: str = None,
+    topic: str = None,
     type: str = None,
     to_agent: str = None,
     from_agent: str = None,
     correlation_id: str = None,
     status: str = None,
     since_event_id: str = None,
+    before_event_id: str = None,
     since_created_at: str = None,
     limit: int = 50,
+    order: str = "asc",
     preview: bool = False,
 ):
-    """List coordination events with structured filters, oldest first.
+    """List coordination events with structured filters.
 
+    ``order='desc'`` returns newest events first (e.g. for sweeping recent inbox
+    or checking recent project history in a single call). Default is ``'asc'``.
     ``preview=True`` truncates each event's verbatim body to a short excerpt
     (marking ``body_truncated`` + ``body_length``) so scanning many events
-    stays cheap. ``since_event_id`` is strictly after that id, so do not
-    pass the truncated event's own id to re-fetch it — repeat the original
-    filters with ``preview=false``.
+    stays cheap.
     """
     try:
         events = _call_logstream(
             lambda ls: ls.list_events(
                 stream=stream,
                 room=room,
+                topic=topic,
                 type=type,
                 to_agent=to_agent,
                 from_agent=from_agent,
                 correlation_id=correlation_id,
                 status=status,
                 since_event_id=since_event_id,
+                before_event_id=before_event_id,
                 since_created_at=since_created_at,
                 limit=limit,
+                order=order,
             )
         )
     except ValueError as e:
@@ -4829,6 +4837,7 @@ def tool_event_list(
 def tool_event_wait(
     stream: str = None,
     room: str = None,
+    topic: str = None,
     type: str = None,
     to_agent: str = None,
     from_agent: str = None,
@@ -4851,6 +4860,7 @@ def tool_event_wait(
                 timeout_ms=timeout_ms,
                 stream=stream,
                 room=room,
+                topic=topic,
                 type=type,
                 to_agent=to_agent,
                 from_agent=from_agent,
@@ -4867,11 +4877,19 @@ def tool_event_wait(
     return result
 
 
-def tool_event_ack(event_id: str, from_agent: str, status: str = None, body: str = ""):
+def tool_event_ack(
+    event_id: str,
+    from_agent: str,
+    status: str = None,
+    body: str = "",
+    topic: str = None,
+):
     """Append an event.ack referencing a prior event (never mutates it)."""
     try:
         event = _call_logstream(
-            lambda ls: ls.ack_event(event_id, from_agent=from_agent, status=status, body=body)
+            lambda ls: ls.ack_event(
+                event_id, from_agent=from_agent, status=status, body=body, topic=topic
+            )
         )
     except ValueError as e:
         return {"success": False, "error": str(e)}
@@ -4913,6 +4931,7 @@ def tool_patch_submit(
     base_commit: str = None,
     body: str = "",
     metadata: dict = None,
+    topic: str = None,
 ):
     """Store a patch artifact and append its patch.ready event in one call."""
     try:
@@ -4928,6 +4947,7 @@ def tool_patch_submit(
                 base_commit=base_commit,
                 body=body,
                 metadata=metadata,
+                topic=topic,
             )
         )
     except ValueError as e:
@@ -5630,6 +5650,10 @@ TOOLS = {
                     "type": "string",
                     "description": "Sub-channel, e.g. 'delegation', 'patches', 'reviews', 'status'",
                 },
+                "topic": {
+                    "type": "string",
+                    "description": "Topic to group related work/sub-team, e.g. 'auth-v2', 'ui-redesign' (optional)",
+                },
                 "from_agent": {"type": "string", "description": "Writer agent identity"},
                 "to_agent": {
                     "type": "string",
@@ -5710,22 +5734,24 @@ TOOLS = {
     },
     "mempalace_event_list": {
         "description": (
-            "List agent-coordination events with structured filters, oldest first (append"
-            " order, not timestamp order). Use since_event_id as the resume cursor: it means"
-            " strictly after that event in append order, so it cannot skip anything. Do NOT"
-            " resume with since_created_at — a peer's event syncs in whenever it arrives, so"
-            " it can already be older than a timestamp cursor and be missed permanently;"
-            " since_created_at is a time window ('what happened today'), not a cursor. Store"
-            " the id of the last event you processed — that is your whole watcher state. Pass"
-            " preview=true when sweeping a busy stream. to_agent=<you> also matches '*'"
-            " broadcasts, so no second call is needed. To wait for something that has not"
-            " happened yet, use mempalace_event_wait instead of polling this."
+            "List agent-coordination events with structured filters. Use order='desc' to return"
+            " newest events first (e.g. for sweeping recent inbox or inspecting project tail in"
+            " a single call); default order is 'asc' (oldest first, append order). Use"
+            " since_event_id as the resume cursor: it means strictly AFTER that event in append"
+            " order (rowid > anchor), so it cannot skip anything. For reverse/historical paging,"
+            " use before_event_id (rowid < anchor). Do NOT resume with since_created_at — a"
+            " peer's event syncs in whenever it arrives, so it can already be older than a"
+            " timestamp cursor and be missed permanently; since_created_at is a time window"
+            " ('what happened today'), not a cursor. Pass preview=true when sweeping a busy"
+            " stream. to_agent=<you> also matches '*' broadcasts. To wait for future events, use"
+            " mempalace_event_wait."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "stream": {"type": "string", "description": "Filter by stream (optional)"},
                 "room": {"type": "string", "description": "Filter by room (optional)"},
+                "topic": {"type": "string", "description": "Filter by topic (optional)"},
                 "type": {"type": "string", "description": "Filter by event type (optional)"},
                 "to_agent": {
                     "type": "string",
@@ -5739,7 +5765,11 @@ TOOLS = {
                 "status": {"type": "string", "description": "Filter by status (optional)"},
                 "since_event_id": {
                     "type": "string",
-                    "description": "Return only events strictly after this event id (optional)",
+                    "description": "Return only events strictly after this event id in append order (optional)",
+                },
+                "before_event_id": {
+                    "type": "string",
+                    "description": "Return only events strictly before this event id in append order (optional)",
                 },
                 "since_created_at": {
                     "type": "string",
@@ -5751,6 +5781,10 @@ TOOLS = {
                     ),
                 },
                 "limit": {"type": "integer", "description": "Max events to return (default 50)"},
+                "order": {
+                    "type": "string",
+                    "description": "'asc' (oldest first, default) or 'desc' (newest first, optional)",
+                },
                 "preview": {
                     "type": "boolean",
                     "description": (
@@ -5774,13 +5808,14 @@ TOOLS = {
             " not wrap it in a tight retry loop: on timeout just call it again with"
             " since_event_id updated to the last event you processed. For long-lived consumers"
             " (daemons, dashboards) prefer the push stream at GET /logstream/stream, which"
-            " takes the same filters and the same since_event_id resume."
+            " takes the live-tail filter subset and the same since_event_id resume."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "stream": {"type": "string", "description": "Filter by stream (optional)"},
                 "room": {"type": "string", "description": "Filter by room (optional)"},
+                "topic": {"type": "string", "description": "Filter by topic (optional)"},
                 "type": {"type": "string", "description": "Filter by event type (optional)"},
                 "to_agent": {
                     "type": "string",
@@ -5833,6 +5868,10 @@ TOOLS = {
                     ),
                 },
                 "body": {"type": "string", "description": "Verbatim ack notes (optional)"},
+                "topic": {
+                    "type": "string",
+                    "description": "Topic override (defaults to target event's topic, optional)",
+                },
             },
             "required": ["event_id", "from_agent"],
         },
@@ -5889,6 +5928,7 @@ TOOLS = {
                     "description": "Logical stream, e.g. 'project/mempalace'",
                 },
                 "room": {"type": "string", "description": "Sub-channel (default 'patches')"},
+                "topic": {"type": "string", "description": "Topic name (optional)"},
                 "to_agent": {"type": "string", "description": "Target agent or '*' (optional)"},
                 "correlation_id": {
                     "type": "string",
@@ -7802,7 +7842,8 @@ def _sse_release_slot(httpd) -> None:
 def _http_serve_logstream_stream(handler) -> None:
     """RFC 003 phase 5: live logstream tail over Server-Sent Events.
 
-    Query params are exactly the ``event_list`` filters plus
+    Query params are the live-tail subset of ``event_list`` filters (stream,
+    room, topic, type, to/from agent, correlation id, and status), plus
     ``since_event_id`` (or the standard ``Last-Event-ID`` header): with a
     cursor the server replays everything after it, then tails live; without
     one it tails only post-connect events. Each event is one SSE frame
@@ -7824,6 +7865,7 @@ def _http_serve_logstream_stream(handler) -> None:
         for key in (
             "stream",
             "room",
+            "topic",
             "type",
             "to_agent",
             "from_agent",

--- a/tests/test_cli_logstream.py
+++ b/tests/test_cli_logstream.py
@@ -24,6 +24,7 @@ def _append_args(palace, **overrides):
         type="task.request",
         stream="project/mempalace",
         room="delegation",
+        topic=None,
         from_agent="mac-fable",
         to_agent="windows-codex",
         correlation_id="task_cli",
@@ -46,14 +47,17 @@ def _list_args(palace, **overrides):
         logstream_action="list",
         stream=None,
         room=None,
+        topic=None,
         type=None,
         to_agent=None,
         from_agent=None,
         correlation_id=None,
         status=None,
         since_event_id=None,
+        before_event_id=None,
         since_created_at=None,
         limit=50,
+        order="asc",
         json=True,
     )
     fields.update(overrides)
@@ -687,6 +691,7 @@ def _watch_args(palace, **overrides):
         agent=None,
         stream=None,
         room=None,
+        topic=None,
         type=None,
         status=None,
         to_agent=None,
@@ -1194,3 +1199,80 @@ class TestLogstreamWatch:
             cmd_logstream(_watch_args(palace_path, agent="mac-claude", limit=0))
         assert exc.value.code == 1
         assert "limit" in json.loads(capsys.readouterr().out)["error"]
+
+
+class TestTopicAndOrderCli:
+    def test_human_output_includes_topic(self, palace_path, capsys):
+        cmd_logstream(
+            _append_args(
+                palace_path,
+                topic="security",
+                body="Review auth boundary",
+                json=False,
+            )
+        )
+
+        output = capsys.readouterr().out
+        assert "topic=security" in output
+
+    def test_append_and_list_topic(self, palace_path, capsys):
+        cmd_logstream(_append_args(palace_path, topic="infra", body="Infra task"))
+        e1 = json.loads(capsys.readouterr().out)
+        assert e1["topic"] == "infra"
+
+        cmd_logstream(_append_args(palace_path, topic="billing", body="Billing task"))
+        e2 = json.loads(capsys.readouterr().out)
+        assert e2["topic"] == "billing"
+
+        cmd_logstream(_list_args(palace_path, topic="infra"))
+        res = json.loads(capsys.readouterr().out)
+        assert res["count"] == 1
+        assert res["events"][0]["id"] == e1["id"]
+
+    def test_list_order_and_before_event_id(self, palace_path, capsys):
+        cmd_logstream(_append_args(palace_path, body="1"))
+        e1 = json.loads(capsys.readouterr().out)
+        cmd_logstream(_append_args(palace_path, body="2"))
+        e2 = json.loads(capsys.readouterr().out)
+        cmd_logstream(_append_args(palace_path, body="3"))
+        e3 = json.loads(capsys.readouterr().out)
+
+        cmd_logstream(_list_args(palace_path, order="desc"))
+        desc_res = json.loads(capsys.readouterr().out)
+        assert [e["id"] for e in desc_res["events"]] == [e3["id"], e2["id"], e1["id"]]
+
+        cmd_logstream(_list_args(palace_path, before_event_id=e3["id"], order="desc"))
+        before_res = json.loads(capsys.readouterr().out)
+        assert [e["id"] for e in before_res["events"]] == [e2["id"], e1["id"]]
+
+    def test_watch_topic_filtering(self, palace_path, capsys):
+        cmd_logstream(_append_args(palace_path, topic="security", to_agent="mac-claude"))
+        capsys.readouterr()
+
+        cmd_logstream(
+            _watch_args(
+                palace_path,
+                agent="mac-claude",
+                topic=["security", "compliance"],
+                from_start=True,
+            )
+        )
+        assert _watch_payload(capsys)["count"] == 1
+
+    def test_ack_topic_override_cli(self, palace_path, capsys):
+        cmd_logstream(_append_args(palace_path, topic="orig-topic", from_agent="target-agent"))
+        target = json.loads(capsys.readouterr().out)
+
+        ack_args = SimpleNamespace(
+            palace=palace_path,
+            logstream_action="ack",
+            event_id=target["id"],
+            from_agent="ack-agent",
+            status="claimed",
+            body="ack body",
+            topic="new-topic",
+            json=True,
+        )
+        cmd_logstream(ack_args)
+        ack_res = json.loads(capsys.readouterr().out)
+        assert ack_res["topic"] == "new-topic"

--- a/tests/test_logstream.py
+++ b/tests/test_logstream.py
@@ -751,3 +751,193 @@ class TestWatchCursorFile:
         # Initial checkpoint: raised, so the caller can refuse to start.
         with pytest.raises(OSError):
             write_watch_cursor(target, "evt_abc", required=True)
+
+
+# ── Topic routing, query ordering, and migration ──────────────────────────
+
+
+class TestTopicAndOrder:
+    def test_migration_pre_topic_db(self, palace_path):
+        """Pre-topic database upgrades idempotently and preserves existing rows."""
+        db_path = os.path.join(palace_path, "logstream.sqlite3")
+        conn = sqlite3.connect(db_path)
+        conn.executescript("""
+            CREATE TABLE events (
+                id TEXT PRIMARY KEY,
+                type TEXT NOT NULL,
+                stream TEXT NOT NULL,
+                room TEXT NOT NULL,
+                from_agent TEXT NOT NULL,
+                to_agent TEXT,
+                correlation_id TEXT,
+                branch TEXT,
+                base_commit TEXT,
+                status TEXT,
+                body TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+            CREATE TABLE artifacts (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                sha256 TEXT NOT NULL,
+                size_bytes INTEGER NOT NULL,
+                content TEXT NOT NULL,
+                created_by TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+            CREATE TABLE event_artifacts (
+                event_id TEXT NOT NULL,
+                artifact_id TEXT NOT NULL,
+                PRIMARY KEY (event_id, artifact_id)
+            );
+            INSERT INTO events (id, type, stream, room, from_agent, created_at)
+            VALUES ('evt_pre_migration', 'task.request', 'project/legacy', 'delegation', 'agent-old', '2026-08-01T12:00:00Z');
+        """)
+        conn.commit()
+        conn.close()
+
+        ls = Logstream(db_path=db_path)
+        try:
+            events = ls.list_events(stream="project/legacy")
+            assert len(events) == 1
+            assert events[0]["id"] == "evt_pre_migration"
+            assert events[0]["topic"] is None
+
+            # Topic column and index exist
+            raw_conn = sqlite3.connect(db_path)
+            cols = {r[1] for r in raw_conn.execute("PRAGMA table_info(events)").fetchall()}
+            assert "topic" in cols
+            indices = {
+                r[1]
+                for r in raw_conn.execute(
+                    "SELECT * FROM sqlite_master WHERE type='index'"
+                ).fetchall()
+            }
+            assert "events_topic_created_idx" in indices
+            raw_conn.close()
+
+            # Appending topic-bearing event works
+            new_evt = _append(ls, topic="auth-upgrade")
+            assert new_evt["topic"] == "auth-upgrade"
+            filtered = ls.list_events(topic="auth-upgrade")
+            assert len(filtered) == 1
+            assert filtered[0]["id"] == new_evt["id"]
+        finally:
+            ls.close()
+
+        # Reopen is idempotent
+        reopened = Logstream(db_path=db_path)
+        try:
+            all_events = reopened.list_events(limit=10)
+            assert len(all_events) == 2
+        finally:
+            reopened.close()
+
+    def test_topic_append_and_list_filtering(self, logstream):
+        e1 = _append(logstream, topic="auth-v2", body="Auth work")
+        e2 = _append(logstream, topic="ui-v2", body="UI work")
+        e3 = _append(logstream, topic=None, body="General work")
+
+        assert e1["topic"] == "auth-v2"
+        assert e2["topic"] == "ui-v2"
+        assert e3["topic"] is None
+
+        auth_events = logstream.list_events(topic="auth-v2")
+        assert [e["id"] for e in auth_events] == [e1["id"]]
+
+        ui_events = logstream.list_events(topic="ui-v2")
+        assert [e["id"] for e in ui_events] == [e2["id"]]
+
+        none_events = logstream.list_events(topic="nonexistent")
+        assert none_events == []
+
+    def test_ack_topic_inheritance_and_override(self, logstream):
+        e = _append(logstream, topic="compiler-team")
+        ack1 = logstream.ack_event(e["id"], from_agent="windows-codex", status="claimed")
+        assert ack1["topic"] == "compiler-team"
+
+        ack2 = logstream.ack_event(
+            e["id"], from_agent="windows-codex", status="claimed", topic="custom-override"
+        )
+        assert ack2["topic"] == "custom-override"
+
+    def test_submit_patch_with_topic(self, logstream):
+        res = logstream.submit_patch(
+            content="diff --git a/a b/b\n",
+            from_agent="agent-a",
+            stream="project/mempalace",
+            topic="fast-path",
+        )
+        assert res["event"]["topic"] == "fast-path"
+        assert logstream.list_events(topic="fast-path")[0]["id"] == res["event"]["id"]
+
+    def test_order_asc_and_desc(self, logstream):
+        e1 = _append(logstream, body="First")
+        e2 = _append(logstream, body="Second")
+        e3 = _append(logstream, body="Third")
+
+        asc = logstream.list_events(order="asc")
+        assert [e["id"] for e in asc] == [e1["id"], e2["id"], e3["id"]]
+
+        desc = logstream.list_events(order="desc")
+        assert [e["id"] for e in desc] == [e3["id"], e2["id"], e1["id"]]
+
+        tail = logstream.list_events(order="desc", limit=2)
+        assert [e["id"] for e in tail] == [e3["id"], e2["id"]]
+
+        with pytest.raises(ValueError, match="order='sideways'"):
+            logstream.list_events(order="sideways")
+
+    def test_since_event_id_cursor_invariance_with_order(self, logstream):
+        e1 = _append(logstream, body="1")
+        e2 = _append(logstream, body="2")
+        e3 = _append(logstream, body="3")
+
+        # since_event_id is strictly after e1 (rowid > e1["rowid"])
+        asc = logstream.list_events(since_event_id=e1["id"], order="asc")
+        assert [e["id"] for e in asc] == [e2["id"], e3["id"]]
+
+        desc = logstream.list_events(since_event_id=e1["id"], order="desc")
+        assert [e["id"] for e in desc] == [e3["id"], e2["id"]]
+
+    def test_before_event_id_filtering(self, logstream):
+        e1 = _append(logstream, body="1")
+        e2 = _append(logstream, body="2")
+        e3 = _append(logstream, body="3")
+
+        before_asc = logstream.list_events(before_event_id=e3["id"], order="asc")
+        assert [e["id"] for e in before_asc] == [e1["id"], e2["id"]]
+
+        before_desc = logstream.list_events(before_event_id=e3["id"], order="desc")
+        assert [e["id"] for e in before_desc] == [e2["id"], e1["id"]]
+
+        with pytest.raises(ValueError, match="before_event_id 'evt_nope' not found"):
+            logstream.list_events(before_event_id="evt_nope")
+
+    def test_watch_topic_spec_and_matching(self):
+        from mempalace.logstream import (
+            event_matches_watch,
+            pushdown_watch_filters,
+            sanitize_watch_spec,
+        )
+
+        spec = sanitize_watch_spec({"topics": {" auth ", "ui "}})
+        assert spec["topics"] == {"auth", "ui"}
+
+        pushdown_single = pushdown_watch_filters({"topics": {"auth"}})
+        assert pushdown_single == {"topic": "auth"}
+
+        pushdown_multi = pushdown_watch_filters({"topics": {"auth", "ui"}})
+        assert "topic" not in pushdown_multi
+
+        event_auth = {"stream": "p", "room": "r", "topic": "auth", "from_agent": "a"}
+        event_ui = {"stream": "p", "room": "r", "topic": "ui", "from_agent": "a"}
+        event_other = {"stream": "p", "room": "r", "topic": "other", "from_agent": "a"}
+        event_none = {"stream": "p", "room": "r", "topic": None, "from_agent": "a"}
+
+        assert event_matches_watch(event_auth, topics={"auth", "ui"}) is True
+        assert event_matches_watch(event_ui, topics={"auth", "ui"}) is True
+        assert event_matches_watch(event_other, topics={"auth", "ui"}) is False
+        assert event_matches_watch(event_none, topics={"auth", "ui"}) is False

--- a/tests/test_logstream_sse.py
+++ b/tests/test_logstream_sse.py
@@ -42,11 +42,12 @@ def http_server(patched_palace):
         thread.join(timeout=5)
 
 
-def _append(body="hello", correlation_id="task_sse", type="task.request"):
+def _append(body="hello", correlation_id="task_sse", type="task.request", topic=None):
     result = mcp.tool_event_append(
         type=type,
         stream="project/mempalace",
         room="delegation",
+        topic=topic,
         from_agent="mac-claude",
         to_agent="windows-codex",
         correlation_id=correlation_id,
@@ -135,6 +136,18 @@ class TestSSEStream:
             wanted = _append(body="signal", correlation_id="task_wanted")
             frames = _read_frames(resp, 1)
             assert [f["id"] for f in frames] == [wanted["id"]]
+        finally:
+            conn.close()
+
+    def test_topic_filter_scopes_the_stream(self, http_server):
+        port, _ = http_server
+        conn, resp = _open_stream(port, query="?topic=topic_wanted")
+        try:
+            _append(body="noise", topic="topic_noise")
+            wanted = _append(body="signal", topic="topic_wanted")
+            frames = _read_frames(resp, 1)
+            assert [f["id"] for f in frames] == [wanted["id"]]
+            assert frames[0]["data"]["topic"] == "topic_wanted"
         finally:
             conn.close()
 

--- a/tests/test_logstream_sync.py
+++ b/tests/test_logstream_sync.py
@@ -299,6 +299,7 @@ class TestSyncPrimitives:
             "type",
             "stream",
             "room",
+            "topic",
             "from_agent",
             "body",
             "created_at",
@@ -310,6 +311,29 @@ class TestSyncPrimitives:
         ):
             assert copy[key] == event[key], key
         assert ls_b.get_artifact(artifact["id"])["content"] == "payload"
+
+    def test_remote_event_with_and_without_topic(self, ls_a, ls_b):
+        event_topic = _append(ls_a, topic="security-track", body="with topic")
+        event_none = _append(ls_a, topic=None, body="without topic")
+
+        assert ls_b.apply_remote_event(event_topic) is True
+        assert ls_b.apply_remote_event(event_none) is True
+
+        b_topic = ls_b.list_events(topic="security-track")
+        assert len(b_topic) == 1
+        assert b_topic[0]["id"] == event_topic["id"]
+        assert b_topic[0]["topic"] == "security-track"
+
+        all_b = ls_b.list_events(limit=10)
+        by_id = {e["id"]: e for e in all_b}
+        assert by_id[event_none["id"]]["topic"] is None
+
+    def test_remote_event_rejects_invalid_topic(self, ls_a, ls_b):
+        event = _append(ls_a, topic="security")
+        event["topic"] = "security\nforged"
+
+        with pytest.raises(ValueError, match="topic"):
+            ls_b.apply_remote_event(event)
 
 
 # ── Convergence (engine over simulated wire) ─────────────────────────────

--- a/tests/test_mcp_logstream.py
+++ b/tests/test_mcp_logstream.py
@@ -401,3 +401,80 @@ class TestGateExemptions:
             assert mcp_server._mcp_sqlite_integrity_refusal(1, name) is None, name
         appended = _result(_call(patched_server, "mempalace_event_append", APPEND_ARGS))
         assert appended["success"] is True
+
+
+class TestTopicAndOrderMcp:
+    def test_mcp_tools_schema_has_topic_and_order(self):
+        append_props = mcp_server.TOOLS["mempalace_event_append"]["input_schema"]["properties"]
+        assert "topic" in append_props
+
+        list_props = mcp_server.TOOLS["mempalace_event_list"]["input_schema"]["properties"]
+        assert "topic" in list_props
+        assert "order" in list_props
+        assert "before_event_id" in list_props
+
+        wait_props = mcp_server.TOOLS["mempalace_event_wait"]["input_schema"]["properties"]
+        assert "topic" in wait_props
+
+        ack_props = mcp_server.TOOLS["mempalace_event_ack"]["input_schema"]["properties"]
+        assert "topic" in ack_props
+
+        patch_props = mcp_server.TOOLS["mempalace_patch_submit"]["input_schema"]["properties"]
+        assert "topic" in patch_props
+
+    def test_mcp_topic_and_order_dispatch(self, patched_server):
+        args1 = dict(APPEND_ARGS, topic="feature-x", body="1")
+        args2 = dict(APPEND_ARGS, topic="feature-y", body="2")
+        args3 = dict(APPEND_ARGS, topic="feature-x", body="3")
+
+        e1 = _result(_call(patched_server, "mempalace_event_append", args1))["event"]
+        e2 = _result(_call(patched_server, "mempalace_event_append", args2))["event"]
+        e3 = _result(_call(patched_server, "mempalace_event_append", args3))["event"]
+
+        assert e1["topic"] == "feature-x"
+        assert e2["topic"] == "feature-y"
+
+        # List by topic
+        list_topic_x = _result(
+            _call(patched_server, "mempalace_event_list", {"topic": "feature-x"})
+        )
+        assert [e["id"] for e in list_topic_x["events"]] == [e1["id"], e3["id"]]
+
+        # List order desc
+        list_desc = _result(_call(patched_server, "mempalace_event_list", {"order": "desc"}))
+        assert [e["id"] for e in list_desc["events"]] == [e3["id"], e2["id"], e1["id"]]
+
+        # List before_event_id
+        list_before = _result(
+            _call(
+                patched_server,
+                "mempalace_event_list",
+                {"before_event_id": e3["id"], "order": "desc"},
+            )
+        )
+        assert [e["id"] for e in list_before["events"]] == [e2["id"], e1["id"]]
+
+        # Ack topic override
+        ack_res = _result(
+            _call(
+                patched_server,
+                "mempalace_event_ack",
+                {"event_id": e1["id"], "from_agent": "windows-codex", "topic": "feature-override"},
+            )
+        )
+        assert ack_res["event"]["topic"] == "feature-override"
+
+        # Patch submit with topic
+        patch_res = _result(
+            _call(
+                patched_server,
+                "mempalace_patch_submit",
+                {
+                    "content": "diff --git a/a b/b\n",
+                    "from_agent": "mac-codex",
+                    "stream": "project/mempalace",
+                    "topic": "feature-patch",
+                },
+            )
+        )
+        assert patch_res["event"]["topic"] == "feature-patch"

--- a/website/concepts/agent-logstream.md
+++ b/website/concepts/agent-logstream.md
@@ -45,6 +45,7 @@ optional verbatim body:
 - **`stream`** is the broad channel — `project/<name>` for per-project work,
   or a shared channel like `shared_agent_brain`.
 - **`room`** is the sub-channel: `delegation`, `patches`, `reviews`, `status`.
+- **`topic`** (optional) groups related tasks or sub-teams around a track (e.g. `auth-v2`, `ui-redesign`), avoiding crosstalk within a shared harness identity.
 - **`correlation_id`** ties a request to its replies and acks. Generate one
   per task and carry it through the whole exchange.
 - **`to_agent`** targets one agent, or `*` to broadcast. Filters on
@@ -154,8 +155,12 @@ event created at 09:10:48Z is appended locally whenever it syncs, which can be
 So there are two different parameters, and only one of them is a cursor:
 
 - **`since_event_id`** — strictly after that event in append order, whatever
-  the timestamps say. This is the resume cursor. A watcher's entire state is
+  the timestamps say. This is the forward resume cursor. A watcher's entire state is
   the id of the last event it processed.
+- **`before_event_id`** — strictly before that event in append order (`rowid < anchor`)
+  for reverse / historical paging.
+- **`order`** — `'asc'` (oldest first, default) or `'desc'` (newest first, ideal for single-call
+  tail sweeps of recent inbox activity).
 - **`since_created_at`** — a time window (`>=`, inclusive; dedup by `id`).
   Good for "what happened today", wrong for resumption: a late-arriving peer
   event is already older than your high-water mark, so you skip it silently
@@ -168,7 +173,7 @@ So there are two different parameters, and only one of them is a cursor:
 | Inbox sweep | Session start, pre-task checks | `mempalace_event_list` + `to_agent` + `since_event_id`, `preview=true` |
 | Background watcher | Being woken while you work | `mempalace logstream watch`, run as a background process |
 | Long-poll | Waiting on one correlation, in-turn | `mempalace_event_wait` — 60s default, 300s max, returns `timed_out` rather than erroring |
-| Server-Sent Events | Daemons, dashboards, live viewers | `GET /logstream/stream`, same filters and `since_event_id` resume |
+| Server-Sent Events | Daemons, dashboards, live viewers | `GET /logstream/stream`, live-tail filters and `since_event_id` resume |
 | Declared-idle | Turn-based agents with no background loop | Publish your cursor and say you need a ping |
 
 `logstream watch` exists because `wait` is a primitive, not a watcher: it caps

--- a/website/guide/shared-brain.md
+++ b/website/guide/shared-brain.md
@@ -173,7 +173,8 @@ Coordination (logstream):
   watch command: an unnoticed prompt stalls the loop silently, and to
   your peers it looks like "claimed but gone quiet".
 - To delegate: mempalace_event_append (type=task.request, stream=
-  project/<name>, room=delegation, correlation_id=task_..., status=open,
+  project/<name>, room=delegation, topic=<name> (optional for sub-teams),
+  correlation_id=task_..., status=open,
   body = goal + branch + base commit + definition of done), then
   mempalace_event_wait on that correlation_id for the reply.
 - When you accept a task: ack it with status=claimed. Deliver code as a

--- a/website/reference/mcp-tools.md
+++ b/website/reference/mcp-tools.md
@@ -517,13 +517,14 @@ task with the user before invoking this immutable append.
 
 ### `mempalace_event_append`
 
-Append an immutable coordination event.
+Append an immutable agent-coordination event to the logstream (RFC 003).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `type` | string | **Yes** | Event type, e.g. `task.request`, `task.reply`, `patch.ready` |
 | `stream` | string | **Yes** | Logical stream, e.g. `project/myapp` or `shared_agent_brain` |
 | `room` | string | **Yes** | Sub-channel: `delegation`, `patches`, `reviews`, `status` |
+| `topic` | string | No | Topic to group related work/sub-team, e.g. `auth-v2` |
 | `from_agent` | string | **Yes** | Writer agent identity |
 | `to_agent` | string | No | Target agent, or `*` for broadcast |
 | `correlation_id` | string | No | Task id tying request and reply events together |
@@ -540,19 +541,22 @@ Append an immutable coordination event.
 
 ### `mempalace_event_list`
 
-List events with structured filters, oldest first.
+List events with structured filters.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `stream` | string | No | Filter by stream |
 | `room` | string | No | Filter by room |
+| `topic` | string | No | Filter by topic |
 | `type` | string | No | Filter by event type |
 | `to_agent` | string | No | Filter by target; also matches `*` broadcasts |
 | `from_agent` | string | No | Filter by writer |
 | `correlation_id` | string | No | Filter by correlation id |
 | `status` | string | No | Filter by status |
-| `since_event_id` | string | No | Only events strictly after this id (precise cursor) |
+| `since_event_id` | string | No | Only events strictly after this id in append order (precise forward cursor) |
+| `before_event_id` | string | No | Only events strictly before this id in append order (reverse/historical paging) |
 | `since_created_at` | string | No | Only events at/after this time (inclusive) |
+| `order` | string | No | `asc` (oldest first, default) or `desc` (newest first) |
 | `limit` | integer | No | Max events (default 50, cap 500) |
 
 **Returns:** `{ events: [...], count }`
@@ -561,7 +565,7 @@ List events with structured filters, oldest first.
 
 ### `mempalace_event_wait`
 
-Block until a matching event exists or the timeout expires (long-poll; max 5 minutes). Accepts the same filters as `event_list` plus:
+Block until a matching event exists or the timeout expires (long-poll; max 5 minutes). Accepts the forward filters `stream`, `room`, `topic`, `type`, `to_agent`, `from_agent`, `correlation_id`, `status`, `since_event_id`, and `since_created_at`, plus:
 
 For live-tail clients that can keep an HTTP connection open, use
 `GET /logstream/stream` SSE instead; `event_wait` is the polling MCP surface.
@@ -577,7 +581,7 @@ For live-tail clients that can keep an HTTP connection open, use
 
 ### `mempalace_event_ack`
 
-Acknowledge an event: appends a new `event.ack` routed back to the original writer, with `correlation_id` copied from the target (falling back to the target's id). Never mutates the target event.
+Acknowledge an event: appends a new `event.ack` routed back to the original writer. It copies `topic` from the target unless overridden, and copies `correlation_id` with the target id as its fallback. It never mutates the target event.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -585,6 +589,7 @@ Acknowledge an event: appends a new `event.ack` routed back to the original writ
 | `from_agent` | string | **Yes** | Acknowledging agent identity |
 | `status` | string | No | e.g. `applied`, `failed` |
 | `body` | string | No | Verbatim ack notes |
+| `topic` | string | No | Topic override (defaults to target event's topic) |
 
 **Returns:** `{ success, event }` — the new ack event.
 
@@ -627,6 +632,7 @@ Convenience: store a patch artifact and append its `patch.ready` event in one ca
 | `from_agent` | string | **Yes** | Submitting agent identity |
 | `stream` | string | **Yes** | Logical stream |
 | `room` | string | No | Sub-channel (default `patches`) |
+| `topic` | string | No | Topic name, e.g. `auth-v2` |
 | `to_agent` | string | No | Target agent or `*` |
 | `correlation_id` | string | No | Task id tying the patch to its request |
 | `branch` | string | No | Git branch |


### PR DESCRIPTION
## Summary
- add optional validated `topic` routing across logstream storage, append/list/wait/watch/ack/patch, MCP, CLI, SSE, and replication
- preserve topics through idempotent SQLite upgrades and acknowledgement inheritance
- add `before_event_id` plus ascending/descending ordering without changing forward-only `since_event_id` semantics
- update RFC, shared coordination guidance, and public reference documentation

## Verification
- `uv run pytest tests/test_cli_rules.py tests/test_logstream.py tests/test_logstream_sse.py tests/test_logstream_sync.py tests/test_mcp_logstream.py tests/test_cli_logstream.py -q` (232 passed)
- Ruff lint and format checks on all changed Python files (passed)
- independent standards and spec reviews: no remaining findings

## Full-suite note
A repository-wide local run was attempted but stalled in unrelated embedding tests. Earlier failures in this checkout were outside the logstream scope; the focused logstream and canonical-template gates above are clean. CI remains the authoritative full-platform gate.