### PR TITLE
fix(search): route CLI filtered query through #1245 recovery helper

### DIFF
--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -743,7 +743,15 @@ def search(
         if where:
             kwargs["where"] = where
 
-        results = col.query(**kwargs)
+        # Route the filtered drawer query through the same recovery helper
+        # `search_memories()` uses. A ChromaDB HNSW/SQLite mismatch makes
+        # `query(where=...)` raise "Error finding id" while an unfiltered
+        # query still works; without this the CLI was the one search path
+        # that surfaced the hard error. The CLI has no source_file dimension
+        # (its filter surface is wing/room only), so let the helper's
+        # source_file default to None and its re-filter re-apply wing/room.
+        # See #1245 / #2373.
+        results = _query_drawers_with_filter_fallback(col, kwargs, query, n_results, wing, room)
 
     except Exception as e:
         print(f"\n  Search error: {e}")

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -804,6 +804,61 @@ class TestSearchCLI:
         mock_probe.assert_not_called()
         mock_open.assert_called_once_with(fake_palace_path, opener=get_collection)
 
+    def test_cli_filtered_query_fallback_engaged_when_where_present(self, fake_palace_path, capsys):
+        """Regression for #2373: CLI `search()` with a wing/room filter must
+        route the filtered ``query(where=...)`` call through the same recovery
+        helper `search_memories()` already uses.
+
+        A ChromaDB HNSW/SQLite index mismatch surfaces as a hard
+        "Error finding id" on *filtered* queries even when unfiltered queries
+        work. Before this fix the CLI path — the one an operator runs by hand
+        — was the only search entry point that surfaced the raw crash while
+        the MCP tool path silently recovered.
+
+        The fallback contract: retry without the ``where`` clause (over-fetch),
+        then post-filter by wing/room in Python. This test asserts that
+        contract end-to-end: the first ``col.query`` raises with the real
+        HNSW error, the second returns a mixed-wing set, and the CLI output
+        contains only the wing the operator asked for.
+        """
+        mock_col = MagicMock()
+        mock_col.metadata = {"hnsw:space": "cosine"}
+        mock_col.query.side_effect = [
+            RuntimeError("Error finding id"),
+            {
+                "documents": [["drop document", "keep document"]],
+                "metadatas": [
+                    [
+                        {"source_file": "drop.md", "wing": "other-wing", "room": "notes"},
+                        {"source_file": "keep.md", "wing": "keep-wing", "room": "notes"},
+                    ]
+                ],
+                "distances": [[1.0, 0.3]],
+            },
+        ]
+        with (
+            patch("mempalace.searcher.resolve_backend_name", return_value="chroma"),
+            patch(
+                "mempalace.backends.chroma.hnsw_capacity_status",
+                return_value={"diverged": False, "status": "ok"},
+            ),
+            patch("mempalace.searcher.get_collection", return_value=mock_col),
+        ):
+            # Must NOT raise SearchError — the helper catches the filtered-query
+            # failure and the unfiltered retry succeeds.
+            search("needle", fake_palace_path, wing="keep-wing")
+
+        captured = capsys.readouterr()
+        # Fallback engaged: both the failing filtered call and the recovery
+        # unfiltered call hit the backend.
+        assert mock_col.query.call_count == 2
+        # The keep-wing drawer made it through to the printed results.
+        assert "keep document" in captured.out
+        assert "keep-wing" in captured.out
+        # The other wing was dropped by the Python-side post-filter.
+        assert "drop document" not in captured.out
+        assert "other-wing" not in captured.out
+
 
 # ── _tokenize stop-word filter ─────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

`mempalace search` with a `--wing` or `--room` filter crashes with a raw
`Error finding id` (ChromaDB HNSW/SQLite index mismatch) on palaces where
the **MCP** `mempalace_search` tool returns results just fine.

The MCP path already routes the same filtered query through the #1245
recovery helper (`_query_drawers_with_filter_fallback`), which retries
unfiltered + re-filters in Python. The CLI path called `col.query(where=...)`
raw and surfaced the hard failure.

## Fix

Wire the CLI filtered query through the existing helper. The CLI has no
`source_file` dimension (filter surface is wing/room only), so the helper's
`source_file` argument defaults to `None` and its Python-side re-filter
re-applies wing/room — exactly the CLI's filter contract.

One function-body change in `mempalace/searcher.py`; no new logic, no new
public API.

## Tests

New regression test
`TestSearchCLI::test_cli_filtered_query_fallback_engaged_when_where_present`
asserts the full contract from the CLI entry point:
- first `col.query` call raises `Error finding id` (the real HNSW failure);
- second call succeeds (unfiltered retry);
- `mock_col.query.call_count == 2` — fallback actually engaged;
- the keep-wing drawer appears in rendered output;
- the other-wing drawer is dropped by the Python-side post-filter.

Full `tests/test_searcher.py` (103 tests) + `tests/test_search_drawer_id.py`
pass; `ruff check` + `ruff format --check` clean.

## Related

- Fixes #2373
- Uses the helper added in #1245 (original issue #1035)