### PR TITLE
fix: paginate diary reads past 10k entries

### DIFF
--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -1833,6 +1833,7 @@ _taxonomy_cache = None
 _taxonomy_cache_time = 0.0
 _TAXONOMY_CACHE_TTL = 5.0  # seconds — same idea as the palace-graph cache
 _MAX_RESULTS = 100  # upper bound for search/list limit params
+_DIARY_READ_PAGE_SIZE = 1000
 
 
 def _invalidate_overview_caches():
@@ -4429,35 +4430,54 @@ def tool_diary_read(agent_name: str, last_n: int = 10, wing: str = ""):
         conditions.insert(0, {"wing": wing})
 
     try:
-        results = col.get(
-            where={"$and": conditions},
-            include=["documents", "metadatas"],
-            limit=10000,
-        )
-
-        if not results["ids"]:
-            return {"agent": agent_name, "entries": [], "message": "No diary entries yet."}
-
-        # Combine and sort by timestamp
+        where = {"$and": conditions}
         entries = []
-        for doc, meta in zip(results["documents"], results["metadatas"]):
-            meta = _safe_meta(meta)
-            entries.append(
-                {
-                    "date": meta.get("date", ""),
-                    "timestamp": meta.get("filed_at", ""),
-                    "topic": meta.get("topic", ""),
-                    "content": doc,
-                }
-            )
+        total = 0
+        offset = 0
 
-        entries.sort(key=lambda x: x["timestamp"], reverse=True)
-        entries = entries[:last_n]
+        while True:
+            results = col.get(
+                where=where,
+                include=["documents", "metadatas"],
+                limit=_DIARY_READ_PAGE_SIZE,
+                offset=offset,
+            )
+            batch_ids = _chroma_field(results, "ids", []) or []
+            if not batch_ids:
+                break
+
+            documents = _chroma_field(results, "documents", []) or []
+            metadatas = _chroma_field(results, "metadatas", []) or []
+            total += len(batch_ids)
+
+            for index in range(len(batch_ids)):
+                doc = documents[index] if index < len(documents) else ""
+                meta = _safe_meta(metadatas[index] if index < len(metadatas) else None)
+                entries.append(
+                    {
+                        "date": meta.get("date", ""),
+                        "timestamp": meta.get("filed_at", ""),
+                        "topic": meta.get("topic", ""),
+                        "content": doc,
+                    }
+                )
+
+            # Keep memory bounded while scanning: only candidates for the
+            # final newest-N result need to survive into the next page.
+            entries.sort(key=lambda x: x["timestamp"], reverse=True)
+            del entries[last_n:]
+
+            offset += len(batch_ids)
+            if len(batch_ids) < _DIARY_READ_PAGE_SIZE:
+                break
+
+        if total == 0:
+            return {"agent": agent_name, "entries": [], "message": "No diary entries yet."}
 
         return {
             "agent": agent_name,
             "entries": entries,
-            "total": len(results["ids"]),
+            "total": total,
             "showing": len(entries),
         }
     except Exception:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4377,6 +4377,54 @@ class TestDiaryTools:
         r = tool_diary_read(agent_name="Nobody")
         assert r["entries"] == []
 
+    def test_diary_read_pages_past_10000_and_returns_true_latest(self, monkeypatch, config, kg):
+        """Entries beyond the old 10k cap must affect both recency and total."""
+        _patch_mcp_server(monkeypatch, config, kg)
+        from mempalace import mcp_server
+
+        class PagedDiaryCollection:
+            total = 10001
+
+            def __init__(self):
+                self.calls = []
+
+            def get(self, *, where, include, limit, offset):
+                self.calls.append(
+                    {"where": where, "include": include, "limit": limit, "offset": offset}
+                )
+                stop = min(offset + limit, self.total)
+                indices = range(offset, stop)
+                return {
+                    "ids": [f"diary-{index}" for index in indices],
+                    "documents": [f"entry-{index}" for index in indices],
+                    "metadatas": [
+                        {
+                            "filed_at": f"2026-01-01T00:00:00.{index:06d}Z",
+                            "date": "2026-01-01",
+                            "topic": "pagination",
+                        }
+                        for index in indices
+                    ],
+                }
+
+        collection = PagedDiaryCollection()
+        monkeypatch.setattr(mcp_server, "_get_collection", lambda: collection)
+
+        result = mcp_server.tool_diary_read(agent_name="TestAgent", last_n=10)
+
+        assert result["total"] == 10001
+        assert result["showing"] == 10
+        assert [entry["content"] for entry in result["entries"]] == [
+            f"entry-{index}" for index in range(10000, 9990, -1)
+        ]
+        assert len(collection.calls) == 11
+        assert all(call["limit"] == 1000 for call in collection.calls)
+        assert [call["offset"] for call in collection.calls] == list(range(0, 11000, 1000))
+        assert all(
+            call["where"] == {"$and": [{"room": "diary"}, {"agent": "testagent"}]}
+            for call in collection.calls
+        )
+
     def test_diary_write_same_second_shared_prefix_no_collision(
         self, monkeypatch, config, palace_path, kg
     ):


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining live part of #563 on current `develop`: `mempalace_diary_read` silently stopped seeing new entries after an agent's filtered diary scope exceeded 10,000 rows.

Previously, the tool fetched at most 10,000 records and only then sorted by `filed_at`. Because backend `get()` order is not timestamp order, entries beyond that cap could never appear in the returned “latest” entries, and `total` was incorrectly capped at 10,000.

This change:

- Pages through matching diary records in bounded batches of 1,000.
- Keeps only the newest `last_n` entries between pages, bounding application memory to one page plus at most 100 retained entries.
- Counts every matching record so `total` is exact.
- Leaves the existing agent and optional wing filtering behavior unchanged.
- Adds a 10,001-record regression test proving the newest records past the old boundary are returned.

This supersedes the remaining diary-read hunk of #563. The four navigation hunks from that PR are already covered by the backend-aware metadata path on `develop`.

## How to test

```bash
uv sync --extra dev
uv run pytest tests/test_mcp_server.py::TestDiaryTools -v
uv run ruff check .
uv run ruff format --check .
```

The full non-benchmark suite was also run locally: 4,841 passed and 57 skipped. Twenty unrelated storage tests failed under the local SQLite/Chroma build (FTS shadow-table mutation and WAL cleanup); all diary tests and repository-wide lint/format checks passed.

## Checklist
- [x] Targeted tests pass (`uv run pytest tests/test_mcp_server.py::TestDiaryTools -v`)
- [x] No hardcoded paths
- [x] Linter passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
