### PR TITLE
fix(mcp): apply case-only drawer metadata updates (#2395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Drawer updates apply case-only wing and room renames.** `mempalace_update_drawer` now compares sanitized metadata values exactly, so consolidating names such as `Projects` and `projects` updates the stored drawer instead of reporting success while retaining the old casing. (#2395)
+
 ---
 
 ## [3.9.0] — 2026-08-31

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -3921,7 +3921,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
                 wing = sanitize_name(wing, "wing")
             except ValueError as e:
                 return {"success": False, "error": str(e)}
-            if wing.lower() != str(old_meta.get("wing") or "").lower():
+            if wing != str(old_meta.get("wing") or ""):
                 new_meta["wing"] = wing
 
         if room is not None:
@@ -3929,7 +3929,7 @@ def tool_update_drawer(drawer_id: str, content: str = None, wing: str = None, ro
                 room = sanitize_name(room, "room")
             except ValueError as e:
                 return {"success": False, "error": str(e)}
-            if room.lower() != str(old_meta.get("room") or "").lower():
+            if room != str(old_meta.get("room") or ""):
                 new_meta["room"] = room
 
         _wal_log(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3128,6 +3128,22 @@ class TestWriteTools:
         assert result["wing"] == "new_wing"
         assert result["room"] == "new_room"
 
+    def test_update_drawer_applies_case_only_wing_and_room_changes(
+        self, monkeypatch, config, palace_path, seeded_collection, kg
+    ):
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace.mcp_server import tool_get_drawer, tool_update_drawer
+
+        result = tool_update_drawer("drawer_proj_backend_aaa", wing="Project", room="Backend")
+
+        assert result["success"] is True
+        assert result["wing"] == "Project"
+        assert result["room"] == "Backend"
+
+        fetched = tool_get_drawer("drawer_proj_backend_aaa")
+        assert fetched["wing"] == "Project"
+        assert fetched["room"] == "Backend"
+
     def test_update_drawer_content_purges_matching_closets(
         self, monkeypatch, config, palace_path, seeded_collection, kg
     ):


### PR DESCRIPTION
## What does this PR do?

Fixes #2395.

`mempalace_update_drawer` previously compared wing and room values case-insensitively before updating metadata. As a result, case-only changes such as `Projects` to `projects` returned success while retaining the old value.

This change:

- compares sanitized wing and room values exactly;
- allows case-only metadata changes to reach the existing update path;
- adds a regression covering both the response and the persisted drawer metadata; and
- documents the fix in the changelog.

## How to test

```bash
python -m pytest -q tests/test_mcp_server.py::TestWriteTools
ruff check .
ruff format --check .
```

Local results:

- 68 tests passed.
- Ruff check passed.
- Ruff formatting check passed.

The regression test fails against the pre-fix implementation because the response and stored drawer retain their original casing.

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)