### PR TITLE
chore(release): 3.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "mempalace",
       "source": "./.claude-plugin",
       "description": "AI memory system — mine projects and conversations into a searchable palace. 45 MCP tools, auto-save hooks, guided setup.",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "author": {
         "name": "milla-jovovich"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 45 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mempalace",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Give your AI a memory — mine projects and conversations into a searchable palace. 44 MCP tools, auto-save hooks, and guided setup.",
   "author": {
     "name": "milla-jovovich"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [3.9.0] — 2026-08-31
+
+One hub now serves every agent: CLI search reuses the live palace index, concurrent reads stop blocking each other, and skill-first coordination plus opt-in release awareness make shared-brain fleets easier to operate safely.
+
 ### Features
 
 - **Release awareness is opt-in and agent-visible.** `mempalace update` can configure or explicitly run stable-release checks and prepare an exact upgrade plan, while `mempalace_status` exposes only cached state so agents can ask for authorization without blocking or installing anything automatically.
@@ -759,7 +765,8 @@ Initial public release.
 
 ---
 
-[Unreleased]: https://github.com/MemPalace/mempalace/compare/v3.7.1...HEAD
+[Unreleased]: https://github.com/MemPalace/mempalace/compare/v3.9.0...HEAD
+[3.9.0]: https://github.com/MemPalace/mempalace/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/MemPalace/mempalace/compare/v3.7.1...v3.8.0
 [3.7.1]: https://github.com/MemPalace/mempalace/compare/v3.7.0...v3.7.1
 [3.7.0]: https://github.com/MemPalace/mempalace/compare/v3.6.0...v3.7.0

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 MIT — see [LICENSE](LICENSE).
 
 <!-- Link Definitions -->
-[version-shield]: https://img.shields.io/badge/version-3.8.0-4dc9f6?style=flat-square&labelColor=0a0e14
+[version-shield]: https://img.shields.io/badge/version-3.9.0-4dc9f6?style=flat-square&labelColor=0a0e14
 [release-link]: https://github.com/MemPalace/mempalace/releases
 [python-shield]: https://img.shields.io/badge/python-3.9+-7dd8f8?style=flat-square&labelColor=0a0e14&logo=python&logoColor=7dd8f8
 [python-link]: https://www.python.org/

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mempalace
 description: "MemPalace — Local AI memory with 96.6% recall. Semantic search, temporal knowledge graph, palace architecture (wings/rooms/drawers). Free, no cloud, no API keys."
-version: 3.8.0
+version: 3.9.0
 homepage: https://github.com/MemPalace/mempalace
 user-invocable: true
 metadata:

--- a/mempalace/version.py
+++ b/mempalace/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the MemPalace package version."""
 
-__version__ = "3.8.0"
+__version__ = "3.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mempalace"
-version = "3.8.0"
+version = "3.9.0"
 description = "Give your AI a memory — mine projects and conversations into a searchable palace. No API key required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -2004,7 +2004,7 @@ wheels = [
 
 [[package]]
 name = "mempalace"
-version = "3.8.0"
+version = "3.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

- promote the accumulated Unreleased changes to v3.9.0 dated 2026-08-31
- include 29 merged PRs since v3.8.0, including #2379, and seven first-time contributors
- bump all package, plugin, integration, badge, and lockfile version sources to 3.9.0
- advance changelog comparison links for the new release

## Validation

- `uv lock --check`
- `uv run --frozen pytest tests/test_version_consistency.py -q`
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`