### PR TITLE
fix(mcp): stop peer sync thread and bind logstream path to avoid test flake

### DIFF
--- a/mempalace/mcp_server/http.py
+++ b/mempalace/mcp_server/http.py
@@ -708,6 +708,10 @@ def _mesh_peers_payload() -> dict:
     }
 
 
+_peer_sync_thread: threading.Thread | None = None
+_peer_sync_stop_event: threading.Event | None = None
+
+
 def _peer_sync_interval_s() -> float:
     try:
         return float(os.environ.get("MEMPALACE_SYNC_INTERVAL", "") or 15)
@@ -715,7 +719,20 @@ def _peer_sync_interval_s() -> float:
         return 15.0
 
 
-def _start_peer_sync_thread() -> None:
+def _stop_peer_sync_thread(timeout: float = 2.0) -> None:
+    """Signal shutdown to the peer sync thread and wait for it to exit."""
+    global _peer_sync_thread, _peer_sync_stop_event
+    if _peer_sync_stop_event is not None:
+        _peer_sync_stop_event.set()
+    if _peer_sync_thread is not None and _peer_sync_thread.is_alive():
+        _peer_sync_thread.join(timeout=timeout)
+    _peer_sync_thread = None
+    _peer_sync_stop_event = None
+
+
+def _start_peer_sync_thread(
+    stop_event: threading.Event | None = None,
+) -> threading.Thread | None:
     """Background anti-entropy loop for the logstream (RFC 004 step 0).
 
     Runs in the serving process so a hub with configured peers converges
@@ -732,19 +749,29 @@ def _start_peer_sync_thread() -> None:
     """
     from ..logsync import sync_all
 
+    global _peer_sync_thread, _peer_sync_stop_event
+    _stop_peer_sync_thread()
+
     palace_path = getattr(_config, "palace_path", None)
     if not palace_path:
-        return
+        return None
     interval = _peer_sync_interval_s()
     if interval <= 0:
-        return
+        return None
+
+    canonical_ls_path = _canonicalize_kg_path(
+        os.path.join(os.path.expanduser(palace_path), LOGSTREAM_DB_FILENAME)
+    )
+    stop = stop_event if stop_event is not None else threading.Event()
 
     def _loop():
         malformed_logged = False
-        while True:
-            time.sleep(interval)
+        while not stop.wait(interval):
             try:
-                ls = _get_logstream()
+                try:
+                    ls = _get_logstream(canonical_ls_path)
+                except TypeError:
+                    ls = _get_logstream()
                 for stats in sync_all(ls, palace_path):
                     _record_peer_sync(stats)
                     if stats.get("error"):
@@ -768,8 +795,11 @@ def _start_peer_sync_thread() -> None:
                 logger.warning("peer sync round failed", exc_info=True)
 
     thread = threading.Thread(target=_loop, name="mempalace-logsync", daemon=True)
+    _peer_sync_thread = thread
+    _peer_sync_stop_event = stop
     thread.start()
     logger.info("peer sync thread started (interval %.0fs)", interval)
+    return thread
 
 
 def _sse_acquire_slot(httpd) -> bool:
@@ -1152,6 +1182,7 @@ def _serve_http(host: str, port: int) -> None:
         except KeyboardInterrupt:
             logger.info("MemPalace MCP HTTP server shutting down")
         finally:
+            _stop_peer_sync_thread()
             if _registered_palace:
                 try:
                     from .. import server_registry

--- a/mempalace/mcp_server/http.py
+++ b/mempalace/mcp_server/http.py
@@ -719,15 +719,24 @@ def _peer_sync_interval_s() -> float:
         return 15.0
 
 
-def _stop_peer_sync_thread(timeout: float = 2.0) -> None:
-    """Signal shutdown to the peer sync thread and wait for it to exit."""
+def _stop_peer_sync_thread(timeout: float = 5.0) -> bool:
+    """Signal shutdown to the peer sync thread and wait for it to exit.
+
+    Returns True if the thread stopped (or was not running), False if it timed out.
+    """
     global _peer_sync_thread, _peer_sync_stop_event
     if _peer_sync_stop_event is not None:
         _peer_sync_stop_event.set()
+    stopped = True
     if _peer_sync_thread is not None and _peer_sync_thread.is_alive():
         _peer_sync_thread.join(timeout=timeout)
