### PR TITLE
feat(kg): paginate kg_timeline with limit/offset (list_drawers convention)

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -695,8 +695,16 @@ class KnowledgeGraph:
                 )
         return results
 
-    def timeline(self, entity_name: str = None):
-        """Get all facts in chronological order, optionally filtered by entity."""
+    def timeline(self, entity_name: str = None, limit: int = 100, offset: int = 0):
+        """Get facts in chronological order, optionally filtered by entity.
+
+        Paginated with ``limit``/``offset`` (same convention as drawer
+        listing); defaults preserve the historical behavior of returning
+        the first 100 facts. Use :meth:`timeline_total` for the full
+        matching count.
+        """
+        limit = max(1, int(limit))
+        offset = max(0, int(offset))
         with self._lock:
             conn = self._conn()
             if entity_name:
@@ -709,19 +717,22 @@ class KnowledgeGraph:
                     JOIN entities o ON t.object = o.id
                     WHERE (t.subject = ? OR t.object = ?)
                     ORDER BY t.valid_from ASC NULLS LAST
-                    LIMIT 100
+                    LIMIT ? OFFSET ?
                 """,
-                    (eid, eid),
+                    (eid, eid, limit, offset),
                 ).fetchall()
             else:
-                rows = conn.execute("""
+                rows = conn.execute(
+                    """
                     SELECT t.*, s.name as sub_name, o.name as obj_name
                     FROM triples t
                     JOIN entities s ON t.subject = s.id
                     JOIN entities o ON t.object = o.id
                     ORDER BY t.valid_from ASC NULLS LAST
-                    LIMIT 100
-                """).fetchall()
+                    LIMIT ? OFFSET ?
+                """,
+                    (limit, offset),
+                ).fetchall()
 
         return [
             {
@@ -734,6 +745,20 @@ class KnowledgeGraph:
             }
             for r in rows
         ]
+
+    def timeline_total(self, entity_name: str = None) -> int:
+        """Total number of facts a :meth:`timeline` query matches (all pages)."""
+        with self._lock:
+            conn = self._conn()
+            if entity_name:
+                eid = self._entity_id(entity_name)
+                row = conn.execute(
+                    "SELECT COUNT(*) FROM triples WHERE subject = ? OR object = ?",
+                    (eid, eid),
+                ).fetchone()
+            else:
+                row = conn.execute("SELECT COUNT(*) FROM triples").fetchone()
+        return row[0]
 
     # ── Stats ─────────────────────────────────────────────────────────────
 

--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -716,7 +716,7 @@ class KnowledgeGraph:
                     JOIN entities s ON t.subject = s.id
                     JOIN entities o ON t.object = o.id
                     WHERE (t.subject = ? OR t.object = ?)
-                    ORDER BY t.valid_from ASC NULLS LAST
+                    ORDER BY t.valid_from ASC NULLS LAST, t.id ASC
                     LIMIT ? OFFSET ?
                 """,
                     (eid, eid, limit, offset),
@@ -728,7 +728,7 @@ class KnowledgeGraph:
                     FROM triples t
                     JOIN entities s ON t.subject = s.id
                     JOIN entities o ON t.object = o.id
