### PR TITLE
fix(mcp): distinguish writer setup failures and forward writes to hub

### DIFF
--- a/mempalace/backends/registry.py
+++ b/mempalace/backends/registry.py
@@ -32,6 +32,21 @@ _discovered = False
 _lock = Lock()
 
 
+class BackendUnavailableError(KeyError):
+    """A selected backend is not registered in this Python process."""
+
+    def __init__(self, name: str, available: list[str]):
+        self.name = name
+        self.available = available
+        super().__init__(
+            f"unknown backend {name!r}; available: {available}. "
+            "Check --backend, ~/.mempalace/config.json backend, and "
+            "MEMPALACE_BACKEND. Select the backend matching the existing storage "
+            "or install its backend package into the MCP server's Python environment "
+            "and restart the MCP server to discover it. No fallback was selected."
+        )
+
+
 def register(name: str, backend_cls: Type[BaseBackend]) -> None:
     """Register ``backend_cls`` under ``name``.
 
@@ -103,7 +118,7 @@ def get_backend_class(name: str) -> Type[BaseBackend]:
     try:
         return _registry[name]
     except KeyError as e:
-        raise KeyError(f"unknown backend {name!r}; available: {available_backends()}") from e
+        raise BackendUnavailableError(name, available_backends()) from e
 
 
 def get_backend(name: str) -> BaseBackend:
@@ -119,7 +134,7 @@ def get_backend(name: str) -> BaseBackend:
             return inst
         cls = _registry.get(name)
         if cls is None:
-            raise KeyError(f"unknown backend {name!r}; available: {sorted(_registry.keys())}")
+            raise BackendUnavailableError(name, sorted(_registry.keys()))
         inst = cls()
         _instances[name] = inst
         return inst

--- a/mempalace/mcp_light_server.py
+++ b/mempalace/mcp_light_server.py
@@ -942,7 +942,12 @@ def dispatch_light_stdio_request(request: Dict[str, Any]) -> Optional[Dict[str, 
         if rewritten is not None:
             forwarded = {k: v for k, v in rewritten.items() if not k.startswith("_")}
             underlying = ((forwarded.get("params") or {}).get("name")) or ""
-            refusal = mcp_server._mcp_tool_preflight_refusal(request.get("id"), underlying)
+            # The destination owns the lease: hub forwarding must not first
+            # compete for the hub's local writer lock. Local dispatch still
+            # runs the full gate inside handle_request, as does the hub.
+            refusal = mcp_server._mcp_tool_preflight_refusal(
+                request.get("id"), underlying, check_writer=False
+            )
             if refusal is not None:
                 return refusal
             try:

--- a/mempalace/mcp_server.py
+++ b/mempalace/mcp_server.py
@@ -721,7 +721,7 @@ def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     """Acquire this process's per-palace MCP writer lease.
 
     Returns (True, "") when this process may write. Returns (False, reason)
-    when another live writer already owns the per-palace lease.
+    when another writer owns the lease or writer initialization fails.
 
     Self-healing: a server that came up read-only (a peer held the lease at
     startup) RE-ATTEMPTS the non-blocking flock on every subsequent call.
@@ -745,6 +745,10 @@ def _acquire_mcp_writer_lock() -> tuple[bool, str]:
     # backend mismatch can be corrected, and lock-directory permissions can be
     # repaired while this long-lived stdio host remains alive. Each mutating
     # request therefore gets a fresh ownership attempt.
+
+    _MCP_WRITER_READ_ONLY = False
+    _MCP_WRITER_LOCK_FAILED = False
+    _MCP_WRITER_LOCK_ERROR = ""
 
     try:
         from .palace import (
@@ -813,12 +817,18 @@ def _mcp_peer_writer_refusal(req_id, tool_name: str):
         "id": req_id,
         "error": {
             "code": -32001,
-            "message": "Peer MCP writer active; this server is read-only for mutating tools",
+            "message": (
+                "MCP writer initialization failed; this server is read-only for mutating tools"
+                if _MCP_WRITER_LOCK_FAILED
+                else "Peer MCP writer active; this server is read-only for mutating tools"
+            ),
             "data": {
                 "tool": tool_name,
                 "palace": _config.palace_path,
                 "reason": reason,
-                "override_env": _MCP_ALLOW_PEER_WRITER_ENV,
+                "failure_kind": (
+                    "initialization_failed" if _MCP_WRITER_LOCK_FAILED else "peer_contention"
+                ),
             },
         },
     }