-    _peer_sync_thread = None
-    _peer_sync_stop_event = None
+        stopped = not _peer_sync_thread.is_alive()
+        if not stopped:
+            logger.warning("peer sync thread did not terminate within %.1fs", timeout)
+    if stopped:
+        _peer_sync_thread = None
+        _peer_sync_stop_event = None
+    return stopped
 
 
 def _start_peer_sync_thread(
@@ -750,7 +759,9 @@ def _start_peer_sync_thread(
     from ..logsync import sync_all
 
     global _peer_sync_thread, _peer_sync_stop_event
-    _stop_peer_sync_thread()
+    if not _stop_peer_sync_thread():
+        logger.warning("cannot start peer sync thread: previous thread is still alive")
+        return None
 
     palace_path = getattr(_config, "palace_path", None)
     if not palace_path:
@@ -767,12 +778,13 @@ def _start_peer_sync_thread(
     def _loop():
         malformed_logged = False
         while not stop.wait(interval):
+            if stop.is_set():
+                break
             try:
-                try:
-                    ls = _get_logstream(canonical_ls_path)
-                except TypeError:
-                    ls = _get_logstream()
+                ls = _get_logstream(canonical_ls_path)
                 for stats in sync_all(ls, palace_path):
+                    if stop.is_set():
+                        break
                     _record_peer_sync(stats)
                     if stats.get("error"):
                         logger.warning("peer sync %s: %s", stats.get("peer_name"), stats["error"])
@@ -783,6 +795,8 @@ def _start_peer_sync_thread(
                             stats["pulled_events"],
                             stats["pulled_artifacts"],
                         )
+                if stop.is_set():
+                    break
                 # Publish once per round, not per peer: the estate is only
                 # coherent after every configured peer has been attempted.
                 _publish_mesh_state(palace_path)

--- a/mempalace/mcp_server/http.py
+++ b/mempalace/mcp_server/http.py
@@ -708,8 +708,8 @@ def _mesh_peers_payload() -> dict:
     }
 
 
-_peer_sync_thread: threading.Thread | None = None
-_peer_sync_stop_event: threading.Event | None = None
+_peer_sync_thread: Optional[threading.Thread] = None
+_peer_sync_stop_event: Optional[threading.Event] = None
 
 
 def _peer_sync_interval_s() -> float:
@@ -740,8 +740,8 @@ def _stop_peer_sync_thread(timeout: float = 5.0) -> bool:
 
 
 def _start_peer_sync_thread(
-    stop_event: threading.Event | None = None,
-) -> threading.Thread | None:
+    stop_event: Optional[threading.Event] = None,
+) -> Optional[threading.Thread]:
     """Background anti-entropy loop for the logstream (RFC 004 step 0).
 
     Runs in the serving process so a hub with configured peers converges

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,6 +192,13 @@ def _reset_mcp_cache(monkeypatch):
 
             mcp_server = sys.modules.get("mempalace.mcp_server")
             if mcp_server is not None:
+                stop_sync = getattr(mcp_server, "_stop_peer_sync_thread", None)
+                if callable(stop_sync):
+                    try:
+                        stop_sync()
+                    except Exception:
+                        pass
+
                 _reset_loaded_mcp_writer_state(mcp_server)
                 for kg in list(getattr(mcp_server, "_kg_by_path", {}).values()):
                     close = getattr(kg, "close", None)
@@ -203,6 +210,17 @@ def _reset_mcp_cache(monkeypatch):
 
                 if hasattr(mcp_server, "_kg_by_path"):
                     mcp_server._kg_by_path.clear()
+
+                for ls in list(getattr(mcp_server, "_logstream_by_path", {}).values()):
+                    close = getattr(ls, "close", None)
+                    if close is not None:
+                        try:
+                            close()
+                        except Exception:
+                            pass
+
+                if hasattr(mcp_server, "_logstream_by_path"):
+                    mcp_server._logstream_by_path.clear()
 
                 # Close (not just dereference) the cached chromadb client so its
                 # rust-side file handles are released; on Windows a bare deref

--- a/tests/test_logstream_sync.py
+++ b/tests/test_logstream_sync.py
@@ -890,6 +890,13 @@ class TestPeerSyncThreadStartup:
     the failure mode is silence, which is why it needs a test.
     """
 
+    @pytest.fixture(autouse=True)
+    def _cleanup_peer_sync_thread(self):
+        from mempalace import mcp_server as mcp
+
+        yield
+        mcp._stop_peer_sync_thread()
+
     def _start(self, tmp_path, monkeypatch, interval="0.05"):
         import threading
 
@@ -898,8 +905,6 @@ class TestPeerSyncThreadStartup:
         monkeypatch.setenv("MEMPALACE_SYNC_INTERVAL", interval)
         monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(tmp_path))
 
