### PR TITLE
fix(mine): resolve relative daemon source against the caller's cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Bug Fixes
 
 - **The transcript-path fallback no longer gives every git worktree its own wing.** `_wing_from_transcript_path`'s primary path (reading `cwd` from the JSONL) already collapsed a `<project>/.claude/worktrees/<wt>` segment before deriving the wing; the fallback path, used whenever `cwd` is absent, had no equivalent strip, so the flattened `--claude-worktrees-<wt>` segment survived into the wing name. Applied the same collapse there. (#2388)
+- **`mempalace mine --daemon` no longer mines the daemon's own working directory instead of the caller's.** The daemon is a long-lived background process that keeps whatever cwd it happened to start with, so a relative source (`mempalace mine .`) submitted to it resolved against that stale cwd rather than the directory the CLI call actually ran from, silently mining the wrong project into the wrong wing on every subsequent hook-driven call. `cmd_mine` now resolves the source to an absolute path before it enters the daemon job payload, matching the resolution `_forward_mine_to_hub` already does for the hub-forwarding path. (#2441)
 
 ---
 

--- a/mempalace/cli/cmd_mine.py
+++ b/mempalace/cli/cmd_mine.py
@@ -17,7 +17,7 @@ def cmd_mine(args):
 
     if getattr(args, "daemon", False):
         payload = {
-            "source": args.dir,
+            "source": os.path.abspath(os.path.expanduser(args.dir)),
             "mode": mode,
             "wing": args.wing,
             "agent": args.agent,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -743,6 +743,44 @@ def test_cmd_mine_daemon_background_submits_job(mock_config_cls, capsys):
 
 
 @patch("mempalace.cli.MempalaceConfig")
+def test_cmd_mine_daemon_resolves_relative_source_against_caller_cwd(
+    mock_config_cls, tmp_path, monkeypatch
+):
+    """#2441: the daemon outlives this process and keeps its own cwd, so a
+    relative source has to be resolved here, against the caller's cwd, before
+    it enters the payload. _forward_mine_to_hub already does this for the hub
+    path; the daemon path did not."""
+    mock_config_cls.return_value.palace_path = "/fake/palace"
+    monkeypatch.chdir(tmp_path)
+    expected_source = os.getcwd()
+    args = argparse.Namespace(
+        dir=".",
+        palace=None,
+        mode="projects",
+        wing=None,
+        agent="mempalace",
+        limit=0,
+        dry_run=False,
+        no_gitignore=False,
+        include_ignored=[],
+        extract="exchange",
+        daemon=True,
+        background=True,
+        backend=None,
+        global_backend=None,
+        max_chunks_per_file=None,
+        redetect_origin=False,
+    )
+    with patch("mempalace.daemon.submit_job", return_value={"id": "job-1"}) as mock_submit:
+        with patch("mempalace.miner.mine") as mock_mine:
+            cmd_mine(args)
+
+    mock_mine.assert_not_called()
+    payload = mock_submit.call_args.args[1]
+    assert payload["source"] == expected_source
+
+
+@patch("mempalace.cli.MempalaceConfig")
 def test_cmd_mine_daemon_lock_deferral_reports_a_runnable_command(mock_config_cls, capsys):
     """A foreground mine refused the palace lock must say so and hand back a
     command that actually works. --palace is global, so it has to be echoed back


### PR DESCRIPTION
`cmd_mine`'s `--daemon` path put the raw `args.dir` straight into the job payload's `source` field. The daemon is a long-lived process with its own cwd, set once at whatever moment it happened to autostart, so a relative source like `.` resolved against that stale cwd instead of the directory the CLI call actually ran from. Every hook-driven mine after the daemon appeared indexed one fixed directory into whatever wing the caller thought it was mining into.

`_forward_mine_to_hub` already resolves the same field with `os.path.abspath(os.path.expanduser(args.dir))` before handing a mine to the palace hub; the daemon path just never got the same treatment. This applies that one line to the daemon payload too.

Added a test that chdirs into a tmp dir, submits `mine . --daemon --background`, and asserts the payload's `source` is the resolved absolute path: fails on `develop` (asserts `.` against the tmp dir), passes with the fix.

`cmd_sync`'s daemon payload has the identical unresolved `args.dir` field. Didn't touch it here since issue #2441 is specifically about `mine`, but it's the same shape if you want it as a follow-up.

Fixes #2441
