### PR TITLE
fix(config): bound temporary-name allocation on Windows

### DIFF
--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -8,10 +8,10 @@ import errno
 import hashlib
 import json
 import os
-import stat
 import re
+import secrets
+import stat
 import sys
-import tempfile
 from datetime import date, datetime
 from functools import lru_cache
 from pathlib import Path
@@ -395,6 +395,56 @@ def _fsync_directory(directory: Path) -> None:
         os.close(fd)
 
 
+_TEMP_NAME_ATTEMPTS = 64
+
+
+def _bounded_mkstemp(
+    directory: Path,
+    *,
+    prefix: str,
+    suffix: str = "",
+) -> tuple[int, str]:
+    """Create a private temporary file without an unbounded retry loop.
+
+    ``tempfile.mkstemp`` retries ``PermissionError`` as a candidate-name
+    collision on Windows while the parent directory appears writable. An ACL,
+    filter driver, or injected EPERM can therefore run through billions of
+    attempts. Generate names locally, retain exclusive/no-follow creation, and
+    retry only real collisions plus Windows' directory-at-candidate case.
+    """
+    directory = Path(directory)
+    flags = (
+        os.O_RDWR
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+    last_collision = None
+
+    for _ in range(_TEMP_NAME_ATTEMPTS):
+        candidate = directory / f"{prefix}{secrets.token_hex(12)}{suffix}"
+        try:
+            fd = os.open(str(candidate), flags, 0o600)
+        except FileExistsError as exc:
+            last_collision = exc
+            continue
+        except PermissionError as exc:
+            # Opening an existing directory as a file can be reported as
+            # PermissionError on Windows rather than FileExistsError.
+            if os.name == "nt" and candidate.is_dir():
+                last_collision = exc
+                continue
+            raise
+        return fd, str(candidate)
+
+    raise FileExistsError(
+        errno.EEXIST,
+        (f"could not allocate a unique temporary file after {_TEMP_NAME_ATTEMPTS} attempts"),
+        str(directory),
+    ) from last_collision
+
+
 def _keep_unreadable_file(path: Path):
     """Move a file whose contents did not parse aside, keeping its bytes.
 
@@ -412,8 +462,8 @@ def _keep_unreadable_file(path: Path):
     """
     path = _write_target(path)
     stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    fd, target = tempfile.mkstemp(
-        dir=str(path.parent),
+    fd, target = _bounded_mkstemp(
+        path.parent,
         prefix=f"{path.name}.unreadable-{stamp}-",
     )
     os.close(fd)
@@ -519,7 +569,11 @@ def _atomic_write_json(path: Path, payload) -> None:
         # directory for a name of its own instead: what it says about a name
         # it chooses is about the directory.
         try:
-            fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+            fd, tmp = _bounded_mkstemp(
+                path.parent,
+                prefix=f".{path.name}.",
+                suffix=".tmp",
+            )
         except OSError as exc:
             if exc.errno not in (errno.EACCES, errno.EPERM, errno.EROFS):
                 raise

--- a/tests/test_config_unreadable_rewrite.py
+++ b/tests/test_config_unreadable_rewrite.py
@@ -576,18 +576,17 @@ def test_a_rename_the_directory_refuses_falls_back(tmp_path, monkeypatch, capsys
     assert leftovers == [], leftovers
 
 
-@needs_unprivileged_posix
 def test_eperm_on_both_names_falls_back_too(tmp_path, monkeypatch, capsys):
-    """``EPERM`` reaches the gate from a filesystem that refuses the operation
-    rather than the caller, an NFS export among them. It belongs beside
-    ``EACCES`` and ``EROFS``, and nothing else pins it."""
+    """EPERM falls back promptly instead of entering tempfile's Windows loop."""
     _config_file(tmp_path).write_text(json.dumps(REAL))
     cfg = MempalaceConfig(config_dir=str(tmp_path))
     real_open = os.open
+    denied_temp_names = []
 
     def not_permitted(path, *args, **kwargs):
         name = os.path.basename(str(path))
         if name.startswith("config.json.") or name.startswith(".config.json."):
+            denied_temp_names.append(name)
             raise OSError(errno.EPERM, "Operation not permitted")
         return real_open(path, *args, **kwargs)
 
@@ -596,6 +595,54 @@ def test_eperm_on_both_names_falls_back_too(tmp_path, monkeypatch, capsys):
 
     assert json.loads(_config_file(tmp_path).read_text())["backend"] == "qdrant"
     assert "written in place" in capsys.readouterr().err
+    assert len(denied_temp_names) == 2
+    assert denied_temp_names[0].startswith("config.json.tmp-")
+    assert denied_temp_names[1].startswith(".config.json.")
+
+
+def test_bounded_mkstemp_retries_collision_then_creates_exclusively(tmp_path, monkeypatch):
+    """Only a real name collision is retried; its contents stay untouched."""
+    from mempalace import config as config_module
+
+    tokens = iter(("occupied", "fresh"))
+    monkeypatch.setattr(config_module.secrets, "token_hex", lambda _: next(tokens))
+    occupied = tmp_path / ".config.json.occupied.tmp"
+    occupied.write_text("occupied")
+
+    fd, created = config_module._bounded_mkstemp(
+        tmp_path,
+        prefix=".config.json.",
+        suffix=".tmp",
+    )
+    try:
+        os.write(fd, b"fresh")
+    finally:
+        os.close(fd)
+
+    assert occupied.read_text() == "occupied"
+    assert created == str(tmp_path / ".config.json.fresh.tmp")
+    assert (tmp_path / ".config.json.fresh.tmp").read_bytes() == b"fresh"
+
+
+def test_bounded_mkstemp_exhausts_collisions_at_local_limit(tmp_path, monkeypatch):
+    """A hostile or crowded namespace has a deterministic local upper bound."""
+    from mempalace import config as config_module
+
+    monkeypatch.setattr(config_module.secrets, "token_hex", lambda _: "collision")
+    occupied = tmp_path / ".config.json.collision.tmp"
+    occupied.write_text("occupied")
+
+    with pytest.raises(
+        FileExistsError,
+        match=str(config_module._TEMP_NAME_ATTEMPTS),
+    ):
+        config_module._bounded_mkstemp(
+            tmp_path,
+            prefix=".config.json.",
+            suffix=".tmp",
+        )
+
+    assert occupied.read_text() == "occupied"
 
 
 @needs_unprivileged_posix


### PR DESCRIPTION
## Summary

- replace both config-writing `tempfile.mkstemp()` paths with a bounded exclusive-create allocator
- keep the EPERM regression enabled on Windows instead of hiding the production behavior behind a platform skip
- add coverage for genuine name collisions and deterministic collision exhaustion

## Root cause

`test_eperm_on_both_names_falls_back_too` rejects both temporary-name forms by making `os.open()` raise `EPERM`.

The first PID-based temporary name fails as expected. The fallback then calls `tempfile.mkstemp()` using a `.config.json.` prefix.

On Windows, CPython's internal temporary-file allocator can interpret `PermissionError` as a possible candidate-name collision while the parent directory still appears writable. It therefore continues through `tempfile.TMP_MAX` rather than returning the filesystem error to MemPalace. In the reported environment, that permits up to 2,147,483,647 attempts and makes the test effectively non-terminating.

Adding `@needs_unprivileged_posix` would stop this particular Windows test run, but it would leave the same production liveness hazard in the configuration write path.

## Implementation

The new local allocator:

- creates candidate names with 96 bits of `secrets` randomness
- retains `O_CREAT | O_EXCL`
- retains mode `0600`
- uses `O_NOFOLLOW` where available
- uses `O_BINARY` where available
- retries genuine `FileExistsError` collisions
- retries the narrow Windows case where the candidate itself is an existing directory
- propagates actual permission and filesystem failures immediately
- stops after 64 genuine candidate-name collisions

Both existing `tempfile.mkstemp()` call sites now use the bounded allocator:

1. allocating the destination used to preserve an unreadable or malformed configuration
2. allocating the random fallback after the fixed PID-based atomic-write name cannot be opened

No new dependency is introduced; `secrets` is part of the Python standard library.

## Regression coverage

`test_eperm_on_both_names_falls_back_too` remains cross-platform and records every rejected temporary name. It requires exactly two rejected opens:

1. `config.json.tmp-<pid>`
2. one `.config.json.<random>.tmp` candidate

This verifies that `EPERM` reaches the existing in-place-write fallback without entering the standard library's very large retry loop.

Additional tests verify that:

- a genuinely occupied candidate is retried
- the occupied file is not modified
- the next unique candidate is created successfully
- persistent collisions terminate at the local 64-attempt limit
- the occupied file remains unchanged after exhaustion

## How to test

- [x] `python3 -m ruff format --check .`
- [x] `python3 -m ruff check .`
- [x] `python3 -m py_compile mempalace/config.py tests/test_config_unreadable_rewrite.py`
- [x] `python3 -m pytest tests/test_config_unreadable_rewrite.py::test_eperm_on_both_names_falls_back_too tests/test_config_unreadable_rewrite.py::test_bounded_mkstemp_retries_collision_then_creates_exclusively tests/test_config_unreadable_rewrite.py::test_bounded_mkstemp_exhausts_collisions_at_local_limit -q`
- [x] `python3 -m pytest tests/test_config_unreadable_rewrite.py -q`
- [x] `python3 -m pytest tests/test_config.py tests/test_config_extra.py tests/test_config_palace_path.py tests/test_config_unreadable_rewrite.py -q`
- [x] `python -m pytest tests/ -v`
- [x] `git diff --check`

Closes #2392