### PR TITLE
feat: add private Palace search benchmark

### DIFF
--- a/benchmarks/PRIVATE_PALACE.md
+++ b/benchmarks/PRIVATE_PALACE.md
@@ -1,0 +1,140 @@
+# Private Palace search benchmark
+
+This harness compares retrieval algorithms against a real Palace without
+copying drawer text into benchmark reports. Queries and judgments stay in a
+local JSONL dataset; reports contain case IDs, ranked logical drawer IDs,
+metrics, timings, and non-content corpus state only.
+
+Keep datasets and reports outside the repository, for example under:
+
+```text
+~/.mempalace/benchmarks/search/my-suite/
+```
+
+## 1. Create the query set
+
+```powershell
+uv run python benchmarks/private_palace_bench.py init `
+  --dataset "$HOME/.mempalace/benchmarks/search/my-suite/cases.jsonl"
+```
+
+Each JSONL row has this shape:
+
+```json
+{"id":"q-001","query":"Which database did we choose?","judgments":{},"filters":{"wing":"project"},"tags":["dev","decision"],"expect_no_results":false}
+```
+
+Use at least 50 development questions and 100 held-out questions. Include
+exact names, paraphrases, dates, preferences, cross-session questions,
+Portuguese and English, ambiguity, and expected misses. Add `dev` or `test`
+to `tags`; do not tune on the held-out set. For an expected miss, set
+`"expect_no_results": true` and keep every judgment at grade 0.
+
+## 2. Build a blinded judgment pool
+
+```powershell
+uv run python benchmarks/private_palace_bench.py pool `
+  --dataset "$HOME/.mempalace/benchmarks/search/my-suite/cases.jsonl" `
+  --out "$HOME/.mempalace/benchmarks/search/my-suite/pool.json" `
+  --tag dev `
+  --pool-depth 20
+```
+
+The pool is the shuffled union of every algorithm's top candidates. It hides
+which algorithm retrieved each drawer and does not contain drawer text. Open
+each candidate locally with `mempalace_get_drawer`, then add its grade to the
+case's `judgments` object:
+
+- `0`: irrelevant
+- `1`: related context, but not useful evidence
+- `2`: useful answer evidence
+- `3`: exact or direct evidence
+
+Re-grade a hidden 10% sample to check judgment consistency. Because pooled
+judgments are not necessarily exhaustive, the report calls its recall metric
+`pooled_recall@k` rather than claiming corpus-wide recall.
+
+## 3. Run the benchmark
+
+Start with a small development smoke run:
+
+```powershell
+uv run python benchmarks/private_palace_bench.py run `
+  --dataset "$HOME/.mempalace/benchmarks/search/my-suite/cases.jsonl" `
+  --out "$HOME/.mempalace/benchmarks/search/my-suite/dev-report.json" `
+  --tag dev `
+  --limit 10 `
+  --ks 1,5,10 `
+  --warmups 1 `
+  --repeats 2
+```
+
+Use at least seven repeats for a real run. Algorithm/query order is seeded and
+interleaved. Reported latency includes query sanitization, embeddings where
+needed, retrieval, fusion, and final ranking. Report serialization is outside
+the timed section. The `current` profile additionally includes local MCP HTTP
+transport and JSON serialization; its end-to-end latency is reported in the
+separate `product_boundary` scope and must not be compared directly with the
+in-process algorithms. If `current` is explicitly allowed to fall back to a
+direct call because no hub is available, the report labels it
+`direct_product_path` instead.
+
+The default matrix is:
+
+- `vector`: raw vector-distance order
+- `bm25`: backend lexical order
+- `current`: exact MCP product replay, including the live safety probe and retry
+- `rrf`: equal Reciprocal Rank Fusion over vector and BM25 rankings
+- `weighted_rrf`: weighted RRF, defaulting to 60% vector and 40% BM25
+
+`union` is also implemented, but MCP does not expose it. Run that profile only
+in a write-quiescent window with the hub stopped and both flags explicit:
+
+```powershell
+uv run python benchmarks/private_palace_bench.py run `
+  --dataset "$HOME/.mempalace/benchmarks/search/my-suite/cases.jsonl" `
+  --out "$HOME/.mempalace/benchmarks/search/my-suite/union-dev.json" `
+  --tag dev `
+  --algorithms union `
+  --max-distance 0 `
+  --allow-direct-product-path
+```
+
+RRF uses `sum(weight / (rank_constant + one_based_rank))`, with a default
+rank constant of 60. It never compares backend score scales.
+
+For the final held-out run:
+
+```powershell
+uv run python benchmarks/private_palace_bench.py run `
+  --dataset "$HOME/.mempalace/benchmarks/search/my-suite/cases.jsonl" `
+  --out "$HOME/.mempalace/benchmarks/search/my-suite/test-report.json" `
+  --tag test `
+  --warmups 1 `
+  --repeats 7
+```
+
+## Safety and interpretation
+
+The controlled vector and BM25 paths currently require the `sqlite_exact`
+backend, the only built-in backend with an enforced read-only open. They call
+`get_collection(..., create=False, read_only=True)`. The `current` profile
+calls the live local MCP hub, so it exercises the product boundary without
+opening another write-capable handle. Direct current/union replay is disabled
+unless `--allow-direct-product-path` is explicit. The report reopens the
+read-only collection and compares public backend maintenance state, including
+SQLite's non-content consistency token, before and after a run. It marks a
+changed corpus invalid and exits nonzero. For a publishable comparison, still
+use a write-quiescent window; never raw-copy an active SQLite database without
+its WAL.
+
+Primary quality metric: macro `nDCG@10`. Secondary metrics are hit rate, MRR,
+pooled recall, judgment coverage, and expected-no-result accuracy at each
+configured cutoff. Relevance grades 2 and 3 count as positive by default.
+Every scored run requires `--tag dev` or `--tag test`, and a case cannot carry
+both tags. Compare latency only within the same `latency_scope` and after the
+warmup because `sqlite_exact` caches its vector matrix after the first scan.
+
+Adopt a new algorithm only if held-out known-target regressions are explained
+or eliminated. Quality comes first; latency chooses among candidates on the
+quality Pareto frontier.

--- a/benchmarks/private_palace_bench.py
+++ b/benchmarks/private_palace_bench.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Thin entry point for the private Palace search benchmark."""
+
+from search_benchmark import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/search_benchmark.py
+++ b/benchmarks/search_benchmark.py
@@ -1,0 +1,1031 @@
+"""Private, text-free evaluation primitives for Palace search algorithms.
+
+The benchmark seam deliberately deals only in query cases and ranked drawer
+IDs. Search adapters may inspect drawer text while retrieving, but neither the
+runner nor its JSON-compatible report accepts or persists document content.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import random
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Mapping, Protocol, Sequence
+
+
+_ALLOWED_FILTERS = frozenset({"wing", "room", "source_file", "since", "before"})
+
+
+def _restrict_private_path(path: Path, *, directory: bool) -> None:
+    """Restrict a path to the current user, or fail before publishing data."""
+
+    if os.name == "nt":
+        identity_result = subprocess.run(["whoami"], capture_output=True, text=True, check=True)
+        identity = identity_result.stdout.strip()
+        if not identity:
+            raise PermissionError("could not resolve the current Windows identity")
+        grant = f"{identity}:{'(OI)(CI)' if directory else ''}F"
+        for arguments in (("/reset",), ("/inheritance:r",), ("/grant:r", grant)):
+            subprocess.run(
+                ["icacls", str(path), *arguments],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        acl = subprocess.run(
+            ["icacls", str(path)], capture_output=True, text=True, check=True
+        ).stdout
+        acl_folded = acl.casefold()
+        acl_lines = [line.strip() for line in acl.splitlines() if ":(" in line]
+        principals = set()
+        path_text = str(path)
+        for line in acl_lines:
+            if line.casefold().startswith(path_text.casefold()):
+                line = line[len(path_text) :].lstrip()
+            principals.add(line.split(":(", 1)[0].strip().casefold())
+        if principals != {identity.casefold()} or "(i)" in acl_folded:
+            raise PermissionError(f"could not verify owner-only ACL for {path}")
+        return
+
+    path.chmod(0o700 if directory else 0o600)
+    if path.stat().st_mode & 0o077:
+        raise PermissionError(f"could not establish owner-only permissions for {path}")
+
+
+def _write_private_text(path: Path, text: str, *, refuse_existing: bool = False) -> None:
+    """Atomically publish a private benchmark artifact with owner-only access."""
+
+    if refuse_existing and path.exists():
+        raise FileExistsError(f"refusing to overwrite existing dataset: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    _restrict_private_path(path.parent, directory=True)
+
+    fd, temp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        _restrict_private_path(Path(temp_name), directory=False)
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if refuse_existing and path.exists():
+            raise FileExistsError(f"refusing to overwrite existing dataset: {path}")
+        os.replace(temp_name, path)
+        _restrict_private_path(path, directory=False)
+    except BaseException:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """One private retrieval question and its graded drawer judgments."""
+
+    id: str
+    query: str
+    judgments: Mapping[str, int] = field(default_factory=dict)
+    filters: Mapping[str, str] = field(default_factory=dict)
+    tags: tuple[str, ...] = ()
+    expect_no_results: bool = False
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    """The only result shape visible to the benchmark runner."""
+
+    drawer_id: str
+    score: float
+
+
+class SearchAlgorithm(Protocol):
+    """Adapter interface for one search implementation under evaluation."""
+
+    name: str
+    latency_scope: str
+
+    def search(self, case: BenchmarkCase, limit: int) -> Sequence[SearchHit]: ...
+
+
+class SearchSource(Protocol):
+    """Raw Palace ranking signals used by controlled benchmark algorithms."""
+
+    def vector_ranking(self, case: BenchmarkCase, depth: int) -> Sequence[SearchHit]: ...
+
+    def lexical_ranking(self, case: BenchmarkCase, depth: int) -> Sequence[SearchHit]: ...
+
+    def current_ranking(
+        self,
+        case: BenchmarkCase,
+        limit: int,
+        *,
+        candidate_strategy: str,
+    ) -> Sequence[SearchHit]: ...
+
+    def current_latency_scope(self, *, candidate_strategy: str) -> str: ...
+
+
+class LocalPalaceSearchSource:
+    """Read-only local Palace adapter for baseline and fusion experiments."""
+
+    def __init__(
+        self,
+        palace_path: str,
+        *,
+        collection_name: str | None = None,
+        backend: str | None = None,
+        max_distance: float = 0.0,
+        allow_direct_product_path: bool = False,
+        collection=None,
+        current_search=None,
+        collection_opener=None,
+    ):
+        from mempalace.palace import get_collection
+        from mempalace.searcher import search_memories
+
+        self.palace_path = palace_path
+        self.collection_name = collection_name
+        self.backend = backend
+        self.max_distance = max_distance
+        self._allow_direct_product_path = allow_direct_product_path
+        self._collection_opener = collection_opener or get_collection
+        self._collection = collection or self._open_collection()
+        self._direct_current_search = current_search or search_memories
+        self._injected_current_search = current_search
+        self._hub_current_search = None if current_search else _live_hub_search(palace_path)
+
+    def _open_collection(self):
+        from mempalace.palace import resolve_backend_name
+
+        backend_name = resolve_backend_name(self.palace_path, explicit=self.backend)
+        if backend_name != "sqlite_exact":
+            raise RuntimeError(
+                "controlled vector/BM25 baselines require backend=sqlite_exact because it is "
+                "the only built-in backend with an enforced read-only open; use the live hub "
+                "for current-product replay, or rerun against a sqlite_exact Palace"
+            )
+        return self._collection_opener(
+            self.palace_path,
+            collection_name=self.collection_name,
+            create=False,
+            backend=self.backend,
+            read_only=True,
+        )
+
+    def snapshot_metadata(self, *, refresh: bool = False) -> dict:
+        """Return non-content corpus state for reproducibility checks."""
+
+        collection = self._open_collection() if refresh else self._collection
+        try:
+            maintenance = collection.maintenance_state()
+        except Exception:
+            maintenance = {}
+        return {
+            "drawer_count": collection.count(),
+            "distance_metric": getattr(collection, "distance_metric", "unknown"),
+            "maintenance": maintenance,
+            "read_only_requested": True,
+        }
+
+    def vector_ranking(self, case: BenchmarkCase, depth: int) -> Sequence[SearchHit]:
+        from mempalace.date_window import filed_at_in_window, parse_window
+        from mempalace.query_sanitizer import sanitize_query
+        from mempalace.searcher import (
+            _distance_to_similarity,
+            _result_drawer_id,
+            build_where_filter,
+        )
+
+        query = sanitize_query(case.query)["clean_query"]
+        where = build_where_filter(
+            case.filters.get("wing"),
+            case.filters.get("room"),
+            case.filters.get("source_file"),
+        )
+        since_dt, before_dt = parse_window(
+            case.filters.get("since"),
+            case.filters.get("before"),
+        )
+        fetch_depth = max(depth * 3, depth)
+        if since_dt is not None or before_dt is not None:
+            fetch_depth = max(fetch_depth, min(depth * 15, 500))
+        kwargs = {
+            "query_texts": [query],
+            "n_results": fetch_depth,
+            "include": ["metadatas", "distances"],
+        }
+        if where:
+            kwargs["where"] = where
+        try:
+            result = self._collection.query(**kwargs)
+        except (ImportError, ModuleNotFoundError, ValueError) as exc:
+            if "onnxruntime" not in str(exc).lower():
+                raise
+            raise RuntimeError(
+                "vector benchmark cannot embed queries because this Python environment lacks "
+                "onnxruntime; use the same environment as the running Palace or install the "
+                "matching local embedding runtime"
+            ) from exc
+        ids = _first_nested(result, "ids")
+        metadatas = _first_nested(result, "metadatas")
+        distances = _first_nested(result, "distances")
+        hits: list[SearchHit] = []
+        seen: set[str] = set()
+        for stored_id, metadata, distance in zip(ids, metadatas, distances):
+            metadata = metadata or {}
+            if self.max_distance > 0 and distance > self.max_distance:
+                continue
+            if (since_dt is not None or before_dt is not None) and not filed_at_in_window(
+                metadata.get("filed_at"), since_dt, before_dt
+            ):
+                continue
+            drawer_id = _result_drawer_id(metadata, stored_id)
+            if not drawer_id or drawer_id in seen:
+                continue
+            seen.add(drawer_id)
+            hits.append(
+                SearchHit(
+                    drawer_id=drawer_id,
+                    score=_distance_to_similarity(distance, self._collection.distance_metric),
+                )
+            )
+            if len(hits) >= depth:
+                break
+        return hits
+
+    def lexical_ranking(self, case: BenchmarkCase, depth: int) -> Sequence[SearchHit]:
+        from mempalace.date_window import filed_at_in_window, parse_window
+        from mempalace.query_sanitizer import sanitize_query
+        from mempalace.searcher import _result_drawer_id, build_where_filter
+
+        query = sanitize_query(case.query)["clean_query"]
+        where = build_where_filter(
+            case.filters.get("wing"),
+            case.filters.get("room"),
+            case.filters.get("source_file"),
+        )
+        since_dt, before_dt = parse_window(
+            case.filters.get("since"),
+            case.filters.get("before"),
+        )
+        fetch_depth = max(depth * 3, depth)
+        if since_dt is not None or before_dt is not None:
+            fetch_depth = max(fetch_depth, min(depth * 15, 500))
+        result = self._collection.lexical_search(
+            query=query,
+            n_results=fetch_depth,
+            where=where or None,
+        )
+        hits: list[SearchHit] = []
+        seen: set[str] = set()
+        for hit in result.hits:
+            metadata = hit.metadata or {}
+            if (since_dt is not None or before_dt is not None) and not filed_at_in_window(
+                metadata.get("filed_at"), since_dt, before_dt
+            ):
+                continue
+            drawer_id = _result_drawer_id(metadata, hit.id)
+            if not drawer_id or drawer_id in seen:
+                continue
+            seen.add(drawer_id)
+            hits.append(SearchHit(drawer_id=drawer_id, score=float(hit.score)))
+            if len(hits) >= depth:
+                break
+        return hits
+
+    def current_ranking(
+        self,
+        case: BenchmarkCase,
+        limit: int,
+        *,
+        candidate_strategy: str,
+    ) -> Sequence[SearchHit]:
+        from mempalace.query_sanitizer import sanitize_query
+
+        query = sanitize_query(case.query)["clean_query"]
+        if self._injected_current_search is not None:
+            current_search = self._injected_current_search
+        elif candidate_strategy == "vector" and self._hub_current_search is not None:
+            current_search = self._hub_current_search
+        elif self._allow_direct_product_path:
+            current_search = self._direct_current_search
+        else:
+            profile = "union" if candidate_strategy == "union" else "current"
+            raise RuntimeError(
+                f"{profile} requires the live Palace MCP hub for exact product replay; "
+                "union is not exposed by MCP, so run it only in a write-quiescent window "
+                "with --allow-direct-product-path"
+            )
+
+        result = current_search(
+            query,
+            self.palace_path,
+            wing=case.filters.get("wing"),
+            room=case.filters.get("room"),
+            source_file=case.filters.get("source_file"),
+            since=case.filters.get("since"),
+            before=case.filters.get("before"),
+            n_results=limit,
+            max_distance=self.max_distance,
+            candidate_strategy=candidate_strategy,
+            collection_name=self.collection_name,
+        )
+        if result.get("error"):
+            raise RuntimeError(str(result["error"]))
+        hits: list[SearchHit] = []
+        for rank, row in enumerate(result.get("results", []), 1):
+            drawer_id = row.get("drawer_id")
+            if not drawer_id:
+                continue
+            score = row.get("similarity")
+            hits.append(
+                SearchHit(
+                    drawer_id=drawer_id,
+                    score=float(score) if isinstance(score, (int, float)) else 1.0 / rank,
+                )
+            )
+        return hits
+
+    def current_latency_scope(self, *, candidate_strategy: str) -> str:
+        """Describe the boundary timed by ``current_ranking`` for this source."""
+
+        if (
+            self._injected_current_search is None
+            and candidate_strategy == "vector"
+            and self._hub_current_search is not None
+        ):
+            return "product_boundary"
+        return "direct_product_path"
+
+
+class HubSearchClient:
+    """Exact product-search replay through the live local MCP hub."""
+
+    def __init__(self, base_url: str, headers: Mapping[str, str]):
+        self._base_url = base_url
+        self._headers = dict(headers)
+
+    def __call__(self, query: str, palace_path: str, **kwargs) -> dict:
+        from mempalace.hub_client import forward_json_rpc
+
+        if kwargs.get("candidate_strategy") != "vector":
+            raise RuntimeError(
+                "the MCP search interface does not expose candidate_strategy='union'"
+            )
+        arguments = {
+            "query": query,
+            "limit": kwargs["n_results"],
+            "max_distance": kwargs["max_distance"],
+        }
+        for name in ("wing", "room", "source_file", "since", "before"):
+            if kwargs.get(name) is not None:
+                arguments[name] = kwargs[name]
+        payload = forward_json_rpc(
+            self._base_url,
+            self._headers,
+            {
+                "jsonrpc": "2.0",
+                "id": f"private-search-benchmark-{time.time_ns()}",
+                "method": "tools/call",
+                "params": {"name": "mempalace_search", "arguments": arguments},
+            },
+            timeout=120,
+        )
+        if not isinstance(payload, dict):
+            raise RuntimeError("Palace MCP search returned an empty response")
+        if payload.get("error"):
+            raise RuntimeError(f"Palace MCP search failed: {payload['error']}")
+        content = payload.get("result", {}).get("content", [])
+        text_block = next(
+            (block.get("text") for block in content if block.get("type") == "text"),
+            None,
+        )
+        if not text_block:
+            raise RuntimeError("Palace MCP search returned no JSON text result")
+        result = json.loads(text_block)
+        if not isinstance(result, dict):
+            raise RuntimeError("Palace MCP search returned a non-object result")
+        return result
+
+
+def _live_hub_search(palace_path: str):
+    from mempalace.hub_client import discover_hub
+
+    target = discover_hub(palace_path)
+    if target is None:
+        return None
+    return HubSearchClient(*target)
+
+
+class _SourceAlgorithm:
+    def __init__(self, name: str, source: SearchSource, candidate_depth: int):
+        self.name = name
+        self.latency_scope = "in_process"
+        if name in {"current", "union"}:
+            strategy = "union" if name == "union" else "vector"
+            scope = getattr(source, "current_latency_scope", None)
+            self.latency_scope = (
+                scope(candidate_strategy=strategy)
+                if callable(scope)
+                else ("direct_product_path" if name == "union" else "product_boundary")
+            )
+        self._source = source
+        self._candidate_depth = candidate_depth
+
+    def search(self, case: BenchmarkCase, limit: int) -> Sequence[SearchHit]:
+        if self.name == "vector":
+            return self._source.vector_ranking(case, max(limit, self._candidate_depth))[:limit]
+        if self.name == "bm25":
+            return self._source.lexical_ranking(case, max(limit, self._candidate_depth))[:limit]
+        strategy = "union" if self.name == "union" else "vector"
+        return self._source.current_ranking(case, limit, candidate_strategy=strategy)[:limit]
+
+
+class _FusionAlgorithm:
+    def __init__(
+        self,
+        name: str,
+        source: SearchSource,
+        candidate_depth: int,
+        rank_constant: int,
+        weights: Mapping[str, float] | None,
+    ):
+        self.name = name
+        self.latency_scope = "in_process"
+        self._source = source
+        self._candidate_depth = candidate_depth
+        self._rank_constant = rank_constant
+        self._weights = weights
+
+    def search(self, case: BenchmarkCase, limit: int) -> Sequence[SearchHit]:
+        depth = max(limit, self._candidate_depth)
+        vector = self._source.vector_ranking(case, depth)
+        lexical = self._source.lexical_ranking(case, depth)
+        return reciprocal_rank_fusion(
+            {
+                "vector": [hit.drawer_id for hit in vector],
+                "bm25": [hit.drawer_id for hit in lexical],
+            },
+            rank_constant=self._rank_constant,
+            weights=self._weights,
+        )[:limit]
+
+
+def build_search_algorithms(
+    source: SearchSource,
+    *,
+    names: Sequence[str] = ("vector", "bm25", "current", "union", "rrf", "weighted_rrf"),
+    candidate_depth: int = 50,
+    rank_constant: int = 60,
+    vector_weight: float = 0.6,
+    bm25_weight: float = 0.4,
+) -> list[SearchAlgorithm]:
+    """Build the fixed algorithm matrix over one Palace search source."""
+
+    supported = frozenset({"vector", "bm25", "current", "union", "rrf", "weighted_rrf"})
+    unknown = sorted(set(names) - supported)
+    if unknown:
+        raise ValueError(f"unknown search algorithms: {', '.join(unknown)}")
+    if candidate_depth <= 0:
+        raise ValueError("candidate_depth must be positive")
+    if rank_constant < 0:
+        raise ValueError("rank_constant must be non-negative")
+
+    algorithms: list[SearchAlgorithm] = []
+    for name in names:
+        if name in {"vector", "bm25", "current", "union"}:
+            algorithms.append(_SourceAlgorithm(name, source, candidate_depth))
+        else:
+            weights = (
+                None
+                if name == "rrf"
+                else {"vector": float(vector_weight), "bm25": float(bm25_weight)}
+            )
+            algorithms.append(
+                _FusionAlgorithm(
+                    name,
+                    source,
+                    candidate_depth,
+                    rank_constant,
+                    weights,
+                )
+            )
+    return algorithms
+
+
+def load_benchmark_cases(path: Path) -> list[BenchmarkCase]:
+    """Load and validate the private JSONL benchmark dataset."""
+
+    cases: list[BenchmarkCase] = []
+    seen: set[str] = set()
+    with Path(path).open(encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, 1):
+            if not raw_line.strip():
+                continue
+            try:
+                row = json.loads(raw_line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"line {line_number}: invalid JSON: {exc.msg}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"line {line_number}: expected a JSON object")
+
+            case_id = _required_text(row, "id", line_number)
+            query = _required_text(row, "query", line_number)
+            if case_id in seen:
+                raise ValueError(f"line {line_number}: duplicate case id {case_id!r}")
+            seen.add(case_id)
+
+            judgments = row.get("judgments", {})
+            if not isinstance(judgments, dict):
+                raise ValueError(f"line {line_number}: judgments must be an object")
+            checked_judgments: dict[str, int] = {}
+            for drawer_id, relevance in judgments.items():
+                if not isinstance(drawer_id, str) or not drawer_id.strip():
+                    raise ValueError(
+                        f"line {line_number}: judgment drawer ids must be non-empty strings"
+                    )
+                if (
+                    isinstance(relevance, bool)
+                    or not isinstance(relevance, int)
+                    or relevance < 0
+                    or relevance > 3
+                ):
+                    raise ValueError(
+                        f"line {line_number}: relevance for {drawer_id!r} must be an integer 0..3"
+                    )
+                checked_judgments[drawer_id] = relevance
+
+            filters = row.get("filters", {})
+            if not isinstance(filters, dict):
+                raise ValueError(f"line {line_number}: filters must be an object")
+            unknown_filters = set(filters) - _ALLOWED_FILTERS
+            if unknown_filters:
+                names = ", ".join(sorted(unknown_filters))
+                raise ValueError(f"line {line_number}: unsupported filters: {names}")
+            checked_filters: dict[str, str] = {}
+            for key, value in filters.items():
+                if not isinstance(value, str) or not value.strip():
+                    raise ValueError(
+                        f"line {line_number}: filter {key!r} must be a non-empty string"
+                    )
+                checked_filters[key] = value
+
+            tags = row.get("tags", [])
+            if not isinstance(tags, list) or any(not isinstance(tag, str) for tag in tags):
+                raise ValueError(f"line {line_number}: tags must be an array of strings")
+            expect_no_results = row.get("expect_no_results", False)
+            if not isinstance(expect_no_results, bool):
+                raise ValueError(f"line {line_number}: expect_no_results must be a boolean")
+            if expect_no_results and any(gain > 0 for gain in checked_judgments.values()):
+                raise ValueError(
+                    f"line {line_number}: expect_no_results cannot have positive judgments"
+                )
+
+            cases.append(
+                BenchmarkCase(
+                    id=case_id,
+                    query=query,
+                    judgments=checked_judgments,
+                    filters=checked_filters,
+                    tags=tuple(tags),
+                    expect_no_results=expect_no_results,
+                )
+            )
+    if not cases:
+        raise ValueError("benchmark dataset contains no cases")
+    return cases
+
+
+def _required_text(row: dict, key: str, line_number: int) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"line {line_number}: {key} must be a non-empty string")
+    return value
+
+
+def reciprocal_rank_fusion(
+    rankings: Mapping[str, Sequence[str]],
+    *,
+    rank_constant: int = 60,
+    weights: Mapping[str, float] | None = None,
+) -> list[SearchHit]:
+    """Fuse ranked drawer IDs using RRF or weighted RRF.
+
+    Rank positions are one-based. Duplicate IDs inside one input ranking count
+    only at their first position. Scores from the source algorithms are never
+    compared or normalized.
+    """
+
+    if rank_constant < 0:
+        raise ValueError("rank_constant must be non-negative")
+
+    fused_scores: dict[str, float] = {}
+    best_ranks: dict[str, int] = {}
+    for source, ranking in rankings.items():
+        weight = 1.0 if weights is None else float(weights.get(source, 1.0))
+        if not math.isfinite(weight) or weight < 0:
+            raise ValueError(f"weight for {source!r} must be finite and non-negative")
+        seen: set[str] = set()
+        for rank, drawer_id in enumerate(ranking, 1):
+            if not drawer_id or drawer_id in seen:
+                continue
+            seen.add(drawer_id)
+            fused_scores[drawer_id] = fused_scores.get(drawer_id, 0.0) + (
+                weight / (rank_constant + rank)
+            )
+            best_ranks[drawer_id] = min(best_ranks.get(drawer_id, rank), rank)
+
+    ordered = sorted(
+        fused_scores,
+        key=lambda drawer_id: (-fused_scores[drawer_id], best_ranks[drawer_id], drawer_id),
+    )
+    return [SearchHit(drawer_id=drawer_id, score=fused_scores[drawer_id]) for drawer_id in ordered]
+
+
+def evaluate_ranking(
+    case: BenchmarkCase,
+    ranking: Sequence[str],
+    *,
+    ks: Sequence[int] = (1, 5, 10),
+    relevance_threshold: int = 2,
+) -> dict[str, float]:
+    """Evaluate one ranking against binary and graded relevance judgments."""
+
+    if relevance_threshold < 1 or relevance_threshold > 3:
+        raise ValueError("relevance_threshold must be in the range 1..3")
+    clean_ranking = _unique_ids(ranking)
+    if case.expect_no_results:
+        metrics: dict[str, float] = {}
+        for k in _validated_ks(ks):
+            top = clean_ranking[:k]
+            metrics[f"no_result_accuracy@{k}"] = float(not top)
+            metrics[f"false_positive_count@{k}"] = float(len(top))
+        return metrics
+
+    positive = {
+        drawer_id for drawer_id, gain in case.judgments.items() if gain >= relevance_threshold
+    }
+    if not positive:
+        raise ValueError(f"case {case.id!r} has no positive relevance judgments")
+    metrics: dict[str, float] = {}
+    for k in _validated_ks(ks):
+        top = clean_ranking[:k]
+        relevant_count = sum(drawer_id in positive for drawer_id in top)
+        metrics[f"hit_rate@{k}"] = float(relevant_count > 0)
+        metrics[f"pooled_recall@{k}"] = relevant_count / len(positive)
+        metrics[f"judgment_coverage@{k}"] = (
+            sum(drawer_id in case.judgments for drawer_id in top) / len(top) if top else 0.0
+        )
+
+        first_relevant = next(
+            (rank for rank, drawer_id in enumerate(top, 1) if drawer_id in positive),
+            None,
+        )
+        metrics[f"mrr@{k}"] = 0.0 if first_relevant is None else 1.0 / first_relevant
+
+        dcg = sum(
+            ((2 ** case.judgments.get(drawer_id, 0)) - 1) / math.log2(rank + 1)
+            for rank, drawer_id in enumerate(top, 1)
+        )
+        ideal_gains = sorted((gain for gain in case.judgments.values() if gain > 0), reverse=True)[
+            :k
+        ]
+        ideal_dcg = sum(
+            ((2**gain) - 1) / math.log2(rank + 1) for rank, gain in enumerate(ideal_gains, 1)
+        )
+        metrics[f"ndcg@{k}"] = dcg / ideal_dcg if ideal_dcg else 0.0
+    return metrics
+
+
+def run_benchmark(
+    cases: Sequence[BenchmarkCase],
+    algorithms: Sequence[SearchAlgorithm],
+    *,
+    limit: int = 10,
+    ks: Sequence[int] = (1, 5, 10),
+    warmups: int = 1,
+    repeats: int = 5,
+    seed: int = 0,
+    relevance_threshold: int = 2,
+    clock: Callable[[], float] = time.perf_counter,
+) -> dict:
+    """Run search adapters in randomized order and return a text-free report."""
+
+    if not cases:
+        raise ValueError("at least one benchmark case is required")
+    if not algorithms:
+        raise ValueError("at least one search algorithm is required")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    if warmups < 0 or repeats <= 0:
+        raise ValueError("warmups must be non-negative and repeats must be positive")
+    checked_ks = _validated_ks(ks)
+    if max(checked_ks) > limit:
+        raise ValueError("every evaluation k must be less than or equal to limit")
+
+    names = [algorithm.name for algorithm in algorithms]
+    if len(names) != len(set(names)):
+        raise ValueError("algorithm names must be unique")
+    for case in cases:
+        if not case.expect_no_results and not any(
+            gain >= relevance_threshold for gain in case.judgments.values()
+        ):
+            raise ValueError(f"case {case.id!r} has no positive relevance judgments")
+
+    rng = random.Random(seed)
+    for _ in range(warmups):
+        schedule = [(algorithm, case) for algorithm in algorithms for case in cases]
+        rng.shuffle(schedule)
+        for algorithm, case in schedule:
+            algorithm.search(case, limit)
+
+    timings: dict[str, list[float]] = {name: [] for name in names}
+    rankings: dict[str, dict[str, list[str]]] = {name: {} for name in names}
+    for _ in range(repeats):
+        schedule = [(algorithm, case) for algorithm in algorithms for case in cases]
+        rng.shuffle(schedule)
+        for algorithm, case in schedule:
+            started = clock()
+            hits = algorithm.search(case, limit)
+            elapsed_ms = (clock() - started) * 1000.0
+            timings[algorithm.name].append(elapsed_ms)
+            if case.id not in rankings[algorithm.name]:
+                rankings[algorithm.name][case.id] = _unique_ids(hit.drawer_id for hit in hits)[
+                    :limit
+                ]
+
+    algorithm_reports: dict[str, dict] = {}
+    for algorithm in algorithms:
+        per_case = [
+            evaluate_ranking(
+                case,
+                rankings[algorithm.name][case.id],
+                ks=checked_ks,
+                relevance_threshold=relevance_threshold,
+            )
+            for case in cases
+        ]
+        metric_names = sorted({name for metrics in per_case for name in metrics})
+        quality = {
+            name: sum(metrics[name] for metrics in per_case if name in metrics)
+            / sum(name in metrics for metrics in per_case)
+            for name in metric_names
+        }
+        samples = timings[algorithm.name]
+        algorithm_reports[algorithm.name] = {
+            "latency_scope": getattr(algorithm, "latency_scope", "in_process"),
+            "quality": quality,
+            "latency_ms": {
+                "samples": len(samples),
+                "mean": sum(samples) / len(samples),
+                "p50": _percentile(samples, 0.50),
+                "p95": _percentile(samples, 0.95),
+                "p99": _percentile(samples, 0.99),
+            },
+            "rankings": rankings[algorithm.name],
+        }
+
+    return {
+        "schema_version": 1,
+        "case_count": len(cases),
+        "limit": limit,
+        "ks": list(checked_ks),
+        "warmups": warmups,
+        "repeats": repeats,
+        "seed": seed,
+        "relevance_threshold": relevance_threshold,
+        "positive_case_count": sum(not case.expect_no_results for case in cases),
+        "negative_case_count": sum(case.expect_no_results for case in cases),
+        "algorithms": algorithm_reports,
+        "latency_comparison_groups": _latency_comparison_groups(algorithms),
+    }
+
+
+def _latency_comparison_groups(algorithms: Sequence[SearchAlgorithm]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {}
+    for algorithm in algorithms:
+        scope = getattr(algorithm, "latency_scope", "in_process")
+        groups.setdefault(scope, []).append(algorithm.name)
+    return groups
+
+
+def build_blind_pool(
+    cases: Sequence[BenchmarkCase],
+    algorithms: Sequence[SearchAlgorithm],
+    *,
+    pool_depth: int = 20,
+    seed: int = 0,
+) -> list[dict]:
+    """Pool unique candidates without exposing source algorithm or query text."""
+
+    if pool_depth <= 0:
+        raise ValueError("pool_depth must be positive")
+    rng = random.Random(seed)
+    pool: list[dict] = []
+    for case in cases:
+        drawer_ids = _unique_ids(
+            hit.drawer_id for algorithm in algorithms for hit in algorithm.search(case, pool_depth)
+        )
+        rng.shuffle(drawer_ids)
+        pool.append({"id": case.id, "drawer_ids": drawer_ids})
+    return pool
+
+
+def _validated_ks(ks: Sequence[int]) -> tuple[int, ...]:
+    checked = tuple(sorted(set(ks)))
+    if not checked or any(isinstance(k, bool) or not isinstance(k, int) or k <= 0 for k in checked):
+        raise ValueError("ks must contain positive integers")
+    return checked
+
+
+def _unique_ids(drawer_ids) -> list[str]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for drawer_id in drawer_ids:
+        if drawer_id and drawer_id not in seen:
+            seen.add(drawer_id)
+            unique.append(drawer_id)
+    return unique
+
+
+def _first_nested(result, field: str) -> list:
+    value = getattr(result, field, None)
+    if value is None and isinstance(result, dict):
+        value = result.get(field)
+    return list(value[0]) if value and value[0] else []
+
+
+def _percentile(values: Sequence[float], quantile: float) -> float:
+    ordered = sorted(values)
+    index = max(0, math.ceil(quantile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI for initializing, pooling, and running a private Palace benchmark."""
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Benchmark Palace search algorithms locally without persisting drawer text."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="create a private JSONL query template")
+    init_parser.add_argument("--dataset", type=Path, required=True)
+
+    for command in ("pool", "run"):
+        command_parser = subparsers.add_parser(command)
+        command_parser.add_argument("--dataset", type=Path, required=True)
+        command_parser.add_argument("--out", type=Path, required=True)
+        command_parser.add_argument("--palace")
+        command_parser.add_argument("--collection")
+        command_parser.add_argument("--backend")
+        command_parser.add_argument(
+            "--algorithms",
+            default="vector,bm25,current,rrf,weighted_rrf",
+        )
+        command_parser.add_argument("--candidate-depth", type=int, default=50)
+        command_parser.add_argument("--rank-constant", type=int, default=60)
+        command_parser.add_argument("--vector-weight", type=float, default=0.6)
+        command_parser.add_argument("--bm25-weight", type=float, default=0.4)
+        command_parser.add_argument("--max-distance", type=float, default=1.5)
+        command_parser.add_argument(
+            "--allow-direct-product-path",
+            action="store_true",
+            help="allow current/union to open the product path directly; use only without live writes",
+        )
+        command_parser.add_argument("--tag", help="only include cases carrying this tag")
+        command_parser.add_argument("--seed", type=int, default=42)
+
+    pool_parser = subparsers.choices["pool"]
+    pool_parser.add_argument("--pool-depth", type=int, default=20)
+
+    run_parser = subparsers.choices["run"]
+    run_parser.add_argument("--limit", type=int, default=10)
+    run_parser.add_argument("--ks", default="1,5,10")
+    run_parser.add_argument("--warmups", type=int, default=1)
+    run_parser.add_argument("--repeats", type=int, default=7)
+    run_parser.add_argument("--relevance-threshold", type=int, default=2)
+
+    args = parser.parse_args(argv)
+    if args.command == "init":
+        return _init_dataset(args.dataset)
+
+    from mempalace.config import MempalaceConfig
+
+    config = MempalaceConfig()
+    cases = load_benchmark_cases(args.dataset)
+    if args.command == "run":
+        if args.tag not in {"dev", "test"}:
+            parser.error("run requires --tag dev or --tag test")
+        overlapping = [case.id for case in cases if {"dev", "test"}.issubset(case.tags)]
+        if overlapping:
+            parser.error("cases cannot belong to both dev and test: " + ", ".join(overlapping[:5]))
+    if args.tag:
+        cases = [case for case in cases if args.tag in case.tags]
+        if not cases:
+            parser.error(f"no cases carry tag {args.tag!r}")
+    palace_path = args.palace or config.palace_path
+    collection_name = args.collection or config.collection_name
+    source = LocalPalaceSearchSource(
+        palace_path,
+        collection_name=collection_name,
+        backend=args.backend,
+        max_distance=args.max_distance,
+        allow_direct_product_path=args.allow_direct_product_path,
+    )
+    algorithm_names = tuple(name.strip() for name in args.algorithms.split(",") if name.strip())
+    algorithms = build_search_algorithms(
+        source,
+        names=algorithm_names,
+        candidate_depth=args.candidate_depth,
+        rank_constant=args.rank_constant,
+        vector_weight=args.vector_weight,
+        bm25_weight=args.bm25_weight,
+    )
+
+    start_state = source.snapshot_metadata()
+    if args.command == "pool":
+        output = build_blind_pool(
+            cases,
+            algorithms,
+            pool_depth=args.pool_depth,
+            seed=args.seed,
+        )
+    else:
+        try:
+            ks = tuple(int(value.strip()) for value in args.ks.split(",") if value.strip())
+        except ValueError as exc:
+            parser.error(f"--ks must be comma-separated integers: {exc}")
+        output = run_benchmark(
+            cases,
+            algorithms,
+            limit=args.limit,
+            ks=ks,
+            warmups=args.warmups,
+            repeats=args.repeats,
+            seed=args.seed,
+            relevance_threshold=args.relevance_threshold,
+        )
+        output["algorithm_config"] = {
+            "names": list(algorithm_names),
+            "candidate_depth": args.candidate_depth,
+            "rank_constant": args.rank_constant,
+            "vector_weight": args.vector_weight,
+            "bm25_weight": args.bm25_weight,
+            "max_distance": args.max_distance,
+        }
+
+    end_state = source.snapshot_metadata(refresh=True)
+    changed = corpus_changed(start_state, end_state)
+    if isinstance(output, dict):
+        output["corpus"] = {
+            "start": start_state,
+            "end": end_state,
+            "changed_during_run": changed,
+        }
+        output["valid"] = not changed
+    _write_private_text(args.out, json.dumps(output, indent=2, ensure_ascii=False) + "\n")
+    print(f"Wrote {args.command} output to {args.out}")
+    if changed:
+        print("Benchmark invalid: Palace changed during the run")
+        return 3
+    return 0
+
+
+def corpus_changed(start: Mapping, end: Mapping) -> bool:
+    """Return whether public backend state indicates writes during a run."""
+
+    if start.get("drawer_count") != end.get("drawer_count"):
+        return True
+    return start.get("maintenance") != end.get("maintenance")
+
+
+def _init_dataset(path: Path) -> int:
+    example = {
+        "id": "q-001",
+        "query": "Replace this with a real question you would ask your Palace",
+        "judgments": {},
+        "filters": {},
+        "tags": ["dev", "replace-me"],
+        "expect_no_results": False,
+    }
+    _write_private_text(
+        path,
+        json.dumps(example, ensure_ascii=False) + "\n",
+        refuse_existing=True,
+    )
+    print(f"Wrote private benchmark template to {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mempalace/backends/base.py
+++ b/mempalace/backends/base.py
@@ -519,7 +519,9 @@ class BaseCollection(ABC):
         Free-form per backend (e.g. row count, whether a vector index exists,
         last-analyze age). Used by benchmark harnesses to record state
         alongside each latency/recall measurement so an un-analyzed store is
-        not compared against a settled one (RFC 001). Defaults to empty.
+        not compared against a settled one (RFC 001). Backends should include
+        a JSON-compatible ``consistency_token`` when they can cheaply detect
+        writes that preserve the row count. Defaults to empty.
         """
         return {}
 

--- a/mempalace/backends/sqlite_exact.py
+++ b/mempalace/backends/sqlite_exact.py
@@ -1288,8 +1288,22 @@ class SQLiteExactCollection(BaseCollection):
             with self._cursor() as cur:
                 page_count = cur.execute("PRAGMA page_count").fetchone()
                 freelist = cur.execute("PRAGMA freelist_count").fetchone()
+                data_version = cur.execute("PRAGMA data_version").fetchone()
             state["page_count"] = int(page_count[0]) if page_count else 0
             state["freelist_pages"] = int(freelist[0]) if freelist else 0
+            db_path = SQLiteExactBackend._db_path(self._handle.palace_path)
+            file_token = []
+            for suffix in ("", "-wal"):
+                path = f"{db_path}{suffix}"
+                try:
+                    stat = os.stat(path)
+                    file_token.append([suffix or "db", stat.st_size, stat.st_mtime_ns])
+                except FileNotFoundError:
+                    file_token.append([suffix or "db", None, None])
+            state["consistency_token"] = {
+                "data_version": int(data_version[0]) if data_version else 0,
+                "files": file_token,
+            }
         except Exception:
             pass
         return state

--- a/mempalace/hub_client.py
+++ b/mempalace/hub_client.py
@@ -1,0 +1,63 @@
+"""Small authenticated client for forwarding JSON-RPC to a live Palace hub."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+from typing import Mapping
+
+logger = logging.getLogger(__name__)
+
+HUB_FORWARD_ENV = "MEMPALACE_HUB_FORWARD"
+HUB_PROXY_TIMEOUT_S = 600.0
+
+
+def _forwarding_disabled() -> bool:
+    return os.environ.get(HUB_FORWARD_ENV, "").strip().lower() in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def discover_hub(palace_path: str | None) -> tuple[str, dict[str, str]] | None:
+    """Return the authenticated endpoint for another live hub, if available."""
+
+    if _forwarding_disabled() or not palace_path:
+        return None
+    try:
+        from . import server_registry
+
+        info = server_registry.read_live_serverinfo(palace_path)
+        if not info or info.get("pid") == os.getpid():
+            return None
+        base_url = server_registry.client_base_url(info)
+        headers = {"Content-Type": "application/json"}
+        token = server_registry.load_server_token(palace_path)
+    except Exception:
+        logger.debug("hub discovery failed", exc_info=True)
+        return None
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return base_url, headers
+
+
+def forward_json_rpc(
+    base_url: str,
+    headers: Mapping[str, str],
+    request: Mapping,
+    *,
+    timeout: float = HUB_PROXY_TIMEOUT_S,
+):
+    """POST one JSON-RPC request to the hub; return ``None`` for an empty body."""
+
+    body = json.dumps(request, ensure_ascii=False).encode("utf-8")
+    http_request = urllib.request.Request(f"{base_url}/mcp", data=body, headers=dict(headers))
+    with urllib.request.urlopen(http_request, timeout=timeout) as response:
+        raw = response.read()
+    if not raw:
+        return None
+    return json.loads(raw.decode("utf-8"))

--- a/mempalace/mcp_proxy.py
+++ b/mempalace/mcp_proxy.py
@@ -23,18 +23,18 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import sys
 import urllib.error
-import urllib.request
+
+from .hub_client import HUB_FORWARD_ENV, HUB_PROXY_TIMEOUT_S, discover_hub, forward_json_rpc
 
 from .update_awareness import cached_update_status, schedule_update_check
 
 logger = logging.getLogger(__name__)
 
 # Shared with the in-server forwarder and the CLI forwarder.
-_HUB_FORWARD_ENV = "MEMPALACE_HUB_FORWARD"
-_HUB_PROXY_TIMEOUT_S = 600.0
+_HUB_FORWARD_ENV = HUB_FORWARD_ENV
+_HUB_PROXY_TIMEOUT_S = HUB_PROXY_TIMEOUT_S
 
 _DEGRADED_NOTICE = (
     "MemPalace is running WITHOUT its shared hub. This session is now serving "
@@ -43,10 +43,6 @@ _DEGRADED_NOTICE = (
     "If several agents are running, expect memory pressure until the hub is "
     "back — check that the MemPalace hub process is alive."
 )
-
-
-def _truthy_env_off(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in {"0", "false", "no", "off"}
 
 
 def _is_plain_stdio_invocation(argv: list) -> bool:
@@ -99,34 +95,12 @@ def _palace_path(argv: list):
 
 def _hub_target(palace_path):
     """Return ``(base_url, headers)`` for a live hub serving our palace, else None."""
-    if _truthy_env_off(_HUB_FORWARD_ENV) or not palace_path:
-        return None
-    try:
-        from . import server_registry
-
-        info = server_registry.read_live_serverinfo(palace_path)
-        if not info or info.get("pid") == os.getpid():
-            return None
-        base_url = server_registry.client_base_url(info)
-        headers = {"Content-Type": "application/json"}
-        token = server_registry.load_server_token(palace_path)
-    except Exception:
-        logger.debug("hub discovery failed", exc_info=True)
-        return None
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return base_url, headers
+    return discover_hub(palace_path)
 
 
 def _forward(base_url: str, headers: dict, request: dict):
     """POST one JSON-RPC request to the hub; None for notifications (202)."""
-    body = json.dumps(request, ensure_ascii=False).encode("utf-8")
-    http_request = urllib.request.Request(f"{base_url}/mcp", data=body, headers=headers)
-    with urllib.request.urlopen(http_request, timeout=_HUB_PROXY_TIMEOUT_S) as resp:
-        raw = resp.read()
-    if not raw:
-        return None
-    return json.loads(raw.decode("utf-8"))
+    return forward_json_rpc(base_url, headers, request, timeout=_HUB_PROXY_TIMEOUT_S)
 
 
 def _annotate_degraded(response):

--- a/tests/test_hub_client.py
+++ b/tests/test_hub_client.py
@@ -1,0 +1,73 @@
+"""Tests for authenticated local hub discovery and JSON-RPC forwarding."""
+
+import json
+
+from mempalace import hub_client, server_registry
+
+
+class _Response:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+def test_discover_hub_propagates_local_bearer_token(monkeypatch):
+    monkeypatch.delenv(hub_client.HUB_FORWARD_ENV, raising=False)
+    monkeypatch.setattr(server_registry, "read_live_serverinfo", lambda _: {"pid": -1})
+    monkeypatch.setattr(server_registry, "client_base_url", lambda _: "http://127.0.0.1:7")
+    monkeypatch.setattr(server_registry, "load_server_token", lambda _: "private-token")
+
+    assert hub_client.discover_hub("C:/private-palace") == (
+        "http://127.0.0.1:7",
+        {"Content-Type": "application/json", "Authorization": "Bearer private-token"},
+    )
+
+
+def test_forward_json_rpc_serializes_request_and_decodes_response(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return _Response(b'{"jsonrpc":"2.0","id":"q","result":{"ok":true}}')
+
+    monkeypatch.setattr(hub_client.urllib.request, "urlopen", fake_urlopen)
+
+    response = hub_client.forward_json_rpc(
+        "http://127.0.0.1:7",
+        {"Authorization": "Bearer private-token"},
+        {"jsonrpc": "2.0", "id": "q", "method": "ping"},
+        timeout=12,
+    )
+
+    request = captured["request"]
+    assert request.full_url == "http://127.0.0.1:7/mcp"
+    assert request.get_header("Authorization") == "Bearer private-token"
+    assert json.loads(request.data) == {"jsonrpc": "2.0", "id": "q", "method": "ping"}
+    assert captured["timeout"] == 12
+    assert response == {"jsonrpc": "2.0", "id": "q", "result": {"ok": True}}
+
+
+def test_forward_json_rpc_returns_none_for_empty_notification_response(monkeypatch):
+    monkeypatch.setattr(
+        hub_client.urllib.request,
+        "urlopen",
+        lambda request, timeout: _Response(b""),
+    )
+
+    assert (
+        hub_client.forward_json_rpc(
+            "http://127.0.0.1:7",
+            {},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        is None
+    )

--- a/tests/test_search_benchmark.py
+++ b/tests/test_search_benchmark.py
@@ -1,0 +1,618 @@
+"""Tests for the local, text-free private Palace benchmark."""
+
+import json
+import importlib.util
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).parents[1] / "benchmarks" / "search_benchmark.py"
+_SPEC = importlib.util.spec_from_file_location("private_palace_search_benchmark", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+search_benchmark = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = search_benchmark
+_SPEC.loader.exec_module(search_benchmark)
+
+BenchmarkCase = search_benchmark.BenchmarkCase
+HubSearchClient = search_benchmark.HubSearchClient
+LocalPalaceSearchSource = search_benchmark.LocalPalaceSearchSource
+SearchHit = search_benchmark.SearchHit
+build_search_algorithms = search_benchmark.build_search_algorithms
+build_blind_pool = search_benchmark.build_blind_pool
+corpus_changed = search_benchmark.corpus_changed
+evaluate_ranking = search_benchmark.evaluate_ranking
+load_benchmark_cases = search_benchmark.load_benchmark_cases
+reciprocal_rank_fusion = search_benchmark.reciprocal_rank_fusion
+run_benchmark = search_benchmark.run_benchmark
+
+
+def test_load_benchmark_cases_validates_and_preserves_private_labels(tmp_path):
+    dataset = tmp_path / "private-search.jsonl"
+    dataset.write_text(
+        json.dumps(
+            {
+                "id": "q-001",
+                "query": "Which database did we choose?",
+                "judgments": {"drawer-postgres": 3, "drawer-options": 1},
+                "filters": {"wing": "project"},
+                "tags": ["decision", "paraphrase"],
+                "expect_no_results": False,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cases = load_benchmark_cases(dataset)
+
+    assert cases == [
+        BenchmarkCase(
+            id="q-001",
+            query="Which database did we choose?",
+            judgments={"drawer-postgres": 3, "drawer-options": 1},
+            filters={"wing": "project"},
+            tags=("decision", "paraphrase"),
+            expect_no_results=False,
+        )
+    ]
+
+
+def test_load_benchmark_cases_rejects_duplicate_ids(tmp_path):
+    dataset = tmp_path / "duplicate.jsonl"
+    row = json.dumps({"id": "same", "query": "q", "judgments": {"drawer": 1}})
+    dataset.write_text(f"{row}\n{row}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate case id 'same'"):
+        load_benchmark_cases(dataset)
+
+
+def test_reciprocal_rank_fusion_has_independently_worked_order():
+    rankings = {
+        "vector": ["a", "b", "c"],
+        "bm25": ["b", "d", "a"],
+    }
+
+    fused = reciprocal_rank_fusion(rankings, rank_constant=0)
+
+    assert [hit.drawer_id for hit in fused] == ["b", "a", "d", "c"]
+    assert fused[0].score == pytest.approx(1.5)
+    assert fused[1].score == pytest.approx(4 / 3)
+
+
+def test_weighted_rrf_can_favor_vector_rank_without_score_normalization():
+    rankings = {
+        "vector": ["a", "b", "c"],
+        "bm25": ["b", "d", "a"],
+    }
+
+    fused = reciprocal_rank_fusion(
+        rankings,
+        rank_constant=0,
+        weights={"vector": 0.6, "bm25": 0.4},
+    )
+
+    assert [hit.drawer_id for hit in fused[:2]] == ["a", "b"]
+    assert fused[0].score == pytest.approx(0.6 + (0.4 / 3))
+    assert fused[1].score == pytest.approx((0.6 / 2) + 0.4)
+
+
+def test_evaluate_ranking_uses_graded_relevance():
+    case = BenchmarkCase(
+        id="q",
+        query="private query",
+        judgments={"a": 3, "b": 2},
+    )
+
+    metrics = evaluate_ranking(case, ["b", "x", "a"], ks=(1, 3))
+
+    assert metrics["hit_rate@1"] == 1.0
+    assert metrics["pooled_recall@1"] == 0.5
+    assert metrics["pooled_recall@3"] == 1.0
+    assert metrics["mrr@3"] == 1.0
+    assert metrics["ndcg@3"] == pytest.approx(6.5 / (7 + (3 / 1.5849625007)))
+
+
+class _FakeAlgorithm:
+    def __init__(self, name, rankings):
+        self.name = name
+        self._rankings = rankings
+
+    def search(self, case, limit):
+        return [
+            SearchHit(drawer_id=item, score=1.0 / rank)
+            for rank, item in enumerate(self._rankings[case.id], 1)
+        ][:limit]
+
+
+def test_run_benchmark_reports_quality_and_latency_without_drawer_text():
+    cases = [
+        BenchmarkCase(id="q1", query="secret first query", judgments={"a": 3}),
+        BenchmarkCase(id="q2", query="secret second query", judgments={"b": 2}),
+    ]
+    algorithms = [
+        _FakeAlgorithm("good", {"q1": ["a", "x"], "q2": ["b", "x"]}),
+        _FakeAlgorithm("bad", {"q1": ["x", "a"], "q2": ["x", "b"]}),
+    ]
+
+    report = run_benchmark(
+        cases,
+        algorithms,
+        limit=2,
+        ks=(1, 2),
+        warmups=1,
+        repeats=2,
+        seed=7,
+    )
+
+    assert report["schema_version"] == 1
+    assert report["case_count"] == 2
+    assert report["algorithms"]["good"]["quality"]["hit_rate@1"] == 1.0
+    assert report["algorithms"]["bad"]["quality"]["hit_rate@1"] == 0.0
+    assert report["algorithms"]["good"]["latency_ms"]["samples"] == 4
+    assert report["algorithms"]["good"]["latency_ms"]["p95"] >= 0.0
+    assert report["algorithms"]["good"]["latency_scope"] == "in_process"
+    assert report["latency_comparison_groups"] == {"in_process": ["good", "bad"]}
+    assert report["algorithms"]["good"]["rankings"] == {"q1": ["a", "x"], "q2": ["b", "x"]}
+
+    serialized = json.dumps(report)
+    assert "secret first query" not in serialized
+    assert "secret second query" not in serialized
+    assert "document" not in serialized
+
+
+def test_run_benchmark_requires_judgments_for_quality():
+    cases = [BenchmarkCase(id="unjudged", query="q")]
+
+    with pytest.raises(ValueError, match="has no positive relevance judgments"):
+        run_benchmark(cases, [_FakeAlgorithm("fake", {"unjudged": []})])
+
+
+def test_run_benchmark_scores_expected_no_result_cases():
+    cases = [BenchmarkCase(id="negative", query="nothing should match", expect_no_results=True)]
+    algorithms = [
+        _FakeAlgorithm("quiet", {"negative": []}),
+        _FakeAlgorithm("noisy", {"negative": ["false-positive"]}),
+    ]
+
+    report = run_benchmark(cases, algorithms, limit=1, ks=(1,), warmups=0, repeats=1)
+
+    assert report["algorithms"]["quiet"]["quality"]["no_result_accuracy@1"] == 1.0
+    assert report["algorithms"]["noisy"]["quality"]["no_result_accuracy@1"] == 0.0
+    assert report["algorithms"]["noisy"]["quality"]["false_positive_count@1"] == 1.0
+
+
+class _FakeSearchSource:
+    def vector_ranking(self, case, depth):
+        return [SearchHit("vector-first", 0.9), SearchHit("shared", 0.8)][:depth]
+
+    def lexical_ranking(self, case, depth):
+        return [SearchHit("shared", 12.0), SearchHit("lexical-first", 8.0)][:depth]
+
+    def current_ranking(self, case, limit, *, candidate_strategy):
+        prefix = "current-union" if candidate_strategy == "union" else "current-vector"
+        return [SearchHit(prefix, 1.0)][:limit]
+
+
+def test_build_search_algorithms_exposes_baselines_and_fusion_without_scores_crossing_seam():
+    algorithms = {
+        algorithm.name: algorithm
+        for algorithm in build_search_algorithms(
+            _FakeSearchSource(),
+            names=("vector", "bm25", "current", "union", "rrf", "weighted_rrf"),
+            candidate_depth=10,
+            rank_constant=0,
+            vector_weight=0.75,
+            bm25_weight=0.25,
+        )
+    }
+    case = BenchmarkCase(id="q", query="private", judgments={"shared": 3})
+
+    assert [hit.drawer_id for hit in algorithms["vector"].search(case, 5)] == [
+        "vector-first",
+        "shared",
+    ]
+    assert [hit.drawer_id for hit in algorithms["bm25"].search(case, 5)] == [
+        "shared",
+        "lexical-first",
+    ]
+    assert algorithms["current"].search(case, 5)[0].drawer_id == "current-vector"
+    assert algorithms["union"].search(case, 5)[0].drawer_id == "current-union"
+    assert algorithms["rrf"].search(case, 5)[0].drawer_id == "shared"
+    assert algorithms["weighted_rrf"].search(case, 5)[0].drawer_id == "vector-first"
+    assert algorithms["current"].latency_scope == "product_boundary"
+    assert algorithms["union"].latency_scope == "direct_product_path"
+    assert algorithms["rrf"].latency_scope == "in_process"
+
+
+def test_build_search_algorithms_rejects_unknown_name():
+    with pytest.raises(ValueError, match="unknown search algorithms: mystery"):
+        build_search_algorithms(_FakeSearchSource(), names=("mystery",))
+
+
+class _QueryResult:
+    ids = [["chunk-a", "physical-b"]]
+    metadatas = [[{"parent_drawer_id": "logical-a"}, {}]]
+    distances = [[0.1, 0.3]]
+
+
+class _LexicalHit:
+    def __init__(self, drawer_id, metadata, score):
+        self.id = drawer_id
+        self.metadata = metadata
+        self.score = score
+        self.document = "must never reach the benchmark report"
+
+
+class _LexicalResult:
+    hits = [
+        _LexicalHit("chunk-a", {"parent_drawer_id": "logical-a"}, 10.0),
+        _LexicalHit("physical-c", {}, 7.0),
+    ]
+
+
+class _FakeCollection:
+    distance_metric = "cosine"
+
+    def __init__(self):
+        self.query_include = None
+
+    def query(self, **kwargs):
+        self.query_include = kwargs["include"]
+        return _QueryResult()
+
+    def lexical_search(self, **kwargs):
+        return _LexicalResult()
+
+    def count(self):
+        return 2
+
+    def maintenance_state(self):
+        return {"row_count": 2, "consistency_token": "before"}
+
+
+def test_local_palace_source_uses_canonical_ids_and_discards_documents():
+    collection = _FakeCollection()
+    source = LocalPalaceSearchSource(
+        "C:/private-palace",
+        collection=collection,
+        current_search=lambda *args, **kwargs: {"results": []},
+    )
+    case = BenchmarkCase(id="q", query="find it", judgments={"logical-a": 3})
+
+    vector = source.vector_ranking(case, 10)
+    lexical = source.lexical_ranking(case, 10)
+
+    assert collection.query_include == ["metadatas", "distances"]
+    assert [(hit.drawer_id, hit.score) for hit in vector] == [
+        ("logical-a", pytest.approx(0.9)),
+        ("physical-b", pytest.approx(0.7)),
+    ]
+    assert [(hit.drawer_id, hit.score) for hit in lexical] == [
+        ("logical-a", 10.0),
+        ("physical-c", 7.0),
+    ]
+
+
+def test_local_palace_source_refuses_backend_without_enforced_read_only(tmp_path):
+    opened = []
+
+    with pytest.raises(RuntimeError, match="require backend=sqlite_exact"):
+        LocalPalaceSearchSource(
+            str(tmp_path),
+            backend="chroma",
+            collection_opener=lambda *args, **kwargs: opened.append((args, kwargs)),
+        )
+
+    assert opened == []
+
+
+def test_date_filtered_lexical_uses_same_widened_cohort_as_vector():
+    class CapturingCollection(_FakeCollection):
+        def __init__(self):
+            super().__init__()
+            self.lexical_limit = None
+
+        def lexical_search(self, **kwargs):
+            self.lexical_limit = kwargs["n_results"]
+            return _LexicalResult()
+
+    collection = CapturingCollection()
+    source = LocalPalaceSearchSource(
+        "C:/private-palace",
+        collection=collection,
+        current_search=lambda *args, **kwargs: {"results": []},
+    )
+    case = BenchmarkCase(id="q", query="find it", filters={"since": "2026-01-01"})
+
+    source.lexical_ranking(case, 10)
+
+    assert collection.lexical_limit == 150
+
+
+def test_local_palace_source_replays_current_strategy_with_case_filters():
+    calls = []
+
+    def current_search(query, palace_path, **kwargs):
+        calls.append((query, palace_path, kwargs))
+        return {"results": [{"drawer_id": "answer", "similarity": 0.75}]}
+
+    source = LocalPalaceSearchSource(
+        "C:/private-palace",
+        collection=_FakeCollection(),
+        current_search=current_search,
+        collection_name="drawers",
+        max_distance=1.5,
+    )
+    case = BenchmarkCase(
+        id="q",
+        query="find it",
+        judgments={"answer": 3},
+        filters={"wing": "project", "room": "search", "since": "2026-01-01"},
+    )
+
+    hits = source.current_ranking(case, 5, candidate_strategy="union")
+
+    assert hits == [SearchHit("answer", 0.75)]
+    assert calls == [
+        (
+            "find it",
+            "C:/private-palace",
+            {
+                "wing": "project",
+                "room": "search",
+                "source_file": None,
+                "since": "2026-01-01",
+                "before": None,
+                "n_results": 5,
+                "max_distance": 1.5,
+                "candidate_strategy": "union",
+                "collection_name": "drawers",
+            },
+        )
+    ]
+
+
+def test_build_blind_pool_deduplicates_and_hides_algorithm_provenance():
+    cases = [BenchmarkCase(id="q", query="private question")]
+    algorithms = [
+        _FakeAlgorithm("first", {"q": ["a", "b"]}),
+        _FakeAlgorithm("second", {"q": ["b", "c"]}),
+    ]
+
+    pool = build_blind_pool(cases, algorithms, pool_depth=2, seed=11)
+
+    assert pool[0]["id"] == "q"
+    assert sorted(pool[0]["drawer_ids"]) == ["a", "b", "c"]
+    serialized = json.dumps(pool)
+    assert "private question" not in serialized
+    assert "first" not in serialized
+    assert "second" not in serialized
+
+
+def test_local_palace_source_explains_missing_embedding_runtime():
+    class MissingRuntimeCollection(_FakeCollection):
+        def query(self, **kwargs):
+            raise ValueError("The onnxruntime python package is not installed")
+
+    source = LocalPalaceSearchSource(
+        "C:/private-palace",
+        collection=MissingRuntimeCollection(),
+        current_search=lambda *args, **kwargs: {"results": []},
+    )
+    case = BenchmarkCase(id="q", query="find it", judgments={"answer": 3})
+
+    with pytest.raises(RuntimeError, match="vector benchmark cannot embed queries.*onnxruntime"):
+        source.vector_ranking(case, 10)
+
+
+def test_hub_search_client_reuses_authenticated_transport_and_parses_tool_result(monkeypatch):
+    calls = []
+
+    def fake_forward(base_url, headers, request, *, timeout):
+        calls.append((base_url, headers, request, timeout))
+        return {
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "result": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"results": [{"drawer_id": "answer", "similarity": 0.8}]}
+                        ),
+                    }
+                ]
+            },
+        }
+
+    monkeypatch.setattr("mempalace.hub_client.forward_json_rpc", fake_forward)
+    client = HubSearchClient(
+        "http://127.0.0.1:9",
+        {"Content-Type": "application/json", "Authorization": "Bearer local-secret"},
+    )
+
+    result = client(
+        "private query",
+        "C:/private-palace",
+        n_results=5,
+        max_distance=1.5,
+        candidate_strategy="vector",
+        wing="project",
+        room=None,
+        source_file=None,
+        since=None,
+        before=None,
+    )
+
+    assert result["results"][0]["drawer_id"] == "answer"
+    base_url, headers, request, timeout = calls[0]
+    assert base_url == "http://127.0.0.1:9"
+    assert headers["Authorization"] == "Bearer local-secret"
+    assert timeout == 120
+    assert request["params"] == {
+        "name": "mempalace_search",
+        "arguments": {
+            "query": "private query",
+            "limit": 5,
+            "max_distance": 1.5,
+            "wing": "project",
+        },
+    }
+
+
+def test_local_palace_source_refuses_uncontrolled_direct_product_replay(monkeypatch):
+    monkeypatch.setattr(search_benchmark, "_live_hub_search", lambda _: None)
+    source = LocalPalaceSearchSource("C:/private-palace", collection=_FakeCollection())
+    case = BenchmarkCase(id="q", query="private", judgments={"answer": 3})
+
+    with pytest.raises(RuntimeError, match="--allow-direct-product-path"):
+        source.current_ranking(case, 5, candidate_strategy="union")
+
+
+def test_current_latency_scope_reflects_direct_fallback_when_explicitly_allowed(monkeypatch):
+    monkeypatch.setattr(search_benchmark, "_live_hub_search", lambda _: None)
+    source = LocalPalaceSearchSource(
+        "C:/private-palace",
+        collection=_FakeCollection(),
+        allow_direct_product_path=True,
+    )
+
+    algorithm = build_search_algorithms(source, names=("current",))[0]
+
+    assert algorithm.latency_scope == "direct_product_path"
+
+
+def test_refreshed_public_backend_state_invalidates_changed_corpus(monkeypatch):
+    class ChangedCollection(_FakeCollection):
+        def maintenance_state(self):
+            return {"row_count": 2, "consistency_token": "after"}
+
+    opened = []
+
+    def opener(*args, **kwargs):
+        opened.append((args, kwargs))
+        return ChangedCollection()
+
+    source = LocalPalaceSearchSource(
+        "C:/private-palace",
+        backend="sqlite_exact",
+        collection=_FakeCollection(),
+        collection_opener=opener,
+        current_search=lambda *args, **kwargs: {"results": []},
+    )
+
+    start = source.snapshot_metadata()
+    end = source.snapshot_metadata(refresh=True)
+
+    assert corpus_changed(start, end) is True
+    assert opened[0][1]["read_only"] is True
+
+
+@pytest.mark.parametrize("tag", [None, "invalid"])
+def test_run_cli_requires_dev_or_test_tag(tmp_path, tag):
+    dataset = tmp_path / "cases.jsonl"
+    dataset.write_text(
+        json.dumps(
+            {
+                "id": "q",
+                "query": "private",
+                "judgments": {"answer": 3},
+                "tags": ["dev"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    argv = ["run", "--dataset", str(dataset), "--out", str(tmp_path / "out.json")]
+    if tag is not None:
+        argv.extend(["--tag", tag])
+
+    with pytest.raises(SystemExit) as exc:
+        search_benchmark.main(argv)
+
+    assert exc.value.code == 2
+
+
+def test_run_cli_rejects_case_in_both_dev_and_test_sets(tmp_path):
+    dataset = tmp_path / "cases.jsonl"
+    dataset.write_text(
+        json.dumps(
+            {
+                "id": "q",
+                "query": "private",
+                "judgments": {"answer": 3},
+                "tags": ["dev", "test"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        search_benchmark.main(
+            [
+                "run",
+                "--dataset",
+                str(dataset),
+                "--out",
+                str(tmp_path / "out.json"),
+                "--tag",
+                "dev",
+            ]
+        )
+
+    assert exc.value.code == 2
+
+
+def test_private_artifacts_are_owner_only_and_replace_broad_existing_mode(tmp_path):
+    directory = tmp_path / "private"
+    directory.mkdir(mode=0o755)
+    target = directory / "report.json"
+    target.write_text("old", encoding="utf-8")
+    target.chmod(0o644)
+
+    search_benchmark._write_private_text(target, "new\n")
+
+    assert target.read_text(encoding="utf-8") == "new\n"
+    if os.name == "nt":
+        import subprocess
+
+        identity = subprocess.run(
+            ["whoami"], capture_output=True, text=True, check=True
+        ).stdout.strip()
+        for path in (directory, target):
+            acl = subprocess.run(
+                ["icacls", str(path)], capture_output=True, text=True, check=True
+            ).stdout.casefold()
+            assert identity.casefold() in acl
+            assert "(i)" not in acl
+    else:
+        assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert not list(directory.glob(f".{target.name}.*.tmp"))
+
+
+def test_windows_acl_verification_rejects_extra_explicit_principal(monkeypatch, tmp_path):
+    class Result:
+        def __init__(self, stdout=""):
+            self.stdout = stdout
+
+    target = tmp_path / "private.json"
+    target.touch()
+    identity = "WORKSTATION\\owner"
+
+    def fake_run(arguments, **_kwargs):
+        if arguments[0] == "whoami":
+            return Result(f"{identity}\n")
+        if len(arguments) == 2:
+            return Result(f"{target} {identity}:(F)\n        Everyone:(R)\n")
+        return Result()
+
+    monkeypatch.setattr(search_benchmark.os, "name", "nt")
+    monkeypatch.setattr(search_benchmark.subprocess, "run", fake_run)
+
+    with pytest.raises(PermissionError, match="owner-only ACL"):
+        search_benchmark._restrict_private_path(target, directory=False)


### PR DESCRIPTION
## Summary
- add a local, text-free retrieval benchmark with blinded pools and graded nDCG/recall metrics
- compare vector, BM25, current product replay, and RRF profiles with explicit latency scopes
- enforce truly read-only sqlite_exact baselines and refuse unsupported Chroma baseline opens
- write private datasets/reports atomically with owner-only POSIX modes or Windows ACLs
- keep the implementation in benchmarks rather than the installed runtime package

## Verification
- uv run pytest tests/test_search_benchmark.py tests/test_hub_client.py tests/test_mcp_proxy.py tests/test_sqlite_exact_backend.py -q (112 passed)
- uv run ruff check .
- uv run ruff format --check .
- independent standards and spec reviews: no findings