### PR TITLE
fix(chroma): close displaced client before clearing shared System cache (#2375)

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -2604,20 +2604,6 @@ class ChromaBackend(BaseBackend):
             # path); an mtime/appearance change means an external in-place
             # write (closet_llm, mine, compress) that may have drifted the
             # HNSW index while this process was running.
-            if (
-                inode_changed
-                or mtime_changed
-                or (mtime_appeared and palace_path in self._freshness)
-            ):
-                ChromaBackend._quarantined_paths.discard(palace_path)
-                # #2028: the same external change means chromadb's path-keyed
-                # System cache is now stale. Reconstructing PersistentClient
-                # below would reuse the cached System (and its in-memory HNSW
-                # segment), so drop the shared cache first -- otherwise the
-                # rebuilt client persists an outdated index over the on-disk
-                # change. Gated on genuine external change (not first open) so
-                # cold opens never pay the global-evict cost.
-                _clear_chroma_system_cache()
             # Release the client we are about to displace. Each live
             # PersistentClient pins its own copy of every HNSW segment it has
             # opened (``max_elements * size_data_per_element`` bytes -- ~440 MB
@@ -2629,7 +2615,32 @@ class ChromaBackend(BaseBackend):
             # point is invalidated -- which is the intent: the rebuild only
             # fires when the palace changed underneath us, and serving the
             # pre-change segment is the stale-index class of #2002/#2028.
+            #
+            # This must run BEFORE _clear_chroma_system_cache(): PersistentClient
+            # releases its native index memory via ``System.stop()`` -- but it
+            # does so through the shared registry (``SharedSystemClient
+            # ._release_system(self._identifier)`` ), so the registry must still
+            # hold this client's identifier. Clearing the cache first empties
+            # it, so ``close()`` becomes a silent no-op and every external-change
+            # rebuild orphans one HNSW segment set. Closing first lets
+            # ``System.stop()`` actually fire, then we drop the (now empty for
+            # this path) shared System cache so the PersistentClient below is
+            # rebuilt fresh.
             _close_client(self._clients.pop(palace_path, None))
+            # #2028: the same external change means chromadb's path-keyed
+            # System cache is now stale. Reconstructing PersistentClient below
+            # would reuse the cached System (and its in-memory HNSW segment),
+            # so drop the shared cache -- otherwise the rebuilt client persists
+            # an outdated index over the on-disk change. Gated on genuine
+            # external change (not first open) so cold opens never pay the
+            # global-evict cost.
+            if (
+                inode_changed
+                or mtime_changed
+                or (mtime_appeared and palace_path in self._freshness)
+            ):
+                ChromaBackend._quarantined_paths.discard(palace_path)
+                _clear_chroma_system_cache()
             ChromaBackend._prepare_palace_for_open(palace_path)
             cached = chromadb.PersistentClient(path=palace_path)
             self._clients[palace_path] = cached

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -2090,6 +2090,116 @@ def test_chroma_backend_resets_system_cache_on_inode_change(tmp_path, monkeypatc
     ], events
 
 
+def test_chroma_backend_closes_displaced_client_before_clearing_cache(tmp_path, monkeypatch):
+    """#2375: on the rebuild branch ``_client`` must ``close()`` the displaced
+    client BEFORE evicting chromadb's shared ``System`` cache.
+
+    ``PersistentClient.close()`` releases native HNSW segment memory via
+    ``System.stop()``, but it does so through the shared registry, keyed by the
+    client's identifier. ``clear_system_cache()`` empties that registry, so if
+    it runs first the ``close()`` that follows can no longer find the
+    identifier -- ``System.stop()`` is silently skipped and every
+    external-change rebuild orphans one HNSW segment set (the native-index leak
+    in the #2002/#2028 stale-data class). Closing first keeps a long-lived
+    server flat across rebuilds.
+
+    This is the same surface as ``test_chroma_backend_resets_system_cache_on_inode_change``
+    (which pins that a clear fires on a genuine external change) but asserts the
+    *relative* order of close vs clear. Under the pre-fix ordering (clear then
+    close) the rebuild branch emits ``[..., "clear", "close", "open"]`` and this
+    test FAILS; with the fix it emits ``[..., "close", "clear", "open"]``.
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    (palace / "chroma.sqlite3").write_text("")
+
+    events = []
+
+    # Neutralize the on-disk HNSW pre-checks so only cache/close ordering is
+    # exercised (mirrors the sibling #2028 test).
+    for _name in (
+        "_fix_missing_collection_type",
+        "_fix_blob_seq_ids",
+        "quarantine_invalid_hnsw_metadata",
+        "quarantine_stale_hnsw",
+    ):
+        monkeypatch.setattr(f"mempalace.backends.chroma.{_name}", lambda *a, **k: [])
+    monkeypatch.setattr(ChromaBackend, "_quarantined_paths", set())
+
+    monkeypatch.setattr(
+        "mempalace.backends.chroma._close_client", lambda client: events.append("close")
+    )
+
+    from chromadb.api.client import SharedSystemClient
+
+    def _record_clear(*args, **kwargs):
+        events.append("clear")
+
+    monkeypatch.setattr(SharedSystemClient, "clear_system_cache", _record_clear)
+
+    def _record_open(path):
+        events.append("open")
+        return object()
+
+    monkeypatch.setattr("mempalace.backends.chroma.chromadb.PersistentClient", _record_open)
+
+    backend = ChromaBackend()
+    # Same stat pattern as the sibling #2028 test: first open (no prior
+    # freshness -> no external change -> no clear), then an inode change.
+    stats = iter([(1, 1.0), (1, 1.0), (2, 2.0), (2, 2.0)])
+    monkeypatch.setattr(backend, "_db_stat", lambda path: next(stats))
+
+    backend._client(str(palace))  # cold open: close(no-op, first), no clear, open
+    backend._client(str(palace))  # inode 1 -> 2: close(displaced) -> clear -> open
+
+    # Rebuild branch (last three events): close FIRST, then clear, then reopen.
+    # A pre-fix (clear-then-close) ordering would read [..., "clear", "close", "open"].
+    assert events[-3:] == ["close", "clear", "open"], events
+    # And the cold (first) open still pays no clear -- the global-evict cost is
+    # gated to genuine external change, as in the sibling #2028 test.
+    assert events[:2] == ["close", "open"], events
+
+
+def test_chroma_displaced_client_close_stops_system_before_cache_clear(monkeypatch):
+    """#2375 mechanism: closing a ``PersistentClient`` only stops its ``System``
+    (releasing native HNSW memory) if the shared registry still holds the
+    client's identifier. Proves the load-bearing reason close must precede
+    ``clear_system_cache()``: registry clear first -> ``System.stop()`` never
+    called; close first -> ``System.stop()`` fires.
+    """
+    from chromadb.api.client import SharedSystemClient
+
+    stops = []
+
+    class _FakeSystem:
+        def stop(self):
+            stops.append("stopped")
+
+    # Restore the class-level registries after the test regardless of outcome.
+    saved_system = SharedSystemClient._identifier_to_system
+    saved_refcount = SharedSystemClient._identifier_to_refcount
+    ident = "#2375-mechanism"
+    try:
+        # Case A: clear the cache FIRST (the pre-fix ordering), then close.
+        # The identifier is already gone, so close() cannot stop the System.
+        SharedSystemClient._identifier_to_system[ident] = _FakeSystem()
+        SharedSystemClient._identifier_to_refcount[ident] = 1
+        SharedSystemClient.clear_system_cache()
+        SharedSystemClient._release_system(ident)  # what PersistentClient.close() calls
+        assert stops == [], stops  # silent no-op: HNSW set orphaned (the bug)
+
+        # Case B: close FIRST (the fix), then clear the cache.
+        # The identifier is still registered, so close() stops the System.
+        SharedSystemClient._identifier_to_system[ident] = _FakeSystem()
+        SharedSystemClient._identifier_to_refcount[ident] = 1
+        SharedSystemClient._release_system(ident)  # PersistentClient.close()
+        SharedSystemClient.clear_system_cache()
+        assert stops == ["stopped"], stops  # System.stop() fired: native memory released
+    finally:
+        SharedSystemClient._identifier_to_system = saved_system
+        SharedSystemClient._identifier_to_refcount = saved_refcount
+
+
 def test_explain_ef_mismatch_recognizes_chromadb_conflict():
     """When ChromaDB rejects a collection read due to an EF-name mismatch
     (user changed MEMPALACE_EMBEDDING_MODEL on an existing palace), the


### PR DESCRIPTION
## What does this PR do?

Fixes a silent HNSW native-memory leak in the chroma rebuild path (`ChromaBackend._client`).

On the external-change rebuild branch, the displaced `PersistentClient` was released
**after** `_clear_chroma_system_cache()` had already emptied chromadb's shared registry.
`PersistentClient.close()` frees its native index memory through
`SharedSystemClient._release_system(self._identifier)`, but that call needs the client's
identifier to still be registered in `_identifier_to_system` / `_identifier_to_refcount`.
Because the clear ran first, those dicts were already `{}` — so `close()` became a silent
no-op (`_decrement_refcount` returned 0, `pop` returned `None`, `System.stop()` never
fired), and every external-change rebuild orphaned one HNSW segment set. This is the
native-index leak in the same stale-data family as #2002/#2028, and it compounds over a
long-lived server.

The fix reorders the rebuild branch so the displaced client is closed **first** (which
lets `System.stop()` fire and release the native HNSW memory), and only then does it drop
the shared System cache so the freshly constructed `PersistentClient` starts clean. The
gating on *genuine external change* (not first open) is preserved, so cold opens still pay
no global-evict cost. The DB-missing early path and the `close_palace`/`close` paths
already closed-before-cleared and are unchanged.

Two regression tests are added (`tests/test_backends.py`):

1. `test_chroma_backend_closes_displaced_client_before_clearing_cache` — pins the
   relative close-then-clear ordering on the rebuild branch. Under the old ordering it
   emits `[..., "clear", "close", "open"]` and **fails**; with the fix it emits
   `[..., "close", "clear", "open"]` and passes.
2. `test_chroma_displaced_client_close_stops_system_before_cache_clear` — proves the
   load-bearing mechanism against the shared registry directly: close-before-clear
   triggers `System.stop()`, clear-before-close does not (the bug).

Scope: `mempalace/backends/chroma.py` (reorder in `_client`, rebuild branch only) and one
new test block in `tests/test_backends.py`. No API, config, or dependency changes.

## How to test

```bash
pip install -e ".[dev]"

# Regression tests (both must pass; the ordering test fails on the pre-fix code):
python -m pytest tests/test_backends.py::test_chroma_backend_closes_displaced_client_before_clearing_cache \
                  tests/test_backends.py::test_chroma_displaced_client_close_stops_system_before_cache_clear -v

# Full suite + coverage gate (CI command):
python -m pytest tests/ -v --ignore=tests/benchmarks --cov=mempalace --cov-report=term-missing --cov-fail-under=80

# Lint / format (pinned ruff 0.16.1):
ruff check .
ruff format --check .
```

Verified locally (chromadb 1.5.7, ruff 0.16.1, Python 3.12): `ruff check .` clean,
`ruff format --check .` clean, full suite green (one pre-existing, unrelated
locale/path-encoding failure in `tests/test_repair.py` reproduces identically on the
`upstream/develop` baseline with this change stashed), and coverage 81.91% (≥ 80% gate).

## Checklist
- [x] Tests pass (`python -m pytest tests/ -v`)
- [x] No hardcoded paths
- [x] Linter passes (`ruff check .`)