@@ -6708,7 +6718,7 @@ def _mcp_stale_library_refusal(req_id, tool_name: str):
     }
 
 
-def _mcp_tool_preflight_refusal(req_id, tool_name: str):
+def _mcp_tool_preflight_refusal(req_id, tool_name: str, *, check_writer: bool = True):
     """Run MCP request preflight gates outside handle_request complexity."""
 
     read_only_error = _mcp_read_only_refusal(req_id, tool_name)
@@ -6737,7 +6747,7 @@ def _mcp_tool_preflight_refusal(req_id, tool_name: str):
     if diverged_index_error is not None:
         return diverged_index_error
 
-    return _mcp_peer_writer_refusal(req_id, tool_name)
+    return _mcp_peer_writer_refusal(req_id, tool_name) if check_writer else None
 
 
 def _decorate_mcp_tool_result(tool_name: str, result):

--- a/tests/test_mcp_writer_diagnostics.py
+++ b/tests/test_mcp_writer_diagnostics.py
@@ -1,0 +1,151 @@
+"""Writer setup failures must not impersonate observed lease contention."""
+
+import json
+
+import pytest
+
+from mempalace import mcp_server as mcp, palace
+
+
+@pytest.fixture
+def isolated_writer(monkeypatch, tmp_path):
+    from mempalace.config import MempalaceConfig
+
+    monkeypatch.setattr(mcp, "_config", MempalaceConfig(palace_path=tmp_path / "palace"))
+    for name, value in (
+        ("_MCP_WRITER_LOCK_CM", None),
+        ("_MCP_WRITER_READ_ONLY", False),
+        ("_MCP_WRITER_LOCK_FAILED", False),
+        ("_MCP_WRITER_LOCK_ERROR", ""),
+    ):
+        monkeypatch.setattr(mcp, name, value)
+    monkeypatch.setattr(mcp, "_discard_mcp_storage_handles", lambda: None)
+    monkeypatch.delenv(mcp._MCP_ALLOW_PEER_WRITER_ENV, raising=False)
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    monkeypatch.delenv(palace._EXPLICIT_BACKEND_ENV, raising=False)
+    yield tmp_path
+    mcp._release_mcp_writer_lock()
+
+
+def test_unavailable_backend_refusal_and_recovery(isolated_writer, monkeypatch):
+    monkeypatch.setenv("MEMPALACE_BACKEND", "unregistered_test_backend")
+    result = mcp._mcp_peer_writer_refusal(1, "mempalace_add_drawer")
+    error = result["error"]
+    assert "Peer MCP writer active" not in error["message"]
+    assert "unregistered_test_backend" in error["data"]["reason"]
+    assert "sqlite_exact" in error["data"]["reason"]
+    assert "restart" in error["data"]["reason"]
+    assert not (isolated_writer / "palace").exists()
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    assert mcp._mcp_peer_writer_refusal(2, "mempalace_add_drawer") is None
+    assert mcp._MCP_WRITER_LOCK_CM is not None
+
+
+def test_contention_then_setup_failure_has_fresh_diagnostic(isolated_writer, monkeypatch):
+    def busy(*args, **kwargs):
+        raise palace.MineAlreadyRunning("synthetic peer")
+
+    monkeypatch.setattr(palace, "mine_palace_lock", busy)
+    result = mcp._mcp_peer_writer_refusal(1, "mempalace_add_drawer")
+    assert "Peer MCP writer active" in result["error"]["message"]
+    monkeypatch.setenv("MEMPALACE_BACKEND", "unregistered_test_backend")
+    result = mcp._mcp_peer_writer_refusal(2, "mempalace_add_drawer")
+    assert "Peer MCP writer active" not in result["error"]["message"]
+    assert not mcp._MCP_WRITER_READ_ONLY
+
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    result = mcp._mcp_peer_writer_refusal(3, "mempalace_add_drawer")
+    assert result["error"]["data"]["failure_kind"] == "peer_contention"
+    assert not mcp._MCP_WRITER_LOCK_FAILED
+
+
+def test_lock_setup_error_does_not_claim_contention(isolated_writer, monkeypatch):
+    def denied(*args, **kwargs):
+        raise PermissionError("synthetic permission failure")
+
+    monkeypatch.setattr(palace, "mine_palace_lock", denied)
+    result = mcp._mcp_peer_writer_refusal(1, "mempalace_add_drawer")
+    assert result["error"]["data"]["failure_kind"] == "initialization_failed"
+    assert "synthetic permission failure" in result["error"]["data"]["reason"]
+    assert "Peer MCP writer active" not in result["error"]["message"]
+
+
+def test_light_dispatch_writes_and_reads_after_config_repair(isolated_writer, monkeypatch, kg):
+    from mempalace import mcp_light_server
+    from mempalace.backends import embedding_wrapper
+
+    monkeypatch.setattr(mcp, "_get_kg", lambda *a, **kw: kg)
+    monkeypatch.setattr(mcp, "_READ_ONLY", False)
+    monkeypatch.setattr(mcp, "_vector_disabled", False)
+    monkeypatch.setattr(mcp, "_hub_proxy_target", lambda: None)
+    for name in (
+        "_collection_cache",
+        "_client_cache",
+        "_collection_cache_backend",
+        "_collection_cache_palace",
+        "_collection_open_error",
+    ):
+        monkeypatch.setattr(mcp, name, None)
+    monkeypatch.setattr(
+        embedding_wrapper, "_embed_texts", lambda texts: [[1.0, 0.0] for _ in texts]
+    )
+
+    def call(name, arguments):
+        return mcp_light_server.dispatch_light_stdio_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+
+    args = {
+        "action": "add_drawer",
+        "wing": "synthetic",
+        "room": "verification",
+        "content": "Synthetic durable write verification.",
+    }
+    monkeypatch.setenv("MEMPALACE_BACKEND", "unregistered_test_backend")
+    refused = call("palace_exec", args)
+    assert refused["error"]["data"]["failure_kind"] == "initialization_failed"
+    monkeypatch.setenv("MEMPALACE_BACKEND", "sqlite_exact")
+    written = call("palace_exec", args)
+    result = json.loads(written["result"]["content"][0]["text"])
+    assert result["success"], result
+    read = call("palace_query", {"target": "drawer", "drawer_id": result["drawer_id"]})
+    drawer = json.loads(read["result"]["content"][0]["text"])
+    assert drawer["content"] == args["content"]
+
+
+def test_light_hub_forward_does_not_acquire_local_writer(isolated_writer, monkeypatch):
+    from mempalace import mcp_light_server
+
+    monkeypatch.setattr(mcp, "_hub_proxy_target", lambda: ("http://127.0.0.1:9", {}))
+    monkeypatch.setattr(
+        mcp,
+        "_acquire_mcp_writer_lock",
+        lambda: pytest.fail("Client must not acquire the hub's writer lease"),
+    )
+    monkeypatch.setattr(
+        mcp,
+        "_forward_request_to_hub",
+        lambda *a: {"jsonrpc": "2.0", "id": 1, "result": {"content": []}},
+    )
+    result = mcp_light_server.dispatch_light_stdio_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "palace_exec",
+                "arguments": {
+                    "action": "add_drawer",
+                    "wing": "synthetic",
+                    "room": "verification",
+                    "content": "Synthetic",
+                },
+            },
+        }
+    )
+    assert "result" in result