-        # Compare thread objects, not names: earlier tests in this class
-        # leave their own daemon loop running under the same name.
         before = set(threading.enumerate())
         mcp._start_peer_sync_thread()
         return [
@@ -925,7 +930,7 @@ class TestPeerSyncThreadStartup:
             return []
 
         monkeypatch.setattr("mempalace.logsync.sync_all", _fake_sync_all)
-        monkeypatch.setattr(mcp, "_get_logstream", lambda: object())
+        monkeypatch.setattr(mcp, "_get_logstream", lambda *args, **kwargs: object())
 
         assert self._start(tmp_path, monkeypatch)
 

--- a/tests/test_mcp_writer_diagnostics.py
+++ b/tests/test_mcp_writer_diagnostics.py
@@ -153,30 +153,41 @@ def test_light_hub_forward_does_not_acquire_local_writer(isolated_writer, monkey
 
 def test_peer_sync_thread_does_not_pollute_unrelated_palace(tmp_path, monkeypatch):
     """Issue #2493: peer sync thread must not create or mutate other palaces."""
-    import time
+    import threading
+    import mempalace.logsync as logsync_mod
     from mempalace.config import MempalaceConfig
 
     palace1 = tmp_path / "sync_palace"
     palace1.mkdir()
-    monkeypatch.setenv("MEMPALACE_SYNC_INTERVAL", "0.05")
+    monkeypatch.setenv("MEMPALACE_SYNC_INTERVAL", "0.01")
     monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace1))
     monkeypatch.setattr(mcp, "_config", MempalaceConfig(palace_path=palace1))
 
-    thread = mcp._start_peer_sync_thread()
-    assert thread is not None
+    sync_round_completed = threading.Event()
+    original_sync_all = logsync_mod.sync_all
+
+    def _sync_all_wrapper(*args, **kwargs):
+        res = original_sync_all(*args, **kwargs)
+        sync_round_completed.set()
+        return res
+
+    monkeypatch.setattr("mempalace.logsync.sync_all", _sync_all_wrapper)
 
     unrelated_palace = tmp_path / "unrelated_palace"
     assert not unrelated_palace.exists()
 
-    # Repoint _config to unrelated_palace
+    thread = mcp._start_peer_sync_thread()
+    assert thread is not None
+
+    # Repoint _config to unrelated_palace AFTER thread starts on palace1
     monkeypatch.setattr(mcp, "_config", MempalaceConfig(palace_path=unrelated_palace))
 
-    # Wait for multiple sync loop ticks
-    time.sleep(0.15)
+    # Wait for the sync round to definitely complete
+    assert sync_round_completed.wait(timeout=5.0), "sync round never executed within deadline"
 
     # Unrelated palace must remain absent!
     assert not unrelated_palace.exists()
 
     # Clean up thread
-    mcp._stop_peer_sync_thread()
+    assert mcp._stop_peer_sync_thread(timeout=5.0)
     assert not thread.is_alive()

--- a/tests/test_mcp_writer_diagnostics.py
+++ b/tests/test_mcp_writer_diagnostics.py
@@ -149,3 +149,34 @@ def test_light_hub_forward_does_not_acquire_local_writer(isolated_writer, monkey
         }
     )
     assert "result" in result
+
+
+def test_peer_sync_thread_does_not_pollute_unrelated_palace(tmp_path, monkeypatch):
+    """Issue #2493: peer sync thread must not create or mutate other palaces."""
+    import time
+    from mempalace.config import MempalaceConfig
+
+    palace1 = tmp_path / "sync_palace"
+    palace1.mkdir()
+    monkeypatch.setenv("MEMPALACE_SYNC_INTERVAL", "0.05")
+    monkeypatch.setenv("MEMPALACE_PALACE_PATH", str(palace1))
+    monkeypatch.setattr(mcp, "_config", MempalaceConfig(palace_path=palace1))
+
+    thread = mcp._start_peer_sync_thread()
+    assert thread is not None
+
+    unrelated_palace = tmp_path / "unrelated_palace"
+    assert not unrelated_palace.exists()
+
+    # Repoint _config to unrelated_palace
+    monkeypatch.setattr(mcp, "_config", MempalaceConfig(palace_path=unrelated_palace))
+
+    # Wait for multiple sync loop ticks
+    time.sleep(0.15)
+
+    # Unrelated palace must remain absent!
+    assert not unrelated_palace.exists()
+
+    # Clean up thread
+    mcp._stop_peer_sync_thread()
+    assert not thread.is_alive()


### PR DESCRIPTION
Summary:
- Bind peer sync logstream database path to the specific palace_path at thread startup instead of dynamically resolving global _config.palace_path in the loop.
- Track `_peer_sync_thread` and `_peer_sync_stop_event`, implement `_stop_peer_sync_thread()`, and terminate the loop immediately via `stop.wait(interval)`.
- Clean up the peer sync thread in `_serve_http()` finally block, `TestPeerSyncThreadStartup` teardown fixture, and global `tests/conftest.py` `_reset_mcp_cache`.
- In `tests/conftest.py` `_reset_mcp_cache`, close and clear cached `Logstream` instances in `_logstream_by_path`.
- Add regression test in `tests/test_mcp_writer_diagnostics.py` ensuring peer sync thread does not mutate or create unrelated palace directories.

Fixes #2493

Verification:
- Deterministic reproduction script confirmed failure before fix and clean pass after fix.
- 10 consecutive iterations of targeted test suites ran with zero flakes.
- 504 tests across `tests/mcp/` and logstream suites: 495 passed, 9 skipped, 0 failures.
- Ruff lint (`uv run ruff check`) and formatting (`uv run ruff format --check`) passed cleanly.
