### PR TITLE
ci: sync ruff pins in ci.yml and pre-commit with pyproject.toml (0.16.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       # dependabot bump to the pin there passes CI without the new version
       # ever running. test_ruff_pins_match asserts the two stay equal, and
       # also covers the pre-commit config's ruff rev (all three must agree).
-      - run: pip install "ruff==0.16.1"
+      - run: pip install "ruff==0.16.6"
       - run: ruff check .
       - run: ruff format --check .
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     # ([project.optional-dependencies].dev / [dependency-groups].dev) and
     # .github/workflows/ci.yml. A different ruff here produces different
     # formatter output than CI and breaks `ruff format --check` in lint.
-    rev: v0.16.1
+    rev: v0.16.6
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
## Summary

Dependabot #2483 bumped `pyproject.toml` to `ruff==0.16.6`, but the lint job in `.github/workflows/ci.yml` and the `rev` in `.pre-commit-config.yaml` stayed at 0.16.1. `tests/test_version_consistency.py::test_ruff_pins_match` exists precisely to catch this, and it has been failing on `develop` since 1e05230 — which is why every open PR currently shows `UNSTABLE`.

Bumps both pins together as the test requires. No other changes.

## Verification

- `pytest tests/test_version_consistency.py` → 4 passed
- `ruff check .` / `ruff format --check .` unchanged (0.16.6 is what `pyproject.toml` already asks for)

Once this merges, open PRs need a re-run against `develop` before their check status means anything.

https://claude.ai/code/session_019aXnb6yiNE8rogs81dj7Un