-                    ORDER BY t.valid_from ASC NULLS LAST
+                    ORDER BY t.valid_from ASC NULLS LAST, t.id ASC
                     LIMIT ? OFFSET ?
                 """,
                     (limit, offset),

--- a/mempalace/mcp_server/schemas.py
+++ b/mempalace/mcp_server/schemas.py
@@ -133,13 +133,24 @@ TOOLS = {
         "handler": tool_kg_supersede,
     },
     "mempalace_kg_timeline": {
-        "description": "Chronological timeline of facts. Shows the story of an entity (or everything) in order.",
+        "description": "Chronological timeline of facts with pagination. Shows the story of an entity (or everything) in order. Returns total matching count for pagination.",
         "input_schema": {
             "type": "object",
             "properties": {
                 "entity": {
                     "type": "string",
                     "description": "Entity to get timeline for (optional — omit for full timeline)",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max facts per page (default 100, max 100)",
+                    "minimum": 1,
+                    "maximum": 100,
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Offset for pagination (default 0)",
+                    "minimum": 0,
                 },
             },
         },

--- a/mempalace/mcp_server/tools_kg.py
+++ b/mempalace/mcp_server/tools_kg.py
@@ -227,15 +227,35 @@ def tool_kg_supersede(
     }
 
 
-def tool_kg_timeline(entity: str = None):
-    """Get chronological timeline of facts, optionally for one entity."""
+def tool_kg_timeline(entity: str = None, limit: int = 100, offset: int = 0):
+    """Get chronological timeline of facts, optionally for one entity.
+
+    Paginated with ``limit``/``offset`` following the ``tool_list_drawers``
+    convention; defaults match the historical behavior (first 100 facts).
+    """
+    limit = max(1, min(limit, _MAX_RESULTS))
+    offset = max(0, offset)
     if entity is not None:
         try:
             entity = sanitize_kg_value(entity, "entity")
         except ValueError as e:
             return {"error": str(e)}
-    results = _call_kg(lambda kg: kg.timeline(entity))
-    return {"entity": entity or "all", "timeline": results, "count": len(results)}
+
+    def _query(kg):
+        return {
+            "timeline": kg.timeline(entity, limit=limit, offset=offset),
+            "total": kg.timeline_total(entity),
+        }
+
+    result = _call_kg(_query)
+    return {
+        "entity": entity or "all",
+        "timeline": result["timeline"],
+        "count": len(result["timeline"]),
+        "total": result["total"],
+        "offset": offset,
+        "limit": limit,
+    }
 
 
 def tool_kg_stats():

--- a/tests/mcp/test_kg.py
+++ b/tests/mcp/test_kg.py
@@ -153,6 +153,34 @@ class TestKGTools:
 
         result = tool_kg_timeline(entity="Alice")
         assert result["count"] > 0
+        assert result["total"] >= result["count"]
+        assert result["offset"] == 0
+        assert result["limit"] == 100
+
+    def test_kg_timeline_paginates(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_timeline
+
+        full = tool_kg_timeline()
+        total = full["total"]
+        assert total == full["count"]  # seeded KG fits in one default page
+
+        page1 = tool_kg_timeline(limit=2, offset=0)
+        page2 = tool_kg_timeline(limit=2, offset=2)
+        assert page1["count"] == 2
+        assert page1["total"] == total
+        assert page1["offset"] == 0 and page1["limit"] == 2
+        assert page2["offset"] == 2
+        # pages are disjoint and in timeline order
+        assert page1["timeline"] + page2["timeline"] == full["timeline"][: 2 + page2["count"]]
+
+    def test_kg_timeline_clamps_pagination_args(self, monkeypatch, config, palace_path, seeded_kg):
+        _patch_mcp_server(monkeypatch, config, seeded_kg)
+        from mempalace.mcp_server import tool_kg_timeline
+
+        result = tool_kg_timeline(limit=10_000, offset=-3)
+        assert result["limit"] == 100  # clamped to _MAX_RESULTS
+        assert result["offset"] == 0
 
     def test_kg_stats(self, monkeypatch, config, palace_path, seeded_kg):
         _patch_mcp_server(monkeypatch, config, seeded_kg)

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -175,6 +175,16 @@ class TestTimeline:
         assert kg.timeline_total() == 106
         assert kg.timeline_total("hub") == 1
 
+    def test_timeline_pagination_stable_under_tied_valid_from(self, kg):
+        # All facts share one valid_from; without a unique ORDER BY tiebreaker
+        # SQLite gives no ordering guarantee and pages could overlap or skip.
+        for i in range(30):
+            kg.add_triple(f"e{i}", "relates_to", f"e{i + 1}", valid_from="2026-01-01")
+        pages = [kg.timeline(limit=7, offset=o) for o in range(0, 30, 7)]
+        seen = [(t["subject"], t["object"]) for page in pages for t in page]
+        assert len(seen) == len(set(seen)) == 30  # disjoint pages, full coverage
+        assert seen == [(t["subject"], t["object"]) for t in kg.timeline(limit=30)]
+
     def test_timeline_clamps_bad_pagination_args(self, kg):
         kg.add_triple("a", "relates_to", "b")
         assert len(kg.timeline(limit=0, offset=-5)) == 1  # clamped to limit=1, offset=0

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -150,7 +150,34 @@ class TestTimeline:
                 "hub", "connects_to", f"spoke_{i}", valid_from=f"2025-01-{(i % 28) + 1:02d}"
             )
         tl = kg.timeline("hub")
-        assert len(tl) == 100  # LIMIT 100 on entity-filtered branch
+        assert len(tl) == 100  # default limit preserves historical behavior
+
+    def test_timeline_pagination_walks_all_facts(self, kg):
+        for i in range(105):
+            kg.add_triple(f"entity_{i}", "relates_to", f"entity_{i + 1}")
+        pages = [kg.timeline(limit=50, offset=o) for o in (0, 50, 100)]
+        assert [len(p) for p in pages] == [50, 50, 5]
+        seen = [(t["subject"], t["predicate"], t["object"]) for page in pages for t in page]
+        assert len(seen) == len(set(seen)) == 105  # disjoint pages, full coverage
+
+    def test_timeline_entity_pagination(self, kg):
+        for i in range(105):
+            kg.add_triple(
+                "hub", "connects_to", f"spoke_{i}", valid_from=f"2025-01-{(i % 28) + 1:02d}"
+            )
+        page = kg.timeline("hub", limit=10, offset=100)
+        assert len(page) == 5
+
+    def test_timeline_total(self, kg):
+        for i in range(105):
+            kg.add_triple(f"entity_{i}", "relates_to", f"entity_{i + 1}")
+        kg.add_triple("hub", "connects_to", "entity_0")
+        assert kg.timeline_total() == 106
+        assert kg.timeline_total("hub") == 1
+
+    def test_timeline_clamps_bad_pagination_args(self, kg):
+        kg.add_triple("a", "relates_to", "b")
+        assert len(kg.timeline(limit=0, offset=-5)) == 1  # clamped to limit=1, offset=0
 
 
 class TestWALMode:


### PR DESCRIPTION
## Problem

`mempalace_kg_timeline` silently returns only the **oldest 100 facts** — a hardcoded `LIMIT 100` in both branches of `KnowledgeGraph.timeline()` — with no pagination parameters and no signal that truncation happened. On a palace with 409 facts, a client sees 100 and has no way to fetch the rest, which makes full KG enumeration impossible for export and visualization clients. (Found while building a read-only graph viewer that assembles the palace over the MCP tool surface.)

## Change

Extends the tool with `limit`/`offset` following the existing `tool_list_drawers` convention (the same pattern recently extended in #1891):

- `tool_kg_timeline(entity, limit=100, offset=0)` — `limit` clamped to `[1, _MAX_RESULTS]`, `offset >= 0`
- response gains `total` / `offset` / `limit` alongside the existing `entity` / `timeline` / `count` fields
- `KnowledgeGraph.timeline(entity_name, limit=100, offset=0)` — parameterized `LIMIT ? OFFSET ?`
- new `KnowledgeGraph.timeline_total(entity_name)` for the all-pages count
- input schema updated to match the `list_drawers` wording

**Backward compatible by construction:** defaults reproduce the historical behavior exactly (first 100 facts, chronological). The existing `LIMIT 100` regression tests (`test_timeline_global_has_limit`, `test_timeline_entity_has_limit`) pass unchanged, as does the Hermes integration caller.

## Tests

- KG layer: pagination walk over 105 facts (disjoint pages, full coverage), entity-filtered pagination, `timeline_total` (global + entity), clamping of bad args
- MCP layer: paginated page walk with `total` stability, clamping at the tool boundary, response-shape fields
- Full suite: 4,745 passed, 32 skipped; ruff check + format clean

## Note on #1902

#1902 adds `_cap_facts` response-size capping to this same handler — the two are complementary (this PR bounds pages *by contract*, #1902 guards raw size). Happy to rebase whichever lands second; the conflict is confined to `tool_kg_timeline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)