### PR TITLE
feat(importance): write importance metadata at all ingestion sites (#2409)

### DIFF
--- a/mempalace/convo_miner.py
+++ b/mempalace/convo_miner.py
@@ -30,6 +30,7 @@ from .ids import (
 )
 from .normalize import normalize_conversations
 from .entities import entities_metadata
+from .importance import score_importance
 from .palace import (
     NORMALIZE_VERSION,
     SKIP_DIRS,
@@ -132,6 +133,7 @@ def file_conversation_exchange(
         "authored_at": authored_at if authored_at is not None else filed_at,
         "ingest_mode": "convos",
         "extract_mode": "exchange",
+        "importance": score_importance(text),
         "normalize_version": NORMALIZE_VERSION,
         "id_recipe": ID_RECIPE,
     }
@@ -728,6 +730,7 @@ def _file_chunks_locked(
                         "authored_at": authored_at if authored_at is not None else filed_at,
                         "ingest_mode": "convos",
                         "extract_mode": extract_mode,
+                        "importance": score_importance(chunk["content"]),
                         "normalize_version": NORMALIZE_VERSION,
                         "id_recipe": ID_RECIPE,
                         "chunk_total": chunk_total,

--- a/mempalace/importance.py
+++ b/mempalace/importance.py
@@ -1,0 +1,70 @@
+"""
+importance.py — Zero-dependency content scoring for drawer importance
+
+Layer 1 (Essential Story) in ``layers.py`` sorts drawers by an
+``importance`` metadata key descending (falling back to ``filed_at``),
+but no ingestion path ever wrote an importance value until now — so
+the sort was effectively flat at 3.0 for every drawer and wake-up
+context was recency-only.
+
+This module provides a small keyword/scorer that writes a sensible
+``importance`` value into metadata so the L1 ranking can actually
+prioritize critical content (health info, credentials, identity facts)
+over trivia. Callers may still override with an explicit numeric
+``importance`` (1.0–5.0) — see ``tool_add_drawer``.
+
+The tiers (mirroring the reporter's proposal in #2409):
+
+    5.0  Critical  — health, credentials, safety, life-threatening info
+    4.0  Identity  — name, role, employer, location, language, etc.
+    3.0  Default   — everything else
+
+Callers write ``metadata["importance"] = score_importance(text)``,
+or pass ``importance=<float>`` explicitly where the ingestion path
+accepts one.
+"""
+
+import re
+from typing import Optional
+
+__all__ = ["DEFAULT_IMPORTANCE", "score_importance"]
+
+DEFAULT_IMPORTANCE = 3.0
+
+_CRITICAL_PATTERNS = re.compile(
+    r"allerg|medical|medication|health|hospital|disease|emergency|password|"
+    r"credential|api.?\s?key|ssn|birth.?\s?date|blood.?\s?type|"
+    r"never.?\s?forget|always.?\s?remember|critical|life.?\s?threatening|"
+    r"doctor|diagnos|prescription|insurance|symptom",
+    re.IGNORECASE,
+)
+
+_IDENTITY_PATTERNS = re.compile(
+    r"my name (?:is|:)|my job|my role|i work at|work[ ]?for|"
+    r"i live in|live in|born in|native language|nationality|"
+    r"\bi am (?:a|an|the)\b",
+    re.IGNORECASE,
+)
+
+
+def score_importance(text: Optional[str]) -> float:
+    """Return an importance score in [3.0, 5.0] from content.
+
+    Uses two regex tiers: critical/identity. Both patterns match
+    case-insensitively across the content. Returns ``DEFAULT_IMPORTANCE``
+    (3.0) when no pattern matches.
+
+    The tiers are deliberately conservative: false positives land a
+    drawer one tier low (still 4.0, near the top of the L1 default
+    range), false negatives keep it at the 3.0 default. Neither
+    tier's presence is required for correctness — callers can
+    always pass an explicit ``importance`` to ``tool_add_drawer``
+    (see the caller-facing ``importance`` parameter on add_drawer).
+    """
+    if not text:
+        return DEFAULT_IMPORTANCE
+    if _CRITICAL_PATTERNS.search(text):
+        return 5.0
+    if _IDENTITY_PATTERNS.search(text):
+        return 4.0
+    return DEFAULT_IMPORTANCE

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -107,6 +107,7 @@ from .knowledge_graph import KnowledgeGraph, DEFAULT_KG_PATH  # noqa: E402
 from .logstream import LOGSTREAM_DB_FILENAME, Logstream  # noqa: E402
 from .collision_scan import assert_no_collisions  # noqa: E402
 from .ids import ID_RECIPE, make_drawer_id_from_content  # noqa: E402
+from .importance import score_importance  # noqa: E402
 
 
 class _MempalaceLogFilter(logging.Filter):
@@ -3148,9 +3149,21 @@ def _build_chunk_rows(drawer_id: str, content: str, meta: dict, chunk_size: int)
 
 
 def tool_add_drawer(
-    wing: str, room: str, content: str, source_file: str = None, added_by: str = "mcp"
+    wing: str,
+    room: str,
+    content: str,
+    source_file: str = None,
+    added_by: str = "mcp",
+    importance: float = None,
 ):
     """File verbatim content into a wing/room. Checks for duplicates first.
+
+    ``importance`` is an optional 1.0–5.0 override for the drawer's
+    ranking priority. When omitted, the drawer's importance is inferred
+    from its content via ``score_importance`` (critical facts like health
+    or credentials score 5.0, identity 4.0, everything else 3.0) so that
+    Layer-1 wake-up context can surface critical memories over trivia
+    (#2409). An explicit value always wins over the inferred one.
 
     Content above ``chunk_size`` is split into bounded per-chunk drawers
     via a single batched upsert. Each chunk carries ``parent_drawer_id``
@@ -3192,12 +3205,20 @@ def tool_add_drawer(
     )
 
     chunk_size = _config.chunk_size
+    # Importance: explicit caller override wins; otherwise infer from
+    # content so L1 wake-up ranking can surface critical memories
+    # (health / credentials) over trivia (#2409).
+    if isinstance(importance, (int, float)):
+        importance_value = float(importance)
+    else:
+        importance_value = score_importance(content)
     base_meta = {
         "wing": wing,
         "room": room,
         "source_file": source_file or "",
         "added_by": added_by,
         "filed_at": datetime.now().isoformat(),
+        "importance": importance_value,
         "id_recipe": ID_RECIPE,
     }
 
@@ -5453,6 +5474,10 @@ TOOLS = {
                 },
                 "source_file": {"type": "string", "description": "Where this came from (optional)"},
                 "added_by": {"type": "string", "description": "Who is filing this (default: mcp)"},
+                "importance": {
+                    "type": "number",
+                    "description": "Optional ranking priority, 1.0-5.0. Omit to auto-infer from content (critical facts like health/credentials score 5.0, identity 4.0, default 3.0). Used to prioritize L1 wake-up context.",
+                },
             },
             "required": ["wing", "room", "content"],
         },

--- a/mempalace/miner.py
+++ b/mempalace/miner.py
@@ -46,6 +46,7 @@ from .palace import (
 from .collision_scan import assert_no_collisions
 from .hallways import compute_hallways_for_wing
 from .ids import ID_RECIPE, make_drawer_id_from_chunk
+from .importance import score_importance
 
 logger = logging.getLogger("mempalace_mcp")
 
@@ -1408,6 +1409,7 @@ def _build_drawer_metadata(
     line_end: Optional[int] = None,
     content_date: Optional[str] = None,
     chunk_total: Optional[int] = None,
+    importance: Optional[float] = None,
 ) -> dict:
     """Build the metadata dict for one drawer without upserting.
 
@@ -1452,6 +1454,12 @@ def _build_drawer_metadata(
         metadata["content_date"] = content_date
     if chunk_total is not None:
         metadata["chunk_total"] = chunk_total
+    # Importance (#2409): explicit override wins, else infer from the
+    # chunk's content so L1 wake-up ranking can surface critical chunks.
+    if isinstance(importance, (int, float)):
+        metadata["importance"] = float(importance)
+    else:
+        metadata["importance"] = score_importance(content)
     metadata["hall"] = detect_hall(content)
     entities = _extract_entities_for_metadata(content)
     if entities:
@@ -1460,13 +1468,17 @@ def _build_drawer_metadata(
 
 
 def add_drawer(
-    collection, wing: str, room: str, content: str, source_file: str, chunk_index: int, agent: str
+    collection, wing: str, room: str, content: str, source_file: str, chunk_index: int, agent: str,
+    importance: Optional[float] = None,
 ):
     """Add one drawer to the palace.
 
     Kept for backward compatibility with external callers. In-tree the
     miner uses ``_build_drawer_metadata`` + a batched ``collection.upsert``
     to amortize the embedding model's forward-pass cost across chunks.
+
+    ``importance`` (optional, 1.0-5.0) — explicit ranking override; omitted
+    values are inferred from content via ``score_importance``.
     """
     drawer_id = make_drawer_id_from_chunk(wing, room, source_file, chunk_index)
     try:
@@ -1474,7 +1486,7 @@ def add_drawer(
     except OSError:
         source_mtime = None
     metadata = _build_drawer_metadata(
-        wing, room, source_file, chunk_index, agent, content, source_mtime
+        wing, room, source_file, chunk_index, agent, content, source_mtime, importance=importance
     )
     collection.upsert(
         documents=[content],

--- a/tests/test_importance.py
+++ b/tests/test_importance.py
@@ -1,0 +1,366 @@
+"""Tests for mempalace.importance and the ingestion write-sites (#2409).
+
+Covers:
+  1. The scorer itself (tier assignment, boundary cases, empty/None input)
+  2. tool_add_drawer writing importance into the stored metadata (explicit +
+     inferred) — exercised against the real backend the same way TestWriteTools
+     does, then read back from the collection.
+  3. miner._build_drawer_metadata writing importance (explicit + inferred)
+  4. convo_miner single-exchange path writing importance
+  5. End-to-end: a critical drawer sorts ABOVE a trivial one in Layer-1
+"""
+
+from unittest.mock import MagicMock, patch
+
+from mempalace.importance import score_importance
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 1. Scorer unit tests
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestScoreImportance:
+    def test_none_returns_default(self):
+        assert score_importance(None) == 3.0
+
+    def test_empty_string_returns_default(self):
+        assert score_importance("") == 3.0
+
+    def test_whitespace_returns_default(self):
+        assert score_importance("   \n\t  ") == 3.0
+
+    def test_critical_allergy(self):
+        assert score_importance("Patient has severe peanut allergy") == 5.0
+
+    def test_critical_credential(self):
+        assert score_importance("API key is sk-abcdefgh12345") == 5.0
+
+    def test_critical_medication(self):
+        assert score_importance("Current medication: 5mg lisinopril daily") == 5.0
+
+    def test_critical_never_forget(self):
+        assert score_importance("Never forget the code 2847") == 5.0
+
+    def test_identity_name(self):
+        assert score_importance("My name is Alice B.") == 4.0
+
+    def test_identity_occupation(self):
+        assert score_importance("I am a software engineer") == 4.0
+
+    def test_identity_born_in(self):
+        assert score_importance("I was born in 1985") == 4.0
+
+    def test_default_technical(self):
+        assert score_importance("Fixed the Python type annotation bug") == 3.0
+
+    def test_default_meeting_notes(self):
+        assert score_importance(
+            "Discussed Q3 roadmap. Action items to be assigned by Friday."
+        ) == 3.0
+
+    def test_case_insensitive(self):
+        assert score_importance("MY NAME IS Alice") == 4.0
+
+    def test_multi_word_boundary(self):
+        # "I am the owner" — identity tier via the "i am a/an/the" trigger
+        assert score_importance("I am the project lead") == 4.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 2. tool_add_drawer writes importance into stored metadata
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _read_last_metadata(col):
+    """Read back the most-recently-filed drawer's metadata from the real DB."""
+    results = col.get(limit=1, include=["metadatas"])
+    return results["metadatas"][0]
+
+
+class TestToolAddDrawerImportance:
+    """The MCP server path must stamp importance into the stored metadata."""
+
+    def test_add_drawer_writes_inferred_importance(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        from tests.test_mcp_server import _get_collection, _patch_mcp_server
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(
+            wing="personal",
+            room="health",
+            content="Patient has a severe peanut allergy — carry an EpiPen",
+        )
+        assert result["success"] is True
+        meta = _read_last_metadata(col)
+        assert "importance" in meta
+        assert meta["importance"] == 5.0
+
+    def test_add_drawer_explicit_importance_overrides_inference(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        from tests.test_mcp_server import _get_collection, _patch_mcp_server
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        # Content that would infer as 5.0, but the caller pins it to 1.0.
+        result = tool_add_drawer(
+            wing="personal",
+            room="health",
+            content="Patient has a severe peanut allergy — carry an EpiPen",
+            importance=1.0,
+        )
+        assert result["success"] is True
+        meta = _read_last_metadata(col)
+        assert meta["importance"] == 1.0
+
+    def test_add_drawer_integer_importance_coerced_to_float(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        from tests.test_mcp_server import _get_collection, _patch_mcp_server
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(
+            wing="personal",
+            room="notes",
+            content="Just a generic meeting note",
+            importance=4,
+        )
+        assert result["success"] is True
+        meta = _read_last_metadata(col)
+        assert meta["importance"] == 4.0
+
+    def test_add_drawer_default_importance_for_trivial_content(
+        self, monkeypatch, config, palace_path, kg
+    ):
+        from tests.test_mcp_server import _get_collection, _patch_mcp_server
+
+        _patch_mcp_server(monkeypatch, config, kg)
+        _client, col = _get_collection(palace_path, create=True)
+        del _client
+        from mempalace.mcp_server import tool_add_drawer
+
+        result = tool_add_drawer(
+            wing="personal",
+            room="notes",
+            content="We discussed the timeline for the release",
+        )
+        assert result["success"] is True
+        meta = _read_last_metadata(col)
+        assert meta["importance"] == 3.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 3. miner._build_drawer_metadata writes importance
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestMinerBuildDrawerMetadata:
+    def test_inferred_importance_identity(self):
+        from mempalace.miner import _build_drawer_metadata
+
+        meta = _build_drawer_metadata(
+            wing="proj",
+            room="arch",
+            source_file="design.md",
+            chunk_index=0,
+            agent="test",
+            content="My name is Alice and I work at Acme Corp",
+            source_mtime=None,
+        )
+        assert meta["importance"] == 4.0
+
+    def test_inferred_importance_critical(self):
+        from mempalace.miner import _build_drawer_metadata
+
+        meta = _build_drawer_metadata(
+            wing="proj",
+            room="health",
+            source_file="symptoms.md",
+            chunk_index=0,
+            agent="test",
+            content="Patient reports a severe peanut allergy",
+            source_mtime=None,
+        )
+        assert meta["importance"] == 5.0
+
+    def test_explicit_importance_override(self):
+        from mempalace.miner import _build_drawer_metadata
+
+        meta = _build_drawer_metadata(
+            wing="proj",
+            room="arch",
+            source_file="design.md",
+            chunk_index=0,
+            agent="test",
+            content="just a generic note about the architecture",
+            source_mtime=None,
+            importance=5.0,
+        )
+        assert meta["importance"] == 5.0
+
+    def test_default_importance(self):
+        from mempalace.miner import _build_drawer_metadata
+
+        meta = _build_drawer_metadata(
+            wing="proj",
+            room="notes",
+            source_file="meeting.md",
+            chunk_index=0,
+            agent="test",
+            content="We discussed the timeline for the release",
+            source_mtime=None,
+        )
+        assert meta["importance"] == 3.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 4. convo_miner single-exchange path writes importance
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestConvoMinerImportance:
+    def test_file_conversation_exchange_includes_importance(self):
+        from mempalace.convo_miner import file_conversation_exchange
+
+        mock_col = MagicMock()
+        with patch("mempalace.convo_miner.make_exchange_drawer_id", return_value="d1"):
+            with patch("mempalace.convo_miner._detect_hall_cached", return_value="technical"):
+                with patch("mempalace.convo_miner.entities_metadata", return_value={}):
+                    file_conversation_exchange(
+                        collection=mock_col,
+                        wing="personal",
+                        room="health",
+                        source_file="dm.txt",
+                        text="My blood type is O-negative",
+                        agent="test",
+                    )
+
+        assert mock_col.upsert.called
+        meta = mock_col.upsert.call_args.kwargs["metadatas"][0]
+        assert "importance" in meta
+        assert meta["importance"] == 5.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 5. End-to-end: Layer-1 sort order reflects importance
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_layer1_critical_drawer_sorts_above_trivial():
+    """A critical (5.0) drawer must appear BEFORE a default (3.0) drawer in
+    the Layer-1 Essential Story, even when the critical one is older."""
+    from mempalace.layers import Layer1
+
+    docs = [
+        "Patient has a severe peanut allergy — carry an EpiPen at all times",  # 5.0, old
+        "We discussed the Q3 roadmap and agreed on the release schedule",      # 3.0, new
+    ]
+    metas = [
+        {"room": "health", "importance": 5.0, "filed_at": "2026-01-01T00:00:00Z"},
+        {"room": "meetings", "importance": 3.0, "filed_at": "2026-06-15T00:00:00Z"},
+    ]
+
+    mock_col = MagicMock()
+    mock_col.get.side_effect = [
+        {"documents": docs, "metadatas": metas},
+        {"documents": [], "metadatas": []},
+    ]
+
+    with (
+        patch("mempalace.layers.MempalaceConfig") as mock_cfg,
+        patch("mempalace.layers._get_collection", return_value=mock_col),
+    ):
+        mock_cfg.return_value.palace_path = "/fake"
+        result = Layer1(palace_path="/fake").generate()
+
+    critical_idx = result.index("EpiPen")
+    trivial_idx = result.index("Q3 roadmap")
+    assert critical_idx < trivial_idx, (
+        f"critical@{critical_idx} should sort before trivial@{trivial_idx}"
+    )
+
+
+def test_layer1_identity_drawer_above_default():
+    """Identity-tier (4.0) drawers must sort above default (3.0)."""
+    from mempalace.layers import Layer1
+
+    docs = [
+        "Just a random note about the afternoon meeting",         # 3.0
+        "My name is Alice and I work at Acme Corp as CTO",       # 4.0
+    ]
+    metas = [
+        {"room": "notes", "importance": 3.0, "filed_at": "2026-06-01T00:00:00Z"},
+        {"room": "identity", "importance": 4.0, "filed_at": "2026-01-01T00:00:00Z"},
+    ]
+
+    mock_col = MagicMock()
+    mock_col.get.side_effect = [
+        {"documents": docs, "metadatas": metas},
+        {"documents": [], "metadatas": []},
+    ]
+
+    with (
+        patch("mempalace.layers.MempalaceConfig") as mock_cfg,
+        patch("mempalace.layers._get_collection", return_value=mock_col),
+    ):
+        mock_cfg.return_value.palace_path = "/fake"
+        result = Layer1(palace_path="/fake").generate()
+
+    identity_idx = result.index("Alice")
+    trivial_idx = result.index("random note")
+    assert identity_idx < trivial_idx
+
+
+def test_importance_end_to_end_from_add_drawer_to_layer1(
+    monkeypatch, config, palace_path, kg
+):
+    """Full loop: file a critical + a trivial drawer through the real
+    tool_add_drawer against the real backend, then confirm Layer-1 surfaces
+    the critical one first. Proves the write-site and the reader agree on
+    both the key name and the inferred value.
+    """
+    from mempalace.layers import Layer1
+    from tests.test_mcp_server import _get_collection, _patch_mcp_server
+    from mempalace.mcp_server import tool_add_drawer
+
+    _patch_mcp_server(monkeypatch, config, kg)
+    _client, col = _get_collection(palace_path, create=True)
+    del _client
+
+    tool_add_drawer(wing="p", room="health", content="severe peanut allergy, carry EpiPen at all times")
+    tool_add_drawer(wing="p", room="notes", content="discussed the q3 release timeline")
+
+    # Read back from the real DB and confirm the stamp
+    rows = col.get(limit=2, include=["documents", "metadatas"])
+    stamped = {d: m["importance"] for d, m in zip(rows["documents"], rows["metadatas"])}
+    crit_val = [v for d, v in stamped.items() if "EpiPen" in d]
+    assert crit_val and crit_val[0] == 5.0
+
+    # Run Layer-1 against the real collection contents
+    mock_col2 = MagicMock()
+    mock_col2.get.side_effect = [
+        {"documents": list(stamped.keys()), "metadatas": [{"room": "r", **{"importance": v, "filed_at": "2026-01-01T00:00:00Z"}} for v in stamped.values()]},
+        {"documents": [], "metadatas": []},
+    ]
+    with (
+        patch("mempalace.layers.MempalaceConfig") as mock_lcfg,
+        patch("mempalace.layers._get_collection", return_value=mock_col2),
+    ):
+        mock_lcfg.return_value.palace_path = "/fake"
+        result = Layer1(palace_path="/fake").generate()
+
+    assert result.index("EpiPen") < result.index("q3 release")
+


### PR DESCRIPTION
## Summary

Layer-1 (Essential Story) in `layers.py` sorts drawers by an `importance` metadata key (falling back to `filed_at`), but **no ingestion path ever wrote that key** — so the sort was effectively flat at the 3.0 default for every drawer and wake-up context was recency-only. That's the gap reported in #2409.

This makes the L1 ranking work as designed by stamping an inferred importance value into drawer metadata at every ingestion site.

## Changes

- **New: `mempalace/importance.py`** — zero-dependency scorer with two regex tiers:
  - `5.0` critical — health, credentials, safety (allergy, medication, blood type, SSN, API key, "never forget", prescription, symptom, …)
  - `4.0` identity — name, role, employer, location, language, birth date
  - `3.0` default — everything else (matches the existing L1 reader default)
- **`mempalace/mcp_server.py`** — `tool_add_drawer` (single + chunked paths) writes `importance` into `base_meta`; new optional `importance: float` parameter with explicit override; MCP schema extended with the `importance` input (`type: number`).
- **`mempalace/miner.py`** — `_build_drawer_metadata` and the backward-compat `add_drawer` accept/write the same optional override + inference.
- **`mempalace/convo_miner.py`** — single-exchange and batched chunk paths stamp `importance` on their metadata.
- **`tests/test_importance.py`** (new, 26 tests) — scorer tiers incl. edge cases; all three write-sites (explicit override, int coercion, inference defaults); two L1 sort-order proofs (critical > trivial, identity > default) and one end-to-end loop: real `tool_add_drawer` → real backend → read-back → `Layer1.generate()` surfaces the critical drawer first.

## Design decisions

- **Reader untouched.** `layers.py` already reads `importance` → `emotional_weight` → `weight` (default 3.0); this PR only supplies the missing write side, so existing palaces behave exactly as before (key was absent → 3.0; now inferred values sort sensibly).
- **Explicit override always wins.** `importance` is optional on every path, `int` is coerced to `float`, and dispatch is backward-compatible — existing MCP calls that don't pass the key work unchanged (`_call_handler_safe` filters unknown kwargs).
- **Conservative tiers.** A false positive only lands a drawer one tier *high* (still well-behaved at 4.0/5.0); a false negative keeps the 3.0 default. Either way L1 stays monotonic in importance → recency.
- **Version bump / release left to maintainer**, per the usual split of responsibilities.

## Verification

- `ruff check` — all checks passed on every touched file.
- `pytest tests/test_importance.py` — **26/26 passed**.
- Full suite — **4850 passed, 31 skipped, 0 failed**.

## Screenshots / evidence

No UI changes. Behavioral example (from the new tests): a critical drawer ("severe peanut allergy, carry EpiPen") filed *before* a trivial meeting note now sorts **above** it in `Layer1.generate()` output, whereas before both flattened to the 3.0 default and ordering was purely `filed_at`.

Closes #2409.