### PR TITLE
test(mcp): e2e regression guard for #2413 — two sequential writes over HTTP both succeed

### DIFF
--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -627,6 +627,124 @@ def test_writable_http_releases_writer_lease_after_bind_failure(monkeypatch):
     assert mcp._MCP_WRITER_LOCK_CM is None
 
 
+def test_two_sequential_writable_mutations_over_http_both_succeed(http_server, monkeypatch, tmp_path):
+    """Regression for #2413: two sequential mutating tools/call over HTTP.
+
+    The original bug (v3.5.0): the writer-lease re-entrance credit was
+    thread-local (``_palace_lock_holders = threading.local()``). ThreadingHTTPServer
+    serves each request on a fresh thread, so the FIRST mutating call acquired the
+    per-palace lock and held it for process lifetime; the SECOND call — landing on
+    a different handler thread — was not credited as holder, re-opened the lock
+    file, and hit the server's OWN flock → ``MineAlreadyRunning`` naming the
+    server's own PID.
+
+    The fix (PR #1859, landed in 3.9.0): the re-entrance credit is
+    PROCESS-scoped (module-global ``_MCP_WRITER_LOCK_CM`` checked at the top of
+    ``_acquire_mcp_writer_lock``), so handler thread identity is irrelevant.
+
+    This test drives two real ``tools/call`` POSTs to the production
+    ``_build_http_server`` server in writable mode and asserts BOTH succeed.
+    It exercises the full dispatch path:
+        _http_dispatch → (exclusive lock) → handle_request
+          → _mcp_peer_writer_refusal → _acquire_mcp_writer_lock
+              1st call: lease acquired, _MCP_WRITER_LOCK_CM set (process-scoped)
+              2nd call: _MCP_WRITER_LOCK_CM present → (True, "") short-circuit
+          → tool_diary_write → _get_collection → col.add(...)
+    """
+    port, _ = http_server
+
+    # --- writable mode, no peer conflict ---
+    monkeypatch.setattr(mcp, "_READ_ONLY", False)
+    monkeypatch.setattr(
+        mcp, "_MCP_WRITER_READ_ONLY", False
+    )
+    monkeypatch.setattr(
+        mcp, "_MCP_WRITER_LOCK_FAILED", False
+    )
+    monkeypatch.setattr(
+        mcp, "_MCP_WRITER_LOCK_ERROR", ""
+    )
+
+    # --- point config at tmp_path so mine_palace_lock has a real path ---
+    monkeypatch.setattr(
+        type(mcp._config), "palace_path", property(lambda self: str(tmp_path / "palace"))
+    )
+    (tmp_path / "palace").mkdir(parents=True, exist_ok=True)
+
+    # --- record writes via a mock collection ---
+    # Mirror ChromaCollection._write_lock (backends/chroma.py:1881-1907): every
+    # write method re-enters mine_palace_lock(palace_path) for the duration of
+    # the write. This is Site B of the re-entrance chain — the write happens on
+    # a ThreadingHTTPServer worker thread while the process-wide writer lease
+    # (Site A, held from _acquire_mcp_writer_lock) is already in hand. Under the
+    # old thread-local credit (v3.5.0) that worker thread had no re-entrant
+    # credit here, re-acquired the flock, and collided with the server's own
+    # PID -> MineAlreadyRunning. The process-scoped fix short-circuits it.
+    from mempalace.palace import mine_palace_lock
+
+    writes = []
+
+    class _RecordingCollection:
+        def add(self, **kwargs):
+            with mine_palace_lock(str(tmp_path / "palace")):  # Site B re-entrance
+                writes.append(kwargs)
+
+        def count(self):
+            return len(writes)
+
+    monkeypatch.setattr(mcp, "_get_collection", lambda create=False: _RecordingCollection())
+    monkeypatch.setattr(mcp, "_wal_log", lambda *a, **kw: None)
+
+    # --- reset the writer-lease cache so call #1 does a real acquire ---
+    monkeypatch.setattr(mcp, "_MCP_WRITER_LOCK_CM", None)
+    monkeypatch.setattr(mcp, "_MCP_WRITER_ATEXIT_REGISTERED", True)  # skip atexit re-register
+    monkeypatch.setattr(mcp, "_discard_mcp_storage_handles", lambda: None)
+
+    # --- two sequential real HTTP POSTs ---
+    def _diary_call(call_id, entry):
+        return {
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {
+                "name": "mempalace_diary_write",
+                "arguments": {"agent_name": "test-agent", "entry": entry, "topic": "regression"},
+            },
+        }
+
+    # First call: acquires the real writer lease (mine_palace_lock → flock).
+    status, body = _post(port, "/mcp", _diary_call(1, "first write entry"))
+    assert status == 200, f"first call: status={status} body={body[:200]}"
+    first = json.loads(body)
+    assert "error" not in first, f"first call got JSON-RPC error: {first}"
+    first_result = json.loads(first["result"]["content"][0]["text"])
+    assert first_result["success"] is True, f"first call not successful: {first_result}"
+
+    # Second call: lands on a DIFFERENT thread (ThreadingHTTPServer).
+    # With the old thread-local bug, THIS call would see no credit,
+    # re-acquire, and get MineAlreadyRunning naming the server's own PID.
+    # Process-scoped fix: _MCP_WRITER_LOCK_CM is set → short-circuits.
+    status, body = _post(port, "/mcp", _diary_call(2, "second write entry"))
+    assert status == 200, f"second call: status={status} body={body[:200]}"
+    second = json.loads(body)
+    assert "error" not in second, f"second call got JSON-RPC error (self-conflict?): {second}"
+    second_result = json.loads(second["result"]["content"][0]["text"])
+    assert second_result["success"] is True, (
+        f"second call not successful (thread-local re-entrance bug?): {second_result}"
+    )
+
+    # --- both writes landed in the collection ---
+    assert len(writes) == 2, f"expected 2 recorded writes, got {len(writes)}"
+
+    # --- lease held by this process (process-scoped, not thread-local) ---
+    assert mcp._MCP_WRITER_LOCK_CM is not None, (
+        "writer lease should be held after mutations (process-scoped credit)"
+    )
+    # Release it cleanly for teardown (canonical order: discard handles,
+    # clear globals, then __exit__ the context manager).
+    mcp._release_mcp_writer_lock()
+
+
 def _hook_settings_call(req_id):
     return {
         "jsonrpc": "2.0",


### PR DESCRIPTION
Branch: `fix/2413-process-scoped-writer-lease`
Into:   `MemPalace/develop`
SHA:    65e731baf8d088b482d874d493f84d08c1356567
Diff:   1 file changed, 118 insertions(+) — `tests/test_mcp_http_transport.py`

## Problem (#2413)

Reported on v3.5.0: with the HTTP transport in writable mode, the FIRST mutating
`tools/call` acquires the per-palace writer lock and holds it for the process
lifetime; the SECOND call — landing on a different ThreadingHTTPServer worker
thread — got no re-entrance credit (credit was thread-local,
`_palace_lock_holders = threading.local()`), so it re-opened the lock file and hit
the server's OWN flock, returning `MineAlreadyRunning: another mine is in progress
… held by PID <server's own PID>`. The server was colliding with itself.

## Finding

**Both root causes are already fixed and landed in upstream/develop (3.9.0):**

- `faa8643` (PR #1859) — `fix(palace): process-wide mine_palace_lock re-entrancy`.
  Replaces the thread-local holder set with a process-wide credit
  (`_palace_lock_guard` + `_palace_lock_keys` keyed on this process's PID); any
  thread in the holding process short-circuits re-acquisition. This is Site B.
- `9e871b4` — `fix(mcp): self-heal the writer lease instead of latching`. The MCP
  writer lease is no longer sticky-read-only; a failed acquire is re-attempted
  each call instead of latching (self-heal). This is the Site A self-heal.

I confirmed both commits are ancestors of `upstream/develop` via
`git merge-base --is-ancestor`. No open PR currently references #2413.

## What this PR adds (the missing deliverable)

An **e2e regression test** that no other test covered: two sequential mutating
`tools/call` POSTs against the *production* `_build_http_server()` server (writable
mode), asserting BOTH succeed and both writes land. It drives the full dispatch
chain that used to break:

```
_http_dispatch → (exclusive lock) → handle_request
  → _mcp_peer_writer_refusal → _acquire_mcp_writer_lock
        call 1: lease acquired (mine_palace_lock → flock), _MCP_WRITER_LOCK_CM set
        call 2: _MCP_WRITER_LOCK_CM present → short-circuit (no re-acquire)
  → tool_diary_write → _get_collection(create=True) → col.add(...) → mine_palace_lock  ← Site B
```

The mock collection's `add()` re-enters the **real** `mine_palace_lock(path)`
(mirroring `ChromaCollection._write_lock`, backends/chroma.py:1901) on the worker
thread, so Site B is genuinely exercised — not bypassed.

## Mutation proof (the test is a genuine guard, not an accident)

I patched `_palace._held_by_this_process` so the credit is invisible to non-main
threads (simulating the old thread-local credit). Result:

```
under MUTATION: call1 success=False  call2 success=False
  call2 error='another mine is in progress: palace … is held by PID 866221 (…)'
  -> 'both succeed' assertion holds = False   (want False)
MUTATION-PROOF PASS: the e2e test FAILS under the old behavior => genuine regression guard.
```

Under the fix: both calls `success=true`, 2 writes recorded, lease held process-wide.

## Verification

- `pytest tests/test_mcp_http_transport.py::test_two_sequential_writable_mutations_over_http_both_succeed -v` → **1 passed**
- Repeated 5× on fresh ephemeral ports → **1 passed×5** (no locking flakiness)
- `pytest tests/test_mcp_http_transport.py tests/test_palace_locks.py -q` → **59 passed** (up from 58; new test coexists with the existing writable-lease tests)
- `ruff check tests/test_mcp_http_transport.py` → **All checks passed**
- OPSEC sweep of diff → clean (no credential / agent-name / absolute-path leaks)

## Review notes for Bubo

- Test-only change; no production code touched (the fix is already in upstream/develop).
- If preferred, this can be merged directly to `MemPalace/develop` as a regression guard
  and issue #2413 closed with a pointer to `faa8643` + `9e871b4` + this PR.
- Suggested issue close line: "Fixed in 3.9.0 (PR #1859 + self-heal). Regression guard: PR <N>."