### PR DESCRIPTION
## What does this PR do?

An unavailable selected backend was reported as an active peer writer, even when backend validation failed before lease acquisition. Report initialization failures separately from observed contention, reset diagnostic flags on each ownership attempt, and include backend configuration/package recovery guidance while retaining KeyError compatibility.

The lightweight MCP client also attempted to acquire the local writer lease before forwarding to a live HTTP hub. Defer that lease check to the destination so the hub can accept writes while retaining ownership. Local dispatch still runs the complete writer gate, and the client retains its other preflight checks. No storage fallback or lock bypass is introduced.

## How to test

Run the scoped MCP and backend suite:

```sh
python -m pytest tests/test_mcp_writer_diagnostics.py tests/test_mcp_server.py tests/test_mcp_light_server.py tests/test_mcp_http_transport.py tests/test_backends.py -q --no-cov -k 'not test_startup_baseline_survives_module_reload'
```

Result on the latest develop base: **573 passed, 11 skipped, 1 deselected**.

The excluded test fails in this Windows environment because its isolated `python -I` subprocess cannot import the user-installed package. The full repository suite was not run.

Five new regressions cover unavailable-backend recovery, changing failure states, permission failures, synthetic durable write/read-back, and hub forwarding without acquiring the client-side writer lease. A restarted lightweight connector also completed a live durable write and exact read-back through the existing HTTP writer.

## Checklist

- [x] Scoped MCP/backend tests pass (command above; full suite not run)
- [x] No machine-specific paths or private report content added
- [x] Ruff lint and format checks pass for all four changed files
- [x] Git diff whitespace check passes

