### PR TITLE
fix(daemon): keep a live daemon's registration when the health probe fails

### DIFF
--- a/mempalace/daemon.py
+++ b/mempalace/daemon.py
@@ -1271,6 +1271,29 @@ def _detached_kwargs(log_path: Path) -> dict[str, Any]:
     return kwargs
 
 
+def _registered_pid(palace_path: str) -> int | None:
+    """Pid recorded by the last daemon that registered for ``palace_path``.
+
+    Reads ``endpoint.json`` first (written together with the pid file by
+    ``run_server``), then the bare pid file, so a partially written
+    registration still yields the pid. Returns None when nothing is registered
+    or the value is not an int.
+    """
+    try:
+        pid = _read_endpoint(palace_path).get("pid")
+    except DaemonError:
+        pid = None
+    if pid is None:
+        try:
+            pid = pid_path(palace_path).read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+    try:
+        return int(pid)
+    except (TypeError, ValueError):
+        return None
+
+
 def start_daemon(
     palace_path: str,
     *,
@@ -1310,6 +1333,19 @@ def start_daemon(
                 return existing
             # The other starter failed without bringing the daemon up; fall
             # through and spawn ourselves (we now hold the lock).
+
+    # The health probe above can fail while the registered daemon is alive but
+    # busy (a long mine) or wedged. Its process still owns the palace lock, so
+    # a replacement would die at startup -- and unlinking the registration
+    # first would leave the live owner unreachable (#2442). Refuse instead of
+    # spawning; ``daemon stop`` is the explicit way to replace it.
+    registered_pid = _registered_pid(palace_path)
+    if registered_pid is not None and _pid_alive(registered_pid):
+        raise DaemonError(
+            f"daemon pid {registered_pid} is running but did not answer the "
+            "health probe (busy or wedged); not starting a second one. "
+            "Retry later or run `mempalace daemon stop` first."
+        )
 
     for stale in (endpoint_path(palace_path), pid_path(palace_path)):
         try:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sqlite3
 import subprocess
@@ -1531,3 +1532,57 @@ def test_detached_kwargs_windows(tmp_path, monkeypatch):
         assert "start_new_session" not in kwargs
     finally:
         fh.close()
+
+
+# --- #2442: start_daemon must not deregister a live daemon ---
+
+
+def _fake_registration(tmp_path, monkeypatch, pid):
+    monkeypatch.setenv(daemon.STATE_ROOT_ENV, str(tmp_path / "state"))
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    daemon.ensure_token(str(palace))
+    sd = daemon.state_dir(str(palace))
+    sd.mkdir(parents=True, exist_ok=True)
+    daemon.endpoint_path(str(palace)).write_text(
+        json.dumps({"host": "127.0.0.1", "port": 1, "pid": pid}), encoding="utf-8"
+    )
+    daemon.pid_path(str(palace)).write_text(f"{pid}\n", encoding="utf-8")
+    # The registered daemon is busy: the health probe times out.
+    monkeypatch.setattr(daemon, "get_client_if_running", lambda *a, **kw: None)
+    return palace
+
+
+def test_start_daemon_refuses_to_replace_a_live_but_busy_daemon(tmp_path, monkeypatch):
+    palace = _fake_registration(tmp_path, monkeypatch, os.getpid())
+
+    def fail_popen(*a, **kw):
+        raise AssertionError("must not spawn a replacement while the registered pid is alive")
+
+    monkeypatch.setattr(daemon.subprocess, "Popen", fail_popen)
+
+    with pytest.raises(daemon.DaemonError, match="busy or wedged"):
+        daemon.start_daemon(str(palace), timeout=0.05)
+
+    # Registration is intact, so the live owner stays reachable once it answers again.
+    assert daemon.endpoint_path(str(palace)).exists()
+    assert daemon.pid_path(str(palace)).exists()
+
+
+def test_start_daemon_replaces_a_dead_registration(tmp_path, monkeypatch):
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    palace = _fake_registration(tmp_path, monkeypatch, dead.pid)
+    spawned = []
+
+    def fake_popen(*a, **kw):
+        spawned.append(a)
+        assert not daemon.endpoint_path(str(palace)).exists()
+        assert not daemon.pid_path(str(palace)).exists()
+        raise OSError("stop here")
+
+    monkeypatch.setattr(daemon.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(OSError, match="stop here"):
+        daemon.start_daemon(str(palace), timeout=0.05)
+    assert spawned


### PR DESCRIPTION
## Summary

Fixes #2442

`start_daemon` unlinked `endpoint.json` and the `pid` file unconditionally once `get_client_if_running` returned `None`, then spawned a replacement. When the probe failed only because the registered daemon was busy with a long mine (hook probes use `HOOK_PROBE_TIMEOUT = 0.5s`) or wedged, the recorded pid was still alive and still owned `mine_palace_lock`: the replacement died at startup and the live owner was left without a registration, so `daemon status` reported "not running" while the original `serve` process kept running.

## Change

- New `_registered_pid()` reads the pid from `endpoint.json` (falling back to the pid file).
- `start_daemon` checks that pid with `_pid_alive` before touching the registration. If it is alive, it refuses to spawn and raises `DaemonError("daemon pid N is running but did not answer the health probe (busy or wedged); not starting a second one. Retry later or run `mempalace daemon stop` first.")`. The CLI already prints `DaemonError` as `mempalace: daemon error: …` and exits 1; `ensure_client` propagates it the same way.
- A dead registered pid is cleaned up and replaced exactly as before.

## Tests

`tests/test_daemon.py`:
- `test_start_daemon_refuses_to_replace_a_live_but_busy_daemon` – registration pointing at the test's own pid, probe returns `None`: `start_daemon` raises, `Popen` is never called, `endpoint.json` and `pid` are still there. Fails on `develop`.
- `test_start_daemon_replaces_a_dead_registration` – registration pointing at an exited child pid: files are removed and the spawn proceeds.

```
pytest tests/test_daemon.py -q   # 58 passed
ruff check / ruff format --check  # clean
```
