### PR TITLE
fix(sqlite): read a WAL palace whose sidecars are gone

### DIFF
--- a/mempalace/backends/chroma.py
+++ b/mempalace/backends/chroma.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 import chromadb
 from chromadb.errors import NotFoundError as _ChromaNotFoundError
 
-from ..config import sqlite_read_uri
+from ..config import connect_sqlite_read
 from ._sidecar import EMBEDDER_SIDECAR_FILENAME, read_embedder_sidecar, write_embedder_sidecar
 from .base import (
     BaseBackend,
@@ -562,7 +562,7 @@ def _vector_segment_id(palace_path: str, collection_name: str) -> Optional[str]:
     if not os.path.isfile(db_path):
         return None
     try:
-        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        conn = connect_sqlite_read(db_path)
         try:
             row = conn.execute(
                 """
@@ -733,7 +733,7 @@ def _read_sync_threshold(palace_path: str, collection_name: str) -> int:
     if not os.path.isfile(db_path):
         return 1000
     try:
-        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        conn = connect_sqlite_read(db_path)
         try:
             cur = conn.cursor()
             cur.execute(
@@ -764,7 +764,7 @@ def _collection_has_sync_threshold_metadata(palace_path: str, collection_name: s
         return False
 
     try:
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn = connect_sqlite_read(db_path)
         try:
             row = conn.execute(
                 """
@@ -1097,7 +1097,7 @@ def _sqlite_embedding_count(palace_path: str, collection_name: str) -> Optional[
     if not os.path.isfile(db_path):
         return None
     try:
-        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        conn = connect_sqlite_read(db_path)
         try:
             row = conn.execute(
                 """
@@ -1158,7 +1158,7 @@ def _sqlite_wing_room_counts(
     if not os.path.isfile(db_path):
         return None
     try:
-        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        conn = connect_sqlite_read(db_path)
         try:
             # Wait out a transient writer/checkpoint lock rather than falling
             # straight back to the expensive vector-index path (#1681).
@@ -1215,7 +1215,7 @@ def sqlite_room_wing_hall_counts(palace_path: str, collection_name: str) -> Opti
     if not os.path.isfile(db_path):
         return None
     try:
-        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        conn = connect_sqlite_read(db_path)
         try:
             conn.execute("PRAGMA busy_timeout = 3000")
             if (
@@ -1317,7 +1317,7 @@ def sqlite_list_id_metadata(
     if filters is None:
         return None
     try:
-        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        conn = connect_sqlite_read(db_path)
         try:
             conn.execute("PRAGMA busy_timeout = 3000")
             if (
@@ -1430,7 +1430,7 @@ def sqlite_documents_for_ids(
     wanted = [str(i) for i in ids]
     docs: dict[str, str] = {}
     try:
-        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        conn = connect_sqlite_read(db_path)
         try:
             conn.execute("PRAGMA busy_timeout = 3000")
             segments = [
@@ -2250,7 +2250,7 @@ class ChromaCollection(BaseCollection):
         # rowid, embedding_id is the user-facing drawer id.
         public_ids: dict[int, str] = {}
         try:
-            conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+            conn = connect_sqlite_read(db_path)
             conn.row_factory = sqlite3.Row
         except sqlite3.Error:
             logger.debug("Chroma lexical sqlite open failed", exc_info=True)

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -265,6 +265,50 @@ def sqlite_read_uri(db_path: str) -> str:
     return f"file:{pathname2url(db_path)}?mode=ro"
 
 
+def _is_wal_without_sidecars(db_path: str) -> bool:
+    """True for a WAL database whose ``-wal``/``-shm`` sidecars are both absent.
+
+    Byte 18 of the SQLite header is the file format write version: 1 for a
+    rollback journal, 2 for WAL. Reading it costs one open and answers the
+    question a connection cannot answer without already being usable.
+    """
+    if os.path.exists(f"{db_path}-shm") or os.path.exists(f"{db_path}-wal"):
+        return False
+    try:
+        with open(db_path, "rb") as handle:
+            header = handle.read(19)
+    except OSError:
+        # Unreadable for another reason; let the normal open report it.
+        return False
+    return len(header) == 19 and header[:16] == b"SQLite format 3\x00" and header[18] == 2
+
+
+def connect_sqlite_read(db_path: str, *, timeout: float | None = None):
+    """Open ``db_path`` for reading, and keep reading when ``mode=ro`` cannot.
+
+    A WAL database whose ``-wal`` and ``-shm`` sidecars are absent cannot be
+    read through a read-only connection on every SQLite build: Apple's system
+    library, which CPython links on macOS, accepts the connect and then fails
+    the first statement with ``SQLITE_CANTOPEN``, because a read-only
+    connection may not create the shared-memory index that WAL needs. The
+    sidecars are absent exactly when nothing holds the palace open, which is
+    the ordinary state before this process opens chroma, so a healthy palace
+    came back as unreadable and the integrity gate refused every tool (#2489).
+
+    Only that case takes a normal open, which creates the sidecars the
+    read-only connection may not and takes SQLite's usual locks. ``immutable=1``
+    would also open, but it disables locking and can read a torn page set from
+    under a live writer, so it is not a substitute. Everything else keeps the
+    read-only connection it had.
+    """
+    import sqlite3
+
+    kwargs = {} if timeout is None else {"timeout": timeout}
+    if _is_wal_without_sidecars(db_path):
+        return sqlite3.connect(os.fspath(db_path), **kwargs)
+    return sqlite3.connect(sqlite_read_uri(db_path), uri=True, **kwargs)
+
+
 @lru_cache(maxsize=1)
 def get_configured_collection_name() -> str:
     """Return the configured drawer collection name without repeated config-file reads."""

--- a/mempalace/config.py
+++ b/mempalace/config.py
@@ -283,7 +283,7 @@ def _is_wal_without_sidecars(db_path: str) -> bool:
     return len(header) == 19 and header[:16] == b"SQLite format 3\x00" and header[18] == 2
 
 
-def connect_sqlite_read(db_path: str, *, timeout: float | None = None):
+def connect_sqlite_read(db_path: str, *, timeout: "float | None" = None):
     """Open ``db_path`` for reading, and keep reading when ``mode=ro`` cannot.
 
     A WAL database whose ``-wal`` and ``-shm`` sidecars are absent cannot be

--- a/mempalace/mcp_server/tools_read.py
+++ b/mempalace/mcp_server/tools_read.py
@@ -17,6 +17,8 @@ def _tool_status_via_sqlite() -> dict:
     """
     import sqlite3 as _sqlite3
 
+    from ..config import connect_sqlite_read
+
     db_path = os.path.join(_config.palace_path, "chroma.sqlite3")
     if not os.path.isfile(db_path):
         return _no_palace()
@@ -26,7 +28,7 @@ def _tool_status_via_sqlite() -> dict:
     rooms: dict = {}
     total = 0
     try:
-        conn = _sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        conn = connect_sqlite_read(db_path)
         try:
             row = conn.execute(
                 """

--- a/mempalace/repair.py
+++ b/mempalace/repair.py
@@ -46,7 +46,11 @@ from typing import Callable, Iterator, Optional
 from chromadb.errors import NotFoundError as ChromaNotFoundError
 
 from .backends.chroma import ChromaBackend, hnsw_capacity_status
-from .config import sqlite_read_uri
+
+# sqlite_read_uri stays in this module's namespace: callers and tests reach the
+# read-only URI through repair, while the connections themselves now go through
+# connect_sqlite_read.
+from .config import connect_sqlite_read, sqlite_read_uri  # noqa: F401
 
 
 COLLECTION_NAME = "mempalace_drawers"
@@ -706,9 +710,7 @@ def sqlite_drawer_count(palace_path: str, collection_name: Optional[str] = None)
     if not os.path.exists(sqlite_path):
         return None
     try:
-        import sqlite3
-
-        conn = sqlite3.connect(sqlite_read_uri(sqlite_path), uri=True)
+        conn = connect_sqlite_read(sqlite_path)
         try:
             row = conn.execute(
                 """
@@ -799,8 +801,8 @@ def _quick_check_errors(sqlite_path: str) -> list[str]:
     would come back as an empty error list, which reads as a clean verdict for
     a database nobody opened.
 
-    ``ValueError`` is reported rather than raised. ``sqlite_read_uri`` builds a
-    URI before SQLite is reached, and up to Python 3.12 that raises for a
+    ``ValueError`` is reported rather than raised. ``connect_sqlite_read`` builds
+    a URI before SQLite is reached, and up to Python 3.12 that raises for a
     directory name holding a byte that came back through ``surrogateescape``;
     3.13 percent-encodes it instead. Such a path reaches here because absence
     was not proven for it, the same reason every unreadable path reaches here,
@@ -818,11 +820,7 @@ def _quick_check_errors(sqlite_path: str) -> list[str]:
         # open, so the descriptor would sit there until the cyclic collector
         # ran.
         with closing(
-            sqlite3.connect(
-                sqlite_read_uri(sqlite_path),
-                uri=True,
-                timeout=_SQLITE_INTEGRITY_BUSY_TIMEOUT_SECONDS,
-            )
+            connect_sqlite_read(sqlite_path, timeout=_SQLITE_INTEGRITY_BUSY_TIMEOUT_SECONDS)
         ) as conn:
             rows = conn.execute("PRAGMA quick_check").fetchall()
     except (sqlite3.Error, ValueError) as e:
@@ -1783,7 +1781,7 @@ def extract_via_sqlite(palace_path: str, collection_name: str) -> Iterator[tuple
     if not os.path.isfile(sqlite_path):
         return
 
-    conn = sqlite3.connect(sqlite_read_uri(sqlite_path), uri=True)
+    conn = connect_sqlite_read(sqlite_path)
     try:
         seg_row = conn.execute(
             """

--- a/mempalace/searcher.py
+++ b/mempalace/searcher.py
@@ -26,7 +26,7 @@ from .backends import (
     PalaceNotFoundError,
     UnsupportedCapabilityError,
 )
-from .config import MempalaceConfig, sqlite_read_uri
+from .config import MempalaceConfig, connect_sqlite_read
 from .date_window import filed_at_in_window, parse_window
 from .i18n import _canonical_lang, get_stopwords
 from .palace import (
@@ -933,7 +933,7 @@ def _bm25_only_via_sqlite(
         return "".join(clauses), params
 
     try:
-        conn = sqlite3.connect(sqlite_read_uri(db_path), uri=True)
+        conn = connect_sqlite_read(db_path)
     except sqlite3.Error as e:
         return _search_error_result(f"sqlite open failed: {e}")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import tempfile
 import pytest
 from mempalace.config import (
     MempalaceConfig,
+    connect_sqlite_read,
     normalize_wing_name,
     sanitize_iso_date,
     sanitize_iso_temporal,
@@ -223,6 +224,86 @@ def test_embeddinggemma_batch_size_invalid_falls_back_to_default(tmp_path, monke
     monkeypatch.setenv("MEMPALACE_EMBEDDINGGEMMA_BATCH_SIZE", "not-a-number")
     cfg = MempalaceConfig(config_dir=str(tmp_path))
     assert cfg.embeddinggemma_batch_size == _EMBEDDINGGEMMA_BATCH_SIZE
+
+
+def _wal_db(tmp_path, name="chroma.sqlite3"):
+    """A WAL database with its sidecars removed, as chroma leaves one behind."""
+    db_path = tmp_path / name
+    setup = sqlite3.connect(str(db_path))
+    setup.execute("PRAGMA journal_mode=WAL")
+    setup.execute("CREATE TABLE t (x INTEGER)")
+    setup.execute("INSERT INTO t VALUES (42)")
+    setup.commit()
+    setup.close()
+    for sidecar in (f"{db_path}-wal", f"{db_path}-shm"):
+        if os.path.exists(sidecar):
+            os.unlink(sidecar)
+    return db_path
+
+
+def test_connect_sqlite_read_reads_a_wal_database_without_sidecars(tmp_path):
+    """A read-only open cannot create the WAL index, so that case takes a normal open.
+
+    Apple's SQLite, which CPython links on macOS, fails the first statement of
+    such a connection with "unable to open database file", and the integrity
+    gate then refused every tool for a healthy palace (#2489).
+    """
+    db_path = _wal_db(tmp_path)
+
+    conn = connect_sqlite_read(str(db_path))
+    try:
+        assert conn.execute("SELECT x FROM t").fetchone()[0] == 42
+        assert conn.execute("PRAGMA quick_check").fetchall() == [("ok",)]
+    finally:
+        conn.close()
+
+
+def test_connect_sqlite_read_takes_a_normal_open_when_the_wal_index_is_missing(tmp_path):
+    """The fallback is a normal open, which is the whole point: it may create the index.
+
+    Asserting the open mode rather than a side effect keeps this meaningful on
+    SQLite builds whose read-only open happens to succeed here.
+    """
+    db_path = _wal_db(tmp_path)
+
+    conn = connect_sqlite_read(str(db_path))
+    try:
+        conn.execute("INSERT INTO t VALUES (1)")
+        conn.rollback()
+    finally:
+        conn.close()
+
+
+def test_connect_sqlite_read_stays_read_only_for_a_rollback_journal_database(tmp_path):
+    db_path = tmp_path / "chroma.sqlite3"
+    setup = sqlite3.connect(str(db_path))
+    setup.execute("CREATE TABLE t (x INTEGER)")
+    setup.commit()
+    setup.close()
+
+    conn = connect_sqlite_read(str(db_path))
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO t VALUES (1)")
+    finally:
+        conn.close()
+
+
+def test_connect_sqlite_read_stays_read_only_while_the_sidecars_are_there(tmp_path):
+    """A WAL palace that something else holds open keeps the read-only connection."""
+    db_path = _wal_db(tmp_path)
+    holder = sqlite3.connect(str(db_path))
+    holder.execute("SELECT x FROM t").fetchone()
+    try:
+        assert os.path.exists(f"{db_path}-shm")
+        conn = connect_sqlite_read(str(db_path))
+        try:
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute("INSERT INTO t VALUES (1)")
+        finally:
+            conn.close()
+    finally:
+        holder.close()
 
 
 def test_sqlite_read_uri_opens_path_with_spaces(tmp_path):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1756,6 +1756,30 @@ def test_sqlite_integrity_errors_returns_empty_for_healthy_db(tmp_path):
     assert repair.sqlite_integrity_errors(str(palace)) == []
 
 
+def test_sqlite_integrity_errors_reads_a_wal_palace_without_sidecars(tmp_path):
+    """A healthy WAL palace nothing holds open must not read as corrupt (#2489).
+
+    chroma removes the ``-wal``/``-shm`` sidecars when its last connection
+    closes cleanly, and a read-only connection may not recreate the index they
+    hold. On SQLite builds that enforce this, the probe failed with "unable to
+    open database file" and the gate then refused every tool.
+    """
+    palace = tmp_path / "palace"
+    palace.mkdir()
+    db_path = palace / "chroma.sqlite3"
+    setup = sqlite3.connect(str(db_path))
+    setup.execute("PRAGMA journal_mode=WAL")
+    setup.execute("CREATE TABLE t (x INTEGER)")
+    setup.execute("INSERT INTO t VALUES (1)")
+    setup.commit()
+    setup.close()
+    for sidecar in (f"{db_path}-wal", f"{db_path}-shm"):
+        if os.path.exists(sidecar):
+            os.unlink(sidecar)
+
+    assert repair.sqlite_integrity_errors(str(palace)) == []
+
+
 def test_sqlite_integrity_errors_uses_bounded_contention_timeout(tmp_path, monkeypatch):
     """Integrity checks wait out routine writers without a real-time sleep.
 


### PR DESCRIPTION
## Summary

Fixes #2489.

Every read-only probe opened `chroma.sqlite3` through `sqlite_read_uri()`, i.e. `file:…?mode=ro`. A WAL database whose `-wal` and `-shm` sidecars are absent cannot be read that way on every SQLite build: Apple's system library, which CPython links on macOS, accepts the connect and fails the first statement with `SQLITE_CANTOPEN`, because a read-only connection may not create the shared-memory index WAL needs. chroma removes both sidecars when its last connection closes cleanly, so that state is ordinary, not damage. The integrity gate then stored

```
PRAGMA quick_check failed: unable to open database file
```

as a verdict and refused every tool until the palace was "repaired", for a palace that `sqlite3 chroma.sqlite3 "PRAGMA quick_check"` calls `ok`.

Reproduced here with the system interpreter, which links Apple's SQLite 3.51.0:

```
sidecars now: ['chroma.sqlite3']
read-only probe FAILED: OperationalError unable to open database file
plain (read-write) probe: [('ok',)]
```

On a Homebrew CPython (SQLite 3.51.3) the same open succeeds, which is why this does not show up everywhere.

## Change

`config.connect_sqlite_read(db_path, *, timeout=None)` keeps the read-only connection in every case except that one, which it recognizes before connecting: byte 18 of the SQLite header is the file format write version (2 for WAL), and neither sidecar exists. Then it opens the file normally, which creates the index the read-only connection may not and takes SQLite's usual locks.

`immutable=1` would also make the read-only open succeed, but it disables locking and can read a torn page set from under a live writer, so it is not a substitute, as the issue notes.

All read-only openers go through the helper: `repair` (the `quick_check` probe, the drawer count, the segment lookup), `searcher`, the chroma backend, and the `_tool_status_via_sqlite` fallback whose traceback is in the report. `sqlite_read_uri` is unchanged and still exported. One raw `f"file:{db_path}?mode=ro"` in the chroma backend now goes through the helper too, so it no longer mis-parses a palace path containing spaces, which is what `sqlite_read_uri` exists to prevent.

Out of scope, from the issue's list, and worth their own changes: treating `SQLITE_CANTOPEN` as "probe could not run" rather than as a verdict, `tool_reconnect()` probing before it closes the backend, and the skip branch leaving `_sqlite_integrity_no_verdict_reason` empty. This PR removes the cause; those harden the reporting around it.

## Tests

`tests/test_config.py`

- a WAL database with both sidecars removed is readable through the helper, including `PRAGMA quick_check`
- that case takes a normal open (asserted on the open mode, not on a side effect, so it means the same on every SQLite build); it fails when the fallback is disabled
- a rollback-journal database and a WAL database whose sidecars are present both keep the read-only connection, so the normal path is unchanged

`tests/test_repair.py`

- `sqlite_integrity_errors()` on a healthy WAL palace with no sidecars returns no errors, which is the reported symptom

```
python -m pytest tests/test_repair.py tests/test_config.py tests/mcp/ tests/test_daemon.py -q
751 passed, 1 skipped
ruff check / ruff format --check   # clean
```
