### PR TITLE
fix(kg): return source_file from query_entity

### DIFF
--- a/mempalace/knowledge_graph.py
+++ b/mempalace/knowledge_graph.py
@@ -525,6 +525,7 @@ class KnowledgeGraph:
                             "valid_to": row["valid_to"],
                             "confidence": row["confidence"],
                             "source_closet": row["source_closet"],
+                            "source_file": row["source_file"],
                             "current": row["valid_to"] is None,
                         }
                     )
@@ -547,6 +548,7 @@ class KnowledgeGraph:
                             "valid_to": row["valid_to"],
                             "confidence": row["confidence"],
                             "source_closet": row["source_closet"],
+                            "source_file": row["source_file"],
                             "current": row["valid_to"] is None,
                         }
                     )

--- a/tests/test_knowledge_graph_metadata.py
+++ b/tests/test_knowledge_graph_metadata.py
@@ -126,3 +126,39 @@ class TestStatsMetadata:
         stats = kg.stats()
 
         assert stats["relationship_types"] == ["loves", "works_at"]
+class TestQueryEntityProvenance:
+    """query_entity must return the source_file it was given (#kg-provenance)."""
+
+    def test_outgoing_fact_returns_source_file(self, kg):
+        kg.add_triple(
+            "Alice",
+            "works_on",
+            "mempalace",
+            valid_from="2026-01-01",
+            source_file="notes/alice.md",
+        )
+
+        (fact,) = kg.query_entity("Alice", direction="outgoing")
+
+        assert fact["source_file"] == "notes/alice.md"
+        assert fact["source_closet"] is None
+
+    def test_incoming_fact_returns_source_file(self, kg):
+        kg.add_triple(
+            "Alice",
+            "works_on",
+            "mempalace",
+            valid_from="2026-01-01",
+            source_file="notes/alice.md",
+        )
+
+        (fact,) = kg.query_entity("mempalace", direction="incoming")
+
+        assert fact["source_file"] == "notes/alice.md"
+
+    def test_source_file_is_none_when_not_supplied(self, kg):
+        kg.add_triple("Bob", "likes", "chess", valid_from="2026-01-01")
+
+        (fact,) = kg.query_entity("Bob", direction="outgoing")
+
+        assert fact["source_file"] is None


### PR DESCRIPTION
`query_entity()` builds its result dicts with `source_closet` but not `source_file`, so `kg_query` drops the provenance that `kg_add` stored. The `triples` table holds both columns and the row is already selected with `SELECT t.*`, so the value is fetched and then discarded.

`source_closet` is null for any fact added directly rather than mined from a closet, which makes `source_file` the only provenance a manually-added fact can carry. Callers reading `kg_query` output have no way to tell where such a fact came from.

This adds `source_file` to both the outgoing and incoming result dicts, matching the field already accepted by `add_triple` and exposed by the `kg_add` MCP tool.

### Tests

Three regression tests in `tests/test_knowledge_graph_metadata.py` cover the outgoing edge, the incoming edge, and the not-supplied-is-None case. All three fail with `KeyError: 'source_file'` without the two-line change and pass with it. The wider knowledge-graph suite (70 tests) passes unchanged.
