### PR TITLE
feat: wire importance scoring into ingestion pipeline

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -21,6 +21,7 @@ from collections import defaultdict
 from typing import Optional
 
 from .backends import PalaceNotFoundError
+from .importance import score_importance
 from .collision_scan import assert_no_collisions
 from .ids import (
     ID_RECIPE,
@@ -134,6 +135,7 @@ def file_conversation_exchange(
         "extract_mode": "exchange",
         "normalize_version": NORMALIZE_VERSION,
         "id_recipe": ID_RECIPE,
+        "importance": score_importance(text),
     }
     if extra_metadata:
         for key, value in extra_metadata.items():

--- a/mempalace/importance.py
+++ b/mempalace/importance.py
@@ -1,0 +1,42 @@
+"""
+importance.py — Rule-based importance scoring for memory drawers.
+
+Assigns an importance tier (1.0–5.0) to drawer content at ingest time
+so Layer 1 (Essential Story) can prioritize critical memories over trivia
+in wake-up context.
+
+See: https://github.com/MemPalace/mempalace/issues/2409
+"""
+
+import re
+
+# Health, safety, credentials — must always surface
+CRITICAL_PATTERNS = re.compile(
+    r"allerg|medical|medication|disease|emergency|password|"
+    r"credential|api.key|ssn|birth.?date|blood.?type|"
+    r"never.?forget|always.?remember|critical|life.?threatening",
+    re.IGNORECASE,
+)
+
+# Identity facts — important but not safety-critical
+IDENTITY_PATTERNS = re.compile(
+    r"my name is|i am a|my job|my role|i work at|"
+    r"i live in|born in|native language|nationality",
+    re.IGNORECASE,
+)
+
+
+def score_importance(text: str) -> float:
+    """Score text importance: 5.0=critical, 4.0=identity, 3.0=normal.
+
+    The default of 3.0 matches the fallback in ``layers.py`` L1, so
+    drawers ingested before this scorer existed sort identically to
+    before — no migration required.
+    """
+    if not text:
+        return 3.0
+    if CRITICAL_PATTERNS.search(text):
+        return 5.0
+    if IDENTITY_PATTERNS.search(text):
+        return 4.0
+    return 3.0

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -107,6 +107,7 @@ from .knowledge_graph import KnowledgeGraph, DEFAULT_KG_PATH  # noqa: E402
 from .logstream import LOGSTREAM_DB_FILENAME, Logstream  # noqa: E402
 from .collision_scan import assert_no_collisions  # noqa: E402
 from .ids import ID_RECIPE, make_drawer_id_from_content  # noqa: E402
+from .importance import score_importance  # noqa: E402
 
 
 class _MempalaceLogFilter(logging.Filter):
@@ -3199,6 +3200,7 @@ def tool_add_drawer(
         "added_by": added_by,
         "filed_at": datetime.now().isoformat(),
         "id_recipe": ID_RECIPE,
+        "importance": score_importance(content),
     }
 
     # Idempotency. Three cases to detect a prior committed write:
@@ -4249,6 +4251,7 @@ def tool_diary_write(agent_name: str, entry: str, topic: str = "general", wing: 
             "agent": agent_name,
             "filed_at": now.isoformat(),
             "date": now.strftime("%Y-%m-%d"),
+            "importance": score_importance(entry),
         }
         chunk_size = _config.chunk_size
         if len(entry) <= chunk_size:

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -45,6 +45,7 @@ from .palace import (
 # ``_compute_topic_tunnels_for_wing`` post-mine block.
 from .collision_scan import assert_no_collisions
 from .hallways import compute_hallways_for_wing
+from .importance import score_importance
 from .ids import ID_RECIPE, make_drawer_id_from_chunk
 
 logger = logging.getLogger("mempalace_mcp")
@@ -1453,6 +1454,7 @@ def _build_drawer_metadata(
     if chunk_total is not None:
         metadata["chunk_total"] = chunk_total
     metadata["hall"] = detect_hall(content)
+    metadata["importance"] = score_importance(content)
     entities = _extract_entities_for_metadata(content)
     if entities:
         metadata["entities"] = entities

--- a/tests/test_importance.py
+++ b/tests/test_importance.py
@@ -1,0 +1,64 @@
+"""Tests for the importance scoring module."""
+
+from mempalace.importance import score_importance
+
+
+def test_critical_allergy():
+    assert score_importance("I am allergic to peanuts") == 5.0
+
+
+def test_critical_medication():
+    assert score_importance("My medication is metformin") == 5.0
+
+
+def test_critical_api_key():
+    assert score_importance("API key is sk-abc123") == 5.0
+
+
+def test_critical_never_forget():
+    assert score_importance("Never forget the deployment password") == 5.0
+
+
+def test_critical_blood_type():
+    assert score_importance("My blood type is O negative") == 5.0
+
+
+def test_critical_life_threatening():
+    assert score_importance("This is a life-threatening condition") == 5.0
+
+
+def test_identity_name():
+    assert score_importance("My name is Radu and I live in Coventry") == 4.0
+
+
+def test_identity_work():
+    assert score_importance("I work at a tech company") == 4.0
+
+
+def test_identity_role():
+    assert score_importance("My role is senior engineer") == 4.0
+
+
+def test_normal_preference():
+    assert score_importance("I like Ethiopian single origin coffee") == 3.0
+
+
+def test_normal_weather():
+    assert score_importance("The weather was nice today") == 3.0
+
+
+def test_normal_discussion():
+    assert score_importance("We discussed the project architecture") == 3.0
+
+
+def test_empty_string():
+    assert score_importance("") == 3.0
+
+
+def test_none_like_empty():
+    assert score_importance("") == 3.0
+
+
+def test_critical_outranks_identity():
+    """When text matches both critical and identity, critical wins."""
+    assert score_importance("My name is allergic-reaction-prone") == 5.0


### PR DESCRIPTION
## Summary

- Adds `importance.py` — a zero-dependency keyword-based scorer that classifies drawer content into tiers: critical (5.0), identity (4.0), normal (3.0)
- Wires `score_importance()` into all ingestion paths: `miner.py`, `convo_miner.py`, `mcp_server.py` (`tool_add_drawer` + `tool_diary_write`)
- Layer 1 already reads `importance` metadata and sorts by it — this PR provides the missing write side

## Problem

L1 (Essential Story) sorts drawers by `importance` to build wake-up context, but no ingestion path ever wrote an importance value. Every drawer defaulted to 3.0, collapsing the sort to `filed_at` order. Critical facts (allergies, medications, credentials) had no way to outrank trivia (coffee preferences, weather notes) in wake-up context.

## Test plan

- [x] 15 unit tests covering critical/identity/normal classification + edge cases
- [x] Verified on a clean RunPod instance: uv venv + mempalace 3.9.0, added drawers with scored importance, confirmed L1 wake-up sorts critical above normal
- [ ] Existing tests should pass — no behavioral change for drawers without importance (default stays 3.0)

Fixes #2409